### PR TITLE
feat: PR2 session continuity

### DIFF
--- a/extensions/openclaw-plugin/index.ts
+++ b/extensions/openclaw-plugin/index.ts
@@ -88,13 +88,12 @@ function resolveHippoCwdFromContext(api: any, ctx: HippoRuntimeContext, configRo
   return resolveHippoCwd(workspace, configRoot);
 }
 
-function getSessionIdentity(ctx: Pick<HippoRuntimeContext, 'sessionId' | 'sessionKey' | 'agentId'>): string | undefined {
-  return ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId;
+function getSessionIdentity(ctx: Pick<HippoRuntimeContext, 'sessionId' | 'sessionKey' | 'agentId'>): string {
+  return ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId ?? `fallback-${Date.now()}-${process.pid}`;
 }
 
 function recordSessionMemory(ctx: Pick<HippoRuntimeContext, 'sessionId' | 'sessionKey' | 'agentId'>): void {
   const key = getSessionIdentity(ctx);
-  if (!key) return;
   sessionMemoryCounts.set(key, (sessionMemoryCounts.get(key) ?? 0) + 1);
 }
 
@@ -102,7 +101,6 @@ function consumeSessionMemoryCount(
   ctx: Pick<HippoRuntimeContext, 'sessionId' | 'sessionKey' | 'agentId'>,
 ): number {
   const key = getSessionIdentity(ctx);
-  if (!key) return 0;
   const count = sessionMemoryCounts.get(key) ?? 0;
   sessionMemoryCounts.delete(key);
   return count;
@@ -440,6 +438,16 @@ export default function register(api: any) {
       const framing = cfg.framing ?? 'observe';
       const hippoCwd = resolveHippoCwdFromContext(api, ctx, cfg.root);
 
+      // Record session_start event
+      try {
+        runHippo(
+          `session log --id "${sessionKey}" --type session_start --content "Session started" --source openclaw`,
+          hippoCwd,
+        );
+      } catch (err) {
+        logger.debug?.('[hippo] session_start event skipped:', err);
+      }
+
       try {
         const context = runHippo(
           `context --auto --budget ${budget} --framing ${framing}`,
@@ -488,13 +496,23 @@ export default function register(api: any) {
     (_event: { sessionId: string; messageCount: number }, ctx: HippoRuntimeContext) => {
       // Clear dedup guard so a new session can inject fresh context
       const sessionKey = getSessionIdentity(ctx);
-      if (sessionKey) injectedSessions.delete(sessionKey);
+      injectedSessions.delete(sessionKey);
 
       const cfg = getConfig(api);
+      const hippoCwd = resolveHippoCwdFromContext(api, ctx, cfg.root);
+
+      // Record session_end event
+      try {
+        runHippo(
+          `session log --id "${sessionKey}" --type session_end --content "Session ended" --source openclaw`,
+          hippoCwd,
+        );
+      } catch (err) {
+        logger.debug?.('[hippo] session_end event skipped:', err);
+      }
+
       const newMemories = consumeSessionMemoryCount(ctx);
       if (!cfg.autoSleep || newMemories < AUTO_SLEEP_SESSION_THRESHOLD) return;
-
-      const hippoCwd = resolveHippoCwdFromContext(api, ctx, cfg.root);
       const result = runHippo('sleep', hippoCwd);
       logger.info?.(
         `[hippo] autoSleep ran for session ${ctx.sessionId ?? ctx.sessionKey ?? 'unknown'} ` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,8 @@
  *   hippo outcome --good | --bad [--id <id>]
  *   hippo conflicts [--status <status>] [--json]
  *   hippo snapshot <save|show|clear>
- *   hippo session <log|show>
+ *   hippo session <log|show|latest|resume>
+ *   hippo handoff <create|latest|show>
  *   hippo forget <id>
  *   hippo inspect <id>
  *   hippo embed [--status]
@@ -55,9 +56,13 @@ import {
   listSessionEvents,
   listMemoryConflicts,
   resolveConflict,
+  saveSessionHandoff,
+  loadLatestHandoff,
+  loadHandoffById,
   TaskSnapshot,
   SessionEvent,
 } from './store.js';
+import type { SessionHandoff } from './handoff.js';
 import { search, markRetrieved, estimateTokens, hybridSearch } from './search.js';
 import { consolidate } from './consolidate.js';
 import {
@@ -124,8 +129,8 @@ function parseArgs(argv: string[]): { command: string; args: string[]; flags: Re
         flags[key] = true;
         i++;
       } else {
-        // Check if it's a repeatable flag (tag)
-        if (key === 'tag') {
+        // Check if it's a repeatable flag (tag, artifact)
+        if (key === 'tag' || key === 'artifact') {
           if (Array.isArray(flags[key])) {
             (flags[key] as string[]).push(next);
           } else {
@@ -868,7 +873,185 @@ function cmdSession(
     return;
   }
 
-  console.error('Usage: hippo session <log|show>');
+  if (subcommand === 'latest') {
+    const snapshot = loadActiveTaskSnapshot(hippoRoot);
+    const events = listSessionEvents(hippoRoot, {
+      session_id: sessionId || snapshot?.session_id || undefined,
+      limit,
+    });
+
+    if (flags['json']) {
+      console.log(JSON.stringify({ snapshot: snapshot ?? null, events }, null, 2));
+      return;
+    }
+
+    if (snapshot) {
+      printActiveTaskSnapshot(snapshot);
+    } else {
+      console.log('No active task snapshot.');
+      console.log('');
+    }
+    printSessionEvents(events);
+    return;
+  }
+
+  if (subcommand === 'resume') {
+    const handoff = loadLatestHandoff(hippoRoot, sessionId || undefined);
+    if (!handoff) {
+      console.log('No handoff to resume from.');
+      return;
+    }
+
+    const lines: string[] = [
+      '## Session Handoff (resumed)',
+      '',
+      `- Session: ${handoff.sessionId}`,
+      `- Updated: ${handoff.updatedAt}`,
+    ];
+    if (handoff.taskId) lines.push(`- Task: ${handoff.taskId}`);
+    if (handoff.repoRoot) lines.push(`- Repo: ${handoff.repoRoot}`);
+    lines.push('', '### Summary', handoff.summary);
+    if (handoff.nextAction) {
+      lines.push('', '### Next action', handoff.nextAction);
+    }
+    if (handoff.artifacts && handoff.artifacts.length > 0) {
+      lines.push('', '### Artifacts');
+      for (const artifact of handoff.artifacts) {
+        lines.push(`- ${artifact}`);
+      }
+    }
+    lines.push('');
+    console.log(lines.join('\n'));
+    return;
+  }
+
+  console.error('Usage: hippo session <log|show|latest|resume>');
+  process.exit(1);
+}
+
+function printHandoff(handoff: SessionHandoff): void {
+  console.log('## Session Handoff\n');
+  console.log(`- Session: ${handoff.sessionId}`);
+  console.log(`- Updated: ${handoff.updatedAt}`);
+  if (handoff.taskId) console.log(`- Task: ${handoff.taskId}`);
+  if (handoff.repoRoot) console.log(`- Repo: ${handoff.repoRoot}`);
+  console.log('');
+  console.log('### Summary');
+  console.log(handoff.summary);
+  if (handoff.nextAction) {
+    console.log('');
+    console.log('### Next action');
+    console.log(handoff.nextAction);
+  }
+  if (handoff.artifacts && handoff.artifacts.length > 0) {
+    console.log('');
+    console.log('### Artifacts');
+    for (const artifact of handoff.artifacts) {
+      console.log(`- ${artifact}`);
+    }
+  }
+  console.log('');
+}
+
+function cmdHandoff(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>
+): void {
+  requireInit(hippoRoot);
+
+  const subcommand = args[0] ?? 'latest';
+
+  if (subcommand === 'create') {
+    const summary = String(flags['summary'] ?? '').trim();
+    if (!summary) {
+      console.error('Usage: hippo handoff create --summary "..." [--next "..."] [--session <id>] [--task <id>] [--artifact <path>...]');
+      process.exit(1);
+    }
+
+    const sessionId = String(flags['session'] ?? flags['id'] ?? '').trim() || `fallback-${Date.now()}-${process.pid}`;
+    const nextAction = String(flags['next'] ?? '').trim() || undefined;
+    const taskId = String(flags['task'] ?? '').trim() || undefined;
+    const artifactFlag = flags['artifact'];
+    const artifacts: string[] = Array.isArray(artifactFlag)
+      ? artifactFlag
+      : (typeof artifactFlag === 'string' ? [artifactFlag] : []);
+
+    const handoff = saveSessionHandoff(hippoRoot, {
+      version: 1,
+      sessionId,
+      repoRoot: process.cwd(),
+      taskId,
+      summary,
+      nextAction,
+      artifacts,
+    });
+
+    console.log(`Created session handoff for session ${handoff.sessionId}`);
+    console.log(`   Summary: ${handoff.summary}`);
+    if (handoff.nextAction) console.log(`   Next: ${handoff.nextAction}`);
+    if (handoff.artifacts && handoff.artifacts.length > 0) {
+      console.log(`   Artifacts: ${handoff.artifacts.join(', ')}`);
+    }
+    return;
+  }
+
+  if (subcommand === 'latest') {
+    const sessionId = String(flags['session'] ?? flags['id'] ?? '').trim() || undefined;
+    const handoff = loadLatestHandoff(hippoRoot, sessionId);
+
+    if (!handoff) {
+      if (flags['json']) {
+        console.log(JSON.stringify({ handoff: null }));
+      } else {
+        console.log('No session handoff found.');
+      }
+      return;
+    }
+
+    if (flags['json']) {
+      console.log(JSON.stringify({ handoff }, null, 2));
+      return;
+    }
+
+    printHandoff(handoff);
+    return;
+  }
+
+  if (subcommand === 'show') {
+    const idArg = args[1];
+    if (!idArg) {
+      console.error('Usage: hippo handoff show <id> [--json]');
+      process.exit(1);
+    }
+
+    const handoffId = parseInt(idArg, 10);
+    if (!Number.isFinite(handoffId) || handoffId <= 0) {
+      console.error(`Invalid handoff ID: ${idArg}`);
+      process.exit(1);
+    }
+
+    const handoff = loadHandoffById(hippoRoot, handoffId);
+
+    if (!handoff) {
+      if (flags['json']) {
+        console.log(JSON.stringify({ handoff: null }));
+      } else {
+        console.log(`No handoff found with ID ${handoffId}.`);
+      }
+      return;
+    }
+
+    if (flags['json']) {
+      console.log(JSON.stringify({ handoff }, null, 2));
+      return;
+    }
+
+    printHandoff(handoff);
+    return;
+  }
+
+  console.error('Usage: hippo handoff <create|latest|show>');
   process.exit(1);
 }
 
@@ -1673,6 +1856,23 @@ Commands:
       --task <task>
       --limit <n>          Event limit (default: 8)
       --json               Output as JSON
+    session latest         Show latest task snapshot + events
+      --id <session-id>   Filter by session
+      --json               Output as JSON
+    session resume         Re-inject latest handoff as context output
+      --id <session-id>   Filter by session
+  handoff <sub>            Manage session handoffs for continuity
+    handoff create         Create a new session handoff
+      --summary <text>     Handoff summary (required)
+      --next <text>        Next action for successor
+      --session <id>       Session ID (auto-generated if omitted)
+      --task <id>          Associated task ID
+      --artifact <path>    Related file path (repeatable)
+    handoff latest         Show the most recent handoff
+      --session <id>       Filter by session
+      --json               Output as JSON
+    handoff show <id>      Show a specific handoff by ID
+      --json               Output as JSON
   forget <id>              Force remove a memory
   inspect <id>             Show full memory detail
   embed                    Embed all memories for semantic search
@@ -1720,7 +1920,10 @@ Examples:
   hippo context --auto --budget 1500
   hippo conflicts
   hippo session log --id sess_123 --task "Ship feature" --type progress --content "Build is green, next step is docs"
+  hippo session latest --json
+  hippo session resume
   hippo snapshot save --task "Ship feature" --summary "Tests are green" --next-step "Open the PR" --session sess_123
+  hippo handoff create --summary "PR is open, tests green" --next "Merge after review" --session sess_123 --artifact src/foo.ts
   hippo embed --status
   hippo watch "npm run build"
   hippo learn --git --days 30
@@ -1792,6 +1995,10 @@ async function main(): Promise<void> {
 
     case 'session':
       cmdSession(hippoRoot, args, flags);
+      break;
+
+    case 'handoff':
+      cmdHandoff(hippoRoot, args, flags);
       break;
 
     case 'forget': {

--- a/src/db.ts
+++ b/src/db.ts
@@ -20,7 +20,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 4;
+const CURRENT_SCHEMA_VERSION = 5;
 
 type Migration = {
   version: number;
@@ -130,6 +130,26 @@ const MIGRATIONS: Migration[] = [
 
         CREATE INDEX IF NOT EXISTS idx_session_events_task_created
         ON session_events(task, created_at DESC, id DESC);
+      `);
+    },
+  },
+  {
+    version: 5,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS session_handoffs (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          session_id TEXT NOT NULL,
+          repo_root TEXT,
+          task_id TEXT,
+          summary TEXT NOT NULL,
+          next_action TEXT,
+          artifacts_json TEXT NOT NULL DEFAULT '[]',
+          created_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_session_handoffs_session
+        ON session_handoffs(session_id, created_at DESC);
       `);
     },
   },

--- a/src/handoff.ts
+++ b/src/handoff.ts
@@ -1,0 +1,52 @@
+/**
+ * Session handoff types and helpers.
+ *
+ * A handoff captures the state of a session so that a successor
+ * session (or a different agent) can pick up where the previous
+ * one left off.
+ */
+
+export interface SessionHandoff {
+  version: 1;
+  sessionId: string;
+  repoRoot?: string;
+  taskId?: string;
+  summary: string;
+  nextAction?: string;
+  artifacts?: string[];
+  updatedAt: string;
+}
+
+export interface SessionHandoffRow {
+  id: number;
+  session_id: string;
+  repo_root: string | null;
+  task_id: string | null;
+  summary: string;
+  next_action: string | null;
+  artifacts_json: string;
+  created_at: string;
+}
+
+export function rowToSessionHandoff(row: SessionHandoffRow): SessionHandoff {
+  let artifacts: string[] = [];
+  try {
+    const parsed = JSON.parse(row.artifacts_json);
+    if (Array.isArray(parsed)) {
+      artifacts = parsed.map((item) => String(item));
+    }
+  } catch {
+    artifacts = [];
+  }
+
+  return {
+    version: 1,
+    sessionId: row.session_id,
+    repoRoot: row.repo_root ?? undefined,
+    taskId: row.task_id ?? undefined,
+    summary: row.summary,
+    nextAction: row.next_action ?? undefined,
+    artifacts,
+    updatedAt: row.created_at,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,13 @@ export {
   listMemoryConflicts,
   replaceDetectedConflicts,
   resolveConflict,
+  saveSessionHandoff,
+  loadLatestHandoff,
+  loadHandoffById,
 } from './store.js';
+
+// Feature 5: Session handoff
+export { SessionHandoff } from './handoff.js';
 export { consolidate, ConsolidationResult } from './consolidate.js';
 
 // Feature 1: Embedding search

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,7 @@ import {
   pruneConsolidationRuns,
   getHippoDbPath,
 } from './db.js';
+import { SessionHandoff, SessionHandoffRow, rowToSessionHandoff } from './handoff.js';
 
 export interface IndexEntry {
   id: string;
@@ -1329,6 +1330,100 @@ export function resolveConflict(
   } catch (error) {
     try { db.exec('ROLLBACK'); } catch { /* ignore */ }
     throw error;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Save a session handoff record. Returns the persisted handoff.
+ */
+export function saveSessionHandoff(
+  hippoRoot: string,
+  handoff: Omit<SessionHandoff, 'updatedAt'>,
+): SessionHandoff {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  const now = new Date().toISOString();
+
+  try {
+    const result = db.prepare(`
+      INSERT INTO session_handoffs(session_id, repo_root, task_id, summary, next_action, artifacts_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      handoff.sessionId,
+      handoff.repoRoot ?? null,
+      handoff.taskId ?? null,
+      handoff.summary,
+      handoff.nextAction ?? null,
+      JSON.stringify(handoff.artifacts ?? []),
+      now,
+    );
+
+    const id = Number(result.lastInsertRowid ?? 0);
+    const row = db.prepare(`
+      SELECT id, session_id, repo_root, task_id, summary, next_action, artifacts_json, created_at
+      FROM session_handoffs
+      WHERE id = ?
+    `).get(id) as SessionHandoffRow | undefined;
+
+    if (!row) {
+      throw new Error('Failed to reload saved session handoff');
+    }
+
+    return rowToSessionHandoff(row);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Load the most recent handoff, optionally filtered by session ID.
+ */
+export function loadLatestHandoff(hippoRoot: string, sessionId?: string): SessionHandoff | null {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+
+  try {
+    let row: SessionHandoffRow | undefined;
+    if (sessionId) {
+      row = db.prepare(`
+        SELECT id, session_id, repo_root, task_id, summary, next_action, artifacts_json, created_at
+        FROM session_handoffs
+        WHERE session_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      `).get(sessionId) as SessionHandoffRow | undefined;
+    } else {
+      row = db.prepare(`
+        SELECT id, session_id, repo_root, task_id, summary, next_action, artifacts_json, created_at
+        FROM session_handoffs
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      `).get() as SessionHandoffRow | undefined;
+    }
+
+    return row ? rowToSessionHandoff(row) : null;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Load a specific handoff by its row ID.
+ */
+export function loadHandoffById(hippoRoot: string, id: number): SessionHandoff | null {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+
+  try {
+    const row = db.prepare(`
+      SELECT id, session_id, repo_root, task_id, summary, next_action, artifacts_json, created_at
+      FROM session_handoffs
+      WHERE id = ?
+    `).get(id) as SessionHandoffRow | undefined;
+
+    return row ? rowToSessionHandoff(row) : null;
   } finally {
     closeHippoDb(db);
   }

--- a/tests/openclaw-plugin.test.ts
+++ b/tests/openclaw-plugin.test.ts
@@ -131,8 +131,12 @@ describe('openclaw hippo plugin', () => {
     const hook = harness.getHook('before_prompt_build');
     const result = hook({ prompt: 'help', messages: [] }, { workspaceDir: 'C:\\repo\\clawd' });
 
-    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    // 2 calls: session_start event + context injection
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+    expect(execSyncMock.mock.calls[0]?.[0]).toContain('session log');
     expect(execSyncMock.mock.calls[0]?.[1]).toMatchObject({ cwd: 'C:\\repo\\clawd' });
+    expect(execSyncMock.mock.calls[1]?.[0]).toContain('context');
+    expect(execSyncMock.mock.calls[1]?.[1]).toMatchObject({ cwd: 'C:\\repo\\clawd' });
     expect(result).toMatchObject({
       appendSystemContext: expect.stringContaining('Project Memory (Hippo)'),
     });

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  initStore,
+  saveSessionHandoff,
+  loadLatestHandoff,
+  loadHandoffById,
+  appendSessionEvent,
+  listSessionEvents,
+  loadActiveTaskSnapshot,
+  saveActiveTaskSnapshot,
+} from '../src/store.js';
+import {
+  openHippoDb,
+  closeHippoDb,
+  getSchemaVersion,
+  getCurrentSchemaVersion,
+} from '../src/db.js';
+import type { SessionHandoff } from '../src/handoff.js';
+import { rowToSessionHandoff } from '../src/handoff.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-pr2-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('schema v5 migration', () => {
+  it('migrates to schema version 5', () => {
+    initStore(tmpDir);
+    const db = openHippoDb(tmpDir);
+    try {
+      expect(getSchemaVersion(db)).toBe(5);
+      expect(getCurrentSchemaVersion()).toBe(5);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates the session_handoffs table', () => {
+    initStore(tmpDir);
+    const db = openHippoDb(tmpDir);
+    try {
+      const tables = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_handoffs'`
+      ).all() as Array<{ name: string }>;
+      expect(tables).toHaveLength(1);
+      expect(tables[0]!.name).toBe('session_handoffs');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates the index on session_handoffs', () => {
+    initStore(tmpDir);
+    const db = openHippoDb(tmpDir);
+    try {
+      const indexes = db.prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_session_handoffs_session'`
+      ).all() as Array<{ name: string }>;
+      expect(indexes).toHaveLength(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});
+
+describe('session handoff create/save/load', () => {
+  it('saves and loads a handoff', () => {
+    initStore(tmpDir);
+
+    const handoff = saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-001',
+      repoRoot: '/tmp/repo',
+      taskId: 'task-42',
+      summary: 'Tests are green, PR is open',
+      nextAction: 'Merge after review',
+      artifacts: ['src/foo.ts', 'src/bar.ts'],
+    });
+
+    expect(handoff.version).toBe(1);
+    expect(handoff.sessionId).toBe('sess-001');
+    expect(handoff.repoRoot).toBe('/tmp/repo');
+    expect(handoff.taskId).toBe('task-42');
+    expect(handoff.summary).toBe('Tests are green, PR is open');
+    expect(handoff.nextAction).toBe('Merge after review');
+    expect(handoff.artifacts).toEqual(['src/foo.ts', 'src/bar.ts']);
+    expect(handoff.updatedAt).toBeTruthy();
+  });
+
+  it('saves a minimal handoff without optional fields', () => {
+    initStore(tmpDir);
+
+    const handoff = saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-min',
+      summary: 'Minimal handoff',
+    });
+
+    expect(handoff.sessionId).toBe('sess-min');
+    expect(handoff.summary).toBe('Minimal handoff');
+    expect(handoff.repoRoot).toBeUndefined();
+    expect(handoff.taskId).toBeUndefined();
+    expect(handoff.nextAction).toBeUndefined();
+    expect(handoff.artifacts).toEqual([]);
+  });
+});
+
+describe('loadLatestHandoff', () => {
+  it('returns null when no handoffs exist', () => {
+    initStore(tmpDir);
+    const result = loadLatestHandoff(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns the most recent handoff', () => {
+    initStore(tmpDir);
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-old',
+      summary: 'First handoff',
+    });
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-new',
+      summary: 'Second handoff',
+    });
+
+    const latest = loadLatestHandoff(tmpDir);
+    expect(latest).not.toBeNull();
+    expect(latest!.sessionId).toBe('sess-new');
+    expect(latest!.summary).toBe('Second handoff');
+  });
+
+  it('filters by session ID when provided', () => {
+    initStore(tmpDir);
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-A',
+      summary: 'Handoff A1',
+    });
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-B',
+      summary: 'Handoff B1',
+    });
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-A',
+      summary: 'Handoff A2',
+    });
+
+    const latestA = loadLatestHandoff(tmpDir, 'sess-A');
+    expect(latestA).not.toBeNull();
+    expect(latestA!.summary).toBe('Handoff A2');
+
+    const latestB = loadLatestHandoff(tmpDir, 'sess-B');
+    expect(latestB).not.toBeNull();
+    expect(latestB!.summary).toBe('Handoff B1');
+
+    const latestC = loadLatestHandoff(tmpDir, 'sess-C');
+    expect(latestC).toBeNull();
+  });
+});
+
+describe('loadHandoffById', () => {
+  it('loads a specific handoff by row ID', () => {
+    initStore(tmpDir);
+
+    // Save handoff and verify we can get it by ID from the DB
+    const handoff = saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-byid',
+      summary: 'Find me by ID',
+    });
+
+    // Find the row ID by loading from DB directly
+    const db = openHippoDb(tmpDir);
+    try {
+      const row = db.prepare(
+        `SELECT id FROM session_handoffs WHERE session_id = 'sess-byid' ORDER BY id DESC LIMIT 1`
+      ).get() as { id: number } | undefined;
+
+      expect(row).toBeTruthy();
+      const loaded = loadHandoffById(tmpDir, row!.id);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.sessionId).toBe('sess-byid');
+      expect(loaded!.summary).toBe('Find me by ID');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('returns null for non-existent ID', () => {
+    initStore(tmpDir);
+    const result = loadHandoffById(tmpDir, 99999);
+    expect(result).toBeNull();
+  });
+});
+
+describe('fallback session ID generation', () => {
+  it('getSessionIdentity produces fallback when all identifiers are missing', async () => {
+    // Dynamically import the plugin to test getSessionIdentity indirectly
+    // We test the pattern directly since the function is not exported
+    const ctx = { sessionId: undefined, sessionKey: undefined, agentId: undefined };
+    const identity = ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId ?? `fallback-${Date.now()}-${process.pid}`;
+
+    expect(identity).toMatch(/^fallback-\d+-\d+$/);
+  });
+
+  it('prefers sessionId over fallback', () => {
+    const ctx = { sessionId: 'real-session', sessionKey: undefined, agentId: undefined };
+    const identity = ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId ?? `fallback-${Date.now()}-${process.pid}`;
+
+    expect(identity).toBe('real-session');
+  });
+
+  it('uses sessionKey when sessionId is missing', () => {
+    const ctx = { sessionId: undefined, sessionKey: 'key-123', agentId: undefined };
+    const identity = ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId ?? `fallback-${Date.now()}-${process.pid}`;
+
+    expect(identity).toBe('key-123');
+  });
+
+  it('uses agentId when both sessionId and sessionKey are missing', () => {
+    const ctx = { sessionId: undefined, sessionKey: undefined, agentId: 'agent-007' };
+    const identity = ctx.sessionId ?? ctx.sessionKey ?? ctx.agentId ?? `fallback-${Date.now()}-${process.pid}`;
+
+    expect(identity).toBe('agent-007');
+  });
+});
+
+describe('rowToSessionHandoff', () => {
+  it('converts a row to SessionHandoff', () => {
+    const row = {
+      id: 1,
+      session_id: 'sess-row',
+      repo_root: '/tmp/repo',
+      task_id: 'task-1',
+      summary: 'Row test',
+      next_action: 'Review',
+      artifacts_json: '["a.ts","b.ts"]',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    const handoff = rowToSessionHandoff(row);
+    expect(handoff.version).toBe(1);
+    expect(handoff.sessionId).toBe('sess-row');
+    expect(handoff.repoRoot).toBe('/tmp/repo');
+    expect(handoff.taskId).toBe('task-1');
+    expect(handoff.summary).toBe('Row test');
+    expect(handoff.nextAction).toBe('Review');
+    expect(handoff.artifacts).toEqual(['a.ts', 'b.ts']);
+    expect(handoff.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('handles null optional fields', () => {
+    const row = {
+      id: 2,
+      session_id: 'sess-null',
+      repo_root: null,
+      task_id: null,
+      summary: 'Null test',
+      next_action: null,
+      artifacts_json: '[]',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    const handoff = rowToSessionHandoff(row);
+    expect(handoff.repoRoot).toBeUndefined();
+    expect(handoff.taskId).toBeUndefined();
+    expect(handoff.nextAction).toBeUndefined();
+    expect(handoff.artifacts).toEqual([]);
+  });
+
+  it('handles malformed artifacts_json gracefully', () => {
+    const row = {
+      id: 3,
+      session_id: 'sess-bad',
+      repo_root: null,
+      task_id: null,
+      summary: 'Bad JSON test',
+      next_action: null,
+      artifacts_json: 'not-json',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    const handoff = rowToSessionHandoff(row);
+    expect(handoff.artifacts).toEqual([]);
+  });
+});
+
+describe('session events integration with handoffs', () => {
+  it('session_start and session_end events can be recorded', () => {
+    initStore(tmpDir);
+
+    appendSessionEvent(tmpDir, {
+      session_id: 'sess-lifecycle',
+      event_type: 'session_start',
+      content: 'Session started',
+      source: 'openclaw',
+    });
+
+    appendSessionEvent(tmpDir, {
+      session_id: 'sess-lifecycle',
+      event_type: 'note',
+      content: 'Did some work',
+      source: 'openclaw',
+    });
+
+    appendSessionEvent(tmpDir, {
+      session_id: 'sess-lifecycle',
+      event_type: 'session_end',
+      content: 'Session ended',
+      source: 'openclaw',
+    });
+
+    const events = listSessionEvents(tmpDir, { session_id: 'sess-lifecycle', limit: 10 });
+    expect(events).toHaveLength(3);
+    expect(events[0]!.event_type).toBe('session_start');
+    expect(events[1]!.event_type).toBe('note');
+    expect(events[2]!.event_type).toBe('session_end');
+  });
+
+  it('handoff + session latest returns combined view', () => {
+    initStore(tmpDir);
+
+    saveActiveTaskSnapshot(tmpDir, {
+      task: 'Ship PR2',
+      summary: 'Implementing session continuity',
+      next_step: 'Run tests',
+      session_id: 'sess-combined',
+    });
+
+    appendSessionEvent(tmpDir, {
+      session_id: 'sess-combined',
+      event_type: 'session_start',
+      content: 'Session started',
+    });
+
+    saveSessionHandoff(tmpDir, {
+      version: 1,
+      sessionId: 'sess-combined',
+      summary: 'Tests pass, ready for review',
+      nextAction: 'Create PR',
+    });
+
+    const snapshot = loadActiveTaskSnapshot(tmpDir);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.session_id).toBe('sess-combined');
+
+    const events = listSessionEvents(tmpDir, { session_id: 'sess-combined' });
+    expect(events.length).toBeGreaterThanOrEqual(1);
+
+    const handoff = loadLatestHandoff(tmpDir, 'sess-combined');
+    expect(handoff).not.toBeNull();
+    expect(handoff!.summary).toBe('Tests pass, ready for review');
+  });
+});


### PR DESCRIPTION
## Summary
- New `SessionHandoff` type and `session_handoffs` table (schema v5)
- `hippo handoff create/latest/show` CLI commands
- `hippo session latest` and `hippo session resume` commands
- Fallback session ID generation when plugin context is null
- Session start/end event recording in OpenClaw plugin

## Test plan
- [x] 19 new tests in `tests/pr2-session-continuity.test.ts`
- [x] All tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)