### PR TITLE
fix(consolidate): raise conflict-detection overlap threshold to 0.85

### DIFF
--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -28,6 +28,13 @@ const DECAY_THRESHOLD = 0.05;
 const MERGE_OVERLAP_THRESHOLD = 0.35;  // Jaccard similarity for "related"
 const MERGE_MIN_CLUSTER = 2;            // minimum cluster size to merge
 
+// Minimum content/tag overlap required before a pair of memories is considered
+// as a potential contradiction. Must be high enough that the polarity keyword
+// heuristics (enabled/disabled, always/never, inferred polarity) only fire on
+// pairs that are clearly about the same statement — otherwise curated policy
+// stores that share domain vocabulary get hundreds of false positives at scale.
+const CONFLICT_OVERLAP_THRESHOLD = 0.85;
+
 export interface ConsolidationResult {
   decayed: number;
   removed: number;
@@ -301,7 +308,7 @@ function describeConflict(a: MemoryEntry, b: MemoryEntry): { reason: string; sco
   const tagOverlap = jaccard(a.tags, b.tags);
   const overlapScore = Math.max(strippedOverlap, rawOverlap, tagOverlap * 0.75);
 
-  if (overlapScore < 0.55) return null;
+  if (overlapScore < CONFLICT_OVERLAP_THRESHOLD) return null;
 
   const polarityA = inferConflictPolarity(a.content);
   const polarityB = inferConflictPolarity(b.content);


### PR DESCRIPTION
## Summary

Raise the conflict-detection overlap threshold in `describeConflict` from `0.55` to `0.85`, and extract the value as a named constant `CONFLICT_OVERLAP_THRESHOLD` with a comment explaining the rationale.

## Motivation

I migrated ~70 curated feedback/project/reference memories (coding rules, workflow conventions, architecture facts) from a Claude Code `MEMORY.md` collection into a single hippo store via `hippo remember`. A fresh `hippo sleep` then detected **709 open conflicts** — essentially C(feedback,2) pairwise noise.

Every flagged pair was a false positive. Examples:
- *"Always create a worktree when working in exemem-workspace"* ↔ *"Don't touch other agents' worktrees"* — flagged \`always/never mismatch\`
- *"Schema service owns schema creation"* ↔ *"Schemas are global"* — flagged \`enabled/disabled mismatch\`
- *"Multi-node dogfood snapshots"* ↔ *"Dogfood database snapshot"* — flagged \`negation polarity mismatch\`

None of these are contradictions. They're curated rules or facts in the same domain that happen to share vocabulary.

## Root cause

`describeConflict` in \`src/consolidate.ts\` computes:

\`\`\`ts
const overlapScore = Math.max(strippedOverlap, rawOverlap, tagOverlap * 0.75);
if (overlapScore < 0.55) return null;
\`\`\`

then runs \`classifyConflictType\` which pattern-matches keywords like \`enabled\`/\`disabled\`, \`always\`/\`never\`, \`true\`/\`false\`, or falls back to \`inferConflictPolarity\` (substring checks for \` not \`, \` never \`, \` must \`, etc.).

Two independent failure modes compound:

1. **Shared domain vocabulary trivially clears 0.55.** Rule-shaped memories in the same codebase share tokens like \`commit\`, \`PR\`, \`schema\`, \`sync\`, \`worktree\`, \`always\`, \`must\`. Text-overlap routinely lands above 0.55 between semantically unrelated rules. Tag Jaccard compounds this — all memories tagged \`feedback, policy\` get \`0.75 * 1.0 = 0.75\`.

2. **Polarity keywords fire on unrelated statements.** Once overlap clears 0.55, any memory containing \"always\" or \"must\" paired with any memory containing \"never\" or \"not\" trips \`always/never mismatch\` — which describes virtually every feedback-style rule memory.

## Fix

Raise \`CONFLICT_OVERLAP_THRESHOLD\` to 0.85. The polarity heuristics now only fire on pairs that are clearly about the same underlying statement.

**On my 72-memory store:**

| Before | After |
| --- | --- |
| 709 detected conflicts | **0 detected conflicts** |

**Preserves real contradiction detection:** I verified that a deliberately contradictory pair (\"always use Sled for local storage\" / \"never use Sled for local storage\") is still caught — both overlap (shared tokens \`sled\`, \`local\`, \`storage\`) clears 0.85 *and* polarity mismatches.

## Test plan

- [x] All 481 existing tests pass (\`npm test\`)
- [x] Manually verified 709 → 0 conflicts on the migrated 72-memory store
- [x] Manually verified an intentional contradiction pair is still flagged

## Alternatives considered

- **Make the threshold configurable** in \`.hippo/config.json\` — more flexible but a larger change and shifts tuning onto users. A sensible default is better.
- **Tighten \`classifyConflictType\`** (e.g. require the polarity keywords to appear near the same noun phrase) — real semantic contradiction detection is worth doing but a much bigger project than this fix.
- **Require both text AND tag overlap** rather than max — helps but doesn't address that text overlap alone trivially clears 0.55 in curated stores.

Happy to take direction on any of these as a follow-up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)