### PR TITLE
feat: PR3 working memory layer

### DIFF
--- a/extensions/openclaw-plugin/index.ts
+++ b/extensions/openclaw-plugin/index.ts
@@ -422,6 +422,49 @@ export default function register(api: any) {
     { optional: true },
   );
 
+  // --- Tool: hippo_wm_push ---
+  api.registerTool(
+    (ctx: HippoRuntimeContext) => ({
+      name: 'hippo_wm_push',
+      description:
+        'Push a note into working memory — a bounded buffer for current-state context. Entries are scoped, importance-ranked, and auto-evicted when the buffer is full (max 20 per scope).',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            description: 'Working memory note',
+          },
+          scope: {
+            type: 'string',
+            description: 'Scope (default: repo)',
+          },
+          importance: {
+            type: 'number',
+            description: 'Priority 0-1 (default: 0.5)',
+          },
+        },
+        required: ['content'],
+      },
+      async execute(
+        _id: string,
+        params: { content: string; scope?: string; importance?: number },
+      ) {
+        const cfg = getConfig(api);
+        const hippoCwd = resolveHippoCwdFromContext(api, ctx, cfg.root);
+        const scope = params.scope ?? 'repo';
+        const importance = params.importance ?? 0.5;
+        const escapedContent = params.content.replace(/"/g, '\\"');
+        const result = runHippo(
+          `wm push --scope ${scope} --content "${escapedContent}" --importance ${importance}`,
+          hippoCwd,
+        );
+        return { content: [{ type: 'text', text: result || 'Working memory entry pushed.' }] };
+      },
+    }),
+    { optional: true },
+  );
+
   // --- Hook: auto-inject context at session start ---
   api.on(
     'before_prompt_build',
@@ -504,5 +547,5 @@ export default function register(api: any) {
     },
   );
 
-  logger.info?.('[hippo] Memory plugin registered (tools: hippo_recall, hippo_remember, hippo_outcome, hippo_status, hippo_context, hippo_conflicts, hippo_resolve, hippo_share, hippo_peers)');
+  logger.info?.('[hippo] Memory plugin registered (tools: hippo_recall, hippo_remember, hippo_outcome, hippo_status, hippo_context, hippo_conflicts, hippo_resolve, hippo_share, hippo_peers, hippo_wm_push)');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@
  *   hippo learn --git [--days <n>] [--repos <paths>]
  *   hippo promote <id>
  *   hippo sync
+ *   hippo wm <push|read|clear|flush>
  */
 
 import * as path from 'path';
@@ -95,6 +96,7 @@ import {
   ImportOptions,
 } from './importers.js';
 import { cmdCapture, CaptureOptions } from './capture.js';
+import { wmPush, wmRead, wmClear, wmFlush, WorkingMemoryItem } from './working-memory.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1610,6 +1612,94 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// ---------------------------------------------------------------------------
+// Working Memory
+// ---------------------------------------------------------------------------
+
+function cmdWm(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>,
+): void {
+  requireInit(hippoRoot);
+
+  const subcommand = args[0] ?? '';
+
+  if (subcommand === 'push') {
+    const scope = String(flags['scope'] ?? 'default').trim();
+    const content = String(flags['content'] ?? '').trim();
+    const importance = parseFloat(String(flags['importance'] ?? '0.5'));
+    const sessionId = flags['session'] ? String(flags['session']).trim() : undefined;
+    const taskId = flags['task'] ? String(flags['task']).trim() : undefined;
+
+    if (!content) {
+      console.error('Usage: hippo wm push --scope <scope> --content "..." [--importance 0.8] [--session <id>] [--task <id>]');
+      process.exit(1);
+    }
+
+    const id = wmPush(hippoRoot, {
+      scope,
+      content,
+      importance: Number.isFinite(importance) ? importance : 0.5,
+      sessionId,
+      taskId,
+    });
+
+    console.log(`Pushed working memory #${id} (scope=${scope}, importance=${Number.isFinite(importance) ? importance : 0.5})`);
+    return;
+  }
+
+  if (subcommand === 'read') {
+    const scope = flags['scope'] ? String(flags['scope']).trim() : undefined;
+    const sessionId = flags['session'] ? String(flags['session']).trim() : undefined;
+    const limit = parseInt(String(flags['limit'] ?? '20'), 10) || 20;
+
+    const items = wmRead(hippoRoot, { scope, sessionId, limit });
+
+    if (flags['json']) {
+      console.log(JSON.stringify({ items }, null, 2));
+      return;
+    }
+
+    if (items.length === 0) {
+      console.log('No working memory entries.');
+      return;
+    }
+
+    console.log(`Working memory (${items.length} entries):\n`);
+    for (const item of items) {
+      const sessionLabel = item.sessionId ? ` session=${item.sessionId}` : '';
+      const taskLabel = item.taskId ? ` task=${item.taskId}` : '';
+      console.log(`  #${item.id} [${item.scope}] importance=${item.importance}${sessionLabel}${taskLabel}`);
+      console.log(`    ${item.content}`);
+      console.log(`    created=${item.createdAt}`);
+      console.log('');
+    }
+    return;
+  }
+
+  if (subcommand === 'clear') {
+    const scope = flags['scope'] ? String(flags['scope']).trim() : undefined;
+    const sessionId = flags['session'] ? String(flags['session']).trim() : undefined;
+
+    const count = wmClear(hippoRoot, { scope, sessionId });
+    console.log(`Cleared ${count} working memory entries.`);
+    return;
+  }
+
+  if (subcommand === 'flush') {
+    const scope = flags['scope'] ? String(flags['scope']).trim() : undefined;
+    const sessionId = flags['session'] ? String(flags['session']).trim() : undefined;
+
+    const count = wmFlush(hippoRoot, { scope, sessionId });
+    console.log(`Flushed ${count} working memory entries.`);
+    return;
+  }
+
+  console.error('Usage: hippo wm <push|read|clear|flush>');
+  process.exit(1);
+}
+
 function printUsage(): void {
   console.log(`
 Hippo - biologically-inspired memory system for AI agents
@@ -1709,6 +1799,24 @@ Commands:
     hook list              Show available hooks
     hook install <target>  Install hook (claude-code|codex|cursor|openclaw)
     hook uninstall <target> Remove hook
+  wm <sub>                 Working memory — bounded buffer for current state
+    wm push                Push a working memory entry
+      --scope <scope>      Scope name (default: default)
+      --content <text>     Content to store (required)
+      --importance <n>     Priority 0-1 (default: 0.5)
+      --session <id>       Session ID
+      --task <id>          Task ID
+    wm read                Read working memory entries
+      --scope <scope>      Filter by scope
+      --session <id>       Filter by session
+      --limit <n>          Max entries (default: 20)
+      --json               Output as JSON
+    wm clear               Clear working memory entries
+      --scope <scope>      Filter by scope
+      --session <id>       Filter by session
+    wm flush               Flush working memory (session end)
+      --scope <scope>      Filter by scope
+      --session <id>       Filter by session
   dashboard                Open web dashboard for memory health
     --port <n>             Port to serve on (default: 3333)
   mcp                      Start MCP server (stdio transport)
@@ -1944,6 +2052,10 @@ async function main(): Promise<void> {
       await new Promise(() => {}); // run until Ctrl+C
       break;
     }
+
+    case 'wm':
+      cmdWm(hippoRoot, args, flags);
+      break;
 
     case 'mcp':
       // Start MCP server over stdio - dynamically import to keep main CLI lean

--- a/src/db.ts
+++ b/src/db.ts
@@ -20,7 +20,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 4;
+const CURRENT_SCHEMA_VERSION = 5;
 
 type Migration = {
   version: number;
@@ -130,6 +130,30 @@ const MIGRATIONS: Migration[] = [
 
         CREATE INDEX IF NOT EXISTS idx_session_events_task_created
         ON session_events(task, created_at DESC, id DESC);
+      `);
+    },
+  },
+  {
+    version: 5,
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS working_memory (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          scope TEXT NOT NULL,
+          session_id TEXT,
+          task_id TEXT,
+          importance REAL NOT NULL DEFAULT 0,
+          content TEXT NOT NULL,
+          metadata_json TEXT NOT NULL DEFAULT '{}',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_working_memory_scope
+        ON working_memory(scope, importance DESC, created_at DESC);
+
+        CREATE INDEX IF NOT EXISTS idx_working_memory_session
+        ON working_memory(session_id, created_at DESC);
       `);
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,16 @@ export {
   autoShare,
 } from './shared.js';
 
+// Feature 5: Working memory
+export {
+  wmPush,
+  wmRead,
+  wmClear,
+  wmFlush,
+  WorkingMemoryItem,
+  WM_MAX_ENTRIES,
+} from './working-memory.js';
+
 // Feature 4: Memory importers
 export {
   importChatGPT,

--- a/src/working-memory.ts
+++ b/src/working-memory.ts
@@ -1,0 +1,201 @@
+/**
+ * Working Memory — bounded buffer for current-state notes.
+ *
+ * Separate from long-term semantic memory. Entries are scoped,
+ * importance-ranked, and automatically evicted when the buffer
+ * exceeds WM_MAX_ENTRIES per scope.
+ */
+
+import { openHippoDb, closeHippoDb } from './db.js';
+import { initStore } from './store.js';
+
+export const WM_MAX_ENTRIES = 20;
+
+export interface WorkingMemoryItem {
+  id: number;
+  scope: string;
+  sessionId: string | null;
+  taskId: string | null;
+  importance: number;
+  content: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface WorkingMemoryRow {
+  id: number;
+  scope: string;
+  session_id: string | null;
+  task_id: string | null;
+  importance: number;
+  content: string;
+  metadata_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToItem(row: WorkingMemoryRow): WorkingMemoryItem {
+  let metadata: Record<string, unknown> = {};
+  try {
+    metadata = JSON.parse(row.metadata_json) as Record<string, unknown>;
+  } catch {
+    // malformed JSON — default to empty
+  }
+  return {
+    id: row.id,
+    scope: row.scope,
+    sessionId: row.session_id,
+    taskId: row.task_id,
+    importance: Number(row.importance),
+    content: row.content,
+    metadata,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Push a new entry into working memory.
+ * If the scope exceeds WM_MAX_ENTRIES, the lowest-importance entry
+ * is evicted (ties broken by oldest created_at).
+ * Returns the new row ID.
+ */
+export function wmPush(hippoRoot: string, opts: {
+  scope: string;
+  content: string;
+  importance?: number;
+  sessionId?: string;
+  taskId?: string;
+  metadata?: Record<string, unknown>;
+}): number {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const now = new Date().toISOString();
+    const importance = opts.importance ?? 0;
+
+    const result = db.prepare(`
+      INSERT INTO working_memory(scope, session_id, task_id, importance, content, metadata_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      opts.scope,
+      opts.sessionId ?? null,
+      opts.taskId ?? null,
+      importance,
+      opts.content,
+      JSON.stringify(opts.metadata ?? {}),
+      now,
+      now,
+    );
+
+    const id = Number(result.lastInsertRowid ?? 0);
+
+    // Evict if over capacity for this scope
+    const countRow = db.prepare(`
+      SELECT COUNT(*) AS cnt FROM working_memory WHERE scope = ?
+    `).get(opts.scope) as { cnt: number } | undefined;
+
+    const count = Number(countRow?.cnt ?? 0);
+    if (count > WM_MAX_ENTRIES) {
+      const excess = count - WM_MAX_ENTRIES;
+      db.prepare(`
+        DELETE FROM working_memory
+        WHERE id IN (
+          SELECT id FROM working_memory
+          WHERE scope = ?
+          ORDER BY importance ASC, created_at ASC
+          LIMIT ?
+        )
+      `).run(opts.scope, excess);
+    }
+
+    return id;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Read working memory entries, sorted by importance DESC.
+ */
+export function wmRead(hippoRoot: string, opts?: {
+  scope?: string;
+  sessionId?: string;
+  limit?: number;
+}): WorkingMemoryItem[] {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (opts?.scope) {
+      clauses.push('scope = ?');
+      params.push(opts.scope);
+    }
+    if (opts?.sessionId) {
+      clauses.push('session_id = ?');
+      params.push(opts.sessionId);
+    }
+
+    const limit = Math.max(1, Math.trunc(opts?.limit ?? WM_MAX_ENTRIES));
+    params.push(limit);
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const rows = db.prepare(`
+      SELECT id, scope, session_id, task_id, importance, content, metadata_json, created_at, updated_at
+      FROM working_memory
+      ${where}
+      ORDER BY importance DESC, created_at DESC
+      LIMIT ?
+    `).all(...params) as WorkingMemoryRow[];
+
+    return rows.map(rowToItem);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Clear (delete) working memory entries. Returns the count deleted.
+ */
+export function wmClear(hippoRoot: string, opts?: {
+  scope?: string;
+  sessionId?: string;
+}): number {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (opts?.scope) {
+      clauses.push('scope = ?');
+      params.push(opts.scope);
+    }
+    if (opts?.sessionId) {
+      clauses.push('session_id = ?');
+      params.push(opts.sessionId);
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const result = db.prepare(`DELETE FROM working_memory ${where}`).run(...params);
+    return Number(result.changes ?? 0);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Flush working memory — delete entries after session end.
+ * Functionally identical to wmClear but semantically distinct:
+ * used at session boundaries to discard ephemeral state.
+ * Returns the count flushed.
+ */
+export function wmFlush(hippoRoot: string, opts?: {
+  scope?: string;
+  sessionId?: string;
+}): number {
+  return wmClear(hippoRoot, opts);
+}

--- a/tests/pr3-working-memory.test.ts
+++ b/tests/pr3-working-memory.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { initStore } from '../src/store.js';
+import {
+  wmPush,
+  wmRead,
+  wmClear,
+  wmFlush,
+  WM_MAX_ENTRIES,
+  WorkingMemoryItem,
+} from '../src/working-memory.js';
+import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-wm-test-'));
+  initStore(tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('schema migration', () => {
+  it('creates the working_memory table at schema version 5', () => {
+    const db = openHippoDb(tmpDir);
+    try {
+      expect(getSchemaVersion(db)).toBe(5);
+      // Table should exist — inserting should not throw
+      db.prepare(`SELECT COUNT(*) AS cnt FROM working_memory`).get();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});
+
+describe('wmPush', () => {
+  it('creates entries and returns the row ID', () => {
+    const id = wmPush(tmpDir, { scope: 'test', content: 'first note' });
+    expect(id).toBeGreaterThan(0);
+
+    const id2 = wmPush(tmpDir, { scope: 'test', content: 'second note' });
+    expect(id2).toBeGreaterThan(id);
+  });
+
+  it('stores all fields correctly', () => {
+    wmPush(tmpDir, {
+      scope: 'build',
+      content: 'npm run build failed',
+      importance: 0.9,
+      sessionId: 'sess_abc',
+      taskId: 'task_123',
+      metadata: { retries: 3 },
+    });
+
+    const items = wmRead(tmpDir, { scope: 'build' });
+    expect(items).toHaveLength(1);
+
+    const item = items[0]!;
+    expect(item.scope).toBe('build');
+    expect(item.content).toBe('npm run build failed');
+    expect(item.importance).toBe(0.9);
+    expect(item.sessionId).toBe('sess_abc');
+    expect(item.taskId).toBe('task_123');
+    expect(item.metadata).toEqual({ retries: 3 });
+    expect(item.createdAt).toBeTruthy();
+    expect(item.updatedAt).toBeTruthy();
+  });
+
+  it('defaults importance to 0 when not provided', () => {
+    wmPush(tmpDir, { scope: 'test', content: 'no importance' });
+    const items = wmRead(tmpDir, { scope: 'test' });
+    expect(items[0]!.importance).toBe(0);
+  });
+});
+
+describe('bounded buffer eviction', () => {
+  it('evicts entries when exceeding WM_MAX_ENTRIES per scope', () => {
+    // Push WM_MAX_ENTRIES + 5 entries
+    for (let i = 0; i < WM_MAX_ENTRIES + 5; i++) {
+      wmPush(tmpDir, {
+        scope: 'evict-test',
+        content: `entry ${i}`,
+        importance: 0.5,
+      });
+    }
+
+    const items = wmRead(tmpDir, { scope: 'evict-test', limit: 100 });
+    expect(items).toHaveLength(WM_MAX_ENTRIES);
+  });
+
+  it('evicts the lowest-importance entries first', () => {
+    // Push entries with varying importance
+    // Low importance entries that should be evicted
+    for (let i = 0; i < WM_MAX_ENTRIES; i++) {
+      wmPush(tmpDir, {
+        scope: 'priority',
+        content: `low-${i}`,
+        importance: 0.1,
+      });
+    }
+
+    // Push one high-importance entry — should evict the oldest low-importance one
+    wmPush(tmpDir, {
+      scope: 'priority',
+      content: 'high-priority',
+      importance: 0.9,
+    });
+
+    const items = wmRead(tmpDir, { scope: 'priority', limit: 100 });
+    expect(items).toHaveLength(WM_MAX_ENTRIES);
+
+    // The high-priority entry should remain
+    const highItem = items.find((item) => item.content === 'high-priority');
+    expect(highItem).toBeDefined();
+    expect(highItem!.importance).toBe(0.9);
+  });
+
+  it('breaks eviction ties by oldest created_at', () => {
+    // All same importance — oldest should be evicted
+    for (let i = 0; i < WM_MAX_ENTRIES; i++) {
+      wmPush(tmpDir, {
+        scope: 'tie-break',
+        content: `entry-${i}`,
+        importance: 0.5,
+      });
+    }
+
+    // Push one more with same importance — should evict entry-0 (oldest)
+    wmPush(tmpDir, {
+      scope: 'tie-break',
+      content: 'newest',
+      importance: 0.5,
+    });
+
+    const items = wmRead(tmpDir, { scope: 'tie-break', limit: 100 });
+    expect(items).toHaveLength(WM_MAX_ENTRIES);
+
+    const contents = items.map((item) => item.content);
+    expect(contents).not.toContain('entry-0');
+    expect(contents).toContain('newest');
+  });
+
+  it('does not evict across different scopes', () => {
+    // Fill scope A to the max
+    for (let i = 0; i < WM_MAX_ENTRIES; i++) {
+      wmPush(tmpDir, { scope: 'scope-a', content: `a-${i}` });
+    }
+
+    // Push to scope B — should not affect scope A
+    wmPush(tmpDir, { scope: 'scope-b', content: 'b-entry' });
+
+    const aItems = wmRead(tmpDir, { scope: 'scope-a', limit: 100 });
+    const bItems = wmRead(tmpDir, { scope: 'scope-b', limit: 100 });
+
+    expect(aItems).toHaveLength(WM_MAX_ENTRIES);
+    expect(bItems).toHaveLength(1);
+  });
+});
+
+describe('wmRead', () => {
+  it('returns entries sorted by importance DESC', () => {
+    wmPush(tmpDir, { scope: 'read', content: 'low', importance: 0.1 });
+    wmPush(tmpDir, { scope: 'read', content: 'high', importance: 0.9 });
+    wmPush(tmpDir, { scope: 'read', content: 'mid', importance: 0.5 });
+
+    const items = wmRead(tmpDir, { scope: 'read' });
+    expect(items.map((i) => i.content)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('filters by scope', () => {
+    wmPush(tmpDir, { scope: 'alpha', content: 'a' });
+    wmPush(tmpDir, { scope: 'beta', content: 'b' });
+    wmPush(tmpDir, { scope: 'alpha', content: 'c' });
+
+    const alpha = wmRead(tmpDir, { scope: 'alpha' });
+    expect(alpha).toHaveLength(2);
+    expect(alpha.every((i) => i.scope === 'alpha')).toBe(true);
+  });
+
+  it('filters by sessionId', () => {
+    wmPush(tmpDir, { scope: 's', content: 'with-session', sessionId: 'sess_1' });
+    wmPush(tmpDir, { scope: 's', content: 'no-session' });
+
+    const filtered = wmRead(tmpDir, { sessionId: 'sess_1' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.content).toBe('with-session');
+  });
+
+  it('respects limit', () => {
+    for (let i = 0; i < 10; i++) {
+      wmPush(tmpDir, { scope: 'limit-test', content: `item-${i}` });
+    }
+
+    const items = wmRead(tmpDir, { scope: 'limit-test', limit: 3 });
+    expect(items).toHaveLength(3);
+  });
+
+  it('returns empty array when no entries', () => {
+    const items = wmRead(tmpDir);
+    expect(items).toEqual([]);
+  });
+});
+
+describe('wmClear', () => {
+  it('deletes all entries when no filter provided', () => {
+    wmPush(tmpDir, { scope: 'a', content: 'one' });
+    wmPush(tmpDir, { scope: 'b', content: 'two' });
+
+    const count = wmClear(tmpDir);
+    expect(count).toBe(2);
+
+    const items = wmRead(tmpDir);
+    expect(items).toHaveLength(0);
+  });
+
+  it('deletes only entries matching scope', () => {
+    wmPush(tmpDir, { scope: 'keep', content: 'keep this' });
+    wmPush(tmpDir, { scope: 'remove', content: 'remove this' });
+
+    const count = wmClear(tmpDir, { scope: 'remove' });
+    expect(count).toBe(1);
+
+    const remaining = wmRead(tmpDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.scope).toBe('keep');
+  });
+
+  it('deletes only entries matching sessionId', () => {
+    wmPush(tmpDir, { scope: 's', content: 'a', sessionId: 'sess_x' });
+    wmPush(tmpDir, { scope: 's', content: 'b', sessionId: 'sess_y' });
+
+    const count = wmClear(tmpDir, { sessionId: 'sess_x' });
+    expect(count).toBe(1);
+
+    const remaining = wmRead(tmpDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.sessionId).toBe('sess_y');
+  });
+
+  it('returns 0 when nothing to clear', () => {
+    const count = wmClear(tmpDir, { scope: 'nonexistent' });
+    expect(count).toBe(0);
+  });
+});
+
+describe('wmFlush', () => {
+  it('deletes entries just like wmClear', () => {
+    wmPush(tmpDir, { scope: 'flush', content: 'temp note', sessionId: 'sess_done' });
+    wmPush(tmpDir, { scope: 'flush', content: 'another', sessionId: 'sess_done' });
+    wmPush(tmpDir, { scope: 'other', content: 'keep' });
+
+    const count = wmFlush(tmpDir, { sessionId: 'sess_done' });
+    expect(count).toBe(2);
+
+    const remaining = wmRead(tmpDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.scope).toBe('other');
+  });
+
+  it('flushes everything when no filter provided', () => {
+    wmPush(tmpDir, { scope: 'a', content: 'one' });
+    wmPush(tmpDir, { scope: 'b', content: 'two' });
+
+    const count = wmFlush(tmpDir);
+    expect(count).toBe(2);
+
+    expect(wmRead(tmpDir)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `working_memory` table with schema migration
- `src/working-memory.ts` module: `wmPush`, `wmRead`, `wmClear`, `wmFlush`
- Bounded buffer (max 20 per scope) with importance-based eviction
- `hippo wm push/read/clear/flush` CLI commands
- `hippo_wm_push` MCP tool in OpenClaw plugin

## Test plan
- [x] 19 new tests in `tests/pr3-working-memory.test.ts`
- [x] All 239 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)