### PR TITLE
feat: PR4 recall UX polish

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,13 +5,14 @@
  * Commands:
  *   hippo init [--global]
  *   hippo remember <text> [--tag <t>] [--error] [--pin] [--global]
- *   hippo recall <query> [--budget <n>] [--json]
+ *   hippo recall <query> [--budget <n>] [--json] [--why]
  *   hippo sleep [--dry-run]
  *   hippo status
  *   hippo outcome --good | --bad [--id <id>]
  *   hippo conflicts [--status <status>] [--json]
  *   hippo snapshot <save|show|clear>
  *   hippo session <log|show>
+ *   hippo current <show>
  *   hippo forget <id>
  *   hippo inspect <id>
  *   hippo embed [--status]
@@ -58,7 +59,7 @@ import {
   TaskSnapshot,
   SessionEvent,
 } from './store.js';
-import { search, markRetrieved, estimateTokens, hybridSearch } from './search.js';
+import { search, markRetrieved, estimateTokens, hybridSearch, explainMatch } from './search.js';
 import { consolidate } from './consolidate.js';
 import {
   isEmbeddingAvailable,
@@ -359,6 +360,7 @@ async function cmdRecall(
   const budget = parseInt(String(flags['budget'] ?? '4000'), 10);
   const limit = flags['limit'] ? Math.max(1, parseInt(String(flags['limit']), 10) || Infinity) : Infinity;
   const asJson = Boolean(flags['json']);
+  const showWhy = Boolean(flags['why']);
   const globalRoot = getGlobalRoot();
 
   const localEntries = loadSearchEntries(hippoRoot, query);
@@ -402,14 +404,27 @@ async function cmdRecall(
   updateStats(hippoRoot, { recalled: results.length });
 
   if (asJson) {
-    const output = results.map((r) => ({
-      id: r.entry.id,
-      score: r.score,
-      strength: r.entry.strength,
-      tokens: r.tokens,
-      tags: r.entry.tags,
-      content: r.entry.content,
-    }));
+    const output = results.map((r) => {
+      const isGlobal = isInitialized(globalRoot) && !localIndex.entries[r.entry.id];
+      const base: Record<string, unknown> = {
+        id: r.entry.id,
+        score: r.score,
+        strength: r.entry.strength,
+        tokens: r.tokens,
+        tags: r.entry.tags,
+        content: r.entry.content,
+      };
+      if (showWhy) {
+        const explanation = explainMatch(query, r);
+        base.layer = r.entry.layer;
+        base.confidence = resolveConfidence(r.entry);
+        base.source = isGlobal ? 'global' : 'local';
+        base.reason = explanation.reason;
+        base.bm25 = r.bm25;
+        base.cosine = r.cosine;
+      }
+      return base;
+    });
     console.log(JSON.stringify({ query, budget, results: output, total: output.length }));
     return;
   }
@@ -422,9 +437,16 @@ async function cmdRecall(
     const conf = resolveConfidence(e);
     const confLabel = conf === 'stale' || conf === 'inferred' ? `[${conf}] \u26A0\uFE0F` : `[${conf}]`;
     const strengthBar = '\u2588'.repeat(Math.round(e.strength * 10)) + '\u2591'.repeat(10 - Math.round(e.strength * 10));
-    const globalMark = (isInitialized(globalRoot) && !loadIndex(hippoRoot).entries[e.id]) ? ' [global]' : '';
+    const isGlobal = isInitialized(globalRoot) && !localIndex.entries[e.id];
+    const globalMark = isGlobal ? ' [global]' : '';
+    const sourceMark = isGlobal ? ' [global]' : ' [local]';
     console.log(`--- ${e.id} [${e.layer}] ${confLabel}${globalMark} score=${fmt(r.score, 3)} strength=${fmt(e.strength)}`);
     console.log(`    [${strengthBar}] tags: ${e.tags.join(', ') || 'none'} | retrieved: ${e.retrieval_count}x`);
+    if (showWhy) {
+      const explanation = explainMatch(query, r);
+      console.log(`    source:${sourceMark} | layer: [${e.layer}] | confidence: [${conf}]`);
+      console.log(`    reason: ${explanation.reason}`);
+    }
     console.log();
     console.log(e.content);
     console.log();
@@ -869,6 +891,73 @@ function cmdSession(
   }
 
   console.error('Usage: hippo session <log|show>');
+  process.exit(1);
+}
+
+function cmdCurrent(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>
+): void {
+  requireInit(hippoRoot);
+
+  const subcommand = args[0] ?? 'show';
+
+  if (subcommand === 'show') {
+    const asJson = Boolean(flags['json']);
+    const snapshot = loadActiveTaskSnapshot(hippoRoot);
+    const sessionId = snapshot?.session_id ?? undefined;
+    const events = listSessionEvents(hippoRoot, {
+      session_id: sessionId,
+      limit: 5,
+    });
+
+    if (asJson) {
+      console.log(JSON.stringify({
+        snapshot: snapshot ?? null,
+        events: events.map((ev) => ({
+          id: ev.id,
+          session_id: ev.session_id,
+          event_type: ev.event_type,
+          content: ev.content,
+          created_at: ev.created_at,
+        })),
+      }));
+      return;
+    }
+
+    if (!snapshot && events.length === 0) {
+      console.log('No active task or recent session events.');
+      return;
+    }
+
+    console.log('# Current State\n');
+
+    if (snapshot) {
+      console.log(`Task: ${snapshot.task}`);
+      console.log(`Status: ${snapshot.status} | Source: ${snapshot.source} | Updated: ${snapshot.updated_at}`);
+      if (snapshot.session_id) {
+        console.log(`Session: ${snapshot.session_id}`);
+      }
+      console.log(`Summary: ${snapshot.summary}`);
+      console.log(`Next: ${snapshot.next_step}`);
+    } else {
+      console.log('No active task snapshot.');
+    }
+
+    if (events.length > 0) {
+      console.log('');
+      console.log('Recent events:');
+      for (const ev of events) {
+        const ts = ev.created_at.slice(0, 19).replace('T', ' ');
+        console.log(`  [${ts}] (${ev.event_type}) ${ev.content}`);
+      }
+    }
+
+    return;
+  }
+
+  console.error('Usage: hippo current <show>');
   process.exit(1);
 }
 
@@ -1632,6 +1721,7 @@ Commands:
   recall <query>           Search and retrieve memories (local + global)
     --budget <n>           Token budget (default: 4000)
     --json                 Output as JSON
+    --why                  Show match reasons and source annotations
   context                  Smart context injection for AI agents
     --auto                 Auto-detect task from git state
     --budget <n>           Token budget (default: 1500)
@@ -1672,6 +1762,9 @@ Commands:
       --id <session-id>
       --task <task>
       --limit <n>          Event limit (default: 8)
+      --json               Output as JSON
+  current <sub>            Show compact current state for agent injection
+    current show           Active task + recent session events (default)
       --json               Output as JSON
   forget <id>              Force remove a memory
   inspect <id>             Show full memory detail
@@ -1792,6 +1885,10 @@ async function main(): Promise<void> {
 
     case 'session':
       cmdSession(hippoRoot, args, flags);
+      break;
+
+    case 'current':
+      cmdCurrent(hippoRoot, args, flags);
       break;
 
     case 'forget': {

--- a/src/search.ts
+++ b/src/search.ts
@@ -15,7 +15,7 @@ import {
 // Tokenizer
 // ---------------------------------------------------------------------------
 
-function tokenize(text: string): string[] {
+export function tokenize(text: string): string[] {
   return text
     .toLowerCase()
     .replace(/[^\w\s]/g, ' ')
@@ -299,6 +299,62 @@ export function markRetrieved(entries: MemoryEntry[], now: Date = new Date()): M
     updated.strength = calculateStrength(updated, now);
     return updated;
   });
+}
+
+// ---------------------------------------------------------------------------
+// Match explanation (--why support)
+// ---------------------------------------------------------------------------
+
+export interface MatchExplanation {
+  /** Human-readable reason string */
+  reason: string;
+  /** Which query terms matched in the document (BM25 component) */
+  matchedTerms: string[];
+  /** Whether BM25 contributed to the score */
+  hasBm25: boolean;
+  /** Whether embedding similarity contributed to the score */
+  hasEmbedding: boolean;
+  /** Raw cosine similarity (0 when embeddings not used) */
+  cosineSimilarity: number;
+}
+
+/**
+ * Explain why a search result matched a query.
+ * Computes which query terms overlapped with the document and whether
+ * BM25 and/or embedding similarity contributed to the composite score.
+ */
+export function explainMatch(query: string, result: SearchResult): MatchExplanation {
+  const queryTerms = new Set(tokenize(query));
+  const docTerms = new Set(tokenize(`${result.entry.content} ${result.entry.tags.join(' ')}`));
+
+  const matchedTerms: string[] = [];
+  for (const term of queryTerms) {
+    if (docTerms.has(term)) {
+      matchedTerms.push(term);
+    }
+  }
+
+  const hasBm25 = result.bm25 > 0;
+  const hasEmbedding = result.cosine > 0;
+
+  const parts: string[] = [];
+  if (hasBm25) {
+    parts.push(`BM25: matched terms [${matchedTerms.join(', ')}]`);
+  }
+  if (hasEmbedding) {
+    parts.push(`embedding similarity: ${result.cosine.toFixed(3)}`);
+  }
+  if (parts.length === 0) {
+    parts.push('no direct term or embedding match');
+  }
+
+  return {
+    reason: parts.join('; '),
+    matchedTerms,
+    hasBm25,
+    hasEmbedding,
+    cosineSimilarity: result.cosine,
+  };
 }
 
 /**

--- a/tests/pr4-recall-ux.test.ts
+++ b/tests/pr4-recall-ux.test.ts
@@ -1,0 +1,221 @@
+/**
+ * PR4: Recall UX Polish tests.
+ *
+ * Tests the --why explainability layer and source annotations.
+ * Validates at the search/explain level since CLI testing is brittle.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { search, hybridSearch, explainMatch, tokenize, SearchResult } from '../src/search.js';
+import { createMemory, resolveConfidence, Layer } from '../src/memory.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntries() {
+  return [
+    createMemory('FRED cache silently dropped the TIPS series during daily refresh', {
+      tags: ['error', 'data-pipeline'],
+    }),
+    createMemory('Gold model uses TIPS 10y as primary inflation signal', {
+      tags: ['model', 'gold'],
+    }),
+    createMemory('Always verify cache contents after refresh failures', {
+      tags: ['error'],
+    }),
+    createMemory('Equities tend to rally in Q4 due to tax-loss harvesting reversal', {
+      tags: ['equities'],
+    }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// tokenize (newly exported)
+// ---------------------------------------------------------------------------
+
+describe('tokenize export', () => {
+  it('lowercases and splits on whitespace', () => {
+    const tokens = tokenize('FRED Cache Error');
+    expect(tokens).toEqual(['fred', 'cache', 'error']);
+  });
+
+  it('strips punctuation', () => {
+    const tokens = tokenize('hello, world! foo-bar');
+    expect(tokens).toEqual(['hello', 'world', 'foo', 'bar']);
+  });
+
+  it('filters single-character tokens', () => {
+    const tokens = tokenize('a b cd ef');
+    expect(tokens).toEqual(['cd', 'ef']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// explainMatch: BM25-only results
+// ---------------------------------------------------------------------------
+
+describe('explainMatch', () => {
+  it('identifies matched BM25 terms for a keyword query', () => {
+    const entries = makeEntries();
+    const results = search('FRED cache failure', entries, { budget: 10000 });
+
+    expect(results.length).toBeGreaterThan(0);
+
+    const explanation = explainMatch('FRED cache failure', results[0]);
+    expect(explanation.hasBm25).toBe(true);
+    expect(explanation.hasEmbedding).toBe(false);
+    expect(explanation.matchedTerms.length).toBeGreaterThan(0);
+    expect(explanation.reason).toContain('BM25');
+    expect(explanation.reason).toContain('matched terms');
+  });
+
+  it('includes specific matched terms in the explanation', () => {
+    const entries = makeEntries();
+    const results = search('cache refresh', entries, { budget: 10000 });
+
+    expect(results.length).toBeGreaterThan(0);
+
+    const explanation = explainMatch('cache refresh', results[0]);
+    // At least one of 'cache' or 'refresh' should appear
+    const hasRelevantTerm = explanation.matchedTerms.some(
+      (t) => t === 'cache' || t === 'refresh'
+    );
+    expect(hasRelevantTerm).toBe(true);
+  });
+
+  it('returns cosine=0 for BM25-only results', () => {
+    const entries = makeEntries();
+    const results = search('FRED cache', entries, { budget: 10000 });
+    expect(results.length).toBeGreaterThan(0);
+
+    const explanation = explainMatch('FRED cache', results[0]);
+    expect(explanation.cosineSimilarity).toBe(0);
+    expect(explanation.hasEmbedding).toBe(false);
+  });
+
+  it('returns reason text that is non-empty', () => {
+    const entries = makeEntries();
+    const results = search('error pipeline', entries, { budget: 10000 });
+    expect(results.length).toBeGreaterThan(0);
+
+    for (const r of results) {
+      const explanation = explainMatch('error pipeline', r);
+      expect(explanation.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('handles a result with no BM25 and no embedding match gracefully', () => {
+    // Construct a synthetic SearchResult with zero scores
+    const entry = createMemory('something completely unrelated');
+    const fakeResult: SearchResult = {
+      entry,
+      score: 0,
+      bm25: 0,
+      cosine: 0,
+      tokens: 10,
+    };
+
+    const explanation = explainMatch('FRED cache', fakeResult);
+    expect(explanation.hasBm25).toBe(false);
+    expect(explanation.hasEmbedding).toBe(false);
+    expect(explanation.reason).toContain('no direct term or embedding match');
+  });
+
+  it('detects embedding contribution when cosine > 0', () => {
+    const entry = createMemory('deployment pipeline broke after merge');
+    const syntheticResult: SearchResult = {
+      entry,
+      score: 0.7,
+      bm25: 0.3,
+      cosine: 0.85,
+      tokens: 15,
+    };
+
+    const explanation = explainMatch('CI deployment failure', syntheticResult);
+    expect(explanation.hasEmbedding).toBe(true);
+    expect(explanation.hasBm25).toBe(true);
+    expect(explanation.reason).toContain('embedding similarity');
+    expect(explanation.reason).toContain('BM25');
+    expect(explanation.cosineSimilarity).toBe(0.85);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --why JSON output shape
+// ---------------------------------------------------------------------------
+
+describe('--why JSON output fields', () => {
+  it('search results contain all fields needed for --why annotation', () => {
+    const entries = makeEntries();
+    const results = search('FRED cache', entries, { budget: 10000 });
+    expect(results.length).toBeGreaterThan(0);
+
+    const r = results[0];
+    // Verify all fields exist on SearchResult that --why needs
+    expect(typeof r.score).toBe('number');
+    expect(typeof r.bm25).toBe('number');
+    expect(typeof r.cosine).toBe('number');
+    expect(typeof r.entry.layer).toBe('string');
+    expect(typeof r.entry.confidence).toBe('string');
+    expect(typeof r.entry.id).toBe('string');
+    expect(typeof r.entry.strength).toBe('number');
+
+    // explainMatch produces the reason field
+    const explanation = explainMatch('FRED cache', r);
+    expect(typeof explanation.reason).toBe('string');
+    expect(explanation.reason.length).toBeGreaterThan(0);
+  });
+
+  it('resolveConfidence returns valid confidence level', () => {
+    const entry = createMemory('test', { confidence: 'observed' });
+    const conf = resolveConfidence(entry);
+    expect(['verified', 'observed', 'inferred', 'stale']).toContain(conf);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source bucket annotation
+// ---------------------------------------------------------------------------
+
+describe('source bucket annotation', () => {
+  it('entry.layer maps to valid bucket names', () => {
+    const bufferEntry = createMemory('buffer test', { layer: Layer.Buffer });
+    const episodicEntry = createMemory('episodic test', { layer: Layer.Episodic });
+    const semanticEntry = createMemory('semantic test', { layer: Layer.Semantic });
+
+    expect(bufferEntry.layer).toBe('buffer');
+    expect(episodicEntry.layer).toBe('episodic');
+    expect(semanticEntry.layer).toBe('semantic');
+  });
+
+  it('confidence levels cover the expected set', () => {
+    const verified = createMemory('v', { confidence: 'verified' });
+    const observed = createMemory('o', { confidence: 'observed' });
+    const inferred = createMemory('i', { confidence: 'inferred' });
+
+    expect(resolveConfidence(verified)).toBe('verified');
+    expect(resolveConfidence(observed)).toBe('observed');
+    expect(resolveConfidence(inferred)).toBe('inferred');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hybridSearch --why compatibility
+// ---------------------------------------------------------------------------
+
+describe('hybridSearch results carry explainMatch data', () => {
+  it('hybridSearch results include bm25 and cosine fields', async () => {
+    const entries = makeEntries();
+    const results = await hybridSearch('FRED cache failure', entries, { budget: 10000 });
+    expect(results.length).toBeGreaterThan(0);
+
+    for (const r of results) {
+      expect(typeof r.bm25).toBe('number');
+      expect(typeof r.cosine).toBe('number');
+
+      const explanation = explainMatch('FRED cache failure', r);
+      expect(explanation.reason.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `hippo recall --why` flag with match reason annotations (BM25 terms, embedding similarity)
- Source bucket annotations: layer, confidence, local/global
- Enhanced JSON output with reason, bm25, cosine fields
- `hippo current show` command for compact current state display
- Exported `tokenize()` and `explainMatch()` from search module

## Test plan
- [x] 14 new tests in `tests/pr4-recall-ux.test.ts`
- [x] All 234 tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)