### PR TITLE
fix(consolidate): gate contradictions by content overlap

### DIFF
--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -27,6 +27,10 @@ import { loadConfig } from './config.js';
 const DECAY_THRESHOLD = 0.05;
 const MERGE_OVERLAP_THRESHOLD = 0.35;  // Jaccard similarity for "related"
 const MERGE_MIN_CLUSTER = 2;            // minimum cluster size to merge
+// Contradictions should be gated by content overlap, not shared tags. Tags like
+// `feedback` / `policy` are too coarse and can make unrelated rules look like
+// conflicts before the polarity heuristics run.
+const CONFLICT_OVERLAP_THRESHOLD = 0.55;
 
 export interface ConsolidationResult {
   decayed: number;
@@ -298,10 +302,9 @@ function detectConflicts(
 function describeConflict(a: MemoryEntry, b: MemoryEntry): { reason: string; score: number } | null {
   const strippedOverlap = textOverlap(stripConflictPolarity(a.content), stripConflictPolarity(b.content));
   const rawOverlap = textOverlap(a.content, b.content);
-  const tagOverlap = jaccard(a.tags, b.tags);
-  const overlapScore = Math.max(strippedOverlap, rawOverlap, tagOverlap * 0.75);
+  const overlapScore = Math.max(strippedOverlap, rawOverlap);
 
-  if (overlapScore < 0.55) return null;
+  if (overlapScore < CONFLICT_OVERLAP_THRESHOLD) return null;
 
   const polarityA = inferConflictPolarity(a.content);
   const polarityB = inferConflictPolarity(b.content);
@@ -351,6 +354,7 @@ function inferConflictPolarity(text: string): 'positive' | 'negative' | 'neutral
   ];
   const positivePatterns = [
     ' enabled ', ' enable ', ' works ', ' working ', ' true ', ' available ', ' present ', ' on ',
+    ' always ', ' must ',
   ];
 
   if (containsAny(lowered, negativePatterns)) return 'negative';
@@ -370,15 +374,3 @@ function containsAny(text: string, needles: string[]): boolean {
   return needles.some((needle) => text.includes(needle));
 }
 
-function jaccard(a: string[], b: string[]): number {
-  const setA = new Set(a.map((item) => item.toLowerCase()));
-  const setB = new Set(b.map((item) => item.toLowerCase()));
-  if (setA.size === 0 && setB.size === 0) return 0;
-
-  let intersection = 0;
-  for (const item of setA) {
-    if (setB.has(item)) intersection++;
-  }
-  const union = setA.size + setB.size - intersection;
-  return union > 0 ? intersection / union : 0;
-}

--- a/tests/consolidate.test.ts
+++ b/tests/consolidate.test.ts
@@ -140,6 +140,134 @@ describe('Merge pass', () => {
     expect(loadedB?.conflicts_with).toContain(a.id);
   });
 
+  it('detects reworded contradictions, not just near-duplicate wording', () => {
+    initStore(tmpDir);
+
+    const a = createMemory('API auth must be enabled in prod', {
+      layer: Layer.Episodic,
+      tags: ['auth', 'prod'],
+    });
+    const b = createMemory('Disable API auth in prod', {
+      layer: Layer.Episodic,
+      tags: ['auth', 'prod'],
+    });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, b);
+
+    consolidate(tmpDir, { now: new Date() });
+
+    const conflicts = listMemoryConflicts(tmpDir);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].reason).toMatch(/enabled\/disabled mismatch|always\/never mismatch|negation polarity mismatch/i);
+  });
+
+  it('preserves contradiction detection across multiple polarity patterns', () => {
+    initStore(tmpDir);
+
+    const pairs = [
+      [
+        'Always use Sled for local storage',
+        'Never use Sled for local storage',
+      ],
+      [
+        'API auth must be enabled in prod',
+        'Disable API auth in prod',
+      ],
+      [
+        'Production deploys must require approval',
+        'Production deploys should not require approval',
+      ],
+      [
+        'Metrics endpoint is available in staging',
+        'Metrics endpoint is missing in staging',
+      ],
+      [
+        'Background sync works on iOS',
+        'Background sync is broken on iOS',
+      ],
+    ] as const;
+
+    for (const [left, right] of pairs) {
+      const caseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-consolidate-case-'));
+      try {
+        initStore(caseDir);
+
+        const a = createMemory(left, { layer: Layer.Episodic, tags: ['conflict-check'] });
+        const b = createMemory(right, { layer: Layer.Episodic, tags: ['conflict-check'] });
+        writeEntry(caseDir, a);
+        writeEntry(caseDir, b);
+
+        consolidate(caseDir, { now: new Date() });
+
+        const conflicts = listMemoryConflicts(caseDir);
+        expect(conflicts, `${left} <> ${right}`).toHaveLength(1);
+      } finally {
+        fs.rmSync(caseDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('does not flag unrelated policy memories just because they share tags and opposite polarity words', () => {
+    initStore(tmpDir);
+
+    const a = createMemory('Always create a worktree when working in exemem-workspace', {
+      layer: Layer.Episodic,
+      tags: ['feedback', 'policy'],
+    });
+    const b = createMemory('Never touch other agents worktrees', {
+      layer: Layer.Episodic,
+      tags: ['feedback', 'policy'],
+    });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, b);
+
+    consolidate(tmpDir, { now: new Date() });
+
+    expect(listMemoryConflicts(tmpDir)).toHaveLength(0);
+    expect(readEntry(tmpDir, a.id)?.conflicts_with ?? []).toEqual([]);
+    expect(readEntry(tmpDir, b.id)?.conflicts_with ?? []).toEqual([]);
+  });
+
+  it('does not flag the unrelated wording pairs reported in PR #11', () => {
+    initStore(tmpDir);
+
+    const pairs = [
+      [
+        'Always create a worktree when working in exemem-workspace',
+        "Don't touch other agents' worktrees",
+      ],
+      [
+        'Schema service owns schema creation',
+        'Schemas are global',
+      ],
+      [
+        'Multi-node dogfood snapshots',
+        'Dogfood database snapshot',
+      ],
+    ] as const;
+
+    const ids = pairs.flatMap(([left, right], index) => {
+      const leftEntry = createMemory(left, {
+        layer: Layer.Episodic,
+        tags: [`pair-${index}`, 'feedback', 'policy'],
+      });
+      const rightEntry = createMemory(right, {
+        layer: Layer.Episodic,
+        tags: [`pair-${index}`, 'feedback', 'policy'],
+      });
+      writeEntry(tmpDir, leftEntry);
+      writeEntry(tmpDir, rightEntry);
+      return [leftEntry.id, rightEntry.id];
+    });
+
+    consolidate(tmpDir, { now: new Date() });
+
+    expect(listMemoryConflicts(tmpDir)).toHaveLength(0);
+    for (const id of ids) {
+      expect(readEntry(tmpDir, id)?.conflicts_with ?? []).toEqual([]);
+    }
+  });
+
   it('resolves open conflicts when the contradiction disappears', () => {
     initStore(tmpDir);
 


### PR DESCRIPTION
## Summary

Replace the broad `0.85` threshold bump with a narrower contradiction fix:

- gate conflict detection by **content overlap only**, not shared tags
- keep contradiction recall for reworded statements
- add regression coverage for the false-positive examples from #11
- add a broader contradiction matrix for polarity variants
- fix a missed `must` polarity case uncovered by the new tests

## Why

PR #11 fixes one false-positive pattern by raising the overlap gate globally, but that suppresses real contradictions that are clearly opposite without being near-duplicate wording.

The underlying false positives came from this path:

```ts
const overlapScore = Math.max(strippedOverlap, rawOverlap, tagOverlap * 0.75);
```

Shared tags like `feedback` / `policy` can clear the gate even when two memories are unrelated. Once that happens, the polarity heuristics fire on unrelated rules.

This PR removes tag overlap from the contradiction gate instead of requiring near-duplicate text.

## Tests

- [x] `npm test -- tests/consolidate.test.ts`
- [x] `npm test`

New regressions cover:
- `API auth must be enabled in prod` vs `Disable API auth in prod`
- the exact false-positive examples reported in #11
- additional polarity forms like `must` vs `should not`, `available` vs `missing`, and `works` vs `broken`

## Relation to #11

This is intended to supersede #11 rather than merge the `0.85` threshold bump as-is.