### PR TITLE
feat(a1): server mode - hippo serve, MCP-over-HTTP, thin-client CLI (v0.36.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ benchmarks/locomo/__pycache__/
 benchmarks/sequential-learning/results/
 ui/tsconfig.tsbuildinfo
 benchmarks/micro/results/latest.json
+benchmarks/a1/results/
 .claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.36.0 (2026-04-29)
+
+### Added
+- **A1 server mode.** `hippo serve` runs a persistent daemon on http://127.0.0.1:6789 (configurable via --port or HIPPO_PORT). Exposes /v1/memories, /v1/auth/keys, /v1/audit, MCP-over-HTTP at /mcp, and /health.
+- **CLI thin-client.** When `hippo serve` is running, CLI invocations auto-detect via .hippo/server.pid and route through HTTP. Stale pidfile self-heals on first ECONNREFUSED.
+- **MCP-over-HTTP/SSE transport.** Existing stdio MCP path unchanged. POST /mcp for synchronous JSON-RPC; GET /mcp/stream for SSE keepalive (server-pushed messages deferred to v0.37.0).
+- **Domain layer src/api.ts.** Pure functions for remember/recall/forget/promote/supersede/archiveRaw/auth*/audit. Both server and CLI handlers delegate through this surface.
+- **HTTP auth middleware.** Bearer token via Authorization header; loopback (127.0.0.1, ::1, ::ffff:127.0.0.1) accepts unauthenticated requests as actor='localhost:cli'. Non-loopback no-token returns 401. Server refuses to bind 0.0.0.0 without auth.
+- **24h soak harness skeleton** at benchmarks/a1/soak.ts. Manual run; results not gated.
+- **p99 recall benchmark** at benchmarks/a1/p99-recall.ts. 10k-memory store, top-10 BM25 against tier-1 queries.
+
+### Fixed
+- Audit-log tenant attribution: `audit()` helper now uses the entry's tenant_id instead of HIPPO_TENANT env (latent bug, exposed during A1 refactor).
+- api.archiveRaw and api.forget now enforce tenant scope: cross-tenant access returns "memory not found" rather than affecting another tenant's row.
+- SIGTERM drain: server.closeAllConnections() before server.close() so SSE keepalive streams don't block shutdown.
+- MCP-over-HTTP threads hippoRoot + tenantId from the auth context (was previously resolving its own root via cwd walk).
+
+### Internal
+- 99 new tests (730 baseline -> 829 + 2 skipped). Headline parity test (cli-thin-client) spawns real subprocess server and verifies audit discriminator. Concurrent recall+write under SQLite single-writer (10 readers x 50 reads + 1 writer x 50 writes) confirms zero locked errors.
+- All 5 /review ship blockers closed (C1 pidfile banner, C2 VERSION constants, C3 MCP context plumbing, H4 drain timeout, H5 tenant deny on archive/forget).
+
+### Known issues (tracked for v0.37.0 in TODOS.md)
+- **p99 latency:** measured 58.4ms vs 50ms target on 10k store. Architecture ships; latency hardening lands in v0.37.0. Profiling candidates: per-request DB open, audit-emit roundtrip, JSON serialization, hybrid embedding wiring.
+- HIPPO_API_KEY silently dropped on stale-pidfile fallback (HIPPO_REQUIRE_SERVER knob coming in v0.37.0).
+- Concurrent `hippo serve` on the same hippoRoot has no winner detection; second serve clobbers the first's pidfile.
+- Recall mode=hybrid query param accepted but ignored (BM25-only over HTTP). Hybrid wiring deferred.
+- MCP-over-HTTP SSE is keepalive-only; no server-pushed messages.
+
+### Deferred to v2 (full multi-tenant)
+No new deferrals. A5 v2 follow-ups still tracked in TODOS.md.
+
 ## 0.35.0 (2026-04-29)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v0.36.0
+
+- **`hippo serve` daemon.** Persistent HTTP server on 127.0.0.1:6789. CLI auto-detects and becomes a thin client; one process owns the SQLite DB.
+- **MCP-over-HTTP.** MCP clients can now connect over HTTP/SSE in addition to stdio. Same tool surface.
+- **Bearer-token auth + loopback trust.** Set HIPPO_API_KEY for remote calls; loopback connections work without a key. Server refuses to bind to non-loopback host without auth.
+- **Audit log fix.** Mutations on non-default tenants are now correctly attributed in the audit log (was using HIPPO_TENANT env, now uses the row's tenant_id).
+- **Tenant deny on archive/forget.** A valid Bearer for tenant A can no longer affect tenant B's memories, cross-tenant requests return "memory not found".
+- **Known issue:** p99 recall latency is 58.4ms on a 10k store, target is 50ms. Architecture ships; latency hardening in v0.37.0.
+
 ### What's new in v0.35.0
 
 - **Stub auth landed.** API keys + audit log + per-tenant data isolation. `hippo auth create` mints a scrypt-hashed key shown plaintext exactly once. `hippo audit list` exposes the mutation trail.

--- a/TODOS.md
+++ b/TODOS.md
@@ -147,3 +147,35 @@ target. The architecture lands; the latency target slips to v0.37.0.
        better — re-baseline after that lands.
   Re-run the bench after each candidate fix; gate ship of v0.37.0 on
   p99 < 50ms.
+
+- [ ] **H1 — stale-pidfile + PID-reuse-with-different-port.** A
+  detectServer caller can read a pidfile whose pid was reused by an
+  unrelated process on a different port; current detection only checks
+  pid liveness. Fix: round-trip the `started_at` value from `/health`
+  against the pidfile's recorded server start so a reused pid with a
+  fresh boot timestamp is treated as stale.
+
+- [ ] **H2 — HIPPO_API_KEY silently dropped on fallback.** When the CLI
+  thin-client cannot reach the server, it falls back to direct mode and
+  silently ignores the configured api key. That's the right default for
+  dev ergonomics but masks production misconfiguration. Add a
+  `HIPPO_REQUIRE_SERVER` env knob: when set, the fallback is an error
+  instead of a silent direct-mode call.
+
+- [ ] **H3 — concurrent serve, no winner detection.** Two `hippo serve`
+  invocations on the same hippoRoot race the listen() and overwrite
+  each other's pidfile; the loser exits with EADDRINUSE but the winner
+  may already have lost its pidfile entry. Call `detectServer` at boot
+  and refuse to start if a live peer responds on the recorded port.
+
+- [ ] **L3 — pidfile JSON has no schema version.** Adding a field today
+  requires sniffing the shape. Add a `schema: 1` field so future
+  pidfile readers can branch on a real version instead of `'startedAt'
+  in payload` checks.
+
+- [ ] **M3 — BodyTooLargeError mid-stream leaves the socket open.**
+  When `readBody` aborts on the 1MB cap, the rest of the request body
+  drains into the listener after the response is sent. Call
+  `req.destroy()` on the BodyTooLargeError path so the socket closes
+  cleanly instead of accepting another MB of bytes the server will
+  immediately discard.

--- a/TODOS.md
+++ b/TODOS.md
@@ -120,3 +120,30 @@ by post-review fixes 2db5017..38339f4). Each item belongs in **A5 v2**
   decay/merge/dedupe across tenants. Cross-tenant isolation must be threaded
   through every background pass before flipping the deployment model. Track
   with the same v2 audit as M2.
+
+---
+
+## v0.37.0 — A1 p99 latency hardening
+
+A1 (v0.36.0) ships `hippo serve` with a 10k-store p99 above the ROADMAP
+target. The architecture lands; the latency target slips to v0.37.0.
+
+- [ ] **A1 p99 latency hardening — current p99 = 58.42ms, target < 50ms.**
+  Measured via `benchmarks/a1/p99-recall.ts` on a 10k synthetic store
+  (1000 BM25 queries, cold cache, single SQLite connection, full HTTP
+  round trip). p50 = 39.5ms / p95 = 54.9ms / p99 = 58.4ms / mean = 41.0ms.
+  Distribution is tight (stddev 6.6ms) so the bottleneck is structural,
+  not tail flakes. Likely candidates to profile:
+    1. FTS5 candidate load in `loadSearchEntries` — current path scans
+       all rows then ranks; a tighter `MATCH` query plan + LIMIT inside
+       the FTS subquery should shave the tail.
+    2. JSON serialization of 10 results — `recall` walks each entry to
+       compute token count; pre-compute or stream.
+    3. Audit-emit roundtrip on every `recall` — opens + closes the DB to
+       insert one row. Cache the prepared stmt against a long-lived
+       handle, or batch via the same connection the recall already uses.
+    4. Hybrid embeddings: ROADMAP pins "hybrid ON" but `src/api.ts:recall`
+       is BM25-only today. Wiring hybrid will likely make p99 worse, not
+       better — re-baseline after that lands.
+  Re-run the bench after each candidate fix; gate ship of v0.37.0 on
+  p99 < 50ms.

--- a/benchmarks/a1/p99-recall.ts
+++ b/benchmarks/a1/p99-recall.ts
@@ -1,0 +1,305 @@
+/**
+ * p99 recall benchmark — A1 ROADMAP success criterion.
+ *
+ * Pinned spec:
+ *   - Query mix: top-10 BM25 against tier-1 micro-eval queries
+ *   - Cold cache (fresh server start, no warmup)
+ *   - Single SQLite connection (server default)
+ *   - Store: 10k synthetic memories with realistic distribution
+ *   - Success: p99 < 50ms
+ *
+ * Note on "Hybrid embeddings ON" from the ROADMAP: src/api.ts:recall is
+ * BM25-only today (the `mode` param is forward-compat). The HTTP recall
+ * surface measured here is the actual implementation. When hybrid lands
+ * (post-A1), re-run with the same harness.
+ *
+ * Last measured (v0.36.0 candidate, 10k / 1000 queries):
+ *   p50 = 39.5ms  p95 = 54.9ms  p99 = 58.4ms  mean = 41.0ms
+ *   gate: FAIL — 58.4ms vs 50ms target. Tracked in TODOS.md under
+ *   "v0.37.0 — A1 p99 latency hardening". Architecture ships; the
+ *   latency target slips one minor.
+ *
+ * Run:
+ *   node --experimental-strip-types benchmarks/a1/p99-recall.ts \
+ *     --store-size 10000 --queries 1000
+ *
+ * Or via vitest harness (downsized) — see tests/server-p99.test.ts.
+ *
+ * Output JSON lands in benchmarks/a1/results/p99-<timestamp>.json.
+ * Exit code 0 if p99 < 50ms, else 1 (CI gate).
+ */
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Imports resolve against the compiled dist/ output. Run `npm run build` first,
+// then `node --experimental-strip-types benchmarks/a1/p99-recall.ts`.
+import { initStore } from '../../dist/store.js';
+import { remember as apiRemember } from '../../dist/api.js';
+import { serve, type ServerHandle } from '../../dist/server.js';
+
+interface CliArgs {
+  storeSize: number;
+  queries: number;
+  port: number;
+}
+
+interface Stats {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  stddev: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  p999: number;
+}
+
+interface Result {
+  store_size: number;
+  query_count: number;
+  total_wall_ms: number;
+  stats_ms: Stats;
+  gate_pass: boolean;
+  gate_threshold_ms: number;
+  notes: string[];
+  generated_at: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { storeSize: 10000, queries: 1000, port: 6789 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--store-size') args.storeSize = Number(argv[++i]);
+    else if (a === '--queries') args.queries = Number(argv[++i]);
+    else if (a === '--port') args.port = Number(argv[++i]);
+  }
+  return args;
+}
+
+const TAG_CLUSTERS: ReadonlyArray<{ tag: string; words: ReadonlyArray<string> }> = [
+  { tag: 'auth', words: ['auth', 'login', 'oauth', 'session', 'token', 'jwt', 'bearer', 'sso'] },
+  { tag: 'database', words: ['database', 'postgres', 'mysql', 'sqlite', 'index', 'query', 'schema', 'migration'] },
+  { tag: 'deploy', words: ['deployment', 'production', 'staging', 'rollout', 'kubernetes', 'docker', 'container'] },
+  { tag: 'people', words: ['Bob', 'Alice', 'Carla', 'team', 'standup', 'manager', 'engineer'] },
+  { tag: 'food', words: ['coffee', 'tea', 'latte', 'oat', 'milk', 'breakfast', 'lunch'] },
+  { tag: 'api', words: ['API', 'rate', 'limit', 'endpoint', 'request', 'response', 'http', 'rest'] },
+  { tag: 'python', words: ['Python', 'venv', 'pip', 'package', 'requirements', 'wheel'] },
+  { tag: 'frontend', words: ['React', 'component', 'state', 'render', 'props', 'css'] },
+  { tag: 'infra', words: ['server', 'load', 'balancer', 'nginx', 'caddy', 'certificate'] },
+  { tag: 'docs', words: ['readme', 'docs', 'spec', 'changelog', 'todo', 'plan'] },
+];
+
+const FILLER_WORDS: ReadonlyArray<string> = [
+  'the', 'a', 'is', 'on', 'in', 'at', 'for', 'with', 'about', 'reference',
+  'note', 'context', 'detail', 'fact', 'value', 'config', 'setting', 'flag',
+  'option', 'parameter', 'data', 'record', 'entry', 'item', 'thing',
+];
+
+/** Deterministic LCG so seedings are reproducible across runs. */
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+function pick<T>(rng: () => number, arr: ReadonlyArray<T>): T {
+  return arr[Math.floor(rng() * arr.length)]!;
+}
+
+function buildContent(rng: () => number, cluster: { tag: string; words: ReadonlyArray<string> }): string {
+  const targetLen = 50 + Math.floor(rng() * 451); // 50–500 chars
+  const parts: string[] = [];
+  let len = 0;
+  while (len < targetLen) {
+    const word = rng() < 0.6 ? pick(rng, cluster.words) : pick(rng, FILLER_WORDS);
+    parts.push(word);
+    len += word.length + 1;
+  }
+  return parts.join(' ').slice(0, targetLen).trim();
+}
+
+function loadTier1Queries(): string[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const fixturesDir = resolve(here, '../micro/fixtures');
+  const queries: string[] = [];
+  try {
+    for (const f of readdirSync(fixturesDir)) {
+      if (!f.endsWith('.json')) continue;
+      const data = JSON.parse(readFileSync(join(fixturesDir, f), 'utf8')) as {
+        queries?: Array<{ q?: string }>;
+      };
+      if (Array.isArray(data.queries)) {
+        for (const q of data.queries) {
+          if (typeof q.q === 'string' && q.q.length > 0) queries.push(q.q);
+        }
+      }
+    }
+  } catch {
+    // fall through to fallback
+  }
+  if (queries.length === 0) {
+    return [
+      'auth migration',
+      'oauth token',
+      'production deployment',
+      'database schema',
+      'API rate limit',
+      'Python deployment',
+      'Bob coffee',
+      'Alice tea',
+      'standup time',
+      'prod db',
+      'login session',
+      'kubernetes rollout',
+      'react component',
+      'nginx certificate',
+      'changelog entry',
+      'requirements wheel',
+      'jwt bearer',
+      'postgres index',
+      'staging container',
+      'team manager',
+    ];
+  }
+  return queries;
+}
+
+function computeStats(samples: number[]): Stats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mean = sorted.reduce((acc, v) => acc + v, 0) / n;
+  const variance = sorted.reduce((acc, v) => acc + (v - mean) ** 2, 0) / n;
+  const pct = (p: number): number => sorted[Math.min(n - 1, Math.floor(p * n))]!;
+  return {
+    count: n,
+    min: sorted[0]!,
+    max: sorted[n - 1]!,
+    mean,
+    stddev: Math.sqrt(variance),
+    p50: pct(0.5),
+    p95: pct(0.95),
+    p99: pct(0.99),
+    p999: pct(0.999),
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`[p99-recall] storeSize=${args.storeSize} queries=${args.queries} port=${args.port}`);
+
+  const home = mkdtempSync(join(tmpdir(), 'hippo-p99-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+
+  // Seed phase. 90-day window of created timestamps is implicit in createMemory's
+  // `now`; the bench uses content distribution, not temporal spread, since recall
+  // ranks by BM25 + decay+strength but cold-cache p99 is dominated by FTS lookup.
+  console.log(`[p99-recall] seeding ${args.storeSize} memories…`);
+  const rng = makeRng(0xC0FFEE);
+  const seedStart = Date.now();
+  for (let i = 0; i < args.storeSize; i++) {
+    const cluster = pick(rng, TAG_CLUSTERS);
+    const content = buildContent(rng, cluster);
+    apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content, tags: [cluster.tag] },
+    );
+    if ((i + 1) % 1000 === 0) {
+      console.log(`[p99-recall]   ${i + 1}/${args.storeSize} (${Date.now() - seedStart}ms)`);
+    }
+  }
+  console.log(`[p99-recall] seed done in ${Date.now() - seedStart}ms`);
+
+  const queries = loadTier1Queries();
+  console.log(`[p99-recall] loaded ${queries.length} tier-1 queries`);
+
+  // Server start AFTER seed so the bench measures cold-cache fetch latency
+  // (no warmup query). Port 0 = ephemeral to avoid collisions.
+  const server: ServerHandle = await serve({ hippoRoot: home, port: 0 });
+  console.log(`[p99-recall] server listening on ${server.url}`);
+
+  const samples: number[] = [];
+  let errorCount = 0;
+  const wallStart = Date.now();
+
+  try {
+    for (let i = 0; i < args.queries; i++) {
+      const q = queries[i % queries.length]!;
+      const url = `${server.url}/v1/memories?q=${encodeURIComponent(q)}&limit=10`;
+      const t0 = performance.now();
+      try {
+        const res = await fetch(url);
+        // Drain body — fetch latency includes full response read.
+        await res.text();
+        const dt = performance.now() - t0;
+        if (!res.ok) {
+          errorCount++;
+        } else {
+          samples.push(dt);
+        }
+      } catch (err) {
+        errorCount++;
+        if (errorCount <= 3) console.error(`[p99-recall] fetch error: ${(err as Error).message}`);
+      }
+    }
+  } finally {
+    await server.stop();
+  }
+
+  const wallMs = Date.now() - wallStart;
+
+  const stats = computeStats(samples);
+  const gateThreshold = 50;
+  const gatePass = stats.p99 < gateThreshold;
+
+  const notes: string[] = [];
+  if (errorCount > 0) notes.push(`${errorCount} fetch errors (excluded from stats)`);
+  notes.push('BM25 only — src/api.ts:recall does not yet wire hybrid embeddings');
+  notes.push('Single SQLite connection (server default)');
+  notes.push('Cold cache: no warmup query');
+
+  const result: Result = {
+    store_size: args.storeSize,
+    query_count: samples.length,
+    total_wall_ms: wallMs,
+    stats_ms: stats,
+    gate_pass: gatePass,
+    gate_threshold_ms: gateThreshold,
+    notes,
+    generated_at: new Date().toISOString(),
+  };
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const resultsDir = resolve(here, 'results');
+  mkdirSync(resultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outPath = join(resultsDir, `p99-${stamp}.json`);
+  writeFileSync(outPath, JSON.stringify(result, null, 2));
+
+  console.log('');
+  console.log('━━━ p99 recall benchmark ━━━');
+  console.log(`  store size:     ${args.storeSize}`);
+  console.log(`  successful:     ${samples.length}/${args.queries}`);
+  console.log(`  wall:           ${wallMs}ms`);
+  console.log(`  min / mean:     ${stats.min.toFixed(2)} / ${stats.mean.toFixed(2)}ms`);
+  console.log(`  p50 / p95:      ${stats.p50.toFixed(2)} / ${stats.p95.toFixed(2)}ms`);
+  console.log(`  p99 / p999:     ${stats.p99.toFixed(2)} / ${stats.p999.toFixed(2)}ms`);
+  console.log(`  max / stddev:   ${stats.max.toFixed(2)} / ${stats.stddev.toFixed(2)}ms`);
+  console.log(`  gate (<${gateThreshold}ms): ${gatePass ? 'PASS' : 'FAIL'}`);
+  console.log(`  output:         ${outPath}`);
+  console.log('');
+
+  rmSync(home, { recursive: true, force: true });
+  process.exit(gatePass ? 0 : 1);
+}
+
+main().catch((err: Error) => {
+  console.error('[p99-recall] fatal:', err);
+  process.exit(2);
+});

--- a/benchmarks/a1/soak.ts
+++ b/benchmarks/a1/soak.ts
@@ -1,0 +1,401 @@
+/**
+ * 24h soak harness — A1 ROADMAP success criterion.
+ *
+ * Drives the server with a steady-state mixed workload (recall/remember/forget)
+ * for N hours and tracks RSS, heap, FD count, SQLite WAL size, and request
+ * latency in 60s windows. The actual 24h run is manual / scheduled; this
+ * harness delivers the skeleton and a smoke run.
+ *
+ * Run:
+ *   npm run build
+ *   node --experimental-strip-types benchmarks/a1/soak.ts \
+ *     --hours 24 --concurrency 4 --rps 20
+ *
+ * Smoke (~36s):
+ *   node --experimental-strip-types benchmarks/a1/soak.ts \
+ *     --hours 0.01 --concurrency 2 --rps 5
+ *
+ * Output:
+ *   benchmarks/a1/results/soak-<timestamp>.jsonl  (one sample per minute)
+ *
+ * Workload mix:
+ *   80% recalls   (GET  /v1/memories?q=...)
+ *   18% remembers (POST /v1/memories)
+ *    2% forgets   (DELETE /v1/memories/:id)
+ *
+ * SIGINT shuts down gracefully and prints a final summary. On Linux/Mac the
+ * FD count is read from /proc/self/fd; on Windows it is logged as null
+ * (no equivalent without WinAPI bindings).
+ */
+
+import {
+  mkdtempSync, rmSync, mkdirSync, writeFileSync, statSync, readdirSync, appendFileSync,
+} from 'node:fs';
+import { tmpdir, platform } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { initStore } from '../../dist/store.js';
+import { remember as apiRemember } from '../../dist/api.js';
+import { serve, type ServerHandle } from '../../dist/server.js';
+
+interface CliArgs {
+  hours: number;
+  concurrency: number;
+  rps: number;
+  port: number;
+}
+
+interface Sample {
+  ts: string;
+  elapsed_s: number;
+  rss_mb: number;
+  heap_mb: number;
+  fd_count: number | null;
+  wal_size_mb: number | null;
+  p50_ms: number | null;
+  p95_ms: number | null;
+  p99_ms: number | null;
+  rps_observed: number;
+  errors_window: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = { hours: 24, concurrency: 4, rps: 20, port: 0 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--hours') args.hours = Number(argv[++i]);
+    else if (a === '--concurrency') args.concurrency = Number(argv[++i]);
+    else if (a === '--rps') args.rps = Number(argv[++i]);
+    else if (a === '--port') args.port = Number(argv[++i]);
+  }
+  return args;
+}
+
+const SEED_TAGS = ['auth', 'database', 'deploy', 'people', 'food', 'api',
+  'python', 'frontend', 'infra', 'docs'];
+
+const QUERIES = [
+  'auth migration', 'oauth token', 'production deployment', 'database schema',
+  'API rate limit', 'Python deployment', 'standup time', 'login session',
+  'kubernetes rollout', 'react component', 'nginx certificate', 'changelog entry',
+  'jwt bearer', 'postgres index', 'staging container', 'team manager',
+];
+
+function seedStore(home: string, count: number): void {
+  for (let i = 0; i < count; i++) {
+    const tag = SEED_TAGS[i % SEED_TAGS.length]!;
+    apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      {
+        content: `seed-${i} ${tag} ${QUERIES[i % QUERIES.length]} payload number ${i}`,
+        tags: [tag],
+      },
+    );
+  }
+}
+
+function readFdCount(): number | null {
+  if (platform() !== 'linux' && platform() !== 'darwin') return null;
+  try {
+    const fdDir = '/proc/self/fd';
+    return readdirSync(fdDir).length;
+  } catch {
+    return null;
+  }
+}
+
+function readWalSizeMb(home: string): number | null {
+  // db.ts puts hippo.db at the hippoRoot top level (`<home>/hippo.db`). The
+  // SQLite WAL file is `<dbpath>-wal`. The current server architecture opens
+  // and closes the DB per request, which auto-checkpoints and removes the WAL
+  // between requests, so this often returns null. Kept for forward-compat
+  // (long-lived connection mode would surface real WAL growth here).
+  for (const candidate of [join(home, 'hippo.db-wal'), join(home, '.hippo', 'hippo.db-wal')]) {
+    try {
+      const s = statSync(candidate);
+      return s.size / 1024 / 1024;
+    } catch { /* keep trying */ }
+  }
+  return null;
+}
+
+function percentile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+  return sorted[idx]!;
+}
+
+interface WindowState {
+  latencies: number[];
+  errors: number;
+  totalRequests: number;
+}
+
+function newWindow(): WindowState {
+  return { latencies: [], errors: 0, totalRequests: 0 };
+}
+
+type RequestKind = 'recall' | 'remember' | 'forget';
+
+function pickKind(): RequestKind {
+  const r = Math.random();
+  if (r < 0.80) return 'recall';
+  if (r < 0.98) return 'remember';
+  return 'forget';
+}
+
+interface RecentIds {
+  buf: string[];
+  cap: number;
+}
+
+function pushRecent(recent: RecentIds, id: string): void {
+  recent.buf.push(id);
+  if (recent.buf.length > recent.cap) recent.buf.shift();
+}
+
+function takeRecent(recent: RecentIds): string | null {
+  if (recent.buf.length === 0) return null;
+  const idx = Math.floor(Math.random() * recent.buf.length);
+  return recent.buf.splice(idx, 1)[0]!;
+}
+
+async function doRequest(
+  url: string,
+  kind: RequestKind,
+  recent: RecentIds,
+): Promise<{ ok: boolean; latencyMs: number; idCreated?: string }> {
+  const t0 = performance.now();
+  try {
+    if (kind === 'recall') {
+      const q = QUERIES[Math.floor(Math.random() * QUERIES.length)]!;
+      const res = await fetch(`${url}/v1/memories?q=${encodeURIComponent(q)}&limit=10`);
+      await res.text();
+      return { ok: res.ok, latencyMs: performance.now() - t0 };
+    } else if (kind === 'remember') {
+      const tag = SEED_TAGS[Math.floor(Math.random() * SEED_TAGS.length)]!;
+      const res = await fetch(`${url}/v1/memories`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          content: `soak-${Date.now()}-${Math.random().toString(36).slice(2, 8)} ${tag}`,
+          tags: [tag],
+        }),
+      });
+      const body = await res.text();
+      let idCreated: string | undefined;
+      if (res.ok) {
+        try {
+          const parsed = JSON.parse(body) as { id?: string };
+          if (parsed.id) idCreated = parsed.id;
+        } catch { /* ignore */ }
+      }
+      return { ok: res.ok, latencyMs: performance.now() - t0, idCreated };
+    } else {
+      const id = takeRecent(recent);
+      if (!id) {
+        // Fall back to a recall if we have nothing to forget yet.
+        const res = await fetch(`${url}/v1/memories?q=anything&limit=1`);
+        await res.text();
+        return { ok: res.ok, latencyMs: performance.now() - t0 };
+      }
+      const res = await fetch(`${url}/v1/memories/${id}`, { method: 'DELETE' });
+      await res.text();
+      return { ok: res.ok, latencyMs: performance.now() - t0 };
+    }
+  } catch {
+    return { ok: false, latencyMs: performance.now() - t0 };
+  }
+}
+
+async function workerLoop(
+  workerId: number,
+  url: string,
+  perWorkerRps: number,
+  stopAt: number,
+  shouldStop: () => boolean,
+  window: { current: WindowState },
+  recent: RecentIds,
+): Promise<void> {
+  const intervalMs = 1000 / perWorkerRps;
+  let nextAt = Date.now();
+  while (Date.now() < stopAt && !shouldStop()) {
+    const now = Date.now();
+    if (now < nextAt) {
+      await new Promise((r) => setTimeout(r, nextAt - now));
+    }
+    nextAt += intervalMs;
+    if (shouldStop() || Date.now() >= stopAt) break;
+    const kind = pickKind();
+    const result = await doRequest(url, kind, recent);
+    const w = window.current;
+    w.totalRequests++;
+    if (result.ok) {
+      w.latencies.push(result.latencyMs);
+      if (result.idCreated) pushRecent(recent, result.idCreated);
+    } else {
+      w.errors++;
+    }
+    void workerId;
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const totalSeconds = Math.round(args.hours * 3600);
+  console.log(`[soak] hours=${args.hours} (${totalSeconds}s) concurrency=${args.concurrency} rps=${args.rps} port=${args.port}`);
+
+  const home = mkdtempSync(join(tmpdir(), 'hippo-soak-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+
+  console.log(`[soak] hippoRoot=${home}`);
+  console.log('[soak] seeding 1000 memories...');
+  const seedStart = Date.now();
+  seedStore(home, 1000);
+  console.log(`[soak] seed done in ${Date.now() - seedStart}ms`);
+
+  const server: ServerHandle = await serve({ hippoRoot: home, port: args.port });
+  console.log(`[soak] server listening on ${server.url}`);
+
+  // Output file
+  const here = dirname(fileURLToPath(import.meta.url));
+  const resultsDir = resolve(here, 'results');
+  mkdirSync(resultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outPath = join(resultsDir, `soak-${stamp}.jsonl`);
+  console.log(`[soak] writing samples to ${outPath}`);
+
+  // RSS baseline taken AFTER seed + server start. Growth is measured against
+  // this steady-state baseline; seed allocations are excluded from the leak
+  // signal. Forces a GC pass first if --expose-gc was set.
+  const maybeGc = (globalThis as { gc?: () => void }).gc;
+  if (typeof maybeGc === 'function') maybeGc();
+  await new Promise((r) => setTimeout(r, 100));
+  const initialRss = process.memoryUsage().rss;
+  let maxRss = initialRss;
+  let totalRequests = 0;
+  let totalErrors = 0;
+  let samplesWritten = 0;
+
+  const startedAt = Date.now();
+  const stopAt = startedAt + totalSeconds * 1000;
+
+  // Window state, swapped on each sample tick.
+  const windowRef = { current: newWindow() };
+  let lastSampleAt = startedAt;
+  const recent: RecentIds = { buf: [], cap: 200 };
+
+  let stopRequested = false;
+  const shouldStop = (): boolean => stopRequested;
+
+  const onSigint = (): void => {
+    if (stopRequested) return;
+    stopRequested = true;
+    console.log('\n[soak] SIGINT received, draining workers...');
+  };
+  process.on('SIGINT', onSigint);
+
+  const perWorkerRps = Math.max(0.1, args.rps / args.concurrency);
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < args.concurrency; i++) {
+    workers.push(workerLoop(i, server.url, perWorkerRps, stopAt, shouldStop, windowRef, recent));
+  }
+
+  // Sample at 60s windows (or earlier on stop).
+  const sampleEveryMs = 60_000;
+  let nextSampleAt = startedAt + sampleEveryMs;
+
+  const writeSample = (_forceLastWindow: boolean): void => {
+    const now = Date.now();
+    const windowState = windowRef.current;
+    windowRef.current = newWindow();
+
+    const latencies = [...windowState.latencies].sort((a, b) => a - b);
+    const rss = process.memoryUsage().rss;
+    const heap = process.memoryUsage().heapUsed;
+    if (rss > maxRss) maxRss = rss;
+
+    const elapsedSec = (now - startedAt) / 1000;
+    const windowDurationSec = Math.max(0.001, (now - lastSampleAt) / 1000);
+    lastSampleAt = now;
+
+    const sample: Sample = {
+      ts: new Date(now).toISOString(),
+      elapsed_s: Math.round(elapsedSec),
+      rss_mb: rss / 1024 / 1024,
+      heap_mb: heap / 1024 / 1024,
+      fd_count: readFdCount(),
+      wal_size_mb: readWalSizeMb(home),
+      p50_ms: percentile(latencies, 0.5),
+      p95_ms: percentile(latencies, 0.95),
+      p99_ms: percentile(latencies, 0.99),
+      rps_observed: windowState.totalRequests / windowDurationSec,
+      errors_window: windowState.errors,
+    };
+    appendFileSync(outPath, JSON.stringify(sample) + '\n');
+    totalRequests += windowState.totalRequests;
+    totalErrors += windowState.errors;
+    samplesWritten++;
+
+    console.log(
+      `[soak] t=${sample.elapsed_s}s rss=${sample.rss_mb.toFixed(1)}MB heap=${sample.heap_mb.toFixed(1)}MB ` +
+      `wal=${sample.wal_size_mb !== null ? sample.wal_size_mb.toFixed(2) + 'MB' : 'n/a'} ` +
+      `fd=${sample.fd_count ?? 'n/a'} ` +
+      `p50=${sample.p50_ms !== null ? sample.p50_ms.toFixed(1) : 'n/a'} ` +
+      `p99=${sample.p99_ms !== null ? sample.p99_ms.toFixed(1) : 'n/a'} ` +
+      `rps=${sample.rps_observed.toFixed(2)} err=${sample.errors_window}`
+    );
+  };
+
+  // Sampling tick loop runs concurrently with workers. Polls on a 1s tick so
+  // a SIGINT or short --hours run exits without burning the rest of a minute.
+  const sampler = (async (): Promise<void> => {
+    while (!stopRequested && Date.now() < stopAt) {
+      await new Promise((r) => setTimeout(r, 1000));
+      if (stopRequested || Date.now() >= stopAt) break;
+      if (Date.now() >= nextSampleAt) {
+        writeSample(false);
+        nextSampleAt += sampleEveryMs;
+      }
+    }
+  })();
+
+  await Promise.all(workers);
+  await sampler;
+
+  // Final partial-window sample if anything ran since the last tick.
+  if (windowRef.current.totalRequests > 0) {
+    writeSample(true);
+  }
+
+  process.off('SIGINT', onSigint);
+
+  console.log('[soak] stopping server...');
+  await server.stop();
+
+  const finalRss = process.memoryUsage().rss;
+  const wallSec = (Date.now() - startedAt) / 1000;
+
+  console.log('');
+  console.log('===== soak summary =====');
+  console.log(`  wall:            ${wallSec.toFixed(1)}s`);
+  console.log(`  total requests:  ${totalRequests}`);
+  console.log(`  total errors:    ${totalErrors}`);
+  console.log(`  samples written: ${samplesWritten}`);
+  console.log(`  initial RSS:     ${(initialRss / 1024 / 1024).toFixed(1)}MB`);
+  console.log(`  final RSS:       ${(finalRss / 1024 / 1024).toFixed(1)}MB`);
+  console.log(`  max RSS:         ${(maxRss / 1024 / 1024).toFixed(1)}MB`);
+  console.log(`  RSS growth:      ${((finalRss - initialRss) / 1024 / 1024).toFixed(1)}MB`);
+  console.log(`  output:          ${outPath}`);
+  console.log('');
+
+  rmSync(home, { recursive: true, force: true });
+  process.exit(0);
+}
+
+main().catch((err: Error) => {
+  console.error('[soak] fatal:', err);
+  process.exit(2);
+});

--- a/docs/plans/2026-04-29-a1-server-mode.md
+++ b/docs/plans/2026-04-29-a1-server-mode.md
@@ -1,0 +1,724 @@
+# A1 Server Mode Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship `hippo serve` — a persistent daemon that exposes HTTP + MCP, with the CLI auto-detecting it and becoming a thin client. SQLite single-writer for v1.
+
+**Architecture:** One process owns the DB. The server owns it; concurrent CLI invocations transparently route HTTP to the server when a pidfile is present. Lift business logic out of `src/cli.ts` handlers into `src/api.ts` callable functions that both the server and direct CLI use, so the CLI can run with or without a server. Auth (A5 API keys) flows through HTTP headers; audit events stamp `actor='api_key:hk_xxx'` for HTTP requests, `'cli'` for direct local CLI. MCP gets a second transport (HTTP/SSE) alongside stdio.
+
+**Tech Stack:** Node's built-in `node:http` (no new deps), TypeScript, vitest with real CLI + real HTTP. Reuses A5 auth/audit/tenant primitives. Existing `src/mcp/server.ts` stdio path stays for compat — A1 adds HTTP/SSE transport beside it.
+
+---
+
+## Schema diagram
+
+### Before (post-A5, v16)
+
+```
+.hippo/
+├── hippo.db                  ← SQLite (WAL mode, single writer)
+├── memories/                 ← markdown mirror
+├── episodic/, semantic/, ...
+└── (no server metadata)
+
+src/cli.ts                    ← all command handlers, calls store.ts directly
+src/mcp/server.ts             ← stdio MCP transport, calls store.ts directly
+```
+
+### After (A1)
+
+```
+.hippo/
+├── hippo.db
+├── memories/
+├── server.pid                ← {pid, port, url, started_at, version} — written on serve, deleted on shutdown
+├── server.log                ← rolling log (rotate at 10 MB)
+└── ...
+
+src/api.ts                    ← NEW — callable domain layer (remember/recall/forget/promote/supersede/archive/auth/audit). Pure functions taking {hippoRoot, tenantId, actor} as context.
+src/server.ts                 ← NEW — HTTP server. Routes to api.ts. Validates Authorization: Bearer hk_... header.
+src/server-detect.ts          ← NEW — pidfile read + health probe. Returns {url, sessionToken?} or null.
+src/cli.ts                    ← UPDATED — handlers check server-detect first. If server alive: HTTP roundtrip. Else: direct api.ts call.
+src/mcp/server.ts             ← UPDATED — splits into stdio (existing) + http-sse (new). Both backed by api.ts.
+```
+
+**Single-writer rule.** When `hippo serve` is running, all writes MUST go through it. CLI invocations detect the pidfile and route via HTTP. If the pidfile is present but the server is unreachable (stale pidfile after crash), the CLI prints a warning, deletes the pidfile, and falls back to direct DB access.
+
+**Auth.** HTTP requests carry `Authorization: Bearer hk_<plaintext>`. Server validates via `validateApiKey`. Without a key, the server accepts requests from `127.0.0.1` only (loopback trust, matches stub auth model). Remote requests require an API key.
+
+**Audit.** HTTP requests audit with `actor='api_key:<key_id>'` (or `'localhost:cli'` for unauthenticated loopback). Direct CLI calls (no server running) keep `actor='cli'`.
+
+---
+
+## Task list (sequence)
+
+1. `src/api.ts` skeleton — domain interface + remember
+2. `src/api.ts` — recall, forget, promote, supersede
+3. `src/api.ts` — archive_raw, auth (create/list/revoke), audit (list)
+4. CLI handlers route through `src/api.ts` (no behavior change yet, just refactor)
+5. `src/server-detect.ts` — pidfile read + health probe
+6. `src/server.ts` — HTTP skeleton: start, health, shutdown
+7. HTTP routes — remember, recall, forget, promote, supersede, archive
+8. HTTP routes — auth, audit
+9. Auth middleware — Bearer token validation, loopback exception
+10. CLI thin-client mode — detect server, HTTP roundtrip, fall back on stale pidfile
+11. MCP/HTTP transport — `hippo serve` exposes MCP-over-HTTP/SSE in addition to existing stdio
+12. Concurrent recall+write test harness (real DB, multiple clients)
+13. p99 recall benchmark on 10k-memory store
+14. 24h soak harness (skeleton only, run is manual / cron)
+15. Eval re-run + bump to v0.36.0
+
+Effort: 4w solo. ~15 commits + bump. The first 4 land the refactor (no user-visible change). Tasks 5-11 add the server. Tasks 12-14 are the success-criterion gate.
+
+---
+
+## Conventions
+
+- **Tests use real DB and real CLI.** Mock-free. Server tests use real HTTP via `node:http` client + a test port (random above 30000).
+- **Pidfile is `.hippo/server.pid`** — JSON, atomic write via temp + rename. Read with stale-check (process probe).
+- **Default port 6789.** Override via `--port` flag or `HIPPO_PORT` env.
+- **No new deps.** `node:http` only. JSON parsing native. Streaming via `node:stream`.
+- **Bite-sized commits.** Every task ends with a passing test and one commit.
+- **NEVER --no-verify.** No em dashes in commit messages.
+- **Auth model.** Loopback (`127.0.0.1`) without API key returns `actor='localhost:cli'`. Non-loopback without key → 401. Any source with a valid API key → `actor='api_key:<key_id>'`.
+
+---
+
+### Task 1: `src/api.ts` skeleton + remember
+
+**Files:**
+- Create: `src/api.ts`
+- Test: `tests/api-remember.test.ts`
+
+**Step 1: Failing test**
+
+```typescript
+// tests/api-remember.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, readEntry } from '../src/store.js';
+import { remember } from '../src/api.js';
+
+describe('api.remember', () => {
+  it('persists a memory and returns its envelope', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-api-rem-'));
+    initStore(home);
+    const result = remember({
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: 'cli',
+    }, {
+      content: 'api-canary-remember-77',
+      kind: 'distilled',
+    });
+    expect(result.id).toMatch(/^mem_/);
+    expect(result.kind).toBe('distilled');
+    const stored = readEntry(home, result.id);
+    expect(stored?.content).toBe('api-canary-remember-77');
+    expect(stored?.tenantId).toBe('default');
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('emits an audit event with the supplied actor', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-api-rem-'));
+    initStore(home);
+    remember({ hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_test' },
+             { content: 'audit-trail-canary' });
+    const { openHippoDb, closeHippoDb } = await import('../src/db.js');
+    const { queryAuditEvents } = await import('../src/audit.js');
+    const db = openHippoDb(home);
+    const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember' });
+    expect(events[0]!.actor).toBe('api_key:hk_test');
+    closeHippoDb(db);
+    rmSync(home, { recursive: true, force: true });
+  });
+});
+```
+
+**Step 2: Run, fail.**
+
+**Step 3: Implement `src/api.ts`**
+
+```typescript
+import type { DatabaseSyncLike } from './db.js';
+import { openHippoDb, closeHippoDb } from './db.js';
+import { writeEntry } from './store.js';
+import { createMemory, type MemoryKind, type MemoryEntry } from './memory.js';
+import { appendAuditEvent } from './audit.js';
+
+export interface Context {
+  hippoRoot: string;
+  tenantId: string;
+  actor: string; // 'cli' | 'localhost:cli' | 'api_key:<key_id>' | 'mcp'
+}
+
+export interface RememberOpts {
+  content: string;
+  kind?: MemoryKind;
+  scope?: string;
+  owner?: string;
+  artifactRef?: string;
+  tags?: string[];
+}
+
+export interface RememberResult {
+  id: string;
+  kind: MemoryKind;
+  tenantId: string;
+}
+
+export function remember(ctx: Context, opts: RememberOpts): RememberResult {
+  const entry = createMemory({
+    content: opts.content,
+    kind: opts.kind ?? 'distilled',
+    scope: opts.scope,
+    owner: opts.owner,
+    artifactRef: opts.artifactRef,
+    tags: opts.tags,
+    tenantId: ctx.tenantId,
+  });
+  writeEntry(ctx.hippoRoot, entry);
+
+  // Audit with the supplied actor (overrides the cli-default in writeEntry's hook).
+  // writeEntry already audits with actor='cli' via its internal helper; we want the
+  // server's actor to land instead. Strategy: pass actor through as a param to
+  // writeEntry, OR audit again with the correct actor and rely on the test asserting
+  // the LATEST event. The cleaner fix is to thread actor into writeEntry — see Task 4.
+  // For now, append a duplicate event with the right actor and let Task 4 deduplicate.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'remember',
+      targetId: entry.id,
+      metadata: { kind: entry.kind, scope: entry.scope ?? null },
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { id: entry.id, kind: entry.kind ?? 'distilled', tenantId: ctx.tenantId };
+}
+```
+
+**Step 4: Run, see pass. Note: the audit double-emit is intentional pending Task 4 (which threads actor through writeEntry).**
+
+**Step 5: Commit**
+
+```bash
+git add src/api.ts tests/api-remember.test.ts
+git commit -m "feat(a1): src/api.ts skeleton + remember domain function"
+```
+
+---
+
+### Task 2: api.ts — recall, forget, promote, supersede
+
+**Files:**
+- Modify: `src/api.ts`
+- Test: `tests/api-domain.test.ts`
+
+Mirror the same shape: each function takes `(ctx, opts)`, calls into store.ts/cli.ts logic, returns plain data.
+
+**Functions to add:**
+
+```typescript
+export interface RecallOpts { query: string; limit?: number; mode?: 'bm25' | 'hybrid' | 'physics'; }
+export interface RecallResult { results: Array<{ id: string; content: string; score: number; ... }>; total: number; tokens: number; }
+
+export function recall(ctx: Context, opts: RecallOpts): RecallResult { ... }
+export function forget(ctx: Context, id: string): { ok: true; id: string } { ... }
+export function promote(ctx: Context, id: string): { ok: true; sourceId: string; globalId: string } { ... }
+export function supersede(ctx: Context, oldId: string, newContent: string): { ok: true; oldId: string; newId: string } { ... }
+```
+
+Each emits the corresponding audit event with `ctx.actor`.
+
+**Tests** mirror api-remember.test.ts: assert behavior + assert audit event has correct actor.
+
+Run, pass, commit:
+```
+feat(a1): api.ts - recall, forget, promote, supersede
+```
+
+---
+
+### Task 3: api.ts — archive_raw, auth, audit
+
+**Files:**
+- Modify: `src/api.ts`
+- Test: append to `tests/api-domain.test.ts`
+
+```typescript
+export function archiveRaw(ctx: Context, id: string, reason: string): { ok: true; archivedAt: string } { ... }
+export function authCreate(ctx: Context, opts: { label?: string; tenantId?: string }): { keyId: string; plaintext: string } { ... }
+export function authList(ctx: Context, opts: { active: boolean }): ApiKeyListItem[] { ... }
+export function authRevoke(ctx: Context, keyId: string): { ok: true; revokedAt: string } { ... }
+export function auditList(ctx: Context, opts: { op?: AuditOp; since?: string; limit?: number }): AuditEvent[] { ... }
+```
+
+Each delegates to existing primitives (`createApiKey`, `revokeApiKey`, `archiveRawMemory`, `queryAuditEvents`).
+
+Commit:
+```
+feat(a1): api.ts - archive_raw, auth, audit
+```
+
+---
+
+### Task 4: CLI handlers route through api.ts
+
+**Files:**
+- Modify: `src/cli.ts` (cmdRemember, cmdRecall, cmdForget, cmdPromote, cmdSupersede, cmdAuthCreate/List/Revoke, cmdAuditList)
+- Modify: `src/store.ts` writeEntry — accept optional `actor: string` so the audit hook uses the supplied actor
+- Modify: `src/api.ts` remember — drop the duplicate audit emit now that writeEntry handles it
+- Test: existing tests must still pass (no behavior change)
+
+**Goal:** every CLI handler becomes a thin wrapper that builds a `Context` and calls into `src/api.ts`. No user-visible behavior change. Removes the audit double-emit from Task 1.
+
+For each handler:
+1. Build `ctx = { hippoRoot, tenantId: resolveTenantId({}), actor: 'cli' }`
+2. Call `api.<op>(ctx, opts)`
+3. Format the result for stdout / JSON output
+
+**Verify:** `npx vitest run` — all 766 existing tests + new api-* tests still green.
+
+**Commit:**
+```
+refactor(a1): CLI handlers delegate to src/api.ts (no behavior change)
+```
+
+---
+
+### Task 5: `src/server-detect.ts` — pidfile + health probe
+
+**Files:**
+- Create: `src/server-detect.ts`
+- Test: `tests/server-detect.test.ts`
+
+**Step 1: Failing tests**
+
+```typescript
+// tests/server-detect.test.ts
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectServer, writePidfile, removePidfile } from '../src/server-detect.js';
+
+describe('server-detect', () => {
+  it('returns null when no pidfile exists', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    expect(detectServer(home)).toBeNull();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('returns null when pidfile exists but process is dead', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    writeFileSync(join(home, '.hippo', 'server.pid'),
+      JSON.stringify({ pid: 99999999, port: 6789, url: 'http://127.0.0.1:6789', started_at: new Date().toISOString() }));
+    expect(detectServer(home)).toBeNull();
+    // Stale pidfile should have been deleted
+    expect(() => require('node:fs').readFileSync(join(home, '.hippo', 'server.pid'))).toThrow();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('writePidfile + removePidfile roundtrip', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    writePidfile(home, { port: 6789, url: 'http://127.0.0.1:6789' });
+    const detected = detectServer(home);
+    expect(detected?.url).toBe('http://127.0.0.1:6789');
+    expect(detected?.pid).toBe(process.pid);
+    removePidfile(home);
+    expect(detectServer(home)).toBeNull();
+    rmSync(home, { recursive: true, force: true });
+  });
+});
+```
+
+**Step 3: Implement**
+
+```typescript
+// src/server-detect.ts
+import { existsSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ServerInfo {
+  pid: number;
+  port: number;
+  url: string;
+  started_at: string;
+}
+
+const PIDFILE = '.hippo/server.pid';
+
+export function detectServer(hippoRoot: string): ServerInfo | null {
+  const path = join(hippoRoot, PIDFILE);
+  if (!existsSync(path)) return null;
+  let info: ServerInfo;
+  try {
+    info = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+  // Probe the process. Sending signal 0 throws if the pid is dead or owned by
+  // another user we can't signal. Either way, treat as stale.
+  try {
+    process.kill(info.pid, 0);
+  } catch {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+  return info;
+}
+
+export function writePidfile(hippoRoot: string, opts: { port: number; url: string }): void {
+  const path = join(hippoRoot, PIDFILE);
+  const tmp = `${path}.tmp.${process.pid}`;
+  const info: ServerInfo = {
+    pid: process.pid,
+    port: opts.port,
+    url: opts.url,
+    started_at: new Date().toISOString(),
+  };
+  writeFileSync(tmp, JSON.stringify(info));
+  renameSync(tmp, path);  // atomic
+}
+
+export function removePidfile(hippoRoot: string): void {
+  const path = join(hippoRoot, PIDFILE);
+  try { unlinkSync(path); } catch {}
+}
+```
+
+Pass, commit:
+```
+feat(a1): server-detect - pidfile + health probe
+```
+
+---
+
+### Task 6: `src/server.ts` HTTP skeleton — start, health, shutdown
+
+**Files:**
+- Create: `src/server.ts`
+- Test: `tests/server-lifecycle.test.ts`
+
+**Test asserts:**
+- `serve()` returns a `{ port, stop }` handle
+- `GET /health` returns 200 with `{ ok: true, version, started_at }`
+- `stop()` closes the HTTP listener and removes the pidfile
+- Lifecycle: start → health → stop → second start succeeds (no port leak)
+- SIGTERM / SIGINT handler calls stop (probe via signal — but be careful in vitest; may skip on Windows)
+
+**Implementation outline:**
+
+```typescript
+// src/server.ts
+import { createServer, type Server } from 'node:http';
+import { writePidfile, removePidfile } from './server-detect.js';
+
+export interface ServerHandle {
+  port: number;
+  url: string;
+  stop: () => Promise<void>;
+}
+
+export interface ServeOpts {
+  hippoRoot: string;
+  port?: number;       // 0 = ephemeral
+  host?: string;       // default '127.0.0.1'
+}
+
+export async function serve(opts: ServeOpts): Promise<ServerHandle> {
+  const host = opts.host ?? '127.0.0.1';
+  const port = opts.port ?? Number(process.env.HIPPO_PORT ?? 6789);
+
+  const server = createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, version: '0.35.0', started_at: new Date().toISOString() }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => resolve());
+  });
+  const actualPort = (server.address() as { port: number }).port;
+  const url = `http://${host}:${actualPort}`;
+  writePidfile(opts.hippoRoot, { port: actualPort, url });
+
+  let stopping = false;
+  const stop = async () => {
+    if (stopping) return;
+    stopping = true;
+    removePidfile(opts.hippoRoot);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  };
+
+  // Best-effort signal handlers. Skip in vitest environment to avoid orphaning the test runner.
+  if (!process.env.VITEST) {
+    process.once('SIGTERM', () => { void stop(); });
+    process.once('SIGINT', () => { void stop(); });
+  }
+
+  return { port: actualPort, url, stop };
+}
+```
+
+Test uses `port: 0` to get an ephemeral port and avoid collisions.
+
+Commit:
+```
+feat(a1): server.ts - HTTP skeleton with /health, lifecycle, pidfile
+```
+
+---
+
+### Task 7: HTTP routes — remember, recall, forget, promote, supersede, archive
+
+**Files:**
+- Modify: `src/server.ts`
+- Test: `tests/server-routes-domain.test.ts`
+
+Each route delegates to `src/api.ts`. JSON in, JSON out. Errors → 4xx with `{ error: string }`.
+
+Routes:
+- `POST /v1/memories` body `{ content, kind?, scope?, ... }` → `{ id, kind, tenantId }`
+- `GET  /v1/memories?q=...&limit=10` → `{ results, total, tokens }`
+- `DELETE /v1/memories/:id` → `{ ok: true, id }`
+- `POST /v1/memories/:id/promote` → `{ ok: true, sourceId, globalId }`
+- `POST /v1/memories/:id/supersede` body `{ content }` → `{ ok: true, oldId, newId }`
+- `POST /v1/memories/:id/archive` body `{ reason }` → `{ ok: true, archivedAt }`
+
+**Tests** spin the server on port 0, hit each route via `fetch()` (Node 18+ native), assert response shapes.
+
+Commit:
+```
+feat(a1): HTTP routes - remember, recall, forget, promote, supersede, archive
+```
+
+---
+
+### Task 8: HTTP routes — auth, audit
+
+Routes:
+- `POST /v1/auth/keys` body `{ label?, tenantId? }` → `{ keyId, plaintext }`
+- `GET /v1/auth/keys?active=true` → `[{ keyId, tenantId, label, createdAt, revokedAt }]`
+- `DELETE /v1/auth/keys/:keyId` → `{ ok: true, revokedAt }`
+- `GET /v1/audit?op=&since=&limit=&json` → `[AuditEvent]`
+
+Commit:
+```
+feat(a1): HTTP routes - auth and audit
+```
+
+---
+
+### Task 9: Auth middleware — Bearer token + loopback exception
+
+**Files:**
+- Modify: `src/server.ts` (insert middleware before route dispatch)
+- Test: `tests/server-auth.test.ts`
+
+**Behavior:**
+- Read `Authorization: Bearer <token>` header
+- If present: `validateApiKey(db, token)` → if valid, ctx.actor = `api_key:<keyId>`, ctx.tenantId = key's tenant_id
+- If absent and `req.socket.remoteAddress` is `127.0.0.1` or `::1`: ctx.actor = `localhost:cli`, ctx.tenantId = `resolveTenantId({})` (env)
+- If absent and remote address is non-loopback: 401 with `{ error: 'auth required' }`
+
+**Tests:**
+- Loopback no-auth → 200, audit shows `localhost:cli`
+- Loopback with valid key → 200, audit shows `api_key:hk_xxx`
+- Loopback with invalid key → 401
+- Non-loopback no-auth → 401 (simulate via `Forwarded:` header or by binding to non-loopback in a test fixture; if too fragile on the test runner, document the gap and fall back to a unit test of the middleware function)
+
+Commit:
+```
+feat(a1): server auth middleware - Bearer token + loopback exception
+```
+
+---
+
+### Task 10: CLI thin-client mode — detect server, route via HTTP
+
+**Files:**
+- Modify: `src/cli.ts` — at the top of main, call `detectServer(hippoRoot)`. If non-null, set a flag and route command handlers through HTTP instead of api.ts directly.
+- Create: `src/client.ts` — thin HTTP wrapper. One function per route. Returns the same shape as `src/api.ts`.
+- Test: `tests/cli-thin-client.test.ts`
+
+**Test:**
+- Spin up server in a child process (`spawn` from `node:child_process`, run `node dist/cli.js serve --port 0 --json-port-on-start`)
+- Wait for pidfile to appear
+- Run `node dist/cli.js remember "..."` in a separate process — must hit the server, not write to DB directly
+- Verify the audit event from the second process shows actor=`localhost:cli` (loopback, no key)
+- Stop server, verify pidfile is gone
+- Run `hippo remember` again — must fall back to direct mode (actor=`cli`)
+
+This is the headline test for A1: "CLI thin-client → server → response round-trip parity with direct CLI" from the ROADMAP commitments.
+
+Commit:
+```
+feat(a1): CLI thin-client mode - HTTP roundtrip when server detected
+```
+
+---
+
+### Task 11: MCP-over-HTTP/SSE transport
+
+**Files:**
+- Modify: `src/server.ts` — add `GET /mcp/stream` (SSE) and `POST /mcp` (request) routes
+- Modify: `src/mcp/server.ts` — extract message-handling into a transport-agnostic dispatcher; stdio and HTTP both feed it
+- Test: `tests/server-mcp-http.test.ts`
+
+**Goal:** any MCP client that supports HTTP/SSE transport can talk to `hippo serve` instead of spawning a stdio child.
+
+The MCP spec for HTTP transport: client opens SSE stream for incoming server messages, posts JSON-RPC requests to the request endpoint, server matches by id and pushes responses to the SSE stream.
+
+**Test:** open SSE stream via `fetch()` with `accept: text/event-stream`, post a `tools/list` request, assert the response arrives on the stream within 1s.
+
+Commit:
+```
+feat(a1): MCP-over-HTTP/SSE transport, stdio path unchanged
+```
+
+---
+
+### Task 12: Concurrent recall + write test
+
+**Files:**
+- Test: `tests/server-concurrency.test.ts`
+
+**Behavior:**
+- Start server on port 0
+- Seed 100 memories
+- Spawn N=10 concurrent reader clients (each does 50 recalls in parallel)
+- Spawn 1 writer client (does 50 remembers serialized)
+- Assert: all reads succeed, all writes succeed, no SQLite locked errors, final memory count is exactly 150
+
+This is "Concurrent recall + write under SQLite single-writer (real DB)" from ROADMAP.
+
+Commit:
+```
+test(a1): concurrent recall + write under single-writer
+```
+
+---
+
+### Task 13: p99 recall benchmark on 10k store
+
+**Files:**
+- Create: `benchmarks/a1/p99-recall.ts`
+- Test: `tests/server-p99.test.ts` (skipped by default, run manually or in CI nightly)
+
+**Benchmark spec (pinned per ROADMAP):**
+- Query mix: top-10 BM25 against tier-1 micro-eval queries
+- Cold cache (fresh server start)
+- Hybrid embeddings on
+- Single SQLite connection
+- Store: 10k memories (synthetic but realistic distribution)
+
+**Run:**
+```bash
+node dist/benchmarks/a1/p99-recall.js --store-size 10000 --queries 1000
+```
+
+Outputs JSON: `{ p50, p95, p99, p999, mean, stddev, total_ms }`.
+
+**Success criterion:** p99 < 50ms. If not, the failing run reports which queries took longest so we can profile (FTS, embedding lookup, JSON serialization, etc.).
+
+This is informational at this stage. The CI gate is in Task 15.
+
+Commit:
+```
+feat(a1): p99 recall benchmark on 10k store
+```
+
+---
+
+### Task 14: 24h soak harness skeleton
+
+**Files:**
+- Create: `benchmarks/a1/soak.ts`
+- Documentation in CHANGELOG / README
+
+**Goal:** a runnable harness that drives the server with realistic load for N hours and tracks RSS, FD count, SQLite WAL size, and request latency over time. The actual 24h run is a manual / scheduled task — this plan delivers the harness, not the result.
+
+```bash
+node dist/benchmarks/a1/soak.js --hours 24 --concurrency 4 --rps 20
+```
+
+Writes `benchmarks/a1/soak-<timestamp>.jsonl` with periodic samples. Plot in any tool.
+
+Commit:
+```
+feat(a1): 24h soak harness skeleton (results pending manual run)
+```
+
+---
+
+### Task 15: Eval re-run + version bump to 0.36.0
+
+**Files:** package.json + 3 manifests, CHANGELOG.md, README.md
+
+**Pre-flight:**
+- `npm run build` — clean
+- `npx vitest run` — 766+30 ≈ 796+ green
+- `python benchmarks/micro/run.py` — 9/9 at 100%
+- `node dist/benchmarks/a1/p99-recall.js --store-size 10000` — p99 < 50ms (the success criterion)
+- Manual smoke: `hippo serve` in one terminal, `hippo remember "..."` in another, verify both behave correctly
+
+If p99 >= 50ms, document in CHANGELOG as a known issue and file a v0.37.0 follow-up rather than blocking ship. The headline value of A1 is the architecture, not necessarily hitting the latency target on day one.
+
+Bump 0.35.0 → 0.36.0. CHANGELOG entry covers serve / thin-client / MCP-HTTP / auth / concurrent-write / p99 result.
+
+README "What's new in v0.36.0":
+- `hippo serve` daemon mode
+- CLI auto-detects and becomes thin client
+- MCP-over-HTTP transport
+- p99 recall < 50ms on 10k store (or known-issue note)
+- Bearer-token auth on remote requests, loopback trust for local CLI
+
+Hand off to `/publish-repo` skill.
+
+---
+
+## Footguns to watch
+
+1. **Stale pidfile after crash.** If the server hard-crashes (OOM, kill -9), the pidfile sticks around. `detectServer` probes via signal 0 — that handles dead PIDs. But if the system has reused the PID for an unrelated process, the probe returns true and the CLI tries to talk to that process. Mitigation: include `started_at` in the pidfile; on health probe, compare `process.uptime()` reported by the server to `started_at`. Mismatch → treat as stale.
+
+2. **SQLite single-writer + WAL.** WAL mode (`src/db.ts:384`) allows concurrent readers. Only one writer can hold the lock at a time. If the server is the canonical writer and a CLI invocation tries to write directly (no server detection, fallback path), they'll fight. The pidfile-routing should prevent this, but for safety, the CLI's direct-write path should set `PRAGMA busy_timeout = 5000` (already there) and surface a clear error if the lock can't be acquired.
+
+3. **Loopback trust.** Treating `127.0.0.1` as authenticated is fine for stub auth, but **`hippo serve --host 0.0.0.0`** would expose it to the network. Add a startup warning: "binding to non-loopback host without API key requirement is not recommended." Or refuse to start without auth on non-loopback. Latter is safer — go with that.
+
+4. **Audit double-emit during the refactor (Task 1 → Task 4).** Task 1 emits a duplicate audit event because writeEntry already audits. Task 4 cleans this up by threading actor through writeEntry. Don't ship between Task 1 and Task 4 — the dirty audit log is unshippable.
+
+5. **Concurrent write races.** SQLite single-writer means writes serialize at the DB level, but the server's HTTP handlers can interleave. If two simultaneous remember requests both compute `mem_id = uuid()` and try to insert, both succeed (different ids). Fine. But if two requests both try to UPDATE the same row (e.g., supersede the same id), the last write wins. Mitigation: optimistic locking via the existing `updated_at` field. Defer to v2 unless a real race shows up in Task 12 testing.
+
+6. **Process exit during request.** Server gets SIGTERM mid-request. `server.close()` waits for in-flight requests by default, but if the request handler is awaiting a slow operation (consolidation), shutdown blocks indefinitely. Add a 30s drain timeout, then `socket.destroy()` on remaining connections.
+
+7. **Pidfile clobber on multi-host shared FS.** Two `hippo serve` instances on different machines pointing at the same NFS-mounted `.hippo`. Each writes its own pidfile. `process.kill(other_pid, 0)` returns true if the local kernel has that PID for an unrelated process. This is a v2 concern — document and move on.
+
+8. **Test runner isolation.** Server tests must use `port: 0` (ephemeral) and unique `hippoRoot` (mkdtemp). Otherwise CI flakes. Seen this pattern in tests/recall-tenant-isolation.test.ts.
+
+---
+
+## Out of scope (v2 / A2)
+
+- **A2 — RESTish HTTP API hardening.** SDK examples, contract polish, OpenAPI spec. A1 ships the surface; A2 productizes it.
+- **Authentication beyond stub.** OAuth, SCIM provisioning, multi-tenant per-key scoping. Already deferred under A5 v2.
+- **Multi-process writers.** SQLite Litestream, Postgres backend (A6), or rqlite. v1 stays single-writer.
+- **TLS termination.** Run behind nginx / Caddy if remote. Server itself is plain HTTP.
+- **Rate limiting per tenant.** Stub auth = single tenant per deployment, no rate limit needed yet.
+- **Streaming responses.** Server-sent events for context assembly is a nice-to-have for A2; A1 ships JSON only.
+- **Hot reload of API keys.** Revoking a key doesn't invalidate in-flight requests — they complete. Acceptable for stub.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.35.0",
+  "version": "0.36.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,9 +8,20 @@
  */
 
 import { openHippoDb, closeHippoDb } from './db.js';
-import { writeEntry } from './store.js';
-import { createMemory, type MemoryKind } from './memory.js';
+import {
+  writeEntry,
+  readEntry,
+  deleteEntry,
+  loadSearchEntries,
+} from './store.js';
+import {
+  createMemory,
+  type MemoryKind,
+  type MemoryEntry,
+  Layer,
+} from './memory.js';
 import { appendAuditEvent } from './audit.js';
+import { promoteToGlobal, getGlobalRoot } from './shared.js';
 
 export interface Context {
   hippoRoot: string;
@@ -64,4 +75,202 @@ export function remember(ctx: Context, opts: RememberOpts): RememberResult {
   }
 
   return { id: entry.id, kind: entry.kind, tenantId: ctx.tenantId };
+}
+
+// ---------------------------------------------------------------------------
+// recall
+// ---------------------------------------------------------------------------
+
+export interface RecallOpts {
+  query: string;
+  limit?: number;
+  mode?: 'bm25' | 'hybrid' | 'physics';
+}
+
+export interface RecallResultItem {
+  id: string;
+  content: string;
+  score: number;
+  layer: string;
+  strength: number;
+}
+
+export interface RecallResult {
+  results: RecallResultItem[];
+  total: number;
+  tokens: number;
+}
+
+/**
+ * Domain-level recall. Loads BM25-ranked candidates from SQLite scoped to
+ * `ctx.tenantId`. The `mode` flag is accepted for forward compatibility (the
+ * CLI exposes hybrid/physics paths) but Task 2 wires only the BM25 candidate
+ * loader; later tasks can extend this to call the physics/hybrid scorer.
+ */
+export function recall(ctx: Context, opts: RecallOpts): RecallResult {
+  const limit = opts.limit ?? 10;
+  const entries = loadSearchEntries(
+    ctx.hippoRoot,
+    opts.query,
+    undefined,
+    ctx.tenantId,
+  );
+  // BM25 ordering already comes from loadSearchEntries; cap to `limit`.
+  // Score is a placeholder — the physics/hybrid scorers in src/search.ts
+  // produce richer breakdowns and will replace this when wired up.
+  const ranked = entries.slice(0, limit).map((entry, idx) => ({
+    id: entry.id,
+    content: entry.content,
+    score: Math.max(0, 1 - idx / Math.max(1, limit)),
+    layer: entry.layer,
+    strength: entry.strength,
+  }));
+  const tokens = ranked.reduce((acc, r) => acc + Math.ceil(r.content.length / 4), 0);
+
+  // TODO(a1-task-4): emit via the shared audit hook in store.ts so we don't
+  // double-emit. Recall does not currently write through writeEntry, so no
+  // duplicate exists today, but we keep the same shape for symmetry.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'recall',
+      metadata: { query: opts.query.slice(0, 200), results: ranked.length },
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { results: ranked, total: entries.length, tokens };
+}
+
+// ---------------------------------------------------------------------------
+// forget
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a memory by id. The underlying `deleteEntry` already emits an audit
+ * event with actor='cli'; we append a second event with `ctx.actor` so HTTP /
+ * api_key callers land in the audit log. Task 4 will dedupe by threading the
+ * actor through deleteEntry.
+ */
+export function forget(ctx: Context, id: string): { ok: true; id: string } {
+  const removed = deleteEntry(ctx.hippoRoot, id);
+  if (!removed) {
+    throw new Error(`Memory not found: ${id}`);
+  }
+
+  // TODO(a1-task-4): deleteEntry's internal audit hook hardcodes actor='cli'.
+  // We append a second event with ctx.actor so the supplied actor lands in
+  // the log. Task 4 will thread `actor` through deleteEntry and dedupe.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'forget',
+      targetId: id,
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { ok: true, id };
+}
+
+// ---------------------------------------------------------------------------
+// promote
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy a local memory into the global store. Mirrors `cmdPromote` in cli.ts:
+ * the `writeEntry` inside `promoteToGlobal` emits a 'remember' on the global
+ * db; we add a 'promote' audit event on the global db so the user-facing
+ * intent stays distinct from the underlying upsert.
+ *
+ * Note: `promoteToGlobal` does not currently take a tenantId override — it
+ * reads the entry from the local root via `readEntry` (no tenant filter) and
+ * preserves the entry's existing tenantId on the global side. Task 4 may
+ * tighten this once writeEntry/readEntry thread tenant context.
+ */
+export function promote(
+  ctx: Context,
+  id: string,
+): { ok: true; sourceId: string; globalId: string } {
+  const globalEntry = promoteToGlobal(ctx.hippoRoot, id);
+
+  // Audit on the global store, since that's where the promoted memory now
+  // lives. Mirrors cmdPromote's emitCliAudit(getGlobalRoot(), ...).
+  // TODO(a1-task-4): collapse with writeEntry's audit hook.
+  const db = openHippoDb(getGlobalRoot());
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'promote',
+      targetId: globalEntry.id,
+      metadata: { sourceId: id },
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { ok: true, sourceId: id, globalId: globalEntry.id };
+}
+
+// ---------------------------------------------------------------------------
+// supersede
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace an old memory with new content, chaining old.superseded_by = new.id.
+ * Mirrors `cmdSupersede` in cli.ts (without flag-driven layer/tag/pin overrides
+ * — A1 keeps the API minimal; the CLI handler will continue to handle those
+ * flags and pass the resolved values once Task 4 lands).
+ */
+export function supersede(
+  ctx: Context,
+  oldId: string,
+  newContent: string,
+): { ok: true; oldId: string; newId: string } {
+  const old: MemoryEntry | null = readEntry(ctx.hippoRoot, oldId, ctx.tenantId);
+  if (!old) {
+    throw new Error(`Memory not found: ${oldId}`);
+  }
+  if (old.superseded_by) {
+    throw new Error(
+      `Memory ${oldId} is already superseded by ${old.superseded_by}. Supersede that one instead.`,
+    );
+  }
+
+  const newEntry = createMemory(newContent, {
+    layer: old.layer ?? Layer.Episodic,
+    tags: [...old.tags],
+    pinned: old.pinned,
+    source: old.source,
+    confidence: 'verified',
+    tenantId: ctx.tenantId,
+  });
+  old.superseded_by = newEntry.id;
+  writeEntry(ctx.hippoRoot, old);
+  writeEntry(ctx.hippoRoot, newEntry);
+
+  // TODO(a1-task-4): writeEntry's audit hook emits 'remember' with actor='cli'
+  // for both writes above; the 'supersede' event below carries ctx.actor and is
+  // the user-facing intent. Task 4 will thread actor and unify.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'supersede',
+      targetId: oldId,
+      metadata: { newId: newEntry.id },
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { ok: true, oldId, newId: newEntry.id };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,25 +66,9 @@ export function remember(ctx: Context, opts: RememberOpts): RememberResult {
     tags: opts.tags,
     tenantId: ctx.tenantId,
   });
-  writeEntry(ctx.hippoRoot, entry);
-
-  // TODO(a1-task-4): writeEntry already emits an audit event with actor='cli'
-  // via its internal hook (see src/store.ts:31 audit()). We append a second
-  // audit event here so the supplied ctx.actor lands in the log, which is
-  // what HTTP / api_key callers need. This is an intentional duplicate emit
-  // pending Task 4, which threads `actor` into writeEntry and dedupes.
-  const db = openHippoDb(ctx.hippoRoot);
-  try {
-    appendAuditEvent(db, {
-      tenantId: ctx.tenantId,
-      actor: ctx.actor,
-      op: 'remember',
-      targetId: entry.id,
-      metadata: { kind: entry.kind, scope: entry.scope ?? null },
-    });
-  } finally {
-    closeHippoDb(db);
-  }
+  // writeEntry threads ctx.actor into its internal audit hook, so exactly
+  // one 'remember' event lands in the log with the supplied actor.
+  writeEntry(ctx.hippoRoot, entry, { actor: ctx.actor });
 
   return { id: entry.id, kind: entry.kind, tenantId: ctx.tenantId };
 }
@@ -162,32 +146,14 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Delete a memory by id. The underlying `deleteEntry` already emits an audit
- * event with actor='cli'; we append a second event with `ctx.actor` so HTTP /
- * api_key callers land in the audit log. Task 4 will dedupe by threading the
- * actor through deleteEntry.
+ * Delete a memory by id. `deleteEntry` threads ctx.actor into its internal
+ * audit hook, so exactly one 'forget' event lands with the supplied actor.
  */
 export function forget(ctx: Context, id: string): { ok: true; id: string } {
-  const removed = deleteEntry(ctx.hippoRoot, id);
+  const removed = deleteEntry(ctx.hippoRoot, id, { actor: ctx.actor });
   if (!removed) {
     throw new Error(`Memory not found: ${id}`);
   }
-
-  // TODO(a1-task-4): deleteEntry's internal audit hook hardcodes actor='cli'.
-  // We append a second event with ctx.actor so the supplied actor lands in
-  // the log. Task 4 will thread `actor` through deleteEntry and dedupe.
-  const db = openHippoDb(ctx.hippoRoot);
-  try {
-    appendAuditEvent(db, {
-      tenantId: ctx.tenantId,
-      actor: ctx.actor,
-      op: 'forget',
-      targetId: id,
-    });
-  } finally {
-    closeHippoDb(db);
-  }
-
   return { ok: true, id };
 }
 
@@ -210,11 +176,12 @@ export function promote(
   ctx: Context,
   id: string,
 ): { ok: true; sourceId: string; globalId: string } {
-  const globalEntry = promoteToGlobal(ctx.hippoRoot, id);
+  // promoteToGlobal threads ctx.actor into the writeEntry call on the global
+  // db, which emits a 'remember' audit row. We then add the user-facing
+  // 'promote' event on the global db so the audit trail keeps the intent
+  // distinct from the underlying upsert.
+  const globalEntry = promoteToGlobal(ctx.hippoRoot, id, { actor: ctx.actor });
 
-  // Audit on the global store, since that's where the promoted memory now
-  // lives. Mirrors cmdPromote's emitCliAudit(getGlobalRoot(), ...).
-  // TODO(a1-task-4): collapse with writeEntry's audit hook.
   const db = openHippoDb(getGlobalRoot());
   try {
     appendAuditEvent(db, {
@@ -265,12 +232,11 @@ export function supersede(
     tenantId: ctx.tenantId,
   });
   old.superseded_by = newEntry.id;
-  writeEntry(ctx.hippoRoot, old);
-  writeEntry(ctx.hippoRoot, newEntry);
+  writeEntry(ctx.hippoRoot, old, { actor: ctx.actor });
+  writeEntry(ctx.hippoRoot, newEntry, { actor: ctx.actor });
 
-  // TODO(a1-task-4): writeEntry's audit hook emits 'remember' with actor='cli'
-  // for both writes above; the 'supersede' event below carries ctx.actor and is
-  // the user-facing intent. Task 4 will thread actor and unify.
+  // The two writeEntry calls above emit 'remember' audit rows; the 'supersede'
+  // event below carries the user-facing intent and the chained newId.
   const db = openHippoDb(ctx.hippoRoot);
   try {
     appendAuditEvent(db, {

--- a/src/api.ts
+++ b/src/api.ts
@@ -148,11 +148,28 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
 /**
  * Delete a memory by id. `deleteEntry` threads ctx.actor into its internal
  * audit hook, so exactly one 'forget' event lands with the supplied actor.
+ *
+ * Tenant scope: deleteEntry looks up the row by id alone, so without an
+ * explicit tenant guard a Bearer for tenant A could delete tenant B's row
+ * by guessing or leaking the id. Pre-check the row's tenant_id and deny
+ * cross-tenant access with a not-found error (no info leak about whether
+ * the id exists in another tenant).
  */
 export function forget(ctx: Context, id: string): { ok: true; id: string } {
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    const row = db
+      .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+      .get(id) as { tenant_id?: string } | undefined;
+    if (!row || row.tenant_id !== ctx.tenantId) {
+      throw new Error(`memory not found: ${id}`);
+    }
+  } finally {
+    closeHippoDb(db);
+  }
   const removed = deleteEntry(ctx.hippoRoot, id, { actor: ctx.actor });
   if (!removed) {
-    throw new Error(`Memory not found: ${id}`);
+    throw new Error(`memory not found: ${id}`);
   }
   return { ok: true, id };
 }
@@ -273,6 +290,17 @@ export function archiveRaw(
 ): { ok: true; archivedAt: string } {
   const db = openHippoDb(ctx.hippoRoot);
   try {
+    // Tenant scope: archiveRawMemory looks up the row by id alone, so a
+    // Bearer for tenant A could archive tenant B's raw row without this
+    // pre-check. Deny cross-tenant access with the same not-found message
+    // archiveRawMemory itself would throw on a missing row, so we don't
+    // leak whether the id exists in another tenant.
+    const row = db
+      .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+      .get(id) as { tenant_id?: string } | undefined;
+    if (!row || row.tenant_id !== ctx.tenantId) {
+      throw new Error(`memory not found: ${id}`);
+    }
     archiveRawMemory(db, id, { reason, who: ctx.actor });
   } finally {
     closeHippoDb(db);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,67 @@
+/**
+ * Domain API layer for Hippo.
+ *
+ * Pure functions taking a Context (hippoRoot + tenantId + actor) plus
+ * operation options. Both the CLI (direct mode) and the HTTP server
+ * (`hippo serve`, A1) call into this module so the business logic lives
+ * in exactly one place.
+ */
+
+import { openHippoDb, closeHippoDb } from './db.js';
+import { writeEntry } from './store.js';
+import { createMemory, type MemoryKind } from './memory.js';
+import { appendAuditEvent } from './audit.js';
+
+export interface Context {
+  hippoRoot: string;
+  tenantId: string;
+  /** 'cli' | 'localhost:cli' | 'api_key:<key_id>' | 'mcp' */
+  actor: string;
+}
+
+export interface RememberOpts {
+  content: string;
+  kind?: MemoryKind;
+  scope?: string;
+  owner?: string;
+  artifactRef?: string;
+  tags?: string[];
+}
+
+export interface RememberResult {
+  id: string;
+  kind: MemoryKind;
+  tenantId: string;
+}
+
+export function remember(ctx: Context, opts: RememberOpts): RememberResult {
+  const entry = createMemory(opts.content, {
+    kind: opts.kind ?? 'distilled',
+    scope: opts.scope ?? null,
+    owner: opts.owner ?? null,
+    artifact_ref: opts.artifactRef ?? null,
+    tags: opts.tags,
+    tenantId: ctx.tenantId,
+  });
+  writeEntry(ctx.hippoRoot, entry);
+
+  // TODO(a1-task-4): writeEntry already emits an audit event with actor='cli'
+  // via its internal hook (see src/store.ts:31 audit()). We append a second
+  // audit event here so the supplied ctx.actor lands in the log, which is
+  // what HTTP / api_key callers need. This is an intentional duplicate emit
+  // pending Task 4, which threads `actor` into writeEntry and dedupes.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    appendAuditEvent(db, {
+      tenantId: ctx.tenantId,
+      actor: ctx.actor,
+      op: 'remember',
+      targetId: entry.id,
+      metadata: { kind: entry.kind, scope: entry.scope ?? null },
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+
+  return { id: entry.id, kind: entry.kind, tenantId: ctx.tenantId };
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,8 +20,20 @@ import {
   type MemoryEntry,
   Layer,
 } from './memory.js';
-import { appendAuditEvent } from './audit.js';
+import {
+  appendAuditEvent,
+  queryAuditEvents,
+  type AuditEvent,
+  type AuditOp,
+} from './audit.js';
 import { promoteToGlobal, getGlobalRoot } from './shared.js';
+import { archiveRawMemory } from './raw-archive.js';
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  type ApiKeyListItem,
+} from './auth.js';
 
 export interface Context {
   hippoRoot: string;
@@ -273,4 +285,178 @@ export function supersede(
   }
 
   return { ok: true, oldId, newId: newEntry.id };
+}
+
+// ---------------------------------------------------------------------------
+// archive_raw
+// ---------------------------------------------------------------------------
+
+/**
+ * Archive a kind='raw' memory: snapshot into raw_archive, mark archived, delete.
+ *
+ * `archiveRawMemory` audits the operation internally (op='archive_raw') using the
+ * row's own tenant_id. We DO NOT emit a second audit event here to avoid double-
+ * emitting the archive_raw op (unlike Task 1 remember/forget where the underlying
+ * helpers hardcode actor='cli'). Instead we pass `ctx.actor` through as `who`,
+ * and raw-archive.ts uses that for the audit row.
+ */
+export function archiveRaw(
+  ctx: Context,
+  id: string,
+  reason: string,
+): { ok: true; archivedAt: string } {
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    archiveRawMemory(db, id, { reason, who: ctx.actor });
+  } finally {
+    closeHippoDb(db);
+  }
+  // archiveRawMemory does not return the archive_at timestamp it wrote. We
+  // emit a fresh ISO timestamp here for the API response. Within a millisecond
+  // of the actual write, fine for a server response shape.
+  return { ok: true, archivedAt: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+// auth: create / list / revoke
+// ---------------------------------------------------------------------------
+
+export interface AuthCreateOpts {
+  label?: string;
+  /** Override the calling tenant (e.g. admin minting a key for tenant B). */
+  tenantId?: string;
+}
+
+export interface AuthCreateResult {
+  keyId: string;
+  plaintext: string;
+  tenantId: string;
+}
+
+/**
+ * Mint a new API key. Per A5 v2 follow-ups (TODOS.md), `auth_create` is currently
+ * unaudited — we intentionally match that behavior here for consistency. When A5
+ * v2 lands and adds the audit op, this function should mirror the cli handler.
+ */
+export function authCreate(ctx: Context, opts: AuthCreateOpts): AuthCreateResult {
+  const tenantId = opts.tenantId ?? ctx.tenantId;
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    const result = createApiKey(db, { tenantId, label: opts.label });
+    return { keyId: result.keyId, plaintext: result.plaintext, tenantId };
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * List API keys visible to the calling tenant.
+ *
+ * Divergence from `cmdAuthList` in src/cli.ts: the CLI today returns ALL keys
+ * regardless of tenant (single-tenant deployments). The API surface is tenant-
+ * scoped because future multi-tenant deployments will share a hippoRoot, and
+ * tenant A must not see tenant B's keys. Read-only — no audit emit (matches A5).
+ */
+export function authList(
+  ctx: Context,
+  opts: { active: boolean },
+): ApiKeyListItem[] {
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    const all = listApiKeys(db, opts);
+    return all.filter((k) => k.tenantId === ctx.tenantId);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Revoke an API key.
+ *
+ * Security: the key must belong to `ctx.tenantId`. Cross-tenant revoke is
+ * rejected with the same "not found" message used for missing keys, so that a
+ * caller cannot probe which key_ids exist on other tenants.
+ *
+ * Audit: emits 'auth_revoke' with `tenantId` set to the KEY ROW's tenant_id
+ * (M1 fix from A5 review, mirrors src/cli.ts:cmdAuthRevoke). Skipped on no-op
+ * revoke (already revoked) so re-running doesn't pad the audit log.
+ */
+export function authRevoke(
+  ctx: Context,
+  keyId: string,
+): { ok: true; revokedAt: string } {
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    const row = db
+      .prepare(`SELECT key_id, tenant_id, revoked_at FROM api_keys WHERE key_id = ?`)
+      .get(keyId) as
+      | { key_id: string; tenant_id: string; revoked_at: string | null }
+      | undefined;
+    if (!row) {
+      throw new Error(`Unknown key_id: ${keyId}`);
+    }
+    // Cross-tenant access denied: same message as missing key, no info leak.
+    if (row.tenant_id !== ctx.tenantId) {
+      throw new Error(`Unknown key_id: ${keyId}`);
+    }
+
+    let revokedAt: string;
+    let alreadyRevoked = false;
+    if (row.revoked_at) {
+      alreadyRevoked = true;
+      revokedAt = row.revoked_at;
+    } else {
+      revokeApiKey(db, keyId);
+      const updated = db
+        .prepare(`SELECT revoked_at FROM api_keys WHERE key_id = ?`)
+        .get(keyId) as { revoked_at: string | null } | undefined;
+      revokedAt = updated?.revoked_at ?? new Date().toISOString();
+    }
+
+    if (!alreadyRevoked) {
+      try {
+        appendAuditEvent(db, {
+          tenantId: row.tenant_id, // M1: KEY's tenant, not ctx.tenantId.
+          actor: ctx.actor,
+          op: 'auth_revoke',
+          targetId: keyId,
+        });
+      } catch {
+        // Audit must not crash a successful revoke.
+      }
+    }
+
+    return { ok: true, revokedAt };
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// audit: list
+// ---------------------------------------------------------------------------
+
+export interface AuditListOpts {
+  op?: AuditOp;
+  /** ISO timestamp lower bound. */
+  since?: string;
+  limit?: number;
+}
+
+/**
+ * Read audit events scoped to `ctx.tenantId`. Read-only — no audit emit (matches
+ * A5: cmdAuditList does not record a 'recall'-style read event).
+ */
+export function auditList(ctx: Context, opts: AuditListOpts): AuditEvent[] {
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    return queryAuditEvents(db, {
+      tenantId: ctx.tenantId,
+      op: opts.op,
+      since: opts.since,
+      limit: opts.limit,
+    });
+  } finally {
+    closeHippoDb(db);
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,7 @@ import {
   type AuditResult,
 } from './audit.js';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyListItem } from './auth.js';
+import * as api from './api.js';
 import { resolveTenantId } from './tenant.js';
 import { runEval, bootstrapCorpus, compareSummaries, type EvalCase, type EvalSummary } from './eval.js';
 import { runFeatureEval, formatResult, resultToBaseline, detectRegressions, type EvalBaseline } from './eval-suite.js';
@@ -2468,11 +2469,16 @@ function cmdOutcome(
 function cmdForget(hippoRoot: string, id: string): void {
   requireInit(hippoRoot);
 
-  const ok = deleteEntry(hippoRoot, id);
-  if (ok) {
+  const ctx: api.Context = {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
+  try {
+    api.forget(ctx, id);
     updateStats(hippoRoot, { forgotten: 1 });
     console.log(`Forgot ${id}`);
-  } else {
+  } catch {
     console.error(`Memory not found: ${id}`);
     process.exit(1);
   }
@@ -3720,14 +3726,14 @@ function cmdPromote(hippoRoot: string, id: string): void {
     process.exit(1);
   }
 
+  const ctx: api.Context = {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
   try {
-    const globalEntry = promoteToGlobal(hippoRoot, id);
-    // Emit audit on the global store (where the promoted memory now lives).
-    // The writeEntry inside promoteToGlobal already fires a 'remember' on the
-    // global db; we add a separate 'promote' event so the audit trail keeps
-    // the user-facing intent distinct from the underlying upsert.
-    emitCliAudit(getGlobalRoot(), 'promote', globalEntry.id, { sourceId: id });
-    console.log(`Promoted ${id} to global store as ${globalEntry.id}`);
+    const result = api.promote(ctx, id);
+    console.log(`Promoted ${id} to global store as ${result.globalId}`);
     console.log(`   Global store: ${getGlobalRoot()}`);
   } catch (err) {
     console.error(`Failed to promote: ${(err as Error).message}`);
@@ -4359,22 +4365,20 @@ function cmdAuthCreate(hippoRoot: string, flags: Record<string, string | boolean
   const root = resolveAuthRoot(hippoRoot, flags);
   const tenantFlag = typeof flags['tenant'] === 'string' ? (flags['tenant'] as string) : undefined;
   const labelFlag = typeof flags['label'] === 'string' ? (flags['label'] as string) : undefined;
-  const tenantId = tenantFlag ?? resolveTenantId({});
   const asJson = Boolean(flags['json']);
 
-  const db = openHippoDb(root);
-  let result;
-  try {
-    result = createApiKey(db, { tenantId, label: labelFlag });
-  } finally {
-    closeHippoDb(db);
-  }
+  const ctx: api.Context = {
+    hippoRoot: root,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
+  const result = api.authCreate(ctx, { tenantId: tenantFlag, label: labelFlag });
 
   if (asJson) {
     console.log(JSON.stringify({
       keyId: result.keyId,
       plaintext: result.plaintext,
-      tenantId,
+      tenantId: result.tenantId,
       label: labelFlag ?? null,
     }));
     return;
@@ -4536,13 +4540,8 @@ function cmdAuditList(hippoRoot: string, flags: Record<string, string | boolean 
     process.exit(1);
   }
 
-  const db = openHippoDb(root);
-  let events: AuditEvent[];
-  try {
-    events = queryAuditEvents(db, { tenantId, op, since, limit });
-  } finally {
-    closeHippoDb(db);
-  }
+  const ctx: api.Context = { hippoRoot: root, tenantId, actor: 'cli' };
+  const events = api.auditList(ctx, { op, since, limit });
 
   if (asJson) {
     console.log(JSON.stringify(events));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,6 +148,8 @@ import {
 } from './audit.js';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyListItem } from './auth.js';
 import * as api from './api.js';
+import * as client from './client.js';
+import { detectServer, removePidfile, type ServerInfo } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { runEval, bootstrapCorpus, compareSummaries, type EvalCase, type EvalSummary } from './eval.js';
 import { runFeatureEval, formatResult, resultToBaseline, detectRegressions, type EvalBaseline } from './eval-suite.js';
@@ -200,6 +202,37 @@ function requireInit(hippoRoot: string): void {
   if (!isInitialized(hippoRoot)) {
     console.error('No .hippo directory found. Run `hippo init` first.');
     process.exit(1);
+  }
+}
+
+/**
+ * Run an HTTP-routed command if a `hippo serve` instance is detected for
+ * `hippoRoot`. Returns:
+ *   - true  if the HTTP path ran (success OR a structured server error that
+ *           was already surfaced to stdout/stderr by `httpFn`),
+ *   - false if no server was detected, or if the detected pidfile turned out
+ *           to be stale (connection refused). On stale, the pidfile is removed
+ *           and the caller should fall back to the direct path.
+ *
+ * Per the A1 plan footgun #1: stale pidfiles must self-heal, not crash.
+ */
+async function runViaServerIfAvailable(
+  hippoRoot: string,
+  httpFn: (info: ServerInfo, apiKey: string | undefined) => Promise<void>,
+): Promise<boolean> {
+  const info = detectServer(hippoRoot);
+  if (!info) return false;
+  const apiKey = process.env['HIPPO_API_KEY'];
+  try {
+    await httpFn(info, apiKey);
+    return true;
+  } catch (err) {
+    if (client.isConnectionRefused(err)) {
+      console.error('hippo: stale server pidfile detected, falling back to direct mode');
+      removePidfile(hippoRoot);
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -4923,6 +4956,37 @@ async function main(): Promise<void> {
         console.error('Memory content too short (minimum 3 characters).');
         process.exit(1);
       }
+      // Thin-client routing. When a server is up, simple `remember` calls go
+      // over HTTP so the daemon stays single-writer (footgun #2). Rich CLI
+      // flags (--pin, --layer, --extract, --global, salience gates) still
+      // need the direct path; we only intercept the minimal envelope.
+      const richFlag =
+        flags['pin'] || flags['global'] || flags['extract'] || flags['force'] ||
+        flags['observed'] || flags['inferred'] || flags['verified'] ||
+        flags['layer'] !== undefined;
+      if (!richFlag) {
+        const rememberKindRaw = typeof flags['kind'] === 'string' ? (flags['kind'] as string).toLowerCase() : undefined;
+        const rememberKindAllowed = ['distilled', 'superseded'] as const;
+        if (rememberKindRaw === undefined || (rememberKindAllowed as readonly string[]).includes(rememberKindRaw)) {
+          const tagsRaw = flags['tag'];
+          const tags = Array.isArray(tagsRaw)
+            ? (tagsRaw as string[]).map(String)
+            : typeof tagsRaw === 'string' ? [tagsRaw] : undefined;
+          const remembered = await runViaServerIfAvailable(hippoRoot, async (info, apiKey) => {
+            const result = await client.remember(info.url, apiKey, {
+              content: text,
+              kind: rememberKindRaw as ('distilled' | 'superseded' | undefined),
+              scope: typeof flags['scope'] === 'string' ? (flags['scope'] as string) : undefined,
+              owner: typeof flags['owner'] === 'string' ? (flags['owner'] as string) : undefined,
+              artifactRef: typeof flags['artifact-ref'] === 'string' ? (flags['artifact-ref'] as string) : undefined,
+              tags,
+            });
+            console.log(`Remembered [${result.id}] (via ${info.url})`);
+            console.log(`   Kind: ${result.kind} | Tenant: ${result.tenantId}`);
+          });
+          if (remembered) break;
+        }
+      }
       await cmdRemember(hippoRoot, text, flags);
       break;
     }
@@ -5095,6 +5159,16 @@ async function main(): Promise<void> {
         console.error('Please provide a memory ID.');
         process.exit(1);
       }
+      const routed = await runViaServerIfAvailable(hippoRoot, async (info, apiKey) => {
+        try {
+          await client.forget(info.url, apiKey, id);
+          console.log(`Forgot ${id}`);
+        } catch (err) {
+          console.error((err as Error).message);
+          process.exit(1);
+        }
+      });
+      if (routed) break;
       cmdForget(hippoRoot, id);
       break;
     }
@@ -5145,6 +5219,16 @@ async function main(): Promise<void> {
         console.error('Please provide a memory ID.');
         process.exit(1);
       }
+      const promoted = await runViaServerIfAvailable(hippoRoot, async (info, apiKey) => {
+        try {
+          const result = await client.promote(info.url, apiKey, id);
+          console.log(`Promoted ${id} to global store as ${result.globalId}`);
+        } catch (err) {
+          console.error(`Failed to promote: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      });
+      if (promoted) break;
       cmdPromote(hippoRoot, id);
       break;
     }
@@ -5298,6 +5382,25 @@ async function main(): Promise<void> {
       // Server runs until stdin closes, so we never reach here
       await new Promise(() => {}); // hang forever
       break;
+
+    case 'serve': {
+      requireInit(hippoRoot);
+      const portRaw = flags['port'] ?? process.env['HIPPO_PORT'] ?? '6789';
+      const port = Number(portRaw);
+      if (!Number.isFinite(port) || port < 0) {
+        console.error(`Invalid --port: ${String(portRaw)}`);
+        process.exit(1);
+      }
+      const host = typeof flags['host'] === 'string' ? (flags['host'] as string) : '127.0.0.1';
+      const { serve } = await import('./server.js');
+      const handle = await serve({ hippoRoot, port, host });
+      console.log(`hippo serve listening on ${handle.url} (pid ${process.pid})`);
+      console.log(`pidfile: ${path.join(hippoRoot, '.hippo', 'server.pid')}`);
+      console.log('press Ctrl+C to stop');
+      // SIGINT/SIGTERM handlers wired in server.ts (skipped under VITEST). Hang.
+      await new Promise(() => {});
+      break;
+    }
 
     case 'invalidate': {
       requireInit(hippoRoot);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5400,7 +5400,7 @@ async function main(): Promise<void> {
       const { serve } = await import('./server.js');
       const handle = await serve({ hippoRoot, port, host });
       console.log(`hippo serve listening on ${handle.url} (pid ${process.pid})`);
-      console.log(`pidfile: ${path.join(hippoRoot, '.hippo', 'server.pid')}`);
+      console.log(`pidfile: ${path.join(hippoRoot, 'server.pid')}`);
       console.log('press Ctrl+C to stop');
       // SIGINT/SIGTERM handlers wired in server.ts (skipped under VITEST). Hang.
       await new Promise(() => {});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5376,12 +5376,17 @@ async function main(): Promise<void> {
       cmdWm(hippoRoot, args, flags);
       break;
 
-    case 'mcp':
-      // Start MCP server over stdio - dynamically import to keep main CLI lean
-      await import('./mcp/server.js');
+    case 'mcp': {
+      // Start MCP server over stdio. Dynamic import keeps main CLI lean; the
+      // dispatcher itself is transport-agnostic, so we explicitly attach the
+      // stdio loop here. (HTTP/SSE transport is wired in src/server.ts and
+      // imports the same module without triggering stdin handlers.)
+      const mod = await import('./mcp/server.js');
+      mod.startStdioLoop();
       // Server runs until stdin closes, so we never reach here
       await new Promise(() => {}); // hang forever
       break;
+    }
 
     case 'serve': {
       requireInit(hippoRoot);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,225 @@
+/**
+ * HTTP client wrapper for `hippo serve`.
+ *
+ * Mirrors the function signatures in src/api.ts so the CLI can route through
+ * either path uniformly. Each function takes (serverUrl, apiKey?, ...) and
+ * returns the same shape that api.ts would.
+ *
+ * Errors from the server (4xx/5xx) are mapped back into thrown Errors with
+ * the server's `error` message preserved verbatim so existing CLI handlers
+ * that match on substrings (e.g. "not found", "already superseded") still
+ * work unchanged.
+ *
+ * Network errors (ECONNREFUSED on a stale pidfile, etc.) propagate as the
+ * native fetch failure so the caller can detect them and self-heal.
+ */
+
+import type { MemoryKind } from './memory.js';
+import type { AuditEvent, AuditOp } from './audit.js';
+import type { ApiKeyListItem } from './auth.js';
+import type {
+  RememberOpts,
+  RememberResult,
+  RecallOpts,
+  RecallResult,
+  AuthCreateOpts,
+  AuthCreateResult,
+  AuditListOpts,
+} from './api.js';
+
+function buildHeaders(apiKey: string | undefined, withBody: boolean): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (withBody) headers['content-type'] = 'application/json';
+  if (apiKey) headers['authorization'] = `Bearer ${apiKey}`;
+  return headers;
+}
+
+/**
+ * Throw an Error matching the server's error message. Keeps message strings
+ * intact so cli.ts handlers can match on the same substrings ("not found",
+ * "already superseded", "Unknown key_id") whether the call went through
+ * api.ts or client.ts.
+ */
+async function throwForStatus(res: Response): Promise<never> {
+  let message = `${res.status} ${res.statusText}`;
+  try {
+    const body = await res.json() as { error?: string };
+    if (body && typeof body.error === 'string' && body.error.length > 0) {
+      message = body.error;
+    }
+  } catch {
+    // body wasn't JSON; fall back to status line.
+  }
+  throw new Error(message);
+}
+
+export async function remember(
+  serverUrl: string,
+  apiKey: string | undefined,
+  opts: RememberOpts,
+): Promise<RememberResult> {
+  const res = await fetch(`${serverUrl}/v1/memories`, {
+    method: 'POST',
+    headers: buildHeaders(apiKey, true),
+    body: JSON.stringify(opts),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as RememberResult;
+}
+
+export async function recall(
+  serverUrl: string,
+  apiKey: string | undefined,
+  opts: RecallOpts,
+): Promise<RecallResult> {
+  const params = new URLSearchParams();
+  params.set('q', opts.query);
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  if (opts.mode !== undefined) params.set('mode', opts.mode);
+  const res = await fetch(`${serverUrl}/v1/memories?${params.toString()}`, {
+    method: 'GET',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as RecallResult;
+}
+
+export async function forget(
+  serverUrl: string,
+  apiKey: string | undefined,
+  id: string,
+): Promise<{ ok: true; id: string }> {
+  const res = await fetch(`${serverUrl}/v1/memories/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as { ok: true; id: string };
+}
+
+export async function promote(
+  serverUrl: string,
+  apiKey: string | undefined,
+  id: string,
+): Promise<{ ok: true; sourceId: string; globalId: string }> {
+  const res = await fetch(`${serverUrl}/v1/memories/${encodeURIComponent(id)}/promote`, {
+    method: 'POST',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as { ok: true; sourceId: string; globalId: string };
+}
+
+export async function supersede(
+  serverUrl: string,
+  apiKey: string | undefined,
+  oldId: string,
+  newContent: string,
+): Promise<{ ok: true; oldId: string; newId: string }> {
+  const res = await fetch(`${serverUrl}/v1/memories/${encodeURIComponent(oldId)}/supersede`, {
+    method: 'POST',
+    headers: buildHeaders(apiKey, true),
+    body: JSON.stringify({ content: newContent }),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as { ok: true; oldId: string; newId: string };
+}
+
+export async function archiveRaw(
+  serverUrl: string,
+  apiKey: string | undefined,
+  id: string,
+  reason: string,
+): Promise<{ ok: true; archivedAt: string }> {
+  const res = await fetch(`${serverUrl}/v1/memories/${encodeURIComponent(id)}/archive`, {
+    method: 'POST',
+    headers: buildHeaders(apiKey, true),
+    body: JSON.stringify({ reason }),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as { ok: true; archivedAt: string };
+}
+
+export async function authCreate(
+  serverUrl: string,
+  apiKey: string | undefined,
+  opts: AuthCreateOpts,
+): Promise<AuthCreateResult> {
+  const res = await fetch(`${serverUrl}/v1/auth/keys`, {
+    method: 'POST',
+    headers: buildHeaders(apiKey, true),
+    body: JSON.stringify(opts),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as AuthCreateResult;
+}
+
+export async function authList(
+  serverUrl: string,
+  apiKey: string | undefined,
+  opts: { active: boolean },
+): Promise<ApiKeyListItem[]> {
+  const params = new URLSearchParams();
+  params.set('active', opts.active ? 'true' : 'false');
+  const res = await fetch(`${serverUrl}/v1/auth/keys?${params.toString()}`, {
+    method: 'GET',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as ApiKeyListItem[];
+}
+
+export async function authRevoke(
+  serverUrl: string,
+  apiKey: string | undefined,
+  keyId: string,
+): Promise<{ ok: true; revokedAt: string }> {
+  const res = await fetch(`${serverUrl}/v1/auth/keys/${encodeURIComponent(keyId)}`, {
+    method: 'DELETE',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as { ok: true; revokedAt: string };
+}
+
+export async function auditList(
+  serverUrl: string,
+  apiKey: string | undefined,
+  opts: AuditListOpts,
+): Promise<AuditEvent[]> {
+  const params = new URLSearchParams();
+  if (opts.op !== undefined) params.set('op', opts.op);
+  if (opts.since !== undefined) params.set('since', opts.since);
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const qs = params.toString();
+  const url = qs.length > 0 ? `${serverUrl}/v1/audit?${qs}` : `${serverUrl}/v1/audit`;
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: buildHeaders(apiKey, false),
+  });
+  if (!res.ok) await throwForStatus(res);
+  return await res.json() as AuditEvent[];
+}
+
+/**
+ * True for fetch failures that look like "server not actually running" (the
+ * pidfile said one was, but the connection refused, or DNS / abort errors).
+ * The CLI uses this to detect a stale pidfile and self-heal back to direct mode.
+ */
+export function isConnectionRefused(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const message = err.message.toLowerCase();
+  // Node fetch wraps the underlying cause; the surface message contains 'fetch failed'
+  // and the cause has the syscall code. We check both shapes.
+  if (message.includes('econnrefused')) return true;
+  if (message.includes('connect econnrefused')) return true;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && typeof cause === 'object') {
+    const code = (cause as { code?: unknown }).code;
+    if (code === 'ECONNREFUSED' || code === 'ECONNRESET') return true;
+  }
+  // Fallthrough: 'fetch failed' alone is suspicious. Treat as connection failure
+  // so the CLI heals on a stale pidfile rather than surfacing a cryptic error.
+  if (message.includes('fetch failed')) return true;
+  return false;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -63,6 +63,22 @@ interface McpResponse {
 
 export type { McpRequest, McpResponse };
 
+/**
+ * Optional execution context threaded from a non-stdio transport. When the
+ * HTTP transport in src/server.ts calls handleMcpRequest, it knows the
+ * server's bound hippoRoot and the auth-resolved tenantId/actor. Passing
+ * those through here lets executeTool skip the findHippoRoot() walk and
+ * the env-based resolveTenantId({}) fallback — both of which would
+ * otherwise produce the wrong store and the wrong tenant for HTTP callers.
+ *
+ * Stdio callers pass nothing; behavior stays unchanged for that path.
+ */
+export interface McpContext {
+  hippoRoot: string;
+  tenantId: string;
+  actor: string;
+}
+
 // MCP stdio transport spec: messages are newline-delimited JSON-RPC, no embedded newlines.
 // https://modelcontextprotocol.io/specification/.../basic/transports#stdio
 function send(msg: McpResponse): void {
@@ -220,14 +236,24 @@ let lastRecalledIds: string[] = [];
 
 // ── Tool execution ──
 
-async function executeTool(name: string, args: Record<string, unknown>): Promise<string> {
-  const hippoRoot = findHippoRoot();
+async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx?: McpContext,
+): Promise<string> {
+  // When a transport hands us a context (HTTP path), trust it: the HTTP
+  // server already resolved hippoRoot from its bound opts and tenantId
+  // from the Bearer token (or the loopback fallback). The stdio path
+  // continues to walk from cwd / fall back to the global root, and to
+  // resolve tenant from HIPPO_TENANT.
+  const hippoRoot = ctx?.hippoRoot ?? findHippoRoot();
   if (!hippoRoot) return 'No .hippo/ store found. Run: hippo init';
 
   const config = loadConfig(hippoRoot);
   // A5: every loadAllEntries() in this server returns to the caller and is
-  // tenant-isolated. Resolved once per tool call from HIPPO_TENANT (or default).
-  const tenantId = resolveTenantId({});
+  // tenant-isolated. Resolved once per tool call: prefer the transport's
+  // ctx.tenantId so an HTTP Bearer for tenant B doesn't drop to HIPPO_TENANT.
+  const tenantId = ctx?.tenantId ?? resolveTenantId({});
 
   switch (name) {
     case 'hippo_recall': {
@@ -263,6 +289,7 @@ async function executeTool(name: string, args: Record<string, unknown>): Promise
         confidence: 'verified',
         baseHalfLifeDays: config.defaultHalfLifeDays,
         schema_fit: schemaFit,
+        tenantId,
       });
       writeEntry(hippoRoot, entry);
 
@@ -379,6 +406,7 @@ async function executeTool(name: string, args: Record<string, unknown>): Promise
           source: 'git',
           confidence: 'observed',
           baseHalfLifeDays: config.defaultHalfLifeDays,
+          tenantId,
         });
         writeEntry(hippoRoot, entry);
         added++;
@@ -434,7 +462,10 @@ async function executeTool(name: string, args: Record<string, unknown>): Promise
  * expected) and a McpResponse otherwise. Errors thrown by `executeTool` are
  * the caller's problem — wrap with try/catch on the transport side.
  */
-export async function handleMcpRequest(req: McpRequest): Promise<McpResponse | null> {
+export async function handleMcpRequest(
+  req: McpRequest,
+  ctx?: McpContext,
+): Promise<McpResponse | null> {
   const { id, method, params } = req;
 
   switch (method) {
@@ -458,7 +489,7 @@ export async function handleMcpRequest(req: McpRequest): Promise<McpResponse | n
     case 'tools/call': {
       const toolName = (params as any)?.name;
       const toolArgs = (params as any)?.arguments ?? {};
-      const output = await executeTool(toolName, toolArgs);
+      const output = await executeTool(toolName, toolArgs, ctx);
       return {
         jsonrpc: '2.0',
         id,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -61,6 +61,8 @@ interface McpResponse {
   error?: { code: number; message: string };
 }
 
+export type { McpRequest, McpResponse };
+
 // MCP stdio transport spec: messages are newline-delimited JSON-RPC, no embedded newlines.
 // https://modelcontextprotocol.io/specification/.../basic/transports#stdio
 function send(msg: McpResponse): void {
@@ -425,7 +427,14 @@ async function executeTool(name: string, args: Record<string, unknown>): Promise
 
 // ── Request handling ──
 
-async function handleRequest(req: McpRequest): Promise<McpResponse | null> {
+/**
+ * Transport-agnostic MCP dispatcher. Both the stdio loop (below) and the
+ * HTTP/SSE transport in src/server.ts route every incoming JSON-RPC message
+ * through this single function. Returns null for notifications (no response
+ * expected) and a McpResponse otherwise. Errors thrown by `executeTool` are
+ * the caller's problem — wrap with try/catch on the transport side.
+ */
+export async function handleMcpRequest(req: McpRequest): Promise<McpResponse | null> {
   const { id, method, params } = req;
 
   switch (method) {
@@ -485,29 +494,61 @@ function dispatch(body: string): void {
   }
   if (!req.method) return;
   if (req.method.startsWith('notifications/')) {
-    handleRequest(req).catch(() => {});
+    handleMcpRequest(req).catch(() => {});
     return;
   }
-  handleRequest(req).then((resp) => { if (resp) send(resp); }).catch((err) => {
+  handleMcpRequest(req).then((resp) => { if (resp) send(resp); }).catch((err) => {
     send({ jsonrpc: '2.0', id: req.id, error: { code: -32603, message: err?.message ?? 'Internal error' } });
   });
 }
 
-process.stdin.on('data', (chunk: Buffer) => {
-  buffer = Buffer.concat([buffer, chunk]);
-  while (true) {
-    const result = parseFrame(buffer);
-    if (result.kind === 'incomplete') break;
-    buffer = result.rest;
-    if (result.kind === 'message') dispatch(result.body);
+/**
+ * Wire stdin/stdout to the dispatcher. Idempotent — only the entrypoint
+ * (cli.ts `hippo mcp`, or running this file directly) should call this.
+ * src/server.ts imports `handleMcpRequest` without invoking this, so the
+ * HTTP daemon does not steal stdin or exit when its parent closes a pipe.
+ */
+export function startStdioLoop(): void {
+  process.stdin.on('data', (chunk: Buffer) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (true) {
+      const result = parseFrame(buffer);
+      if (result.kind === 'incomplete') break;
+      buffer = result.rest;
+      if (result.kind === 'message') dispatch(result.body);
+    }
+  });
+
+  process.stdin.on('end', () => process.exit(0));
+
+  process.on('uncaughtException', (err) => {
+    process.stderr.write(`hippo-mcp uncaught: ${err?.message ?? err}\n`);
+  });
+  process.on('unhandledRejection', (err) => {
+    process.stderr.write(`hippo-mcp unhandled: ${err instanceof Error ? err.message : String(err)}\n`);
+  });
+}
+
+// Auto-start when invoked as the main module (node dist/mcp/server.js or via
+// the cli's `import('./mcp/server.js')`). Importing this file from another
+// module (e.g. src/server.ts wiring up the HTTP/SSE transport) will NOT
+// trigger the stdio loop. The cli imports this file specifically to start
+// stdio; that import is also `import.meta.url === main`-equivalent because
+// it's executed as the program, so we keep a fallback: if HIPPO_MCP_STDIO=1
+// or argv1 ends in /mcp/server.js we start.
+const isMainModule = (() => {
+  try {
+    const argv1 = process.argv[1] ?? '';
+    if (argv1.endsWith('mcp/server.js') || argv1.endsWith('mcp\\server.js')) return true;
+    if (process.env.HIPPO_MCP_STDIO === '1') return true;
+    // ESM main-module check
+    const mainUrl = `file://${argv1.replace(/\\/g, '/')}`;
+    return import.meta.url === mainUrl || import.meta.url === `file:///${argv1.replace(/\\/g, '/')}`;
+  } catch {
+    return false;
   }
-});
+})();
 
-process.stdin.on('end', () => process.exit(0));
-
-process.on('uncaughtException', (err) => {
-  process.stderr.write(`hippo-mcp uncaught: ${err?.message ?? err}\n`);
-});
-process.on('unhandledRejection', (err) => {
-  process.stderr.write(`hippo-mcp unhandled: ${err instanceof Error ? err.message : String(err)}\n`);
-});
+if (isMainModule) {
+  startStdioLoop();
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -445,7 +445,7 @@ export async function handleMcpRequest(req: McpRequest): Promise<McpResponse | n
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'hippo-memory', version: '0.19.1' },
+          serverInfo: { name: 'hippo-memory', version: '0.36.0' },
         },
       };
 

--- a/src/server-detect.ts
+++ b/src/server-detect.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ServerInfo {
+  pid: number;
+  port: number;
+  url: string;
+  started_at: string;
+}
+
+const PIDFILE = '.hippo/server.pid';
+
+/**
+ * Read .hippo/server.pid and return the embedded ServerInfo if the recorded
+ * pid is still alive. Returns null on missing, malformed, or stale pidfiles,
+ * and best-effort unlinks the file in the latter two cases.
+ */
+export function detectServer(hippoRoot: string): ServerInfo | null {
+  const path = join(hippoRoot, PIDFILE);
+  if (!existsSync(path)) return null;
+
+  let info: ServerInfo;
+  try {
+    info = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+
+  // Probe the process. Sending signal 0 throws if the pid is dead or owned
+  // by another user we cannot signal. Either way, treat as stale.
+  // Node's process.kill(pid, 0) is implemented on Windows via OpenProcess +
+  // GetExitCodeProcess, so this works cross-platform for the dead-pid case.
+  try {
+    process.kill(info.pid, 0);
+  } catch {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+  return info;
+}
+
+/**
+ * Atomically write the pidfile. Writes to a process-scoped temp file then
+ * renames into place, which is atomic on POSIX and on NTFS via MoveFileEx.
+ */
+export function writePidfile(hippoRoot: string, opts: { port: number; url: string }): void {
+  const path = join(hippoRoot, PIDFILE);
+  const tmp = `${path}.tmp.${process.pid}`;
+  const info: ServerInfo = {
+    pid: process.pid,
+    port: opts.port,
+    url: opts.url,
+    started_at: new Date().toISOString(),
+  };
+  writeFileSync(tmp, JSON.stringify(info));
+  renameSync(tmp, path);
+}
+
+/**
+ * Best-effort pidfile removal. Silent on ENOENT or any other error so the
+ * caller can use this in shutdown paths without fear of throwing.
+ */
+export function removePidfile(hippoRoot: string): void {
+  const path = join(hippoRoot, PIDFILE);
+  try { unlinkSync(path); } catch {}
+}

--- a/src/server-detect.ts
+++ b/src/server-detect.ts
@@ -8,7 +8,10 @@ export interface ServerInfo {
   started_at: string;
 }
 
-const PIDFILE = '.hippo/server.pid';
+// Pidfile sits directly inside hippoRoot. `hippoRoot` is the `.hippo`
+// directory itself (the same convention used by api.ts / store.ts /
+// openHippoDb), so this resolves to `${hippoRoot}/server.pid`.
+const PIDFILE = 'server.pid';
 
 /**
  * Read .hippo/server.pid and return the embedded ServerInfo if the recorded

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,9 +8,29 @@ import {
   promote,
   supersede,
   archiveRaw,
+  authCreate,
+  authList,
+  authRevoke,
+  auditList,
   type Context,
 } from './api.js';
 import type { MemoryKind } from './memory.js';
+import type { AuditOp } from './audit.js';
+
+const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set([
+  'remember',
+  'recall',
+  'promote',
+  'supersede',
+  'forget',
+  'archive_raw',
+  'auth_revoke',
+]);
+
+// Cap on GET /v1/audit?limit=. Matches docs/api.md (when written) and is large
+// enough to dump a small deployment's full audit log without paginating, but
+// small enough that a malicious client can't ask for the world.
+const MAX_AUDIT_LIMIT = 10000;
 
 const VALID_KINDS: ReadonlySet<MemoryKind> = new Set([
   'raw',
@@ -288,6 +308,93 @@ async function handleRequest(
   if (method === 'DELETE' && idMatch) {
     const ctx = buildContext(opts.hippoRoot);
     const result = forget(ctx, idMatch.id!);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // POST /v1/auth/keys — mint a new API key. Plaintext lands in the response
+  // body (Task 8): the HTTP layer hands it to the client; the user-facing
+  // "store this somewhere safe" warning belongs in the CLI client, not here.
+  if (method === 'POST' && path === '/v1/auth/keys') {
+    const body = await parseJsonBody(req);
+    const labelRaw = body['label'];
+    if (labelRaw !== undefined && typeof labelRaw !== 'string') {
+      throw new HttpError(400, 'label must be a string');
+    }
+    const tenantIdRaw = body['tenantId'];
+    if (tenantIdRaw !== undefined && typeof tenantIdRaw !== 'string') {
+      throw new HttpError(400, 'tenantId must be a string');
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = authCreate(ctx, {
+      label: labelRaw,
+      tenantId: tenantIdRaw,
+    });
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // GET /v1/auth/keys?active=true — list keys visible to ctx.tenantId.
+  // `active` defaults to true so the common case (show me usable keys) is
+  // a single GET; ?active=false includes revoked rows.
+  if (method === 'GET' && path === '/v1/auth/keys') {
+    const activeRaw = query.get('active');
+    let active = true;
+    if (activeRaw !== null) {
+      if (activeRaw === 'true') active = true;
+      else if (activeRaw === 'false') active = false;
+      else throw new HttpError(400, "active must be 'true' or 'false'");
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = authList(ctx, { active });
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // DELETE /v1/auth/keys/:keyId — revoke. authRevoke throws "Unknown key_id"
+  // for missing OR cross-tenant keys (no info leak), which mapApiError
+  // converts to 404. We return 200 with the result body rather than 204 to
+  // surface revokedAt to the caller.
+  const keyMatch = matchPath('/v1/auth/keys/:keyId', path);
+  if (method === 'DELETE' && keyMatch) {
+    const ctx = buildContext(opts.hippoRoot);
+    const result = authRevoke(ctx, keyMatch.keyId!);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // GET /v1/audit?op=&since=&limit= — read audit events. All three filters
+  // validated at the route boundary so an invalid value lands a 400 before
+  // we hit the DB.
+  if (method === 'GET' && path === '/v1/audit') {
+    const opRaw = query.get('op');
+    let op: AuditOp | undefined;
+    if (opRaw !== null) {
+      if (!VALID_AUDIT_OPS.has(opRaw as AuditOp)) {
+        throw new HttpError(400, `invalid op: ${opRaw}`);
+      }
+      op = opRaw as AuditOp;
+    }
+    const sinceRaw = query.get('since');
+    let since: string | undefined;
+    if (sinceRaw !== null) {
+      const parsed = Date.parse(sinceRaw);
+      if (!Number.isFinite(parsed)) {
+        throw new HttpError(400, `invalid since: ${sinceRaw}`);
+      }
+      since = sinceRaw;
+    }
+    const limitRaw = query.get('limit');
+    let limit: number | undefined;
+    if (limitRaw !== null) {
+      const parsed = Number(limitRaw);
+      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1 || parsed > MAX_AUDIT_LIMIT) {
+        throw new HttpError(400, `limit must be an integer between 1 and ${MAX_AUDIT_LIMIT}`);
+      }
+      limit = parsed;
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = auditList(ctx, { op, since, limit });
     sendJson(res, 200, result);
     return;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -526,7 +526,12 @@ async function handleRequest(
   // loopback no-auth fallback. SSE check runs once at stream-open.
 
   if (method === 'POST' && path === '/mcp') {
-    requireAuth(req, opts.hippoRoot);
+    // Build the same Context the /v1/* routes use so MCP tool calls inherit
+    // the server's bound hippoRoot and the auth-resolved tenantId / actor.
+    // Without this, executeTool would walk from cwd via findHippoRoot() and
+    // pull tenant from HIPPO_TENANT, dropping a valid Bearer for tenant B
+    // back to whatever the env says.
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const raw = await readBody(req);
     let mcpReq: McpRequest;
     try {
@@ -539,7 +544,11 @@ async function handleRequest(
     }
     let mcpRes;
     try {
-      mcpRes = await handleMcpRequest(mcpReq);
+      mcpRes = await handleMcpRequest(mcpReq, {
+        hippoRoot: ctx.hippoRoot,
+        tenantId: ctx.tenantId,
+        actor: ctx.actor,
+      });
     } catch (err) {
       mcpRes = {
         jsonrpc: '2.0' as const,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,33 @@
-import { createServer, type Server } from 'node:http';
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { writePidfile, removePidfile } from './server-detect.js';
+import { resolveTenantId } from './tenant.js';
+import {
+  remember,
+  recall,
+  forget,
+  promote,
+  supersede,
+  archiveRaw,
+  type Context,
+} from './api.js';
+import type { MemoryKind } from './memory.js';
+
+const VALID_KINDS: ReadonlySet<MemoryKind> = new Set([
+  'raw',
+  'distilled',
+  'superseded',
+  'archived',
+]);
 
 // Pinned at module load. Bumped alongside package.json on releases. The
 // HTTP /health response uses this; reading package.json synchronously here
 // would couple the daemon to its on-disk install path, which we want to
 // avoid for tests that mkdtemp a hippoRoot.
 const VERSION = '0.35.0';
+
+// 1 MB body cap. The CLI never sends payloads near this; anything bigger is
+// almost certainly a misconfigured client or a deliberate memory-blowup attempt.
+const MAX_BODY_BYTES = 1024 * 1024;
 
 export interface ServerHandle {
   port: number;
@@ -20,6 +42,259 @@ export interface ServeOpts {
 }
 
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
+const JSON_HEADERS = { 'content-type': 'application/json' } as const;
+
+class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+class BodyTooLargeError extends Error {}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, JSON_HEADERS);
+  res.end(JSON.stringify(body));
+}
+
+function sendError(res: ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: message });
+}
+
+/**
+ * Read the entire request body into a Buffer. Caps at MAX_BODY_BYTES to keep
+ * a malicious or buggy client from exhausting memory. The cap is enforced
+ * mid-stream so we don't wait for an attacker to finish before erroring out.
+ */
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      throw new BodyTooLargeError('request body exceeds 1MB');
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function parseJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const raw = await readBody(req);
+  if (raw.length === 0) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new HttpError(400, 'request body must be a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (e) {
+    if (e instanceof HttpError) throw e;
+    throw new HttpError(400, 'invalid JSON body');
+  }
+}
+
+/**
+ * Map an error thrown by an api.* function into an HTTP status + message.
+ * api.* uses plain Error, so we discriminate by message pattern. Stable
+ * patterns we rely on:
+ *   - /not found/i  → 404 (forget on unknown id, supersede on unknown old id, etc.)
+ *   - /unknown/i    → 404 (auth_revoke on unknown key_id)
+ *   - /already superseded/i → 409 (chain conflict)
+ *   - /not raw/i    → 400 (archive_raw on non-raw row)
+ * Everything else maps to 400 (bad input).
+ */
+function mapApiError(err: unknown): { status: number; message: string } {
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  if (/not found/.test(lower) || /^unknown /.test(lower)) {
+    return { status: 404, message };
+  }
+  if (/already superseded/.test(lower)) {
+    return { status: 409, message };
+  }
+  return { status: 400, message };
+}
+
+interface ParsedRoute {
+  method: string;
+  path: string;
+  query: URLSearchParams;
+}
+
+function parseRequest(req: IncomingMessage): ParsedRoute {
+  const url = new URL(req.url ?? '/', 'http://placeholder');
+  return {
+    method: req.method ?? 'GET',
+    path: url.pathname,
+    query: url.searchParams,
+  };
+}
+
+/**
+ * Lightweight pattern matcher for /v1/memories/:id/<action>. Avoids pulling
+ * in a router dependency for the half-dozen patterns we actually use.
+ *
+ * Returns null if `path` does not match `pattern`. Otherwise returns an object
+ * mapping each :param name to its value. Path segments are exact-matched
+ * except for parameter slots.
+ */
+function matchPath(pattern: string, path: string): Record<string, string> | null {
+  const patternParts = pattern.split('/');
+  const pathParts = path.split('/');
+  if (patternParts.length !== pathParts.length) return null;
+  const params: Record<string, string> = {};
+  for (let i = 0; i < patternParts.length; i++) {
+    const pp = patternParts[i]!;
+    const ap = pathParts[i]!;
+    if (pp.startsWith(':')) {
+      if (ap.length === 0) return null;
+      params[pp.slice(1)] = decodeURIComponent(ap);
+    } else if (pp !== ap) {
+      return null;
+    }
+  }
+  return params;
+}
+
+function buildContext(hippoRoot: string): Context {
+  return {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    // Task 9 (auth middleware) overrides this for authenticated requests.
+    actor: 'localhost:cli',
+  };
+}
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const v = obj[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function getStringArray(obj: Record<string, unknown>, key: string): string[] | undefined {
+  const v = obj[key];
+  if (!Array.isArray(v)) return undefined;
+  if (!v.every((x) => typeof x === 'string')) return undefined;
+  return v as string[];
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: ServeOpts,
+  startedAt: string,
+): Promise<void> {
+  const { method, path, query } = parseRequest(req);
+
+  if (method === 'GET' && path === '/health') {
+    sendJson(res, 200, {
+      ok: true,
+      version: VERSION,
+      started_at: startedAt,
+      pid: process.pid,
+    });
+    return;
+  }
+
+  // POST /v1/memories
+  if (method === 'POST' && path === '/v1/memories') {
+    const body = await parseJsonBody(req);
+    const content = getString(body, 'content');
+    if (!content) {
+      throw new HttpError(400, 'content is required');
+    }
+    const kindRaw = getString(body, 'kind');
+    if (kindRaw !== undefined && !VALID_KINDS.has(kindRaw as MemoryKind)) {
+      throw new HttpError(400, `invalid kind: ${kindRaw}`);
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = remember(ctx, {
+      content,
+      kind: kindRaw as MemoryKind | undefined,
+      scope: getString(body, 'scope'),
+      owner: getString(body, 'owner'),
+      artifactRef: getString(body, 'artifactRef'),
+      tags: getStringArray(body, 'tags'),
+    });
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // GET /v1/memories?q=...&limit=...&mode=...
+  if (method === 'GET' && path === '/v1/memories') {
+    const q = query.get('q');
+    if (!q) {
+      throw new HttpError(400, 'q is required');
+    }
+    const limitRaw = query.get('limit');
+    const limit = limitRaw === null ? undefined : Number(limitRaw);
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
+      throw new HttpError(400, 'limit must be a positive number');
+    }
+    const mode = query.get('mode');
+    if (mode !== null && mode !== 'bm25' && mode !== 'hybrid' && mode !== 'physics') {
+      throw new HttpError(400, "mode must be 'bm25', 'hybrid', or 'physics'");
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = recall(ctx, {
+      query: q,
+      limit,
+      mode: (mode ?? undefined) as 'bm25' | 'hybrid' | 'physics' | undefined,
+    });
+    sendJson(res, 200, result);
+    return;
+  }
+
+  // /v1/memories/:id/* and DELETE /v1/memories/:id
+  const archiveMatch = matchPath('/v1/memories/:id/archive', path);
+  if (method === 'POST' && archiveMatch) {
+    const body = await parseJsonBody(req);
+    const reason = getString(body, 'reason');
+    if (!reason) {
+      throw new HttpError(400, 'reason is required');
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = archiveRaw(ctx, archiveMatch.id!, reason);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  const supersedeMatch = matchPath('/v1/memories/:id/supersede', path);
+  if (method === 'POST' && supersedeMatch) {
+    const body = await parseJsonBody(req);
+    const content = getString(body, 'content');
+    if (!content) {
+      throw new HttpError(400, 'content is required');
+    }
+    const ctx = buildContext(opts.hippoRoot);
+    const result = supersede(ctx, supersedeMatch.id!, content);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  const promoteMatch = matchPath('/v1/memories/:id/promote', path);
+  if (method === 'POST' && promoteMatch) {
+    const ctx = buildContext(opts.hippoRoot);
+    const result = promote(ctx, promoteMatch.id!);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  const idMatch = matchPath('/v1/memories/:id', path);
+  if (method === 'DELETE' && idMatch) {
+    const ctx = buildContext(opts.hippoRoot);
+    const result = forget(ctx, idMatch.id!);
+    sendJson(res, 200, result);
+    return;
+  }
+
+  res.writeHead(404, JSON_HEADERS);
+  res.end(JSON.stringify({ error: 'not found' }));
+}
 
 /**
  * Boot the HTTP daemon on host:port and write the pidfile under hippoRoot.
@@ -47,19 +322,22 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
   const startedAt = new Date().toISOString();
 
   const server: Server = createServer((req, res) => {
-    if (req.method === 'GET' && req.url === '/health') {
-      const body = JSON.stringify({
-        ok: true,
-        version: VERSION,
-        started_at: startedAt,
-        pid: process.pid,
-      });
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(body);
-      return;
-    }
-    res.writeHead(404, { 'content-type': 'application/json' });
-    res.end(JSON.stringify({ error: 'not found' }));
+    handleRequest(req, res, opts, startedAt).catch((err: unknown) => {
+      if (res.headersSent) {
+        try { res.end(); } catch { /* socket already gone */ }
+        return;
+      }
+      if (err instanceof BodyTooLargeError) {
+        sendError(res, 413, err.message);
+        return;
+      }
+      if (err instanceof HttpError) {
+        sendError(res, err.status, err.message);
+        return;
+      }
+      const mapped = mapApiError(err);
+      sendError(res, mapped.status, mapped.message);
+    });
   });
 
   await new Promise<void>((resolve, reject) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { writePidfile, removePidfile } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
+import { openHippoDb, closeHippoDb } from './db.js';
+import { validateApiKey } from './auth.js';
 import {
   remember,
   recall,
@@ -181,11 +183,87 @@ function matchPath(pattern: string, path: string): Record<string, string> | null
   return params;
 }
 
-function buildContext(hippoRoot: string): Context {
+/**
+ * Recognise loopback remote addresses. Node reports IPv6-mapped IPv4 as
+ * '::ffff:127.0.0.1' on dual-stack sockets, so we accept that alongside
+ * the bare v4 and v6 loopbacks. Anything else is treated as remote.
+ */
+export function isLoopback(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) return false;
+  if (remoteAddress === '127.0.0.1') return true;
+  if (remoteAddress === '::1') return true;
+  if (remoteAddress === '::ffff:127.0.0.1') return true;
+  return false;
+}
+
+/**
+ * Read the Authorization header in a case-insensitive way and pull the
+ * bearer token out. Returns:
+ *   - { kind: 'absent' } when no Authorization header is present
+ *   - { kind: 'malformed' } when the header is set but not 'Bearer <token>'
+ *   - { kind: 'bearer', token } when a non-empty bearer token is present
+ *
+ * The header NAME is case-insensitive (Node lowercases all header names on
+ * IncomingMessage.headers); the SCHEME ('Bearer') is also matched
+ * case-insensitively per RFC 6750.
+ */
+type AuthHeader =
+  | { kind: 'absent' }
+  | { kind: 'malformed' }
+  | { kind: 'bearer'; token: string };
+
+function readAuthHeader(req: IncomingMessage): AuthHeader {
+  const raw = req.headers['authorization'];
+  if (raw === undefined) return { kind: 'absent' };
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== 'string' || value.length === 0) return { kind: 'malformed' };
+  const space = value.indexOf(' ');
+  if (space < 0) return { kind: 'malformed' };
+  const scheme = value.slice(0, space);
+  const token = value.slice(space + 1).trim();
+  if (scheme.toLowerCase() !== 'bearer') return { kind: 'malformed' };
+  if (token.length === 0) return { kind: 'malformed' };
+  return { kind: 'bearer', token };
+}
+
+/**
+ * Build a per-request Context from the Authorization header and remote
+ * address. Throws HttpError(401) for invalid / missing credentials. Opens
+ * the DB only when a Bearer token is present so loopback no-auth requests
+ * stay cheap.
+ */
+function buildContextWithAuth(req: IncomingMessage, hippoRoot: string): Context {
+  const auth = readAuthHeader(req);
+
+  if (auth.kind === 'malformed') {
+    throw new HttpError(401, 'invalid api key');
+  }
+
+  if (auth.kind === 'bearer') {
+    const db = openHippoDb(hippoRoot);
+    try {
+      const result = validateApiKey(db, auth.token);
+      if (!result.valid || !result.tenantId || !result.keyId) {
+        throw new HttpError(401, 'invalid api key');
+      }
+      return {
+        hippoRoot,
+        tenantId: result.tenantId,
+        actor: `api_key:${result.keyId}`,
+      };
+    } finally {
+      closeHippoDb(db);
+    }
+  }
+
+  // No Authorization header. Loopback-only fallback.
+  if (!isLoopback(req.socket.remoteAddress)) {
+    throw new HttpError(401, 'auth required');
+  }
+
   return {
     hippoRoot,
     tenantId: resolveTenantId({}),
-    // Task 9 (auth middleware) overrides this for authenticated requests.
     actor: 'localhost:cli',
   };
 }
@@ -231,7 +309,7 @@ async function handleRequest(
     if (kindRaw !== undefined && !VALID_KINDS.has(kindRaw as MemoryKind)) {
       throw new HttpError(400, `invalid kind: ${kindRaw}`);
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = remember(ctx, {
       content,
       kind: kindRaw as MemoryKind | undefined,
@@ -259,7 +337,7 @@ async function handleRequest(
     if (mode !== null && mode !== 'bm25' && mode !== 'hybrid' && mode !== 'physics') {
       throw new HttpError(400, "mode must be 'bm25', 'hybrid', or 'physics'");
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = recall(ctx, {
       query: q,
       limit,
@@ -277,7 +355,7 @@ async function handleRequest(
     if (!reason) {
       throw new HttpError(400, 'reason is required');
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = archiveRaw(ctx, archiveMatch.id!, reason);
     sendJson(res, 200, result);
     return;
@@ -290,7 +368,7 @@ async function handleRequest(
     if (!content) {
       throw new HttpError(400, 'content is required');
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = supersede(ctx, supersedeMatch.id!, content);
     sendJson(res, 200, result);
     return;
@@ -298,7 +376,7 @@ async function handleRequest(
 
   const promoteMatch = matchPath('/v1/memories/:id/promote', path);
   if (method === 'POST' && promoteMatch) {
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = promote(ctx, promoteMatch.id!);
     sendJson(res, 200, result);
     return;
@@ -306,7 +384,7 @@ async function handleRequest(
 
   const idMatch = matchPath('/v1/memories/:id', path);
   if (method === 'DELETE' && idMatch) {
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = forget(ctx, idMatch.id!);
     sendJson(res, 200, result);
     return;
@@ -325,7 +403,7 @@ async function handleRequest(
     if (tenantIdRaw !== undefined && typeof tenantIdRaw !== 'string') {
       throw new HttpError(400, 'tenantId must be a string');
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = authCreate(ctx, {
       label: labelRaw,
       tenantId: tenantIdRaw,
@@ -345,7 +423,7 @@ async function handleRequest(
       else if (activeRaw === 'false') active = false;
       else throw new HttpError(400, "active must be 'true' or 'false'");
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = authList(ctx, { active });
     sendJson(res, 200, result);
     return;
@@ -357,7 +435,7 @@ async function handleRequest(
   // surface revokedAt to the caller.
   const keyMatch = matchPath('/v1/auth/keys/:keyId', path);
   if (method === 'DELETE' && keyMatch) {
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = authRevoke(ctx, keyMatch.keyId!);
     sendJson(res, 200, result);
     return;
@@ -393,7 +471,7 @@ async function handleRequest(
       }
       limit = parsed;
     }
-    const ctx = buildContext(opts.hippoRoot);
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = auditList(ctx, { op, since, limit });
     sendJson(res, 200, result);
     return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,106 @@
+import { createServer, type Server } from 'node:http';
+import { writePidfile, removePidfile } from './server-detect.js';
+
+// Pinned at module load. Bumped alongside package.json on releases. The
+// HTTP /health response uses this; reading package.json synchronously here
+// would couple the daemon to its on-disk install path, which we want to
+// avoid for tests that mkdtemp a hippoRoot.
+const VERSION = '0.35.0';
+
+export interface ServerHandle {
+  port: number;
+  url: string;
+  stop: () => Promise<void>;
+}
+
+export interface ServeOpts {
+  hippoRoot: string;
+  port?: number;
+  host?: string;
+}
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
+/**
+ * Boot the HTTP daemon on host:port and write the pidfile under hippoRoot.
+ *
+ * Refuses non-loopback hosts at boot (Footgun #3 from the A1 plan): without
+ * the A5 v2 auth middleware we have no way to gate remote requests, so we
+ * fail fast rather than expose the DB to the network. Task 9 will lift this
+ * restriction once Bearer-token validation lands.
+ *
+ * Use port: 0 in tests to bind to an ephemeral port and read the actual
+ * port back via server.address() after listen.
+ */
+export async function serve(opts: ServeOpts): Promise<ServerHandle> {
+  const host = opts.host ?? '127.0.0.1';
+  const requestedPort = opts.port ?? Number(process.env.HIPPO_PORT ?? 6789);
+
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `Refusing to bind hippo serve to non-loopback host '${host}' without auth. ` +
+      `Remote-host serving requires the A5 v2 auth middleware (Task 9 of the A1 plan). ` +
+      `Bind to 127.0.0.1 / ::1 / localhost, or wait for auth support.`,
+    );
+  }
+
+  const startedAt = new Date().toISOString();
+
+  const server: Server = createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      const body = JSON.stringify({
+        ok: true,
+        version: VERSION,
+        started_at: startedAt,
+        pid: process.pid,
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(requestedPort, host);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('server.address() returned unexpected shape');
+  }
+  const actualPort = address.port;
+  const url = `http://${host}:${actualPort}`;
+
+  writePidfile(opts.hippoRoot, { port: actualPort, url });
+
+  let stopping = false;
+  const stop = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    removePidfile(opts.hippoRoot);
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  };
+
+  // Skip signal handlers under vitest so each test run does not register a
+  // stray SIGTERM/SIGINT listener that survives until the runner exits.
+  if (!process.env.VITEST) {
+    process.once('SIGTERM', () => { void stop(); });
+    process.once('SIGINT', () => { void stop(); });
+  }
+
+  return { port: actualPort, url, stop };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,7 @@ const VALID_KINDS: ReadonlySet<MemoryKind> = new Set([
 // HTTP /health response uses this; reading package.json synchronously here
 // would couple the daemon to its on-disk install path, which we want to
 // avoid for tests that mkdtemp a hippoRoot.
-const VERSION = '0.35.0';
+const VERSION = '0.36.0';
 
 // 1 MB body cap. The CLI never sends payloads near this; anything bigger is
 // almost certainly a misconfigured client or a deliberate memory-blowup attempt.
@@ -657,6 +657,11 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
     if (stopping) return;
     stopping = true;
     removePidfile(opts.hippoRoot);
+    // Force-close any long-lived idle connections (e.g. SSE keepalive streams
+    // on /mcp/stream) so server.close() can resolve. Without this, SIGTERM
+    // would hang the process until the SSE client cancels. Available on
+    // Node 18.2+; gate via optional chaining to avoid crashing on older runtimes.
+    server.closeAllConnections?.();
     await new Promise<void>((resolve) => {
       server.close(() => resolve());
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
 } from './api.js';
 import type { MemoryKind } from './memory.js';
 import type { AuditOp } from './audit.js';
+import { handleMcpRequest, type McpRequest } from './mcp/server.js';
 
 const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set([
   'remember',
@@ -268,6 +269,34 @@ function buildContextWithAuth(req: IncomingMessage, hippoRoot: string): Context 
   };
 }
 
+/**
+ * Auth check for routes that do not need a tenant Context (e.g. MCP transport,
+ * which builds its own root resolution via findHippoRoot). Throws HttpError
+ * 401 the same way buildContextWithAuth does, but skips building the Context
+ * envelope. Loopback no-auth still passes.
+ */
+function requireAuth(req: IncomingMessage, hippoRoot: string): void {
+  const auth = readAuthHeader(req);
+  if (auth.kind === 'malformed') {
+    throw new HttpError(401, 'invalid api key');
+  }
+  if (auth.kind === 'bearer') {
+    const db = openHippoDb(hippoRoot);
+    try {
+      const result = validateApiKey(db, auth.token);
+      if (!result.valid) {
+        throw new HttpError(401, 'invalid api key');
+      }
+    } finally {
+      closeHippoDb(db);
+    }
+    return;
+  }
+  if (!isLoopback(req.socket.remoteAddress)) {
+    throw new HttpError(401, 'auth required');
+  }
+}
+
 function getString(obj: Record<string, unknown>, key: string): string | undefined {
   const v = obj[key];
   return typeof v === 'string' ? v : undefined;
@@ -474,6 +503,81 @@ async function handleRequest(
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = auditList(ctx, { op, since, limit });
     sendJson(res, 200, result);
+    return;
+  }
+
+  // ── MCP-over-HTTP/SSE transport (Task 11) ──
+  //
+  // Two routes implement an MCP HTTP transport alongside the stdio one. Both
+  // dispatch to the same `handleMcpRequest` as the stdio loop in src/mcp/server.ts.
+  //
+  // POST /mcp        — Send a JSON-RPC request, get a JSON-RPC response synchronously
+  //                    in the body. Content-type: application/json both ways.
+  // GET  /mcp/stream — Open an SSE stream for server-initiated messages.
+  //                    v1 simplification: this stream is keepalive-only. Clients
+  //                    that need server-pushed notifications/progress will see
+  //                    only `: ping` comments every 30s. All real responses come
+  //                    back synchronously on POST /mcp. This matches the
+  //                    "synchronous JSON in body" leg of the MCP HTTP spec and
+  //                    is enough for `tools/list` / `tools/call` round-trips.
+  //                    Server-initiated SSE messages will be wired in a later task.
+  //
+  // Auth: same as /v1/* — Bearer token validated via `requireAuth`, with the
+  // loopback no-auth fallback. SSE check runs once at stream-open.
+
+  if (method === 'POST' && path === '/mcp') {
+    requireAuth(req, opts.hippoRoot);
+    const raw = await readBody(req);
+    let mcpReq: McpRequest;
+    try {
+      mcpReq = JSON.parse(raw) as McpRequest;
+    } catch {
+      throw new HttpError(400, 'invalid JSON-RPC body');
+    }
+    if (!mcpReq || typeof mcpReq !== 'object' || typeof mcpReq.method !== 'string') {
+      throw new HttpError(400, 'JSON-RPC body must include a method string');
+    }
+    let mcpRes;
+    try {
+      mcpRes = await handleMcpRequest(mcpReq);
+    } catch (err) {
+      mcpRes = {
+        jsonrpc: '2.0' as const,
+        id: mcpReq.id,
+        error: { code: -32603, message: err instanceof Error ? err.message : 'internal error' },
+      };
+    }
+    if (mcpRes === null) {
+      // Notification — no body, 202 Accepted.
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+    sendJson(res, 200, mcpRes);
+    return;
+  }
+
+  if (method === 'GET' && path === '/mcp/stream') {
+    requireAuth(req, opts.hippoRoot);
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    });
+    // Initial ping so smoke tests can confirm the stream is live without
+    // waiting 30s for the first keepalive interval.
+    res.write(': ping\n\n');
+    const ping = setInterval(() => {
+      try {
+        res.write(': ping\n\n');
+      } catch {
+        clearInterval(ping);
+      }
+    }, 30000);
+    // Don't keep the event loop alive just for this timer — the server's
+    // listener already does that, and tests want the process to exit cleanly.
+    if (typeof ping.unref === 'function') ping.unref();
+    req.on('close', () => clearInterval(ping));
     return;
   }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -49,7 +49,11 @@ export function initGlobal(): void {
  * Assigns a new ID (prefixed with 'g_') to avoid collisions.
  * Returns the new global entry.
  */
-export function promoteToGlobal(localRoot: string, id: string): MemoryEntry {
+export function promoteToGlobal(
+  localRoot: string,
+  id: string,
+  opts?: { actor?: string },
+): MemoryEntry {
   const entry = readEntry(localRoot, id);
   if (!entry) throw new Error(`Memory not found: ${id}`);
 
@@ -63,7 +67,7 @@ export function promoteToGlobal(localRoot: string, id: string): MemoryEntry {
     source: `promoted:${localRoot}`,
   };
 
-  writeEntry(globalRoot, globalEntry);
+  writeEntry(globalRoot, globalEntry, { actor: opts?.actor });
   return globalEntry;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,11 +33,13 @@ function audit(
   op: AuditOp,
   targetId?: string,
   metadata?: Record<string, unknown>,
+  actor: string = 'cli',
+  tenantId?: string,
 ): void {
   try {
     appendAuditEvent(db, {
-      tenantId: resolveTenantId({}),
-      actor: 'cli',
+      tenantId: tenantId ?? resolveTenantId({}),
+      actor,
       op,
       targetId,
       metadata,
@@ -932,18 +934,34 @@ export function saveIndex(hippoRoot: string, index: HippoIndex): void {
 
 /**
  * Write a memory entry to SQLite and refresh compatibility mirrors.
+ *
+ * `opts.actor` defaults to 'cli' so unauthenticated direct-CLI callers still
+ * get the right audit attribution. The HTTP server (A1) and api.* layer pass
+ * the resolved actor (`api_key:<key_id>` / `localhost:cli`) so audit events
+ * land with one row per write, no double-emit.
  */
-export function writeEntry(hippoRoot: string, entry: MemoryEntry): void {
+export function writeEntry(
+  hippoRoot: string,
+  entry: MemoryEntry,
+  opts?: { actor?: string },
+): void {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
     upsertEntryRow(db, entry);
     writeMarkdownMirror(hippoRoot, entry);
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
-    audit(db, 'remember', entry.id, {
-      kind: entry.kind ?? 'distilled',
-      scope: entry.scope ?? null,
-    });
+    audit(
+      db,
+      'remember',
+      entry.id,
+      {
+        kind: entry.kind ?? 'distilled',
+        scope: entry.scope ?? null,
+      },
+      opts?.actor ?? 'cli',
+      entry.tenantId,
+    );
   } finally {
     closeHippoDb(db);
   }
@@ -975,19 +993,29 @@ export function readEntry(hippoRoot: string, id: string, tenantId?: string): Mem
 
 /**
  * Delete an entry from SQLite and mirrors.
+ *
+ * `opts.actor` defaults to 'cli'. The api.* layer threads `ctx.actor` so HTTP
+ * callers land with `api_key:<key_id>` in the audit log without a duplicate
+ * emit from the api wrapper.
  */
-export function deleteEntry(hippoRoot: string, id: string): boolean {
+export function deleteEntry(
+  hippoRoot: string,
+  id: string,
+  opts?: { actor?: string },
+): boolean {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    const exists = db.prepare(`SELECT id FROM memories WHERE id = ?`).get(id) as { id?: string } | undefined;
-    if (!exists?.id) return false;
+    const row = db
+      .prepare(`SELECT id, tenant_id FROM memories WHERE id = ?`)
+      .get(id) as { id?: string; tenant_id?: string } | undefined;
+    if (!row?.id) return false;
 
     db.prepare(`DELETE FROM memories WHERE id = ?`).run(id);
     deleteFtsRow(db, id);
     removeEntryMirrors(hippoRoot, id);
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
-    audit(db, 'forget', id);
+    audit(db, 'forget', id, undefined, opts?.actor ?? 'cli', row.tenant_id);
     return true;
   } finally {
     closeHippoDb(db);

--- a/tests/api-domain.test.ts
+++ b/tests/api-domain.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, readEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
+import { remember, recall, forget, promote, supersede } from '../src/api.js';
+
+describe('api domain — recall/forget/promote/supersede', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-api-dom-'));
+    globalHome = mkdtempSync(join(tmpdir(), 'hippo-api-glob-'));
+    initStore(home);
+    initStore(globalHome);
+    // Pin the global store to our tmpdir for promote().
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+  });
+
+  afterEach(() => {
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(globalHome, { recursive: true, force: true });
+  });
+
+  it('recall returns BM25 candidates and audits with the supplied actor', () => {
+    remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'cli' },
+      { content: 'recall-canary alpha-token sentinel' },
+    );
+    remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'cli' },
+      { content: 'unrelated content for noise' },
+    );
+
+    const result = recall(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_recall' },
+      { query: 'alpha-token' },
+    );
+
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0]!.content).toContain('alpha-token');
+    expect(result.results[0]!.id).toMatch(/^mem_/);
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.tokens).toBeGreaterThan(0);
+
+    const db = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'recall' });
+      expect(events[0]!.actor).toBe('api_key:hk_recall');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('forget deletes the row and audits with the supplied actor', () => {
+    const { id } = remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'cli' },
+      { content: 'forget-me-please' },
+    );
+    expect(readEntry(home, id)?.id).toBe(id);
+
+    const result = forget(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_forget' },
+      id,
+    );
+    expect(result).toEqual({ ok: true, id });
+    expect(readEntry(home, id)).toBeNull();
+
+    const db = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'forget' });
+      // The api.forget event lands AFTER the cli-default audit emit from
+      // deleteEntry, so DESC ordering returns ours first (matches Task 1
+      // shape; Task 4 will dedupe).
+      expect(events[0]!.actor).toBe('api_key:hk_forget');
+      expect(events[0]!.targetId).toBe(id);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('promote copies a memory into the global store and audits with the supplied actor', () => {
+    const { id } = remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'cli' },
+      { content: 'promote-me-to-global' },
+    );
+
+    const result = promote(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_promote' },
+      id,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.sourceId).toBe(id);
+    expect(result.globalId).toMatch(/^g_/);
+
+    // Global copy exists with new id.
+    const globalEntry = readEntry(globalHome, result.globalId);
+    expect(globalEntry?.content).toBe('promote-me-to-global');
+
+    const db = openHippoDb(globalHome);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'promote' });
+      expect(events[0]!.actor).toBe('api_key:hk_promote');
+      expect(events[0]!.targetId).toBe(result.globalId);
+      expect(events[0]!.metadata).toMatchObject({ sourceId: id });
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('supersede chains old -> new and audits with the supplied actor', () => {
+    const { id: oldId } = remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'cli' },
+      { content: 'original-belief' },
+    );
+
+    const result = supersede(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_supersede' },
+      oldId,
+      'updated-belief',
+    );
+    expect(result.ok).toBe(true);
+    expect(result.oldId).toBe(oldId);
+    expect(result.newId).toMatch(/^mem_/);
+    expect(result.newId).not.toBe(oldId);
+
+    const oldEntry = readEntry(home, oldId);
+    const newEntry = readEntry(home, result.newId);
+    expect(oldEntry?.superseded_by).toBe(result.newId);
+    expect(newEntry?.content).toBe('updated-belief');
+
+    const db = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'supersede' });
+      expect(events[0]!.actor).toBe('api_key:hk_supersede');
+      expect(events[0]!.targetId).toBe(oldId);
+      expect(events[0]!.metadata).toMatchObject({ newId: result.newId });
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});

--- a/tests/api-domain.test.ts
+++ b/tests/api-domain.test.ts
@@ -5,7 +5,19 @@ import { join } from 'node:path';
 import { initStore, readEntry } from '../src/store.js';
 import { openHippoDb, closeHippoDb } from '../src/db.js';
 import { queryAuditEvents } from '../src/audit.js';
-import { remember, recall, forget, promote, supersede } from '../src/api.js';
+import {
+  remember,
+  recall,
+  forget,
+  promote,
+  supersede,
+  archiveRaw,
+  authCreate,
+  authList,
+  authRevoke,
+  auditList,
+} from '../src/api.js';
+import { appendAuditEvent } from '../src/audit.js';
 
 describe('api domain — recall/forget/promote/supersede', () => {
   let home: string;
@@ -148,5 +160,162 @@ describe('api domain — recall/forget/promote/supersede', () => {
     } finally {
       closeHippoDb(db);
     }
+  });
+});
+
+describe('api domain — archive_raw / auth / audit', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-api-aux-'));
+    initStore(home);
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('archiveRaw moves a kind=raw row into raw_archive and removes it from memories', () => {
+    // createMemory defaults to distilled, but archiveRawMemory only accepts
+    // kind='raw'. Insert a raw row directly via SQL to seed the test.
+    const db = openHippoDb(home);
+    let rawId: string;
+    try {
+      rawId = `mem_raw_${Math.random().toString(36).slice(2, 10)}`;
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO memories(
+           id, created, last_retrieved, retrieval_count, strength, half_life_days, layer,
+           tags_json, emotional_valence, schema_fit, source, outcome_score,
+           outcome_positive, outcome_negative,
+           conflicts_with_json, pinned, confidence, content,
+           parents_json, starred,
+           valid_from, kind, tenant_id, updated_at
+         ) VALUES (?, ?, ?, 0, 0.5, 30, 'episodic',
+                   '[]', 0, 0, 'manual', 0,
+                   0, 0,
+                   '[]', 0, 'verified', 'raw-payload-canary',
+                   '[]', 0,
+                   ?, 'raw', 'default', datetime('now'))`,
+      ).run(rawId, now, now, now);
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const result = archiveRaw(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_archive' },
+      rawId,
+      'gdpr-request',
+    );
+    expect(result.ok).toBe(true);
+    expect(result.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Row should be gone from memories, snapshot present in raw_archive,
+    // and an archive_raw audit event with the supplied actor.
+    const db2 = openHippoDb(home);
+    try {
+      const stillThere = db2.prepare(`SELECT id FROM memories WHERE id = ?`).get(rawId);
+      expect(stillThere).toBeUndefined();
+
+      const archived = db2
+        .prepare(`SELECT memory_id, reason, archived_by FROM raw_archive WHERE memory_id = ?`)
+        .get(rawId) as { memory_id: string; reason: string; archived_by: string } | undefined;
+      expect(archived?.memory_id).toBe(rawId);
+      expect(archived?.reason).toBe('gdpr-request');
+      expect(archived?.archived_by).toBe('api_key:hk_archive');
+
+      const events = queryAuditEvents(db2, { tenantId: 'default', op: 'archive_raw' });
+      expect(events.length).toBe(1); // not double-emitted
+      expect(events[0]!.actor).toBe('api_key:hk_archive');
+      expect(events[0]!.targetId).toBe(rawId);
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('authCreate + authList + authRevoke flow with cross-tenant guard', () => {
+    const ctxA = { hippoRoot: home, tenantId: 'tenant-a', actor: 'cli' };
+    const ctxB = { hippoRoot: home, tenantId: 'tenant-b', actor: 'cli' };
+
+    const k1 = authCreate(ctxA, { label: 'first' });
+    expect(k1.keyId).toMatch(/^hk_/);
+    expect(k1.plaintext).toContain(`${k1.keyId}.`);
+    expect(k1.tenantId).toBe('tenant-a');
+
+    const k2 = authCreate(ctxA, { label: 'second' });
+    const kOther = authCreate(ctxB, { label: 'other-tenant' });
+
+    // List active for tenant-a sees k1 + k2 only (not kOther).
+    const activeA = authList(ctxA, { active: true });
+    const activeIds = activeA.map((k) => k.keyId).sort();
+    expect(activeIds).toEqual([k1.keyId, k2.keyId].sort());
+
+    // Revoke k2 as tenant-a.
+    const revoked = authRevoke(ctxA, k2.keyId);
+    expect(revoked.ok).toBe(true);
+    expect(revoked.revokedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // After revoke: active = [k1], all = [k1, k2].
+    const activeAfter = authList(ctxA, { active: true });
+    expect(activeAfter.map((k) => k.keyId)).toEqual([k1.keyId]);
+    const allAfter = authList(ctxA, { active: false });
+    expect(allAfter.map((k) => k.keyId).sort()).toEqual([k1.keyId, k2.keyId].sort());
+
+    // Cross-tenant revoke must be rejected with the same "not found" message
+    // as a missing key, so caller cannot probe other tenants' key_ids.
+    expect(() => authRevoke(ctxA, kOther.keyId)).toThrow(/Unknown key_id/);
+
+    // kOther must still be active on tenant-b.
+    const activeB = authList(ctxB, { active: true });
+    expect(activeB.map((k) => k.keyId)).toEqual([kOther.keyId]);
+
+    // Audit: the auth_revoke event uses the KEY's tenant, not ctx.tenantId.
+    // Here ctx.tenantId === key.tenant_id (both tenant-a) so the check is
+    // implicit; the cross-tenant case throws before audit and so leaves no
+    // audit trail.
+    const db = openHippoDb(home);
+    try {
+      const aEvents = queryAuditEvents(db, { tenantId: 'tenant-a', op: 'auth_revoke' });
+      expect(aEvents.length).toBe(1);
+      expect(aEvents[0]!.targetId).toBe(k2.keyId);
+
+      const bEvents = queryAuditEvents(db, { tenantId: 'tenant-b', op: 'auth_revoke' });
+      expect(bEvents.length).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('auditList scopes to ctx.tenantId and filters by op', () => {
+    // Seed events directly so the test is independent of remember/recall.
+    const db = openHippoDb(home);
+    try {
+      appendAuditEvent(db, { tenantId: 'tenant-a', actor: 'cli', op: 'remember', targetId: 'a1' });
+      appendAuditEvent(db, { tenantId: 'tenant-a', actor: 'cli', op: 'forget', targetId: 'a2' });
+      appendAuditEvent(db, { tenantId: 'tenant-b', actor: 'cli', op: 'remember', targetId: 'b1' });
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const aAll = auditList(
+      { hippoRoot: home, tenantId: 'tenant-a', actor: 'cli' },
+      {},
+    );
+    expect(aAll.length).toBe(2);
+    expect(aAll.every((e) => e.tenantId === 'tenant-a')).toBe(true);
+
+    const aRemember = auditList(
+      { hippoRoot: home, tenantId: 'tenant-a', actor: 'cli' },
+      { op: 'remember' },
+    );
+    expect(aRemember.length).toBe(1);
+    expect(aRemember[0]!.targetId).toBe('a1');
+
+    const bAll = auditList(
+      { hippoRoot: home, tenantId: 'tenant-b', actor: 'cli' },
+      {},
+    );
+    expect(bAll.length).toBe(1);
+    expect(bAll[0]!.targetId).toBe('b1');
   });
 });

--- a/tests/api-domain.test.ts
+++ b/tests/api-domain.test.ts
@@ -68,6 +68,7 @@ describe('api domain — recall/forget/promote/supersede', () => {
     const db = openHippoDb(home);
     try {
       const events = queryAuditEvents(db, { tenantId: 'default', op: 'recall' });
+      expect(events.length).toBe(1);
       expect(events[0]!.actor).toBe('api_key:hk_recall');
     } finally {
       closeHippoDb(db);
@@ -91,9 +92,8 @@ describe('api domain — recall/forget/promote/supersede', () => {
     const db = openHippoDb(home);
     try {
       const events = queryAuditEvents(db, { tenantId: 'default', op: 'forget' });
-      // The api.forget event lands AFTER the cli-default audit emit from
-      // deleteEntry, so DESC ordering returns ours first (matches Task 1
-      // shape; Task 4 will dedupe).
+      // Task 4 dedupe: deleteEntry threads ctx.actor; exactly one event lands.
+      expect(events.length).toBe(1);
       expect(events[0]!.actor).toBe('api_key:hk_forget');
       expect(events[0]!.targetId).toBe(id);
     } finally {
@@ -122,6 +122,8 @@ describe('api domain — recall/forget/promote/supersede', () => {
     const db = openHippoDb(globalHome);
     try {
       const events = queryAuditEvents(db, { tenantId: 'default', op: 'promote' });
+      // Task 4 dedupe: exactly one 'promote' event on the global store.
+      expect(events.length).toBe(1);
       expect(events[0]!.actor).toBe('api_key:hk_promote');
       expect(events[0]!.targetId).toBe(result.globalId);
       expect(events[0]!.metadata).toMatchObject({ sourceId: id });
@@ -154,6 +156,10 @@ describe('api domain — recall/forget/promote/supersede', () => {
     const db = openHippoDb(home);
     try {
       const events = queryAuditEvents(db, { tenantId: 'default', op: 'supersede' });
+      // Task 4 dedupe: exactly one 'supersede' event with the supplied actor.
+      // (The two 'remember' events from the underlying writeEntry calls land
+      // under op='remember' and are not counted here.)
+      expect(events.length).toBe(1);
       expect(events[0]!.actor).toBe('api_key:hk_supersede');
       expect(events[0]!.targetId).toBe(oldId);
       expect(events[0]!.metadata).toMatchObject({ newId: result.newId });

--- a/tests/api-remember.test.ts
+++ b/tests/api-remember.test.ts
@@ -37,6 +37,8 @@ describe('api.remember', () => {
     const { queryAuditEvents } = await import('../src/audit.js');
     const db = openHippoDb(home);
     const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember' });
+    // Task 4 dedupe: exactly one audit row, with the supplied actor.
+    expect(events.length).toBe(1);
     expect(events[0]!.actor).toBe('api_key:hk_test');
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });

--- a/tests/api-remember.test.ts
+++ b/tests/api-remember.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, readEntry } from '../src/store.js';
+import { remember } from '../src/api.js';
+
+describe('api.remember', () => {
+  it('persists a memory and returns its envelope', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-api-rem-'));
+    initStore(home);
+    const result = remember({
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: 'cli',
+    }, {
+      content: 'api-canary-remember-77',
+      kind: 'distilled',
+    });
+    expect(result.id).toMatch(/^mem_/);
+    expect(result.kind).toBe('distilled');
+    expect(result.tenantId).toBe('default');
+    const stored = readEntry(home, result.id);
+    expect(stored?.content).toBe('api-canary-remember-77');
+    expect(stored?.tenantId).toBe('default');
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('emits an audit event with the supplied actor', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-api-rem-'));
+    initStore(home);
+    remember(
+      { hippoRoot: home, tenantId: 'default', actor: 'api_key:hk_test' },
+      { content: 'audit-trail-canary' },
+    );
+    const { openHippoDb, closeHippoDb } = await import('../src/db.js');
+    const { queryAuditEvents } = await import('../src/audit.js');
+    const db = openHippoDb(home);
+    const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember' });
+    expect(events[0]!.actor).toBe('api_key:hk_test');
+    closeHippoDb(db);
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/tests/api-tenant-deny.test.ts
+++ b/tests/api-tenant-deny.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { remember, forget, archiveRaw } from '../src/api.js';
+
+// Regression: archiveRaw and forget previously looked up the target row by
+// id alone, with no tenant filter. A valid Bearer for tenant A could
+// archive or delete tenant B's row by guessing or leaking the id. Both
+// paths now pre-check tenant_id and throw a not-found error on mismatch
+// (same shape as the missing-row error, no info leak).
+
+describe('api tenant deny — archiveRaw and forget', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-tenant-deny-'));
+    initStore(home);
+  });
+
+  afterEach(() => {
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  it('archiveRaw refuses to archive a row that belongs to another tenant', () => {
+    // Tenant A creates a kind='raw' memory.
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'raw-row-from-alpha tenant-deny canary', kind: 'raw' },
+    );
+
+    // Tenant B (bravo) tries to archive it. Should fail with not-found.
+    expect(() =>
+      archiveRaw(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+        'cross-tenant probe',
+      ),
+    ).toThrow(/memory not found/i);
+
+    // Original row must still exist with its kind intact.
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id, kind FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string; kind: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+      expect(row!.kind).toBe('raw');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('forget refuses to delete a row that belongs to another tenant', () => {
+    // Tenant A creates a kind='distilled' memory.
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'distilled-row-from-alpha tenant-deny canary', kind: 'distilled' },
+    );
+
+    // Tenant B tries to forget it.
+    expect(() =>
+      forget(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+      ),
+    ).toThrow(/memory not found/i);
+
+    // Original row must still exist.
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('forget still works for the owning tenant', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'owning-tenant forget happy-path' },
+    );
+    const result = forget(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      created.id,
+    );
+    expect(result.ok).toBe(true);
+
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT id FROM memories WHERE id = ?`)
+        .get(created.id) as { id?: string } | undefined;
+      expect(row).toBeUndefined();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});

--- a/tests/cli-thin-client.test.ts
+++ b/tests/cli-thin-client.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, writeFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
+
+/**
+ * Headline parity test for A1: when `hippo serve` is running, CLI invocations
+ * route through HTTP; when it's gone (or stale pidfile), they fall back to
+ * direct DB access. We assert by reading the audit log: HTTP path stamps
+ * actor='localhost:cli', direct path stamps actor='cli'.
+ */
+
+const REPO_ROOT = join(__dirname, '..');
+const CLI_PATH = join(REPO_ROOT, 'dist', 'cli.js');
+
+function makeWorkspace(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-thin-'));
+  const hippoRoot = join(home, '.hippo');
+  mkdirSync(hippoRoot, { recursive: true });
+  initStore(hippoRoot);
+  return home;
+}
+
+/**
+ * Pick a random high port and verify it's actually free by trying to bind a
+ * throwaway server. Retries a handful of times before giving up.
+ */
+async function pickFreePort(): Promise<number> {
+  const { createServer } = await import('node:http');
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const port = 30000 + Math.floor(Math.random() * 30000);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const probe = createServer();
+        probe.once('error', reject);
+        probe.listen(port, '127.0.0.1', () => {
+          probe.close(() => resolve());
+        });
+      });
+      return port;
+    } catch {
+      // taken; try another
+    }
+  }
+  throw new Error('could not find a free port after 8 attempts');
+}
+
+interface SpawnedServer {
+  child: ChildProcessWithoutNullStreams;
+  port: number;
+  url: string;
+  stop: () => Promise<void>;
+}
+
+async function startServer(workspace: string, port: number): Promise<SpawnedServer> {
+  const child = spawn(process.execPath, [CLI_PATH, 'serve', '--port', String(port)], {
+    cwd: workspace,
+    env: { ...process.env, HIPPO_PORT: String(port) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  let stdoutBuf = '';
+  let stderrBuf = '';
+  child.stdout.on('data', (chunk: Buffer) => { stdoutBuf += chunk.toString('utf8'); });
+  child.stderr.on('data', (chunk: Buffer) => { stderrBuf += chunk.toString('utf8'); });
+
+  // Wait for the pidfile to appear AND /health to respond. The pidfile-only
+  // gate is racy because writePidfile fires synchronously before the listen
+  // ack returns to userland; combine with a real health probe to be safe.
+  const pidfilePath = join(workspace, '.hippo', 'server.pid');
+  const deadline = Date.now() + 10_000;
+  let ready = false;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `hippo serve exited early (code=${child.exitCode}). stdout=${stdoutBuf} stderr=${stderrBuf}`,
+      );
+    }
+    if (existsSync(pidfilePath)) {
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/health`);
+        if (res.status === 200) { ready = true; break; }
+      } catch { /* server not up yet */ }
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  if (!ready) {
+    child.kill('SIGKILL');
+    throw new Error(`server did not become ready within 10s. stdout=${stdoutBuf} stderr=${stderrBuf}`);
+  }
+
+  const stop = async (): Promise<void> => {
+    if (child.exitCode !== null) return;
+    child.kill('SIGTERM');
+    // Windows doesn't actually deliver SIGTERM; fall back to SIGKILL after a beat.
+    const stopDeadline = Date.now() + 3_000;
+    while (Date.now() < stopDeadline && child.exitCode === null) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (child.exitCode === null) child.kill('SIGKILL');
+    // Wait for the pidfile to be cleared OR for the process to be gone, then
+    // best-effort wipe so the next spawn starts clean.
+    const wipeDeadline = Date.now() + 2_000;
+    while (Date.now() < wipeDeadline && existsSync(pidfilePath)) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (existsSync(pidfilePath)) {
+      try { rmSync(pidfilePath); } catch { /* ignore */ }
+    }
+  };
+
+  return { child, port, url: `http://127.0.0.1:${port}`, stop };
+}
+
+function runCli(workspace: string, ...cliArgs: string[]): { stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI_PATH, ...cliArgs], {
+      cwd: workspace,
+      env: { ...process.env },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '' };
+  } catch (e) {
+    const err = e as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number };
+    return {
+      stdout: typeof err.stdout === 'string' ? err.stdout : (err.stdout?.toString('utf8') ?? ''),
+      stderr: typeof err.stderr === 'string' ? err.stderr : (err.stderr?.toString('utf8') ?? ''),
+    };
+  }
+}
+
+function getActorForContent(workspace: string, contentNeedle: string): string | null {
+  const db = openHippoDb(join(workspace, '.hippo'));
+  try {
+    const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember', limit: 200 });
+    for (const ev of events) {
+      const meta = ev.metadata ?? {};
+      const target = ev.targetId;
+      if (!target) continue;
+      // Check whether this audit row corresponds to a memory whose content
+      // contains our needle. We look it up via the memories table directly
+      // since api/store don't expose a content lookup helper here.
+      const row = db.prepare(`SELECT content FROM memories WHERE id = ?`).get(target) as
+        | { content: string }
+        | undefined;
+      if (row && row.content.includes(contentNeedle)) {
+        return ev.actor;
+      }
+    }
+    return null;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+describe('cli thin-client mode', () => {
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH)) {
+      throw new Error(`dist/cli.js not found at ${CLI_PATH}. Run \`npm run build\` first.`);
+    }
+    if (!statSync(CLI_PATH).isFile()) {
+      throw new Error(`${CLI_PATH} is not a file`);
+    }
+  });
+
+  it('routes through HTTP when server is up, falls back to direct when stopped', async () => {
+    const workspace = makeWorkspace();
+    let server: SpawnedServer | null = null;
+    try {
+      const port = await pickFreePort();
+      server = await startServer(workspace, port);
+
+      // Run remember through the spawned CLI. With pidfile present, this must
+      // route over HTTP and audit with actor='localhost:cli'.
+      const httpRun = runCli(workspace, 'remember', 'thin-client-canary-99');
+      expect(httpRun.stdout, `stderr: ${httpRun.stderr}`).toMatch(/Remembered/);
+
+      const httpActor = getActorForContent(workspace, 'thin-client-canary-99');
+      expect(httpActor).toBe('localhost:cli');
+
+      // Stop server. Pidfile must be gone.
+      await server.stop();
+      server = null;
+      const pidfilePath = join(workspace, '.hippo', 'server.pid');
+      expect(existsSync(pidfilePath)).toBe(false);
+
+      // Without server, remember must take the direct path (actor='cli').
+      const directRun = runCli(workspace, 'remember', 'fallback-canary-88');
+      expect(directRun.stdout, `stderr: ${directRun.stderr}`).toMatch(/Remembered/);
+      const directActor = getActorForContent(workspace, 'fallback-canary-88');
+      expect(directActor).toBe('cli');
+    } finally {
+      if (server) await server.stop();
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('self-heals on a stale pidfile', async () => {
+    const workspace = makeWorkspace();
+    try {
+      // Forge a pidfile pointing at a definitely-dead pid. detectServer probes
+      // via signal 0 — if we're unlucky this PID happens to belong to a live
+      // process, in which case the test would route HTTP to a random listener.
+      // Mitigate by also pointing at a port nothing's bound to: the
+      // connection-refused fallback in client.ts then takes over.
+      const stalePid = 99_999_999;
+      const stalePort = 31_111; // arbitrary; any real listener would be coincidental
+      const pidfilePath = join(workspace, '.hippo', 'server.pid');
+      writeFileSync(pidfilePath, JSON.stringify({
+        pid: stalePid,
+        port: stalePort,
+        url: `http://127.0.0.1:${stalePort}`,
+        started_at: new Date().toISOString(),
+      }));
+
+      const run = runCli(workspace, 'remember', 'stale-pidfile-canary-77');
+      expect(run.stdout + run.stderr).toMatch(/Remembered|stale|fallback/i);
+
+      // Pidfile should have been cleaned up by detectServer (dead pid) or by
+      // the stale-fallback handler (if the pid happened to be alive).
+      expect(existsSync(pidfilePath)).toBe(false);
+
+      // Memory landed via direct path → audit actor='cli'.
+      const actor = getActorForContent(workspace, 'stale-pidfile-canary-77');
+      expect(actor).toBe('cli');
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/tests/server-auth.test.ts
+++ b/tests/server-auth.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey, revokeApiKey } from '../src/auth.js';
+import { queryAuditEvents } from '../src/audit.js';
+import { serve, type ServerHandle, isLoopback } from '../src/server.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-srv-auth-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('isLoopback helper', () => {
+  it('accepts 127.0.0.1', () => {
+    expect(isLoopback('127.0.0.1')).toBe(true);
+  });
+
+  it('accepts ::1 (IPv6 loopback)', () => {
+    expect(isLoopback('::1')).toBe(true);
+  });
+
+  it('accepts ::ffff:127.0.0.1 (IPv4-mapped IPv6)', () => {
+    expect(isLoopback('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('rejects undefined', () => {
+    expect(isLoopback(undefined)).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isLoopback('')).toBe(false);
+  });
+
+  it('rejects a real LAN address', () => {
+    expect(isLoopback('192.168.1.42')).toBe(false);
+  });
+
+  it('rejects a public IPv4', () => {
+    expect(isLoopback('8.8.8.8')).toBe(false);
+  });
+
+  it('rejects an IPv6 address that is not loopback', () => {
+    expect(isLoopback('fe80::1')).toBe(false);
+  });
+
+  it('rejects ::ffff:8.8.8.8 (IPv4-mapped non-loopback)', () => {
+    expect(isLoopback('::ffff:8.8.8.8')).toBe(false);
+  });
+});
+
+describe('server auth middleware', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    globalHome = makeRoot();
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(globalHome, { recursive: true, force: true });
+  });
+
+  it('loopback no-auth: 200 and audit shows actor=localhost:cli', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'auth-canary-loopback-noauth' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { id: string };
+    expect(body.id).toMatch(/^mem_/);
+
+    const db = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember' });
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0]!.actor).toBe('localhost:cli');
+      expect(events[0]!.targetId).toBe(body.id);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('loopback with valid Bearer: 200 and audit shows actor=api_key:<keyId>', async () => {
+    const db = openHippoDb(home);
+    let keyId: string;
+    let plaintext: string;
+    try {
+      const created = createApiKey(db, { tenantId: 'default', label: 'auth-test' });
+      keyId = created.keyId;
+      plaintext = created.plaintext;
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        // Mixed case scheme to confirm case-insensitive matching.
+        'Authorization': `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ content: 'auth-canary-bearer-valid' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { id: string; tenantId: string };
+    expect(body.id).toMatch(/^mem_/);
+    expect(body.tenantId).toBe('default');
+
+    const db2 = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db2, { tenantId: 'default', op: 'remember' });
+      const matching = events.find((e) => e.targetId === body.id);
+      expect(matching).toBeDefined();
+      expect(matching!.actor).toBe(`api_key:${keyId}`);
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('loopback with invalid Bearer: 401 and no remember audit event', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': 'Bearer hk_does_not_exist.bogussecret',
+      },
+      body: JSON.stringify({ content: 'auth-canary-bearer-invalid' }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('invalid api key');
+
+    const db = openHippoDb(home);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'remember' });
+      // No remember should have landed.
+      expect(events.length).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('loopback with revoked Bearer: 401', async () => {
+    const db = openHippoDb(home);
+    let plaintext: string;
+    try {
+      const created = createApiKey(db, { tenantId: 'default', label: 'revoke-test' });
+      plaintext = created.plaintext;
+      revokeApiKey(db, created.keyId);
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ content: 'auth-canary-revoked' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('loopback with malformed Authorization (no scheme): 401', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': 'just-a-token-no-scheme',
+      },
+      body: JSON.stringify({ content: 'auth-canary-malformed' }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('invalid api key');
+  });
+
+  it('loopback with non-Bearer scheme: 401', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': 'Basic dXNlcjpwYXNz',
+      },
+      body: JSON.stringify({ content: 'auth-canary-basic' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /health is reachable without auth', async () => {
+    const res = await fetch(`${handle.url}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  // Integration-test of "non-loopback request without auth → 401" requires
+  // binding the server to a non-loopback interface, which is fragile across
+  // CI/dev machines (NIC presence, firewall, OS dual-stack behaviour). The
+  // unit test in `describe('isLoopback helper')` above covers the address
+  // classification side; this skipped block documents what the full
+  // round-trip would look like once we have a stable test fixture.
+  it.skip('non-loopback no-auth: 401 (skipped - requires real network interface)', async () => {
+    // Would require: serve({ hippoRoot, host: '0.0.0.0' }) plus a way to
+    // dial in from a non-loopback address. Lifted in the soak harness.
+  });
+});

--- a/tests/server-concurrency.test.ts
+++ b/tests/server-concurrency.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { remember as apiRemember } from '../src/api.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+// Concurrent recall + write under SQLite single-writer (real DB).
+// Proves no SQLite locked errors when readers and a writer hammer the
+// server simultaneously. ROADMAP A1 commitment.
+describe('server concurrency — recall + write under single-writer', () => {
+  it(
+    'handles 10 readers x 50 GETs + 50 writes with no SQLite locked errors',
+    async () => {
+      const home = mkdtempSync(join(tmpdir(), 'hippo-srv-conc-'));
+      mkdirSync(join(home, '.hippo'), { recursive: true });
+      initStore(home);
+
+      // Pre-seed 100 memories spanning a small pool of search terms so
+      // recall queries land hits.
+      const seedTerms = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+      for (let i = 0; i < 100; i++) {
+        const term = seedTerms[i % seedTerms.length]!;
+        apiRemember(
+          { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+          { content: `seed-${term}-doc-${i} reference content for recall test` },
+        );
+      }
+
+      const handle: ServerHandle = await serve({ hippoRoot: home, port: 0 });
+      const lockedErrors: string[] = [];
+
+      try {
+        // 10 reader workers, each issuing 50 parallel GETs against the
+        // server. Queries cycle through the seeded terms. Reads are chunked
+        // (10 at a time per worker) to avoid bursting all 500 SYN packets
+        // into the loopback listener simultaneously, which trips
+        // ECONNREFUSED on Windows when the kernel accept queue overflows.
+        // Across all 10 workers we still keep ~100 reads in flight at any
+        // moment, plenty to exercise the WAL-mode concurrent-reader path.
+        const readerCount = 10;
+        const readsPerWorker = 50;
+        const readChunk = 10;
+        const readerWork = Array.from({ length: readerCount }, async (_, workerIdx) => {
+          const responses: Response[] = [];
+          for (let chunkStart = 0; chunkStart < readsPerWorker; chunkStart += readChunk) {
+            const chunkEnd = Math.min(chunkStart + readChunk, readsPerWorker);
+            const fetches: Promise<Response>[] = [];
+            for (let reqIdx = chunkStart; reqIdx < chunkEnd; reqIdx++) {
+              const term = seedTerms[(workerIdx + reqIdx) % seedTerms.length]!;
+              fetches.push(fetch(`${handle.url}/v1/memories?q=${term}&limit=5`));
+            }
+            const chunkRes = await Promise.all(fetches);
+            responses.push(...chunkRes);
+          }
+          return responses;
+        });
+
+        // 1 writer worker, sequential POSTs with unique markers.
+        const writeCount = 50;
+        const writerWork = (async () => {
+          const responses: Response[] = [];
+          for (let n = 0; n < writeCount; n++) {
+            const res = await fetch(`${handle.url}/v1/memories`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                content: `concurrent-canary-${n}`,
+                kind: 'distilled',
+              }),
+            });
+            responses.push(res);
+          }
+          return responses;
+        })();
+
+        const [readerResultsByWorker, writerResults] = await Promise.all([
+          Promise.all(readerWork),
+          writerWork,
+        ]);
+
+        // Validate writes: 50 x 200 with valid envelopes.
+        expect(writerResults).toHaveLength(writeCount);
+        for (const [idx, res] of writerResults.entries()) {
+          if (res.status !== 200) {
+            const text = await res.text();
+            if (/SQLITE_BUSY|database is locked/i.test(text)) {
+              lockedErrors.push(`writer #${idx}: ${text}`);
+            }
+            throw new Error(`writer #${idx} status=${res.status} body=${text}`);
+          }
+          const body = (await res.json()) as { id: string; kind: string; tenantId: string };
+          expect(body.id).toMatch(/^mem_/);
+          expect(body.kind).toBe('distilled');
+          expect(body.tenantId).toBe('default');
+        }
+
+        // Validate reads: 10 * 50 = 500 x 200, no locked errors.
+        const flatReads = readerResultsByWorker.flat();
+        expect(flatReads).toHaveLength(readerCount * readsPerWorker);
+        for (const [idx, res] of flatReads.entries()) {
+          if (res.status !== 200) {
+            const text = await res.text();
+            if (/SQLITE_BUSY|database is locked/i.test(text)) {
+              lockedErrors.push(`reader #${idx}: ${text}`);
+            }
+            throw new Error(`reader #${idx} status=${res.status} body=${text}`);
+          }
+          // Drain the body so the socket is released.
+          await res.json();
+        }
+
+        expect(lockedErrors).toEqual([]);
+
+        // Final DB state: exactly 150 memories (100 seed + 50 concurrent).
+        const db = openHippoDb(home);
+        try {
+          const row = db
+            .prepare(`SELECT COUNT(*) AS n FROM memories WHERE tenant_id = 'default'`)
+            .get() as { n: number };
+          expect(row.n).toBe(150);
+
+          // Spot-check: every concurrent-canary-N marker landed.
+          const stmt = db.prepare(
+            `SELECT COUNT(*) AS n FROM memories WHERE content = ? AND tenant_id = 'default'`,
+          );
+          for (let n = 0; n < writeCount; n++) {
+            const hit = stmt.get(`concurrent-canary-${n}`) as { n: number };
+            expect(hit.n, `marker concurrent-canary-${n} missing`).toBe(1);
+          }
+        } finally {
+          closeHippoDb(db);
+        }
+      } finally {
+        await handle.stop();
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/tests/server-detect.test.ts
+++ b/tests/server-detect.test.ts
@@ -13,8 +13,9 @@ describe('server-detect', () => {
 
   it('returns null when pidfile exists but process is dead', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
-    mkdirSync(join(home, '.hippo'), { recursive: true });
-    const pidfile = join(home, '.hippo', 'server.pid');
+    // hippoRoot is the .hippo directory itself, matching the api.ts/store.ts
+    // convention; pidfile sits directly inside it.
+    const pidfile = join(home, 'server.pid');
     writeFileSync(pidfile,
       JSON.stringify({ pid: 99999999, port: 6789, url: 'http://127.0.0.1:6789', started_at: new Date().toISOString() }));
     expect(detectServer(home)).toBeNull();
@@ -25,7 +26,6 @@ describe('server-detect', () => {
 
   it('writePidfile + removePidfile roundtrip', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
-    mkdirSync(join(home, '.hippo'), { recursive: true });
     writePidfile(home, { port: 6789, url: 'http://127.0.0.1:6789' });
     const detected = detectServer(home);
     expect(detected?.url).toBe('http://127.0.0.1:6789');

--- a/tests/server-detect.test.ts
+++ b/tests/server-detect.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectServer, writePidfile, removePidfile } from '../src/server-detect.js';
+
+describe('server-detect', () => {
+  it('returns null when no pidfile exists', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    expect(detectServer(home)).toBeNull();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('returns null when pidfile exists but process is dead', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    const pidfile = join(home, '.hippo', 'server.pid');
+    writeFileSync(pidfile,
+      JSON.stringify({ pid: 99999999, port: 6789, url: 'http://127.0.0.1:6789', started_at: new Date().toISOString() }));
+    expect(detectServer(home)).toBeNull();
+    // Stale pidfile should have been deleted
+    expect(existsSync(pidfile)).toBe(false);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('writePidfile + removePidfile roundtrip', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    writePidfile(home, { port: 6789, url: 'http://127.0.0.1:6789' });
+    const detected = detectServer(home);
+    expect(detected?.url).toBe('http://127.0.0.1:6789');
+    expect(detected?.pid).toBe(process.pid);
+    removePidfile(home);
+    expect(detectServer(home)).toBeNull();
+    rmSync(home, { recursive: true, force: true });
+  });
+});

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -59,7 +59,7 @@ describe('server lifecycle', () => {
   it('stop() removes the pidfile and closes the listener', async () => {
     const home = makeRoot();
     const handle = await serve({ hippoRoot: home, port: 0 });
-    const pidfile = join(home, '.hippo', 'server.pid');
+    const pidfile = join(home, 'server.pid');
     expect(existsSync(pidfile)).toBe(true);
 
     const port = handle.port;

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { serve } from '../src/server.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-srv-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  return home;
+}
+
+describe('server lifecycle', () => {
+  it('serve returns a handle with a positive port and matching url', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    try {
+      expect(handle.port).toBeGreaterThan(0);
+      expect(handle.url).toBe(`http://127.0.0.1:${handle.port}`);
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('GET /health returns 200 with ok, version, started_at, pid', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    try {
+      const res = await fetch(`${handle.url}/health`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+      expect(typeof body.version).toBe('string');
+      expect(body.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(typeof body.started_at).toBe('string');
+      // ISO 8601 sanity check
+      expect(Number.isFinite(Date.parse(body.started_at as string))).toBe(true);
+      expect(body.pid).toBe(process.pid);
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('unknown routes return 404', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    try {
+      const res = await fetch(`${handle.url}/does-not-exist`);
+      expect(res.status).toBe(404);
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('stop() removes the pidfile and closes the listener', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    const pidfile = join(home, '.hippo', 'server.pid');
+    expect(existsSync(pidfile)).toBe(true);
+
+    const port = handle.port;
+    await handle.stop();
+
+    expect(existsSync(pidfile)).toBe(false);
+
+    // Listener is closed: a fetch to the old url must fail to connect.
+    let connected = false;
+    try {
+      await fetch(`http://127.0.0.1:${port}/health`);
+      connected = true;
+    } catch {
+      connected = false;
+    }
+    expect(connected).toBe(false);
+
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('stop() is idempotent (safe to call twice)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    await handle.stop();
+    await expect(handle.stop()).resolves.toBeUndefined();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('full lifecycle: start, health, stop, second start succeeds', async () => {
+    const home = makeRoot();
+
+    const first = await serve({ hippoRoot: home, port: 0 });
+    const firstHealth = await fetch(`${first.url}/health`);
+    expect(firstHealth.status).toBe(200);
+    await first.stop();
+
+    const second = await serve({ hippoRoot: home, port: 0 });
+    try {
+      const secondHealth = await fetch(`${second.url}/health`);
+      expect(secondHealth.status).toBe(200);
+      const body = await secondHealth.json() as Record<string, unknown>;
+      expect(body.ok).toBe(true);
+    } finally {
+      await second.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to bind to a non-loopback host without auth', async () => {
+    const home = makeRoot();
+    try {
+      await expect(serve({ hippoRoot: home, port: 0, host: '0.0.0.0' }))
+        .rejects.toThrow(/auth/i);
+      await expect(serve({ hippoRoot: home, port: 0, host: '192.168.1.1' }))
+        .rejects.toThrow(/loopback/i);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/server-mcp-http.test.ts
+++ b/tests/server-mcp-http.test.ts
@@ -22,38 +22,19 @@ function makeRoot(): string {
 
 describe('MCP-over-HTTP transport', () => {
   let home: string;
-  let hippoDir: string;
   let handle: ServerHandle;
-  let prevHippoHome: string | undefined;
-  let prevHome: string | undefined;
-  let prevUserProfile: string | undefined;
 
   beforeEach(async () => {
     home = makeRoot();
-    hippoDir = join(home, '.hippo');
-    // The MCP dispatcher resolves its hippo root via findHippoRoot(), which
-    // walks up from cwd first and falls back to the global store. Vitest
-    // worker pools forbid process.chdir, so we can't redirect the cwd walk
-    // away from the repo root's own .hippo/. Instead we verify via the MCP
-    // recall tool itself, which lands in whatever store the dispatcher picks
-    // — same store the remember call wrote to, end-to-end through HTTP.
-    prevHippoHome = process.env.HIPPO_HOME;
-    prevHome = process.env.HOME;
-    prevUserProfile = process.env.USERPROFILE;
-    process.env.HIPPO_HOME = hippoDir;
-    process.env.HOME = home;
-    process.env.USERPROFILE = home;
+    // The HTTP transport now threads hippoRoot + auth-resolved tenant
+    // through handleMcpRequest, so executeTool no longer walks cwd via
+    // findHippoRoot() or reads HIPPO_TENANT from the env. No env hacks
+    // needed — the per-test temp root is the source of truth end-to-end.
     handle = await serve({ hippoRoot: home, port: 0 });
   });
 
   afterEach(async () => {
     await handle.stop();
-    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
-    else process.env.HIPPO_HOME = prevHippoHome;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
     try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
   });
 

--- a/tests/server-mcp-http.test.ts
+++ b/tests/server-mcp-http.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+// MCP-over-HTTP/SSE transport (Task 11 of A1 plan).
+//
+// Both routes — POST /mcp and GET /mcp/stream — dispatch through the same
+// transport-agnostic handler that backs the stdio MCP loop. The stdio path is
+// covered by tests/mcp-stdio.test.ts; this file pins the HTTP transport
+// surface: synchronous JSON-RPC responses on POST, keepalive-only SSE on GET,
+// and the auth middleware reuse.
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-mcp-http-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('MCP-over-HTTP transport', () => {
+  let home: string;
+  let hippoDir: string;
+  let handle: ServerHandle;
+  let prevHippoHome: string | undefined;
+  let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    hippoDir = join(home, '.hippo');
+    // The MCP dispatcher resolves its hippo root via findHippoRoot(), which
+    // walks up from cwd first and falls back to the global store. Vitest
+    // worker pools forbid process.chdir, so we can't redirect the cwd walk
+    // away from the repo root's own .hippo/. Instead we verify via the MCP
+    // recall tool itself, which lands in whatever store the dispatcher picks
+    // — same store the remember call wrote to, end-to-end through HTTP.
+    prevHippoHome = process.env.HIPPO_HOME;
+    prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
+    process.env.HIPPO_HOME = hippoDir;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = prevHippoHome;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  it('POST /mcp tools/list returns the tool catalog', async () => {
+    const res = await fetch(`${handle.url}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json() as { jsonrpc: string; id: number; result?: { tools: Array<{ name: string }> } };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.id).toBe(1);
+    expect(Array.isArray(body.result?.tools)).toBe(true);
+    const names = body.result!.tools.map((t) => t.name);
+    expect(names).toContain('hippo_remember');
+    expect(names).toContain('hippo_recall');
+  });
+
+  it('POST /mcp tools/call hippo_remember stores a memory recoverable via recall', async () => {
+    // A token unique enough that a stray hit in the global store is implausible.
+    const sentinel = `mcp-http-sentinel-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const rememberRes = await fetch(`${handle.url}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'hippo_remember',
+          arguments: { text: `mcp-http-canary-99 ${sentinel}` },
+        },
+      }),
+    });
+    expect(rememberRes.status).toBe(200);
+    const rememberBody = await rememberRes.json() as { id: number; result?: { content: Array<{ text: string }> } };
+    expect(rememberBody.id).toBe(2);
+    const rememberText = rememberBody.result?.content?.[0]?.text ?? '';
+    expect(rememberText).toMatch(/Remembered/i);
+
+    // Round-trip: recall the same sentinel through the same HTTP transport.
+    // This proves the dispatcher lands in a single coherent store across
+    // back-to-back calls without leaning on any specific filesystem layout.
+    const recallRes = await fetch(`${handle.url}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'hippo_recall',
+          arguments: { query: sentinel, budget: 2000 },
+        },
+      }),
+    });
+    expect(recallRes.status).toBe(200);
+    const recallBody = await recallRes.json() as { id: number; result?: { content: Array<{ text: string }> } };
+    const recallText = recallBody.result?.content?.[0]?.text ?? '';
+    expect(recallText).toContain(sentinel);
+  });
+
+  it('GET /mcp/stream opens an SSE stream and emits a keepalive', async () => {
+    const ac = new AbortController();
+    try {
+      const res = await fetch(`${handle.url}/mcp/stream`, {
+        headers: { accept: 'text/event-stream' },
+        signal: ac.signal,
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+      const reader = res.body!.getReader();
+      const { value, done } = await Promise.race([
+        reader.read(),
+        new Promise<{ value: undefined; done: true }>((resolve) =>
+          setTimeout(() => resolve({ value: undefined, done: true }), 1000),
+        ),
+      ]);
+      expect(done).toBe(false);
+      const text = new TextDecoder().decode(value);
+      expect(text).toContain(': ping');
+      try { reader.cancel().catch(() => {}); } catch { /* no-op */ }
+    } finally {
+      ac.abort();
+    }
+  });
+
+  it('rejects POST /mcp without auth from a non-loopback origin', async () => {
+    // Smoke check: the auth middleware fires on /mcp routes too. We can't
+    // easily fake a non-loopback connection in-process, so this asserts the
+    // happy-path 200 (loopback no-auth) — the negative case is covered by
+    // the broader auth tests in tests/server-auth.test.ts. Treat the
+    // positive case as a minimal regression guard: if requireAuth threw on
+    // loopback, it would 401 here.
+    const res = await fetch(`${handle.url}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 99, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/server-mcp-tenant.test.ts
+++ b/tests/server-mcp-tenant.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey } from '../src/auth.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+// Regression: MCP-over-HTTP must thread the auth-resolved tenant into the
+// MCP dispatcher. Before the fix, executeTool resolved tenantId from
+// HIPPO_TENANT (env), so a Bearer for tenant 'alpha' silently dropped to
+// whatever the env said — defaulting to 'default' when HIPPO_TENANT was
+// unset. Hippo root suffered the same bug via findHippoRoot() walking
+// from cwd. This test pins both: the per-test root is used (no env hacks)
+// AND the resulting memory carries tenant_id='alpha'.
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-mcp-tenant-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('MCP-over-HTTP tenant context', () => {
+  let home: string;
+  let handle: ServerHandle;
+  let prevTenant: string | undefined;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    // Explicitly clear HIPPO_TENANT so any leak from executeTool's old
+    // resolveTenantId({}) path would surface as 'default' rather than
+    // accidentally matching 'alpha'.
+    prevTenant = process.env.HIPPO_TENANT;
+    delete process.env.HIPPO_TENANT;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (prevTenant === undefined) delete process.env.HIPPO_TENANT;
+    else process.env.HIPPO_TENANT = prevTenant;
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  it('Bearer token for tenant alpha lands the memory under tenant_id=alpha', async () => {
+    // Mint an API key bound to tenant 'alpha' directly via the auth helper —
+    // the same path the /v1/auth/keys POST exercises end-to-end.
+    const db = openHippoDb(home);
+    let plaintext: string;
+    try {
+      const minted = createApiKey(db, { tenantId: 'alpha', label: 'mcp-test' });
+      plaintext = minted.plaintext;
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const sentinel = `mcp-tenant-canary-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const res = await fetch(`${handle.url}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'hippo_remember',
+          arguments: { text: sentinel },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { result?: { content: Array<{ text: string }> } };
+    const replyText = body.result?.content?.[0]?.text ?? '';
+    expect(replyText).toMatch(/Remembered/i);
+
+    // Inspect the row directly: tenant_id MUST be 'alpha'. The bug we are
+    // guarding against would have written 'default' here.
+    const verify = openHippoDb(home);
+    try {
+      const rows = verify
+        .prepare(`SELECT tenant_id, content FROM memories WHERE content = ?`)
+        .all(sentinel) as Array<{ tenant_id: string; content: string }>;
+      expect(rows.length).toBe(1);
+      expect(rows[0]!.tenant_id).toBe('alpha');
+    } finally {
+      closeHippoDb(verify);
+    }
+  });
+});

--- a/tests/server-p99.test.ts
+++ b/tests/server-p99.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Plumbing test for the p99 recall benchmark. Skipped by default — manual run.
+ *
+ * The actual ROADMAP gate (10k store, 1000 queries, p99 < 50ms) is the
+ * standalone benchmark at benchmarks/a1/p99-recall.ts. This test is a
+ * downsized smoke run that proves the harness still wires correctly:
+ * server starts, queries return 200, latency stats compute, no flake.
+ *
+ * Run manually:
+ *   npx vitest run tests/server-p99.test.ts -t p99 --no-skip
+ *   (or remove the .skip locally)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { remember as apiRemember } from '../src/api.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+describe.skip('p99 recall benchmark plumbing — manual run', () => {
+  it('1k store, 100 queries, reports p99 (no hard gate)', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-p99-test-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    initStore(home);
+
+    const tags = ['auth', 'database', 'deploy', 'people', 'food'];
+    for (let i = 0; i < 1000; i++) {
+      const tag = tags[i % tags.length]!;
+      apiRemember(
+        { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+        { content: `seed-${tag}-doc-${i} reference content for p99 plumbing test`, tags: [tag] },
+      );
+    }
+
+    const queries = ['auth migration', 'production deployment', 'API rate limit', 'Bob coffee', 'database query'];
+    const handle: ServerHandle = await serve({ hippoRoot: home, port: 0 });
+    const samples: number[] = [];
+
+    try {
+      for (let i = 0; i < 100; i++) {
+        const q = queries[i % queries.length]!;
+        const url = `${handle.url}/v1/memories?q=${encodeURIComponent(q)}&limit=10`;
+        const t0 = performance.now();
+        const res = await fetch(url);
+        await res.text();
+        expect(res.ok).toBe(true);
+        samples.push(performance.now() - t0);
+      }
+    } finally {
+      await handle.stop();
+    }
+
+    const sorted = [...samples].sort((a, b) => a - b);
+    const p99 = sorted[Math.floor(0.99 * sorted.length)]!;
+    console.log(`[p99-plumbing] p99=${p99.toFixed(2)}ms count=${samples.length}`);
+    expect(samples.length).toBe(100);
+    expect(p99).toBeGreaterThan(0);
+
+    rmSync(home, { recursive: true, force: true });
+  }, 120000);
+});

--- a/tests/server-routes-domain.test.ts
+++ b/tests/server-routes-domain.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { remember as apiRemember } from '../src/api.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-srv-routes-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('server HTTP routes — memories', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    globalHome = makeRoot();
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(globalHome, { recursive: true, force: true });
+  });
+
+  it('POST /v1/memories creates a memory and returns the envelope', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'http-canary-remember-77', kind: 'distilled' }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json() as { id: string; kind: string; tenantId: string };
+    expect(body.id).toMatch(/^mem_/);
+    expect(body.kind).toBe('distilled');
+    expect(body.tenantId).toBe('default');
+  });
+
+  it('GET /v1/memories?q= returns matching results', async () => {
+    apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'recall-via-http alpha-token-http sentinel' },
+    );
+    apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'unrelated noise' },
+    );
+
+    const res = await fetch(`${handle.url}/v1/memories?q=alpha-token-http&limit=5`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      results: Array<{ id: string; content: string; score: number }>;
+      total: number;
+      tokens: number;
+    };
+    expect(body.results.length).toBeGreaterThan(0);
+    expect(body.results[0]!.content).toContain('alpha-token-http');
+    expect(body.total).toBeGreaterThan(0);
+    expect(body.tokens).toBeGreaterThan(0);
+  });
+
+  it('DELETE /v1/memories/:id removes the row', async () => {
+    const { id } = apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'forget-canary-target' },
+    );
+    const res = await fetch(`${handle.url}/v1/memories/${id}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; id: string };
+    expect(body.ok).toBe(true);
+    expect(body.id).toBe(id);
+
+    // Verify gone from DB.
+    const db = openHippoDb(home);
+    try {
+      const row = db.prepare(`SELECT id FROM memories WHERE id = ?`).get(id);
+      expect(row).toBeUndefined();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('DELETE /v1/memories/:id with unknown id returns 404', async () => {
+    const res = await fetch(`${handle.url}/v1/memories/mem_does_not_exist`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it('POST /v1/memories/:id/promote copies to global store', async () => {
+    const { id } = apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'promote-canary-payload' },
+    );
+    const res = await fetch(`${handle.url}/v1/memories/${id}/promote`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; sourceId: string; globalId: string };
+    expect(body.ok).toBe(true);
+    expect(body.sourceId).toBe(id);
+    // promoteToGlobal mints a fresh id on the global store; prefix is 'g_'.
+    expect(body.globalId).toMatch(/^g_/);
+  });
+
+  it('POST /v1/memories/:id/supersede chains old to new', async () => {
+    const { id } = apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'supersede-old-content' },
+    );
+    const res = await fetch(`${handle.url}/v1/memories/${id}/supersede`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'supersede-new-content' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; oldId: string; newId: string };
+    expect(body.ok).toBe(true);
+    expect(body.oldId).toBe(id);
+    expect(body.newId).toMatch(/^mem_/);
+    expect(body.newId).not.toBe(id);
+  });
+
+  it('POST /v1/memories/:id/archive archives a kind=raw row', async () => {
+    // Seed a raw row directly: createMemory defaults to distilled, but
+    // archiveRawMemory requires kind='raw'.
+    const db = openHippoDb(home);
+    let rawId: string;
+    try {
+      rawId = `mem_raw_http_${Math.random().toString(36).slice(2, 10)}`;
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO memories(
+           id, created, last_retrieved, retrieval_count, strength, half_life_days, layer,
+           tags_json, emotional_valence, schema_fit, source, outcome_score,
+           outcome_positive, outcome_negative,
+           conflicts_with_json, pinned, confidence, content,
+           parents_json, starred,
+           valid_from, kind, tenant_id, updated_at
+         ) VALUES (?, ?, ?, 0, 0.5, 30, 'episodic',
+                   '[]', 0, 0, 'manual', 0,
+                   0, 0,
+                   '[]', 0, 'verified', 'raw-http-canary',
+                   '[]', 0,
+                   ?, 'raw', 'default', datetime('now'))`,
+      ).run(rawId, now, now, now);
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const res = await fetch(`${handle.url}/v1/memories/${rawId}/archive`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'gdpr-http' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; archivedAt: string };
+    expect(body.ok).toBe(true);
+    expect(body.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const db2 = openHippoDb(home);
+    try {
+      const row = db2.prepare(`SELECT id FROM memories WHERE id = ?`).get(rawId);
+      expect(row).toBeUndefined();
+      const archived = db2
+        .prepare(`SELECT memory_id, reason FROM raw_archive WHERE memory_id = ?`)
+        .get(rawId) as { memory_id: string; reason: string } | undefined;
+      expect(archived?.memory_id).toBe(rawId);
+      expect(archived?.reason).toBe('gdpr-http');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('POST /v1/memories with invalid JSON body returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not valid json',
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it('POST /v1/memories with missing content returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kind: 'distilled' }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/content/i);
+  });
+
+  it('GET /v1/memories without q returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/memories`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/q is required/i);
+  });
+});

--- a/tests/server-routes-domain.test.ts
+++ b/tests/server-routes-domain.test.ts
@@ -218,3 +218,144 @@ describe('server HTTP routes — memories', () => {
     expect(body.error).toMatch(/q is required/i);
   });
 });
+
+describe('server HTTP routes — auth + audit', () => {
+  let home: string;
+  let originalHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = home;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('POST /v1/auth/keys returns plaintext + keyId', async () => {
+    const res = await fetch(`${handle.url}/v1/auth/keys`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'http-test-key' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { keyId: string; plaintext: string; tenantId: string };
+    expect(body.keyId).toMatch(/^hk_/);
+    // Plaintext is the only place a caller will ever see the raw secret —
+    // ensure it actually lands in the JSON response (not just the keyId).
+    expect(body.plaintext).toMatch(/^hk_/);
+    expect(body.plaintext.length).toBeGreaterThan(body.keyId.length);
+    expect(body.tenantId).toBe('default');
+  });
+
+  it('GET /v1/auth/keys defaults to active=true; ?active=false includes revoked', async () => {
+    // Mint two keys, revoke one.
+    const r1 = await fetch(`${handle.url}/v1/auth/keys`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'k1' }),
+    });
+    const k1 = await r1.json() as { keyId: string };
+    const r2 = await fetch(`${handle.url}/v1/auth/keys`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'k2' }),
+    });
+    const k2 = await r2.json() as { keyId: string };
+    await fetch(`${handle.url}/v1/auth/keys/${k2.keyId}`, { method: 'DELETE' });
+
+    // Default (active=true): only k1.
+    const activeRes = await fetch(`${handle.url}/v1/auth/keys`);
+    expect(activeRes.status).toBe(200);
+    const activeBody = await activeRes.json() as Array<{ keyId: string; revokedAt: string | null }>;
+    const activeIds = activeBody.map((k) => k.keyId);
+    expect(activeIds).toContain(k1.keyId);
+    expect(activeIds).not.toContain(k2.keyId);
+
+    // active=false: includes the revoked k2.
+    const allRes = await fetch(`${handle.url}/v1/auth/keys?active=false`);
+    expect(allRes.status).toBe(200);
+    const allBody = await allRes.json() as Array<{ keyId: string }>;
+    const allIds = allBody.map((k) => k.keyId);
+    expect(allIds).toContain(k1.keyId);
+    expect(allIds).toContain(k2.keyId);
+  });
+
+  it('DELETE /v1/auth/keys/:keyId revokes; second DELETE returns 200 (already revoked) idempotent path or 404 on unknown', async () => {
+    const mintRes = await fetch(`${handle.url}/v1/auth/keys`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'revoke-target' }),
+    });
+    const minted = await mintRes.json() as { keyId: string };
+
+    const first = await fetch(`${handle.url}/v1/auth/keys/${minted.keyId}`, { method: 'DELETE' });
+    expect(first.status).toBe(200);
+    const firstBody = await first.json() as { ok: boolean; revokedAt: string };
+    expect(firstBody.ok).toBe(true);
+    expect(firstBody.revokedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Second DELETE on the same id: authRevoke returns ok:true with the
+    // existing revokedAt (idempotent), per src/api.ts authRevoke.
+    const second = await fetch(`${handle.url}/v1/auth/keys/${minted.keyId}`, { method: 'DELETE' });
+    expect(second.status).toBe(200);
+    const secondBody = await second.json() as { ok: boolean; revokedAt: string };
+    expect(secondBody.revokedAt).toBe(firstBody.revokedAt);
+
+    // Unknown key_id → 404 (mapApiError sees "Unknown key_id: ..." and routes 404).
+    const missing = await fetch(`${handle.url}/v1/auth/keys/hk_does_not_exist`, { method: 'DELETE' });
+    expect(missing.status).toBe(404);
+    const missingBody = await missing.json() as { error: string };
+    expect(missingBody.error).toMatch(/unknown key_id/i);
+  });
+
+  it('GET /v1/audit returns events; filter by op works', async () => {
+    // Generate at least one audit event by remembering through the API.
+    apiRemember(
+      { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' },
+      { content: 'audit-canary-row' },
+    );
+
+    const allRes = await fetch(`${handle.url}/v1/audit`);
+    expect(allRes.status).toBe(200);
+    const allBody = await allRes.json() as Array<{ op: string; actor: string }>;
+    expect(allBody.length).toBeGreaterThan(0);
+    expect(allBody.some((e) => e.op === 'remember')).toBe(true);
+
+    const filteredRes = await fetch(`${handle.url}/v1/audit?op=remember&limit=5`);
+    expect(filteredRes.status).toBe(200);
+    const filteredBody = await filteredRes.json() as Array<{ op: string }>;
+    expect(filteredBody.length).toBeGreaterThan(0);
+    expect(filteredBody.every((e) => e.op === 'remember')).toBe(true);
+  });
+
+  it('GET /v1/audit with invalid op returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/audit?op=not_a_real_op`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid op/i);
+  });
+
+  it('GET /v1/audit with invalid since returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/audit?since=not-a-date`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid since/i);
+  });
+
+  it('GET /v1/audit with out-of-range limit returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/audit?limit=99999999`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/limit must be/i);
+  });
+});


### PR DESCRIPTION
## Summary

- `hippo serve` daemon on 127.0.0.1:6789 with /v1/* HTTP routes and /mcp HTTP transport
- CLI auto-detects via pidfile and routes through HTTP; stale pidfile self-heals
- Bearer-token auth + loopback trust; refuses non-loopback bind without auth
- src/api.ts domain layer; CLI handlers and server both delegate through it
- MCP stdio transport unchanged; new HTTP/SSE transport alongside

## Test plan

- [x] 829/829 vitest green + 2 skipped (was 730 baseline, +99 new)
- [x] 9/9 micro-eval at 100%
- [x] TS build clean
- [x] Headline parity test: spawned subprocess + real HTTP, audit discriminator confirms thin-client routing
- [x] Concurrent recall+write under single-writer: 0 SQLite locked errors
- [x] All 5 /review ship blockers closed (C1 pidfile banner, C2 VERSION bumps, C3 MCP context, H4 drain timeout, H5 tenant deny)

## Known issues (tracked for v0.37.0)

- p99 recall latency 58.4ms vs 50ms target on 10k store, architecture ships, hardening follows
- HIPPO_API_KEY silently dropped on stale-pidfile fallback
- Concurrent serve on same root has no winner detection
- Recall ?mode=hybrid accepted but ignored (BM25-only)
- MCP-over-HTTP SSE is keepalive-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)