### PR TITLE
Fix configured embedding model handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.19.1 (2026-04-09)
+
+### Fixed
+- **Configured embedding model propagation.** `hippo embed`, hybrid search, and physics search now all respect `embeddings.model` from `config.json` instead of silently falling back to the default model.
+- **Stale embedding index on model change.** Switching `embeddings.model` now forces a full embedding rebuild and physics-state reset so query vectors and cached vectors stay compatible.
+- **Model-specific pipeline caching.** Embedding pipeline instances are now cached per model instead of being reused across different configured models.
+- **Version metadata drift.** Synced package, plugin, MCP server, and dashboard version strings for the 0.19.1 release.
+
 ## 0.19.0 (2026-04-08)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v0.19.1
+
+- **Configured embedding models now work end to end.** `hippo embed`, hybrid search, and physics search all respect `embeddings.model` from `.hippo/config.json`.
+- **Safe rebuild on model change.** If you switch embedding models, rerun `hippo embed`. Hippo now rebuilds cached embeddings and resets physics state so old vectors are not mixed with the new model.
+
 ### What's new in v0.18
 
 - **Multi-project auto-discovery.** `hippo init --scan [dir]` finds all git repos under a directory and initializes each one. Seeds with a full year of git history by default. One command to set up memory across all your projects.
@@ -126,6 +131,7 @@ hippo recall "data pipeline issues" --budget 2000
 ### What's new in v0.8.0
 
 - **Hybrid search** blends BM25 keywords with cosine embedding similarity. Install `@xenova/transformers`, run `hippo embed`, recall quality jumps. Falls back to BM25 otherwise.
+- Configure a custom embedding model with `embeddings.model` in `.hippo/config.json`. If you change models later, rerun `hippo embed` so Hippo rebuilds cached embeddings and physics state for the new vector space.
 - **Schema acceleration** auto-computes how well new memories fit existing patterns. Familiar memories consolidate faster; novel ones decay faster if unused.
 - **Multi-agent shared memory** with `hippo share`, `hippo peers`, and transfer scoring. Universal lessons travel between projects; project-specific config stays local.
 - **Conflict resolution** via `hippo resolve <id> --keep <mem_id>`. Closes the detect-inspect-resolve loop.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.19.0",
+  "version": "0.19.1",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "bin": {
         "hippo": "bin/hippo.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,6 +76,7 @@ import {
   embedAll,
   embedMemory,
   loadEmbeddingIndex,
+  resolveEmbeddingModel,
 } from './embeddings.js';
 import { loadPhysicsState, resetAllPhysicsState } from './physics-state.js';
 import { computeSystemEnergy, vecNorm } from './physics.js';
@@ -1619,7 +1620,7 @@ async function cmdEmbed(
   }
 
   console.log('Embedding all memories (this may take a moment on first run to download model)...');
-  const count = await embedAll(hippoRoot);
+  const count = await embedAll(hippoRoot, resolveEmbeddingModel(hippoRoot));
   const entriesAfter = loadAllEntries(hippoRoot);
   const embIndexAfter = loadEmbeddingIndex(hippoRoot);
   console.log(`Done. ${count} new embeddings created. ${Object.keys(embIndexAfter).length}/${entriesAfter.length} total.`);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -196,7 +196,7 @@ function dashboardHTML(data: DashboardData): string {
 </style>
 </head>
 <body>
-<h1>Hippo Dashboard <span>v0.8.0</span></h1>
+<h1>Hippo Dashboard <span>v0.19.1</span></h1>
 <p style="color: var(--muted); margin-bottom: 24px;">Memory health at a glance. Auto-refreshes on page load.</p>
 
 <div class="section">

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -9,8 +9,9 @@ import * as path from 'path';
 import { createRequire } from 'module';
 import { MemoryEntry } from './memory.js';
 import { loadAllEntries } from './store.js';
-import { openHippoDb, closeHippoDb } from './db.js';
-import { initializeParticle, savePhysicsState, loadPhysicsState } from './physics-state.js';
+import { openHippoDb, closeHippoDb, getMeta, setMeta } from './db.js';
+import { initializeParticle, savePhysicsState, loadPhysicsState, resetAllPhysicsState } from './physics-state.js';
+import { loadConfig } from './config.js';
 
 // Use createRequire for synchronous module resolution check in ESM
 const _require = createRequire(import.meta.url);
@@ -19,9 +20,11 @@ const _require = createRequire(import.meta.url);
 let _embeddingAvailable: boolean | null = null;
 
 // Lazy-loaded pipeline (expensive to initialize)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _pipelineInstance: any = null;
-let _pipelineLoading: Promise<unknown> | null = null;
+const _pipelineInstances = new Map<string, unknown>();
+const _pipelineLoading = new Map<string, Promise<unknown>>();
+
+const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
+const EMBEDDING_MODEL_META_KEY = 'embedding_model';
 
 // Use Function constructor to bypass TypeScript static module resolution
 // for optional peer dependencies that may not be installed.
@@ -55,44 +58,131 @@ export function isEmbeddingAvailable(): boolean {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function loadPipeline(model: string): Promise<any> {
-  if (_pipelineInstance) return _pipelineInstance;
+  if (_pipelineInstances.has(model)) return _pipelineInstances.get(model);
+  if (_pipelineLoading.has(model)) return _pipelineLoading.get(model);
 
-  if (!_pipelineLoading) {
-    _pipelineLoading = (async () => {
+  const loading = (async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let pipelineFn: any = null;
+
+    try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let pipelineFn: any = null;
-
+      const mod = await _dynImport('@xenova/transformers') as any;
+      pipelineFn = mod.pipeline ?? mod.default?.pipeline;
+    } catch {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const mod = await _dynImport('@xenova/transformers') as any;
+        const mod = await _dynImport('@huggingface/transformers') as any;
         pipelineFn = mod.pipeline ?? mod.default?.pipeline;
       } catch {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const mod = await _dynImport('@huggingface/transformers') as any;
-          pipelineFn = mod.pipeline ?? mod.default?.pipeline;
-        } catch {
-          _pipelineLoading = null; // Allow retry on next call
-          return null;
-        }
-      }
-
-      if (!pipelineFn) {
-        _pipelineLoading = null; // Allow retry on next call
         return null;
       }
+    }
 
-      try {
-        _pipelineInstance = await pipelineFn('feature-extraction', model, { quantized: true });
-        return _pipelineInstance;
-      } catch {
-        _pipelineLoading = null; // Allow retry on next call
-        return null;
-      }
-    })();
+    if (!pipelineFn) return null;
+
+    try {
+      const instance = await pipelineFn('feature-extraction', model, { quantized: true });
+      _pipelineInstances.set(model, instance);
+      return instance;
+    } catch {
+      return null;
+    } finally {
+      _pipelineLoading.delete(model);
+    }
+  })();
+
+  _pipelineLoading.set(model, loading);
+  return loading;
+}
+
+export function resolveEmbeddingModel(hippoRoot: string, explicitModel?: string): string {
+  const direct = explicitModel?.trim();
+  if (direct) return direct;
+
+  try {
+    const configured = loadConfig(hippoRoot).embeddings.model?.trim();
+    if (configured) return configured;
+  } catch {
+    // Fall back to the default model when config cannot be read.
   }
 
-  return _pipelineLoading;
+  return DEFAULT_EMBEDDING_MODEL;
+}
+
+function loadStoredEmbeddingModel(hippoRoot: string): string | null {
+  try {
+    const db = openHippoDb(hippoRoot);
+    try {
+      const model = getMeta(db, EMBEDDING_MODEL_META_KEY, '').trim();
+      return model || null;
+    } finally {
+      closeHippoDb(db);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function saveStoredEmbeddingModel(hippoRoot: string, model: string): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    setMeta(db, EMBEDDING_MODEL_META_KEY, model);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export function resolveIndexedEmbeddingModel(
+  hippoRoot: string,
+  index: Record<string, number[]> = loadEmbeddingIndex(hippoRoot),
+): string | null {
+  const stored = loadStoredEmbeddingModel(hippoRoot);
+  if (stored) return stored;
+  return Object.keys(index).length > 0 ? DEFAULT_EMBEDDING_MODEL : null;
+}
+
+export function embeddingModelRequiresReindex(
+  hippoRoot: string,
+  model: string,
+  index: Record<string, number[]> = loadEmbeddingIndex(hippoRoot),
+): boolean {
+  const indexedModel = resolveIndexedEmbeddingModel(hippoRoot, index);
+  return indexedModel !== null && indexedModel !== model;
+}
+
+async function rebuildEmbeddingIndex(
+  entries: MemoryEntry[],
+  model: string,
+): Promise<Record<string, number[]>> {
+  const rebuilt: Record<string, number[]> = {};
+
+  for (const entry of entries) {
+    const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
+    const vector = await getEmbedding(text, model);
+    if (vector.length > 0) {
+      rebuilt[entry.id] = vector;
+    }
+  }
+
+  return rebuilt;
+}
+
+function resetPhysicsFromIndex(
+  hippoRoot: string,
+  entries: MemoryEntry[],
+  index: Record<string, number[]>,
+): void {
+  try {
+    const db = openHippoDb(hippoRoot);
+    try {
+      resetAllPhysicsState(db, entries, index);
+    } finally {
+      closeHippoDb(db);
+    }
+  } catch {
+    // Physics reset is best-effort; retrieval will still fall back gracefully.
+  }
 }
 
 /**
@@ -101,7 +191,7 @@ async function loadPipeline(model: string): Promise<any> {
  */
 export async function getEmbedding(
   text: string,
-  model = 'Xenova/all-MiniLM-L6-v2'
+  model = DEFAULT_EMBEDDING_MODEL
 ): Promise<number[]> {
   if (!isEmbeddingAvailable()) return [];
 
@@ -193,18 +283,31 @@ async function withEmbedLock<T>(fn: () => Promise<T>): Promise<T> {
 export async function embedMemory(
   hippoRoot: string,
   entry: MemoryEntry,
-  model = 'Xenova/all-MiniLM-L6-v2'
+  model?: string
 ): Promise<void> {
   if (!isEmbeddingAvailable()) return;
 
   return withEmbedLock(async () => {
+    const effectiveModel = resolveEmbeddingModel(hippoRoot, model);
+    const existingIndex = loadEmbeddingIndex(hippoRoot);
+
+    if (embeddingModelRequiresReindex(hippoRoot, effectiveModel, existingIndex)) {
+      const entries = loadAllEntries(hippoRoot);
+      const rebuiltIndex = await rebuildEmbeddingIndex(entries, effectiveModel);
+      saveEmbeddingIndex(hippoRoot, rebuiltIndex);
+      saveStoredEmbeddingModel(hippoRoot, effectiveModel);
+      resetPhysicsFromIndex(hippoRoot, entries, rebuiltIndex);
+      return;
+    }
+
     const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
-    const vector = await getEmbedding(text, model);
+    const vector = await getEmbedding(text, effectiveModel);
     if (vector.length === 0) return;
 
-    const index = loadEmbeddingIndex(hippoRoot);
+    const index = existingIndex;
     index[entry.id] = vector;
     saveEmbeddingIndex(hippoRoot, index);
+    saveStoredEmbeddingModel(hippoRoot, effectiveModel);
 
     // Initialize physics state for this memory
     try {
@@ -231,13 +334,23 @@ export async function embedMemory(
  */
 export async function embedAll(
   hippoRoot: string,
-  model = 'Xenova/all-MiniLM-L6-v2'
+  model?: string
 ): Promise<number> {
   if (!isEmbeddingAvailable()) return 0;
 
   return withEmbedLock(async () => {
+    const effectiveModel = resolveEmbeddingModel(hippoRoot, model);
     const entries = loadAllEntries(hippoRoot);
     const index = loadEmbeddingIndex(hippoRoot);
+
+    if (embeddingModelRequiresReindex(hippoRoot, effectiveModel, index)) {
+      const rebuiltIndex = await rebuildEmbeddingIndex(entries, effectiveModel);
+      saveEmbeddingIndex(hippoRoot, rebuiltIndex);
+      saveStoredEmbeddingModel(hippoRoot, effectiveModel);
+      resetPhysicsFromIndex(hippoRoot, entries, rebuiltIndex);
+      return Object.keys(rebuiltIndex).length;
+    }
+
     let count = 0;
     let dirty = false;
 
@@ -254,7 +367,7 @@ export async function embedAll(
       if (index[entry.id]) continue; // already embedded
 
       const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
-      const vector = await getEmbedding(text, model);
+      const vector = await getEmbedding(text, effectiveModel);
       if (vector.length > 0) {
         index[entry.id] = vector;
         count++;
@@ -265,6 +378,7 @@ export async function embedAll(
     if (dirty) {
       saveEmbeddingIndex(hippoRoot, index);
     }
+    saveStoredEmbeddingModel(hippoRoot, effectiveModel);
 
     return count;
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -432,7 +432,7 @@ async function handleRequest(req: McpRequest): Promise<McpResponse | null> {
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'hippo-memory', version: '0.8.1' },
+          serverInfo: { name: 'hippo-memory', version: '0.19.1' },
         },
       };
 

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -100,6 +100,7 @@ export function vecClampMagnitude(v: number[], maxMag: number): number[] {
 
 /** Cosine similarity between two vectors. */
 function cosine(a: number[], b: number[]): number {
+  if (a.length === 0 || b.length === 0 || a.length !== b.length) return 0;
   const dot = vecDot(a, b);
   const na = vecNorm(a);
   const nb = vecNorm(b);
@@ -157,6 +158,7 @@ export function velocityAlignmentBonus(
   particle: PhysicsParticle,
   queryEmbedding: number[],
 ): number {
+  if (particle.velocity.length === 0 || particle.velocity.length !== queryEmbedding.length) return 0;
   const velMag = vecNorm(particle.velocity);
   const qNorm = vecNorm(queryEmbedding);
   if (velMag < 1e-10 || qNorm < 1e-10) return 0;
@@ -490,6 +492,7 @@ export function applyOutcomeFeedback(
   good: boolean,
   feedbackAlpha: number,
 ): void {
+  if (particle.position.length === 0 || particle.position.length !== queryEmbedding.length) return;
   const sign = good ? 1 : -1;
   const direction = vecSub(queryEmbedding, particle.position);
   const nudge = vecScale(direction, sign * feedbackAlpha * particle.temperature);

--- a/src/search.ts
+++ b/src/search.ts
@@ -9,7 +9,9 @@ import {
   isEmbeddingAvailable,
   getEmbedding,
   cosineSimilarity,
+  embeddingModelRequiresReindex,
   loadEmbeddingIndex,
+  resolveEmbeddingModel,
 } from './embeddings.js';
 import { physicsScore as computePhysicsScores } from './physics.js';
 import type { PhysicsParticle } from './physics.js';
@@ -164,10 +166,13 @@ export async function hybridSearch(
 
   if (isEmbeddingAvailable() && options.hippoRoot) {
     try {
-      queryVector = await getEmbedding(query);
-      if (queryVector.length > 0) {
-        embeddingIndex = loadEmbeddingIndex(options.hippoRoot);
-        useEmbeddings = true;
+      const model = resolveEmbeddingModel(options.hippoRoot);
+      if (!embeddingModelRequiresReindex(options.hippoRoot, model)) {
+        queryVector = await getEmbedding(query, model);
+        if (queryVector.length > 0) {
+          embeddingIndex = loadEmbeddingIndex(options.hippoRoot);
+          useEmbeddings = true;
+        }
       }
     } catch {
       // Fall through to BM25-only
@@ -267,7 +272,11 @@ export async function physicsSearch(
     if (!isEmbeddingAvailable()) {
       return hybridSearch(query, entries, options);
     }
-    queryVector = await getEmbedding(query);
+    const model = resolveEmbeddingModel(options.hippoRoot);
+    if (embeddingModelRequiresReindex(options.hippoRoot, model)) {
+      return hybridSearch(query, entries, options);
+    }
+    queryVector = await getEmbedding(query, model);
     if (queryVector.length === 0) {
       return hybridSearch(query, entries, options);
     }
@@ -293,7 +302,12 @@ export async function physicsSearch(
 
   for (const entry of entries) {
     const particle = physicsMap.get(entry.id);
-    if (particle && particle.position.length > 0) {
+    if (
+      particle
+      && particle.position.length > 0
+      && particle.position.length === queryVector.length
+      && particle.velocity.length === queryVector.length
+    ) {
       physicsEntries.push(entry);
       physicsParticles.push(particle);
     } else {

--- a/tests/embedding-model-config.test.ts
+++ b/tests/embedding-model-config.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+function writeConfig(hippoRoot: string, model: string): void {
+  fs.writeFileSync(
+    path.join(hippoRoot, 'config.json'),
+    JSON.stringify({ embeddings: { model } }, null, 2),
+    'utf8',
+  );
+}
+
+describe('embedding model configuration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unmock('../src/embeddings.js');
+    vi.unmock('../src/search.js');
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-embed-model-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves the configured embedding model when no explicit override is provided', async () => {
+    writeConfig(tmpDir, 'custom/model');
+
+    const embeddings = await import('../src/embeddings.js') as typeof import('../src/embeddings.js') & {
+      resolveEmbeddingModel?: (hippoRoot: string, explicitModel?: string) => string;
+    };
+
+    expect(typeof embeddings.resolveEmbeddingModel).toBe('function');
+    expect(embeddings.resolveEmbeddingModel?.(tmpDir)).toBe('custom/model');
+  });
+
+  it('hybridSearch passes the configured model to getEmbedding', async () => {
+    writeConfig(tmpDir, 'custom/model');
+
+    const getEmbeddingMock = vi.fn(async () => [1, 0, 0]);
+    const entryId = 'mem_custom_model';
+
+    vi.doMock('../src/embeddings.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/embeddings.js')>('../src/embeddings.js');
+      return {
+        ...actual,
+        isEmbeddingAvailable: () => true,
+        getEmbedding: getEmbeddingMock,
+        embeddingModelRequiresReindex: () => false,
+        loadEmbeddingIndex: () => ({ [entryId]: [1, 0, 0] }),
+        cosineSimilarity: () => 1,
+      };
+    });
+
+    const { hybridSearch } = await import('../src/search.js');
+    const { createMemory } = await import('../src/memory.js');
+
+    const entry = createMemory('semantic-only match');
+    entry.id = entryId;
+
+    await hybridSearch('query text', [entry], { hippoRoot: tmpDir, budget: 1000 });
+
+    expect(getEmbeddingMock).toHaveBeenCalledWith('query text', 'custom/model');
+  });
+
+  it('treats a legacy embedding index as stale when the configured model changes', async () => {
+    writeConfig(tmpDir, 'custom/model');
+
+    const { saveEmbeddingIndex, embeddingModelRequiresReindex } =
+      await vi.importActual<typeof import('../src/embeddings.js')>('../src/embeddings.js');
+    saveEmbeddingIndex(tmpDir, { mem_legacy: [1, 0, 0] });
+
+    expect(embeddingModelRequiresReindex(tmpDir, 'custom/model')).toBe(true);
+  });
+
+  it('falls back to BM25 when the embedding index needs reindexing', async () => {
+    writeConfig(tmpDir, 'custom/model');
+
+    const getEmbeddingMock = vi.fn(async () => [1, 0, 0]);
+
+    vi.doMock('../src/embeddings.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/embeddings.js')>('../src/embeddings.js');
+      return {
+        ...actual,
+        isEmbeddingAvailable: () => true,
+        embeddingModelRequiresReindex: () => true,
+        getEmbedding: getEmbeddingMock,
+        loadEmbeddingIndex: () => ({ mem_legacy: [1, 0, 0] }),
+      };
+    });
+
+    const { hybridSearch } = await import('../src/search.js');
+    const { createMemory } = await import('../src/memory.js');
+
+    const entry = createMemory('query text semantic-only match');
+    const results = await hybridSearch('query text', [entry], { hippoRoot: tmpDir, budget: 1000 });
+
+    expect(getEmbeddingMock).not.toHaveBeenCalled();
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/physics.test.ts
+++ b/tests/physics.test.ts
@@ -490,6 +490,14 @@ describe('Scoring', () => {
       expect(results).toEqual([]);
     });
 
+    it('returns finite zero scores for mismatched query dimensions', () => {
+      const particles = [makeParticle({ memoryId: 'a', position: [1, 0, 0], velocity: [1, 0, 0] })];
+      const results = physicsScore(particles, [1, 0], { ...DEFAULT_PHYSICS_CONFIG });
+      expect(results).toHaveLength(1);
+      expect(results[0].baseScore).toBe(0);
+      expect(Number.isFinite(results[0].finalScore)).toBe(true);
+    });
+
     it('velocity alignment contributes to score', () => {
       const still = makeParticle({ memoryId: 'still', position: [1, 0, 0], velocity: [0, 0, 0] });
       const moving = makeParticle({ memoryId: 'moving', position: [1, 0, 0], velocity: [0.1, 0, 0] });


### PR DESCRIPTION
## Summary
- respect `embeddings.model` in `hippo embed`, hybrid search, and physics search
- key pipeline caching by model and rebuild embeddings plus physics state when the configured model changes
- add regression coverage for configured-model propagation, stale index fallback, and vector-dimension guards

## Test Plan
- `npm run build`
- `npm test`

Closes #8