### PR TITLE
feat(e1.3): Slack append-only ingestion (v0.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.37.0 (2026-04-29)
+
+### Added
+- **E1.3 Slack append-only ingestion.** Webhook to kind='raw' memories with full provenance (slack:// artifact_ref, scope from channel privacy). Idempotency via slack_event_log, cursor-based backfill resume via slack_cursors, malformed payloads to slack_dlq. Source deletion (Slack message_deleted) routes through archiveRawMemory for GDPR compliance.
+- **PUBLIC_ROUTES allow-list + HIPPO_REQUIRE_AUTH knob.** Slack webhook (HMAC-signed, no Bearer) is the first explicit public /v1/* route. Bearer-lockdown test asserts every other /v1/* route returns 401 without auth when HIPPO_REQUIRE_AUTH=1.
+- **slack_workspaces tenant routing.** Multi-workspace deployments map team_id to tenant_id; single-workspace deployments fall back to HIPPO_TENANT.
+- **api.remember afterWrite hook.** Connectors now stamp idempotency rows atomically with the memory row via a SAVEPOINT-scoped callback, closing the Slack-retry race.
+- **Recall scope filter + default-deny on private channels.** No-scope queries cannot see scope='slack:private:*' memories; frontend callers passing undefined scope no longer leak private content.
+- **hippo slack CLI.** `hippo slack backfill --channel <id>` (requires SLACK_BOT_TOKEN), `hippo slack dlq list` for malformed-event review.
+
+### Fixed
+- **archiveRaw leaves no orphaned mirrors.** Centralized GDPR fix: api.archiveRaw now removes legacy markdown mirrors (mirroring forget()), so an archived raw row cannot be revived by bootstrapLegacyStore on the next process start. Surfaced by the Slack source-deletion test.
+- **Schema-version test pins.** Bumped a3-envelope-migration / a5-tenant-migration / pr2-session-continuity from 16 to 17 (was tracking "latest version", not "this migration's version").
+
+### Changed
+- Schema v17 adds slack_event_log, slack_cursors, slack_dlq, slack_workspaces tables.
+
 ## 0.36.0 (2026-04-29)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v0.37.0
+
+- **Slack ingestion (E1.3).** First end-to-end ingestion connector. `POST /v1/connectors/slack/events` accepts HMAC-signed Events API webhooks; messages land as `kind='raw'` memories with `slack://team/channel/ts` provenance and a `slack:public:*` or `slack:private:*` scope. Source deletions route through `archiveRawMemory` (GDPR). Backfill via `hippo slack backfill --channel <id>`; malformed events to `hippo slack dlq list`.
+- **Schema v17.** New tables: `slack_event_log` (idempotency), `slack_cursors` (backfill resume), `slack_dlq` (parse failures), `slack_workspaces` (team_id to tenant_id routing).
+- **PUBLIC_ROUTES allow-list + HIPPO_REQUIRE_AUTH knob.** Slack webhook is the first explicit public `/v1/*` route (HMAC-signed, no Bearer). Every other `/v1/*` route returns 401 without auth when `HIPPO_REQUIRE_AUTH=1`.
+- **Recall default-deny on private scopes.** No-scope queries cannot see `slack:private:*` memories. Frontend callers passing undefined scope no longer leak private content.
+- **api.remember afterWrite hook.** Connectors stamp idempotency rows atomically with the memory row via a SAVEPOINT-scoped callback.
+
 ### What's new in v0.36.0
 
 - **`hippo serve` daemon.** Persistent HTTP server on 127.0.0.1:6789. CLI auto-detects and becomes a thin client; one process owns the SQLite DB.
@@ -361,6 +369,14 @@ hippo capture --file conversation.md
 # Preview first
 hippo capture --file conversation.md --dry-run
 ```
+
+### Slack ingestion (E1.3)
+
+Hippo accepts Slack Events API webhooks at `POST /v1/connectors/slack/events`. Configure `SLACK_SIGNING_SECRET` (validated on every request) and point Slack at `https://<your-host>/v1/connectors/slack/events`. Messages land as `kind='raw'` memories with `slack://team/channel/ts` provenance and a `slack:public:Cxxx` or `slack:private:Cxxx` scope. Source deletions are honored (GDPR).
+
+Backfill an existing channel: `SLACK_BOT_TOKEN=xoxb-... hippo slack backfill --channel C0000`. Inspect malformed events: `hippo slack dlq list`.
+
+Multi-workspace deployments populate `slack_workspaces (team_id, tenant_id)` to route events per tenant; single-workspace falls back to `HIPPO_TENANT`.
 
 ### Active task snapshots
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -138,6 +138,16 @@ ranking improvements; none are correctness blockers.
 
 - [ ] **BM25 sentinel-token leakage in evals.** During E1.3 eval authoring, descriptive scenario IDs polluted the ambient noise messages and inflated recall scores. Opaque IDs (e.g. `S1A2B3`) work; document this in any future eval template so the next connector eval doesn't repeat the mistake.
 
+- [ ] **Lockdown test misses `/mcp/stream`.** `tests/server-bearer-lockdown.test.ts` covers `/v1/memories`, `/v1/auth/keys`, `/v1/audit` but not `GET /mcp/stream`. Both routes call `requireAuth` with the same shape, so any future regression there won't fail the lockdown. Add `{ method: 'GET', path: '/mcp/stream' }` to `v1Routes` and assert 401 without Bearer when `HIPPO_REQUIRE_AUTH=1`. Surfaced by /review on the E1.3 branch.
+
+- [ ] **DLQ-on-parse-failure tenant attribution.** When `JSON.parse(rawBody)` fails after a valid Slack signature, we cannot read `team_id` from un-parseable JSON, so the DLQ row lands under `process.env.HIPPO_TENANT ?? 'default'`. On multi-workspace deployments this means a parse failure from workspace A lands in the wrong tenant's DLQ. Document or revisit after multi-workspace adoption.
+
+- [ ] **Audit emit ordering vs mirror write.** `writeEntry` releases the SAVEPOINT before writing the markdown mirror and emitting the audit row. If the mirror write throws (ENOSPC, EACCES), the memory row commits without an audit entry — `bootstrapLegacyStore` self-heals the orphan-row state, but the audit log is permanently missing the `remember` event. Fix: either move audit emit before the mirror write, or wrap mirror writes in try/catch that still emits audit. Surfaced by /review (MEDIUM).
+
+- [ ] **`ingestMessage` skipped→duplicate status string.** Replay of an empty-body event returns `status: 'duplicate'` whereas the first call returned `status: 'skipped'`. Functionally idempotent (same memoryId of `null`), but the differing status strings could confuse a caller that switch/cases on the value. Either unify the status (always 'skipped' for empty bodies) or document the asymmetry.
+
+- [ ] **Multi-workspace tenant-routing e2e test.** `tests/slack-tenant-routing.test.ts` covers the helper unit; no end-to-end webhook test populates `slack_workspaces` and asserts the resolved tenant lands on the memory row. Add one webhook test that mints a row in `slack_workspaces` and asserts the ingested memory's `tenant_id` matches.
+
 ---
 
 ## v0.37.0 — A1 p99 latency hardening

--- a/TODOS.md
+++ b/TODOS.md
@@ -66,8 +66,6 @@ From `/review` on commits 41b1f4d..6456e7d (now hardened to 00764ce). Each item 
 
 - [ ] **--scope CLI semantics.** `hippo remember --scope <v>` writes both the envelope `scope` column AND a `scope:<v>` tag. Recall's `--scope` filter currently matches the tag form. Decide: rename envelope flag to `--envelope-scope`, OR teach recall to filter the envelope column. Belongs in **A5** (auth/multi-tenancy) where scope semantics tighten. Until then, dual-write is documented in MEMORY_ENVELOPE.md.
 
-- [ ] **Importers/capture relabel pass.** `src/importers.ts` (ChatGPT/Claude/Cursor pastes) and `src/capture.ts` (session capture) currently use `kind='distilled'` (default). When **E1.x** ingestion connectors land (Slack/Jira/Gmail webhooks), audit these callers and decide per-source whether the content is raw-transcript-grade (`kind='raw'` + `archiveRawMemory` deletion path) or curated (`kind='distilled'`). Inline comments in both files flag the decision.
-
 - [ ] **Wire `hippo forget` for raw rows.** Today `hippo forget <raw-id>` aborts via the append-only trigger with no user-facing recovery. Add a `--archive --reason --owner` mode to `hippo forget` that routes through `archiveRawMemory`. Belongs in **A4** (lifecycle compliance). Until then, `--kind raw` is gated at the CLI so users can't create unforgettable rows.
 
 - [ ] **--owner format validation.** Currently any string is accepted. The documented contract is `user:<id>` or `agent:<id>`. Add regex validation `^(user|agent):[A-Za-z0-9_-]+$` either as warn-only (log, accept) or strict-reject. Decide alongside A5.
@@ -120,6 +118,25 @@ by post-review fixes 2db5017..38339f4). Each item belongs in **A5 v2**
   decay/merge/dedupe across tenants. Cross-tenant isolation must be threaded
   through every background pass before flipping the deployment model. Track
   with the same v2 audit as M2.
+
+---
+
+## v0.38.0 — E1.3 v2 follow-ups
+
+From the E1.3 Slack ingestion ship (v0.37.0). Operator UX, eval polish, and
+ranking improvements; none are correctness blockers.
+
+- [ ] **DLQ replay command.** `hippo slack dlq retry <id>` to re-run a parked event after fixing the underlying parser. Today the DLQ is read-only via `hippo slack dlq list`.
+
+- [ ] **Workspace registration CLI.** `hippo slack workspaces add --team <T> --tenant <t>`. Today the `slack_workspaces` table is populated via direct SQL, which is fine for single-machine deployments but awkward for multi-workspace operators.
+
+- [ ] **Eval scoring by `artifact_ref`.** The 10-scenario incident-recall eval matches on a per-message sentinel today. For real-traffic evals we want to score on `artifact_ref` so the eval doesn't depend on synthetic tokens in content. Would need to extend `RecallResultItem` (or a second SQL round-trip).
+
+- [ ] **Thread-aware ranking.** Treat `thread_ts` as a parent boost so replies surface their thread root in recall. V1 ranks each message independently.
+
+- [ ] **Incremental real-time backfill.** Today `backfillChannel` drains the channel until exhaustion. For live workspaces add a "stop at cursor" mode so the loop terminates when it catches up to the live cursor instead of paginating to history start.
+
+- [ ] **BM25 sentinel-token leakage in evals.** During E1.3 eval authoring, descriptive scenario IDs polluted the ambient noise messages and inflated recall scores. Opaque IDs (e.g. `S1A2B3`) work; document this in any future eval template so the next connector eval doesn't repeat the mistake.
 
 ---
 

--- a/benchmarks/e1.3/incident-recall-eval.ts
+++ b/benchmarks/e1.3/incident-recall-eval.ts
@@ -1,0 +1,115 @@
+/**
+ * E1.3 incident-recall eval (Task 17).
+ *
+ * ROADMAP success criterion: recall surfaces incident context faster than
+ * transcript replay on at least 7 of 10 staged scenarios.
+ *
+ * Approach (review patch #8): stamp a per-message sentinel
+ * `[s:<scenario.id>:<m.ts>]` into the ingested text. Sentinels are unique
+ * across the corpus, so checking sentinel substring presence in
+ * `RecallResultItem.content` is a deterministic equality test — no false
+ * positives from ambient phrase repetition, no need to extend the recall
+ * response shape with artifact_ref.
+ *
+ * Baseline: take the last 10 messages of the raw transcript (the
+ * "transcript replay" a human would do by scrolling to the bottom). Answers
+ * are buried mid-transcript so the baseline misses them. Recall must beat
+ * that on >=7/10 scenarios.
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { ingestMessage } from '../../src/connectors/slack/ingest.js';
+import { recall, type Context } from '../../src/api.js';
+
+interface TranscriptMessage {
+  user: string;
+  text: string;
+  ts: string;
+}
+
+interface Scenario {
+  id: string;
+  channel: string;
+  transcript: TranscriptMessage[];
+  query: string;
+  answer_ts: string[];
+}
+
+export interface ScenarioResult {
+  id: string;
+  recallPrecision: number;
+  baselinePrecision: number;
+  beat: boolean;
+}
+
+export interface IncidentRecallEvalResult {
+  scenarios: ScenarioResult[];
+  scenariosBeaten: number;
+}
+
+export async function runIncidentRecallEval(opts: {
+  hippoRoot: string;
+}): Promise<IncidentRecallEvalResult> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const scenarios = JSON.parse(
+    readFileSync(join(here, 'scenarios.json'), 'utf-8'),
+  ) as Scenario[];
+  const ctx: Context = {
+    hippoRoot: opts.hippoRoot,
+    tenantId: 'default',
+    actor: 'eval:slack',
+  };
+  const results: ScenarioResult[] = [];
+
+  for (const sc of scenarios) {
+    const sentinel = (m: { ts: string }): string => `[s:${sc.id}:${m.ts}]`;
+
+    for (const m of sc.transcript) {
+      ingestMessage(ctx, {
+        teamId: 'T1',
+        channel: { id: sc.channel, is_private: false },
+        message: {
+          type: 'message',
+          channel: sc.channel,
+          user: m.user,
+          text: `${m.text} ${sentinel(m)}`,
+          ts: m.ts,
+        },
+        eventId: `${sc.id}:${m.ts}`,
+      });
+    }
+
+    const r = recall(ctx, {
+      query: sc.query,
+      limit: 10,
+      scope: `slack:public:${sc.channel}`,
+    });
+    const recallHit = sc.answer_ts.filter((ts) =>
+      r.results.some((res) => res.content.includes(sentinel({ ts }))),
+    ).length;
+    const recallPrecision = recallHit / sc.answer_ts.length;
+
+    // Baseline: linear transcript scan returning the last 10 messages — what a
+    // human does when they scroll to the bottom of a Slack channel. Direct
+    // ts equality is enough; sentinels are not in the raw transcript.
+    const tail = sc.transcript.slice(-10);
+    const baselineHit = sc.answer_ts.filter((ts) =>
+      tail.some((m) => m.ts === ts),
+    ).length;
+    const baselinePrecision = baselineHit / sc.answer_ts.length;
+
+    results.push({
+      id: sc.id,
+      recallPrecision,
+      baselinePrecision,
+      beat: recallPrecision > baselinePrecision,
+    });
+  }
+
+  return {
+    scenarios: results,
+    scenariosBeaten: results.filter((r) => r.beat).length,
+  };
+}

--- a/benchmarks/e1.3/scenarios.json
+++ b/benchmarks/e1.3/scenarios.json
@@ -1,0 +1,2587 @@
+[
+  {
+    "id": "S01-incident",
+    "channel": "C-incidents",
+    "query": "postgres database outage connection pool",
+    "answer_ts": [
+      "1700000300.000000",
+      "1700000310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "morning all coffee machine broken again",
+        "ts": "1700000001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "same here vending eating my coins",
+        "ts": "1700000010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "anyone watching football tonight",
+        "ts": "1700000020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I might catch the second half",
+        "ts": "1700000030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "lunch options thread please",
+        "ts": "1700000040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "thai place down the road is decent",
+        "ts": "1700000050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "weekly demo moved to thursday",
+        "ts": "1700000060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "thanks for the heads up",
+        "ts": "1700000070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "anyone deploying staging today",
+        "ts": "1700000080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "I will be after standup",
+        "ts": "1700000090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "remember to update the runbook",
+        "ts": "1700000100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "got it will do",
+        "ts": "1700000110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "office wifi flaky again",
+        "ts": "1700000120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "tethering to phone",
+        "ts": "1700000130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "hr lunch and learn at noon",
+        "ts": "1700000140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ack thanks",
+        "ts": "1700000150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "did anyone see the new logo mock",
+        "ts": "1700000160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "yeah it looks pretty clean",
+        "ts": "1700000170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "engineering all hands at three",
+        "ts": "1700000180.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I will be there",
+        "ts": "1700000190.000000"
+      },
+      {
+        "user": "U5",
+        "text": "checkout has been laggy this morning",
+        "ts": "1700000200.000000"
+      },
+      {
+        "user": "U6",
+        "text": "I noticed too p99 latency up",
+        "ts": "1700000210.000000"
+      },
+      {
+        "user": "U7",
+        "text": "checking grafana now",
+        "ts": "1700000220.000000"
+      },
+      {
+        "user": "U8",
+        "text": "looks elevated since 14:02 UTC",
+        "ts": "1700000230.000000"
+      },
+      {
+        "user": "U1",
+        "text": "checkout API throwing 500s now",
+        "ts": "1700000240.000000"
+      },
+      {
+        "user": "U2",
+        "text": "confirmed seeing 500s on checkout",
+        "ts": "1700000250.000000"
+      },
+      {
+        "user": "U3",
+        "text": "paging on call",
+        "ts": "1700000260.000000"
+      },
+      {
+        "user": "U4",
+        "text": "joined the bridge",
+        "ts": "1700000270.000000"
+      },
+      {
+        "user": "U5",
+        "text": "rolling back last deploy first",
+        "ts": "1700000280.000000"
+      },
+      {
+        "user": "U6",
+        "text": "rollback complete errors still climbing",
+        "ts": "1700000290.000000"
+      },
+      {
+        "user": "U7",
+        "text": "postgres database outage: connection pool exhausted on primary",
+        "ts": "1700000300.000000"
+      },
+      {
+        "user": "U8",
+        "text": "confirmed postgres outage from analytics query holding connection pool locks",
+        "ts": "1700000310.000000"
+      },
+      {
+        "user": "U1",
+        "text": "killing the analytics query now",
+        "ts": "1700000320.000000"
+      },
+      {
+        "user": "U2",
+        "text": "pool draining connections recovering",
+        "ts": "1700000330.000000"
+      },
+      {
+        "user": "U3",
+        "text": "checkout 500s back to baseline",
+        "ts": "1700000340.000000"
+      },
+      {
+        "user": "U4",
+        "text": "good work team postmortem tomorrow",
+        "ts": "1700000350.000000"
+      },
+      {
+        "user": "U5",
+        "text": "I will draft it",
+        "ts": "1700000360.000000"
+      },
+      {
+        "user": "U6",
+        "text": "thanks all",
+        "ts": "1700000370.000000"
+      },
+      {
+        "user": "U7",
+        "text": "going for coffee brb",
+        "ts": "1700000380.000000"
+      },
+      {
+        "user": "U8",
+        "text": "same need a break",
+        "ts": "1700000390.000000"
+      },
+      {
+        "user": "U1",
+        "text": "back what did I miss",
+        "ts": "1700000400.000000"
+      },
+      {
+        "user": "U2",
+        "text": "nothing new all calm",
+        "ts": "1700000410.000000"
+      },
+      {
+        "user": "U3",
+        "text": "sprint planning at four pm reminder",
+        "ts": "1700000420.000000"
+      },
+      {
+        "user": "U4",
+        "text": "ack",
+        "ts": "1700000430.000000"
+      },
+      {
+        "user": "U5",
+        "text": "anyone want dinner after",
+        "ts": "1700000440.000000"
+      },
+      {
+        "user": "U6",
+        "text": "I am in",
+        "ts": "1700000450.000000"
+      },
+      {
+        "user": "U7",
+        "text": "me too",
+        "ts": "1700000460.000000"
+      },
+      {
+        "user": "U8",
+        "text": "great place to be decided",
+        "ts": "1700000470.000000"
+      },
+      {
+        "user": "U1",
+        "text": "italian or sushi",
+        "ts": "1700000480.000000"
+      },
+      {
+        "user": "U2",
+        "text": "sushi",
+        "ts": "1700000490.000000"
+      },
+      {
+        "user": "U3",
+        "text": "sushi works",
+        "ts": "1700000500.000000"
+      },
+      {
+        "user": "U4",
+        "text": "ok sushi it is",
+        "ts": "1700000510.000000"
+      },
+      {
+        "user": "U5",
+        "text": "see you all at seven",
+        "ts": "1700000520.000000"
+      },
+      {
+        "user": "U6",
+        "text": "perfect",
+        "ts": "1700000530.000000"
+      },
+      {
+        "user": "U7",
+        "text": "leaving soon",
+        "ts": "1700000540.000000"
+      },
+      {
+        "user": "U8",
+        "text": "on my way",
+        "ts": "1700000550.000000"
+      },
+      {
+        "user": "U1",
+        "text": "ok bye all have a good evening",
+        "ts": "1700000560.000000"
+      }
+    ]
+  },
+  {
+    "id": "S02-incident",
+    "channel": "C-incidents",
+    "query": "helm chart memory limit oom kill",
+    "answer_ts": [
+      "1700100400.000000",
+      "1700100410.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "good morning team",
+        "ts": "1700100001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700100010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "anyone reviewed my pr yet",
+        "ts": "1700100020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I will look after coffee",
+        "ts": "1700100030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "ci is slow today",
+        "ts": "1700100040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "yeah github actions queue is long",
+        "ts": "1700100050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "lunch order going in",
+        "ts": "1700100060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "burrito for me please",
+        "ts": "1700100070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "salad please",
+        "ts": "1700100080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "weekly survey reminder",
+        "ts": "1700100090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "filled it in",
+        "ts": "1700100100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "same",
+        "ts": "1700100110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "demo went well yesterday",
+        "ts": "1700100120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "the new dashboard looks great",
+        "ts": "1700100130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "headphones found in meeting room three",
+        "ts": "1700100140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "those are mine thanks",
+        "ts": "1700100150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "starting the production deploy now",
+        "ts": "1700100160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "ack",
+        "ts": "1700100170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "watching the dashboard",
+        "ts": "1700100180.000000"
+      },
+      {
+        "user": "U4",
+        "text": "first canary looks ok",
+        "ts": "1700100190.000000"
+      },
+      {
+        "user": "U5",
+        "text": "second wave green",
+        "ts": "1700100200.000000"
+      },
+      {
+        "user": "U6",
+        "text": "third wave failing",
+        "ts": "1700100210.000000"
+      },
+      {
+        "user": "U7",
+        "text": "deploy paused",
+        "ts": "1700100220.000000"
+      },
+      {
+        "user": "U8",
+        "text": "looking at logs",
+        "ts": "1700100230.000000"
+      },
+      {
+        "user": "U1",
+        "text": "lots of pod crashloops",
+        "ts": "1700100240.000000"
+      },
+      {
+        "user": "U2",
+        "text": "out of memory kills suspected",
+        "ts": "1700100250.000000"
+      },
+      {
+        "user": "U3",
+        "text": "kubectl describe shows oom yes",
+        "ts": "1700100260.000000"
+      },
+      {
+        "user": "U4",
+        "text": "checking limits in helm chart",
+        "ts": "1700100270.000000"
+      },
+      {
+        "user": "U5",
+        "text": "increased memory limit recently",
+        "ts": "1700100280.000000"
+      },
+      {
+        "user": "U6",
+        "text": "no but the app might be loading more",
+        "ts": "1700100290.000000"
+      },
+      {
+        "user": "U7",
+        "text": "rollback to previous version please",
+        "ts": "1700100300.000000"
+      },
+      {
+        "user": "U8",
+        "text": "rolling back now",
+        "ts": "1700100310.000000"
+      },
+      {
+        "user": "U1",
+        "text": "rollback in progress",
+        "ts": "1700100320.000000"
+      },
+      {
+        "user": "U2",
+        "text": "still seeing crashes",
+        "ts": "1700100330.000000"
+      },
+      {
+        "user": "U3",
+        "text": "old image getting same crash",
+        "ts": "1700100340.000000"
+      },
+      {
+        "user": "U4",
+        "text": "weird",
+        "ts": "1700100350.000000"
+      },
+      {
+        "user": "U5",
+        "text": "looking at the chart values diff",
+        "ts": "1700100360.000000"
+      },
+      {
+        "user": "U6",
+        "text": "the new values bumped requests but not limits",
+        "ts": "1700100370.000000"
+      },
+      {
+        "user": "U7",
+        "text": "wait what changed exactly",
+        "ts": "1700100380.000000"
+      },
+      {
+        "user": "U8",
+        "text": "let me pull up the diff",
+        "ts": "1700100390.000000"
+      },
+      {
+        "user": "U1",
+        "text": "helm chart memory limit too low caused oom kill on pod startup",
+        "ts": "1700100400.000000"
+      },
+      {
+        "user": "U2",
+        "text": "confirmed: helm chart memory limit mismatch with request triggers oom kill",
+        "ts": "1700100410.000000"
+      },
+      {
+        "user": "U3",
+        "text": "patching the chart",
+        "ts": "1700100420.000000"
+      },
+      {
+        "user": "U4",
+        "text": "redeploy",
+        "ts": "1700100430.000000"
+      },
+      {
+        "user": "U5",
+        "text": "green",
+        "ts": "1700100440.000000"
+      },
+      {
+        "user": "U6",
+        "text": "deploy succeeded",
+        "ts": "1700100450.000000"
+      },
+      {
+        "user": "U7",
+        "text": "great recovery",
+        "ts": "1700100460.000000"
+      },
+      {
+        "user": "U8",
+        "text": "drink anyone",
+        "ts": "1700100470.000000"
+      },
+      {
+        "user": "U1",
+        "text": "yes please",
+        "ts": "1700100480.000000"
+      },
+      {
+        "user": "U2",
+        "text": "I am in",
+        "ts": "1700100490.000000"
+      },
+      {
+        "user": "U3",
+        "text": "bar across the street",
+        "ts": "1700100500.000000"
+      },
+      {
+        "user": "U4",
+        "text": "see you at six",
+        "ts": "1700100510.000000"
+      },
+      {
+        "user": "U5",
+        "text": "I will be late",
+        "ts": "1700100520.000000"
+      },
+      {
+        "user": "U6",
+        "text": "no worries",
+        "ts": "1700100530.000000"
+      },
+      {
+        "user": "U7",
+        "text": "see you",
+        "ts": "1700100540.000000"
+      },
+      {
+        "user": "U8",
+        "text": "later",
+        "ts": "1700100550.000000"
+      }
+    ]
+  },
+  {
+    "id": "S03-incident",
+    "channel": "C-incidents",
+    "query": "stripe payment api third party outage",
+    "answer_ts": [
+      "1700200300.000000",
+      "1700200310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "morning",
+        "ts": "1700200001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700200010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "great weekend",
+        "ts": "1700200020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "yes had a hike",
+        "ts": "1700200030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "sprint review at ten",
+        "ts": "1700200040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "ack",
+        "ts": "1700200050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "design team posted new mocks",
+        "ts": "1700200060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "looking now",
+        "ts": "1700200070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "office snacks restocked",
+        "ts": "1700200080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "finally",
+        "ts": "1700200090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "anyone going to the meetup tonight",
+        "ts": "1700200100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I am",
+        "ts": "1700200110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "me too",
+        "ts": "1700200120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "see you there",
+        "ts": "1700200130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "support tickets spiking from billing",
+        "ts": "1700200200.000000"
+      },
+      {
+        "user": "U8",
+        "text": "users say payments not going through",
+        "ts": "1700200210.000000"
+      },
+      {
+        "user": "U1",
+        "text": "checking our dashboards",
+        "ts": "1700200220.000000"
+      },
+      {
+        "user": "U2",
+        "text": "checkout success rate down sixty percent",
+        "ts": "1700200230.000000"
+      },
+      {
+        "user": "U3",
+        "text": "logs showing 502 from upstream",
+        "ts": "1700200240.000000"
+      },
+      {
+        "user": "U4",
+        "text": "checking which upstream",
+        "ts": "1700200250.000000"
+      },
+      {
+        "user": "U5",
+        "text": "the billing upstream",
+        "ts": "1700200260.000000"
+      },
+      {
+        "user": "U6",
+        "text": "checking status page",
+        "ts": "1700200270.000000"
+      },
+      {
+        "user": "U7",
+        "text": "loading",
+        "ts": "1700200280.000000"
+      },
+      {
+        "user": "U8",
+        "text": "yep elevated errors reported",
+        "ts": "1700200290.000000"
+      },
+      {
+        "user": "U1",
+        "text": "stripe payment api third party outage causing failed charges",
+        "ts": "1700200300.000000"
+      },
+      {
+        "user": "U2",
+        "text": "confirmed: third party stripe payment api outage on their side not us",
+        "ts": "1700200310.000000"
+      },
+      {
+        "user": "U3",
+        "text": "post status banner on our site",
+        "ts": "1700200320.000000"
+      },
+      {
+        "user": "U4",
+        "text": "banner up",
+        "ts": "1700200330.000000"
+      },
+      {
+        "user": "U5",
+        "text": "support team has the comms",
+        "ts": "1700200340.000000"
+      },
+      {
+        "user": "U6",
+        "text": "fix in thirty minutes",
+        "ts": "1700200350.000000"
+      },
+      {
+        "user": "U7",
+        "text": "watching",
+        "ts": "1700200360.000000"
+      },
+      {
+        "user": "U8",
+        "text": "success rate climbing back",
+        "ts": "1700200370.000000"
+      },
+      {
+        "user": "U1",
+        "text": "back to normal",
+        "ts": "1700200380.000000"
+      },
+      {
+        "user": "U2",
+        "text": "removing banner",
+        "ts": "1700200390.000000"
+      },
+      {
+        "user": "U3",
+        "text": "great",
+        "ts": "1700200400.000000"
+      },
+      {
+        "user": "U4",
+        "text": "lunch",
+        "ts": "1700200410.000000"
+      },
+      {
+        "user": "U5",
+        "text": "yes please",
+        "ts": "1700200420.000000"
+      },
+      {
+        "user": "U6",
+        "text": "the tacos place",
+        "ts": "1700200430.000000"
+      },
+      {
+        "user": "U7",
+        "text": "in",
+        "ts": "1700200440.000000"
+      },
+      {
+        "user": "U8",
+        "text": "in",
+        "ts": "1700200450.000000"
+      },
+      {
+        "user": "U1",
+        "text": "leaving now",
+        "ts": "1700200460.000000"
+      },
+      {
+        "user": "U2",
+        "text": "right behind you",
+        "ts": "1700200470.000000"
+      },
+      {
+        "user": "U3",
+        "text": "back from lunch",
+        "ts": "1700200480.000000"
+      },
+      {
+        "user": "U4",
+        "text": "same",
+        "ts": "1700200490.000000"
+      },
+      {
+        "user": "U5",
+        "text": "afternoon focus block",
+        "ts": "1700200500.000000"
+      },
+      {
+        "user": "U6",
+        "text": "headphones on",
+        "ts": "1700200510.000000"
+      },
+      {
+        "user": "U7",
+        "text": "do not disturb",
+        "ts": "1700200520.000000"
+      },
+      {
+        "user": "U8",
+        "text": "shipping the auth refactor today",
+        "ts": "1700200530.000000"
+      },
+      {
+        "user": "U1",
+        "text": "good luck",
+        "ts": "1700200540.000000"
+      },
+      {
+        "user": "U2",
+        "text": "drinks at six",
+        "ts": "1700200550.000000"
+      },
+      {
+        "user": "U3",
+        "text": "see you",
+        "ts": "1700200560.000000"
+      }
+    ]
+  },
+  {
+    "id": "S04-incident",
+    "channel": "C-incidents",
+    "query": "jwt token expiry session logout bug",
+    "answer_ts": [
+      "1700300300.000000",
+      "1700300310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "hello team",
+        "ts": "1700300001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "hi",
+        "ts": "1700300010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "any plans for the long weekend",
+        "ts": "1700300020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "camping",
+        "ts": "1700300030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "sounds great",
+        "ts": "1700300040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "I am staying in",
+        "ts": "1700300050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "weekly retro at two pm",
+        "ts": "1700300060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ack",
+        "ts": "1700300070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "the new chairs arrived",
+        "ts": "1700300080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "very comfortable",
+        "ts": "1700300090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "engineering newsletter is out",
+        "ts": "1700300100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "good read",
+        "ts": "1700300110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "interview at eleven",
+        "ts": "1700300120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "good luck",
+        "ts": "1700300130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "thanks",
+        "ts": "1700300140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "I am running late",
+        "ts": "1700300150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "no worries",
+        "ts": "1700300160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "support pinging us about logouts",
+        "ts": "1700300200.000000"
+      },
+      {
+        "user": "U3",
+        "text": "users complaining they get logged out every few minutes",
+        "ts": "1700300210.000000"
+      },
+      {
+        "user": "U4",
+        "text": "started after this morning release",
+        "ts": "1700300220.000000"
+      },
+      {
+        "user": "U5",
+        "text": "checking the auth service",
+        "ts": "1700300230.000000"
+      },
+      {
+        "user": "U6",
+        "text": "session table looks fine",
+        "ts": "1700300240.000000"
+      },
+      {
+        "user": "U7",
+        "text": "could be expiry",
+        "ts": "1700300250.000000"
+      },
+      {
+        "user": "U8",
+        "text": "we changed something earlier",
+        "ts": "1700300260.000000"
+      },
+      {
+        "user": "U1",
+        "text": "from twenty four hours to what",
+        "ts": "1700300270.000000"
+      },
+      {
+        "user": "U2",
+        "text": "by mistake",
+        "ts": "1700300280.000000"
+      },
+      {
+        "user": "U3",
+        "text": "found it",
+        "ts": "1700300290.000000"
+      },
+      {
+        "user": "U4",
+        "text": "auth bug: jwt token expiry set to five minutes causing session logout loop",
+        "ts": "1700300300.000000"
+      },
+      {
+        "user": "U5",
+        "text": "confirmed jwt token expiry typo is the auth bug behind the session logout storm",
+        "ts": "1700300310.000000"
+      },
+      {
+        "user": "U6",
+        "text": "patching now",
+        "ts": "1700300320.000000"
+      },
+      {
+        "user": "U7",
+        "text": "deployed",
+        "ts": "1700300330.000000"
+      },
+      {
+        "user": "U8",
+        "text": "logouts stopped",
+        "ts": "1700300340.000000"
+      },
+      {
+        "user": "U1",
+        "text": "support confirms users stable",
+        "ts": "1700300350.000000"
+      },
+      {
+        "user": "U2",
+        "text": "good catch",
+        "ts": "1700300360.000000"
+      },
+      {
+        "user": "U3",
+        "text": "writing it up",
+        "ts": "1700300370.000000"
+      },
+      {
+        "user": "U4",
+        "text": "tea break",
+        "ts": "1700300380.000000"
+      },
+      {
+        "user": "U5",
+        "text": "join you",
+        "ts": "1700300390.000000"
+      },
+      {
+        "user": "U6",
+        "text": "back",
+        "ts": "1700300400.000000"
+      },
+      {
+        "user": "U7",
+        "text": "afternoon standup in five",
+        "ts": "1700300410.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ok",
+        "ts": "1700300420.000000"
+      },
+      {
+        "user": "U1",
+        "text": "all calm here",
+        "ts": "1700300430.000000"
+      },
+      {
+        "user": "U2",
+        "text": "same",
+        "ts": "1700300440.000000"
+      },
+      {
+        "user": "U3",
+        "text": "sprint demo prep",
+        "ts": "1700300450.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I will record screens",
+        "ts": "1700300460.000000"
+      },
+      {
+        "user": "U5",
+        "text": "thanks",
+        "ts": "1700300470.000000"
+      },
+      {
+        "user": "U6",
+        "text": "wrapping up",
+        "ts": "1700300480.000000"
+      },
+      {
+        "user": "U7",
+        "text": "see you tomorrow",
+        "ts": "1700300490.000000"
+      },
+      {
+        "user": "U8",
+        "text": "have a good night",
+        "ts": "1700300500.000000"
+      },
+      {
+        "user": "U1",
+        "text": "you too",
+        "ts": "1700300510.000000"
+      }
+    ]
+  },
+  {
+    "id": "S05-incident",
+    "channel": "C-incidents",
+    "query": "search endpoint elasticsearch missing index latency regression",
+    "answer_ts": [
+      "1700400300.000000",
+      "1700400310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "hi",
+        "ts": "1700400001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "hi",
+        "ts": "1700400010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "weekend recap thread",
+        "ts": "1700400020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "watched a movie",
+        "ts": "1700400030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "which one",
+        "ts": "1700400040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "the new sci fi one",
+        "ts": "1700400050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "any good",
+        "ts": "1700400060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "decent",
+        "ts": "1700400070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "review session at eleven",
+        "ts": "1700400080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "sec",
+        "ts": "1700400090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "back",
+        "ts": "1700400100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "did the npm upgrade go ok yesterday",
+        "ts": "1700400110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "yes mostly",
+        "ts": "1700400120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "any flakes",
+        "ts": "1700400130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "two tests rerun green",
+        "ts": "1700400140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ok",
+        "ts": "1700400150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "lunch in thirty",
+        "ts": "1700400160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "going to the gym first",
+        "ts": "1700400170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "queries slow this afternoon",
+        "ts": "1700400200.000000"
+      },
+      {
+        "user": "U4",
+        "text": "p99 jumped from 200ms to 4 seconds",
+        "ts": "1700400210.000000"
+      },
+      {
+        "user": "U5",
+        "text": "users complaining",
+        "ts": "1700400220.000000"
+      },
+      {
+        "user": "U6",
+        "text": "looking at flame graphs",
+        "ts": "1700400230.000000"
+      },
+      {
+        "user": "U7",
+        "text": "cpu high upstream",
+        "ts": "1700400240.000000"
+      },
+      {
+        "user": "U8",
+        "text": "any recent changes",
+        "ts": "1700400250.000000"
+      },
+      {
+        "user": "U1",
+        "text": "we deployed a new feature this morning",
+        "ts": "1700400260.000000"
+      },
+      {
+        "user": "U2",
+        "text": "with sort by score plus recency",
+        "ts": "1700400270.000000"
+      },
+      {
+        "user": "U3",
+        "text": "full text scoring on every doc",
+        "ts": "1700400280.000000"
+      },
+      {
+        "user": "U4",
+        "text": "missing index",
+        "ts": "1700400290.000000"
+      },
+      {
+        "user": "U5",
+        "text": "search endpoint latency regression caused by missing elasticsearch index",
+        "ts": "1700400300.000000"
+      },
+      {
+        "user": "U6",
+        "text": "confirmed: missing elasticsearch index on search endpoint is the latency regression root cause",
+        "ts": "1700400310.000000"
+      },
+      {
+        "user": "U7",
+        "text": "creating it",
+        "ts": "1700400320.000000"
+      },
+      {
+        "user": "U8",
+        "text": "built",
+        "ts": "1700400330.000000"
+      },
+      {
+        "user": "U1",
+        "text": "p99 back to 250ms",
+        "ts": "1700400340.000000"
+      },
+      {
+        "user": "U2",
+        "text": "great",
+        "ts": "1700400350.000000"
+      },
+      {
+        "user": "U3",
+        "text": "ship it",
+        "ts": "1700400360.000000"
+      },
+      {
+        "user": "U4",
+        "text": "writeup tomorrow",
+        "ts": "1700400370.000000"
+      },
+      {
+        "user": "U5",
+        "text": "early dinner",
+        "ts": "1700400380.000000"
+      },
+      {
+        "user": "U6",
+        "text": "yep",
+        "ts": "1700400390.000000"
+      },
+      {
+        "user": "U7",
+        "text": "cya",
+        "ts": "1700400400.000000"
+      },
+      {
+        "user": "U8",
+        "text": "later",
+        "ts": "1700400410.000000"
+      },
+      {
+        "user": "U1",
+        "text": "morning check in",
+        "ts": "1700400420.000000"
+      },
+      {
+        "user": "U2",
+        "text": "all calm",
+        "ts": "1700400430.000000"
+      },
+      {
+        "user": "U3",
+        "text": "no alerts",
+        "ts": "1700400440.000000"
+      },
+      {
+        "user": "U4",
+        "text": "good",
+        "ts": "1700400450.000000"
+      },
+      {
+        "user": "U5",
+        "text": "moving on to the next ticket",
+        "ts": "1700400460.000000"
+      },
+      {
+        "user": "U6",
+        "text": "ack",
+        "ts": "1700400470.000000"
+      },
+      {
+        "user": "U7",
+        "text": "wrap up",
+        "ts": "1700400480.000000"
+      }
+    ]
+  },
+  {
+    "id": "S06-incident",
+    "channel": "C-incidents",
+    "query": "feature flag config production push staging mistake",
+    "answer_ts": [
+      "1700500300.000000",
+      "1700500310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "morning all",
+        "ts": "1700500001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700500010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "did anyone catch the game",
+        "ts": "1700500020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "great match",
+        "ts": "1700500030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "sprint planning at ten",
+        "ts": "1700500040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "I will be there",
+        "ts": "1700500050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "snack stash refilled",
+        "ts": "1700500060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "thank god",
+        "ts": "1700500070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "running our weekly cleanup",
+        "ts": "1700500080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "need help with anything",
+        "ts": "1700500090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "I got it",
+        "ts": "1700500100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "thanks",
+        "ts": "1700500110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "design reviews this afternoon",
+        "ts": "1700500120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "ok",
+        "ts": "1700500130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "one on one in five",
+        "ts": "1700500140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "sec",
+        "ts": "1700500150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "users seeing weird ui changes",
+        "ts": "1700500200.000000"
+      },
+      {
+        "user": "U2",
+        "text": "what kind",
+        "ts": "1700500210.000000"
+      },
+      {
+        "user": "U3",
+        "text": "experimental beta features showing up for everyone",
+        "ts": "1700500220.000000"
+      },
+      {
+        "user": "U4",
+        "text": "checking",
+        "ts": "1700500230.000000"
+      },
+      {
+        "user": "U5",
+        "text": "checking flag rollout",
+        "ts": "1700500240.000000"
+      },
+      {
+        "user": "U6",
+        "text": "all flags showing one hundred percent",
+        "ts": "1700500250.000000"
+      },
+      {
+        "user": "U7",
+        "text": "should be five percent or off",
+        "ts": "1700500260.000000"
+      },
+      {
+        "user": "U8",
+        "text": "git log on the repo",
+        "ts": "1700500270.000000"
+      },
+      {
+        "user": "U1",
+        "text": "someone pushed",
+        "ts": "1700500280.000000"
+      },
+      {
+        "user": "U2",
+        "text": "checking who",
+        "ts": "1700500290.000000"
+      },
+      {
+        "user": "U3",
+        "text": "feature flag config push from staging branch landed on production by mistake",
+        "ts": "1700500300.000000"
+      },
+      {
+        "user": "U4",
+        "text": "confirmed: staging feature flag config pushed to production main is the mistake",
+        "ts": "1700500310.000000"
+      },
+      {
+        "user": "U5",
+        "text": "reverting",
+        "ts": "1700500320.000000"
+      },
+      {
+        "user": "U6",
+        "text": "revert merged",
+        "ts": "1700500330.000000"
+      },
+      {
+        "user": "U7",
+        "text": "back to normal",
+        "ts": "1700500340.000000"
+      },
+      {
+        "user": "U8",
+        "text": "support team notified",
+        "ts": "1700500350.000000"
+      },
+      {
+        "user": "U1",
+        "text": "writing up the postmortem",
+        "ts": "1700500360.000000"
+      },
+      {
+        "user": "U2",
+        "text": "we should add a ci check",
+        "ts": "1700500370.000000"
+      },
+      {
+        "user": "U3",
+        "text": "agreed",
+        "ts": "1700500380.000000"
+      },
+      {
+        "user": "U4",
+        "text": "filing the ticket",
+        "ts": "1700500390.000000"
+      },
+      {
+        "user": "U5",
+        "text": "afternoon work focus",
+        "ts": "1700500400.000000"
+      },
+      {
+        "user": "U6",
+        "text": "back to work",
+        "ts": "1700500410.000000"
+      },
+      {
+        "user": "U7",
+        "text": "shipping my pr",
+        "ts": "1700500420.000000"
+      },
+      {
+        "user": "U8",
+        "text": "review please",
+        "ts": "1700500430.000000"
+      },
+      {
+        "user": "U1",
+        "text": "looking",
+        "ts": "1700500440.000000"
+      },
+      {
+        "user": "U2",
+        "text": "lgtm",
+        "ts": "1700500450.000000"
+      },
+      {
+        "user": "U3",
+        "text": "merging",
+        "ts": "1700500460.000000"
+      },
+      {
+        "user": "U4",
+        "text": "deployed",
+        "ts": "1700500470.000000"
+      },
+      {
+        "user": "U5",
+        "text": "great",
+        "ts": "1700500480.000000"
+      },
+      {
+        "user": "U6",
+        "text": "going home",
+        "ts": "1700500490.000000"
+      },
+      {
+        "user": "U7",
+        "text": "good night",
+        "ts": "1700500500.000000"
+      }
+    ]
+  },
+  {
+    "id": "S07-incident",
+    "channel": "C-incidents",
+    "query": "ssl tls certificate expired certbot renewal",
+    "answer_ts": [
+      "1700600300.000000",
+      "1700600310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "morning team",
+        "ts": "1700600001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700600010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "tea",
+        "ts": "1700600020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "yes thanks",
+        "ts": "1700600030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "any updates from yesterday",
+        "ts": "1700600040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "all green",
+        "ts": "1700600050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "engineering all hands at two",
+        "ts": "1700600060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ack",
+        "ts": "1700600070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "the office plant looks sad",
+        "ts": "1700600080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "watering it",
+        "ts": "1700600090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "bug bash on friday reminder",
+        "ts": "1700600100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "putting it on calendar",
+        "ts": "1700600110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "lunch options",
+        "ts": "1700600120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "salads or burgers",
+        "ts": "1700600130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "burgers",
+        "ts": "1700600140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "salads",
+        "ts": "1700600150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "alerts firing on api endpoint",
+        "ts": "1700600200.000000"
+      },
+      {
+        "user": "U2",
+        "text": "what kind",
+        "ts": "1700600210.000000"
+      },
+      {
+        "user": "U3",
+        "text": "client connections failing",
+        "ts": "1700600220.000000"
+      },
+      {
+        "user": "U4",
+        "text": "users seeing connection refused errors",
+        "ts": "1700600230.000000"
+      },
+      {
+        "user": "U5",
+        "text": "openssl s_client check",
+        "ts": "1700600240.000000"
+      },
+      {
+        "user": "U6",
+        "text": "running it",
+        "ts": "1700600250.000000"
+      },
+      {
+        "user": "U7",
+        "text": "verify return code ten cert has expired",
+        "ts": "1700600260.000000"
+      },
+      {
+        "user": "U8",
+        "text": "the cert",
+        "ts": "1700600270.000000"
+      },
+      {
+        "user": "U1",
+        "text": "auto renew not set up",
+        "ts": "1700600280.000000"
+      },
+      {
+        "user": "U2",
+        "text": "checking",
+        "ts": "1700600290.000000"
+      },
+      {
+        "user": "U3",
+        "text": "ssl tls certificate expired and certbot renewal disabled three months ago",
+        "ts": "1700600300.000000"
+      },
+      {
+        "user": "U4",
+        "text": "confirmed ssl tls certificate expiry: certbot renewal job stopped, issuing new cert now",
+        "ts": "1700600310.000000"
+      },
+      {
+        "user": "U5",
+        "text": "issuing",
+        "ts": "1700600320.000000"
+      },
+      {
+        "user": "U6",
+        "text": "installed",
+        "ts": "1700600330.000000"
+      },
+      {
+        "user": "U7",
+        "text": "lb reloaded",
+        "ts": "1700600340.000000"
+      },
+      {
+        "user": "U8",
+        "text": "errors gone",
+        "ts": "1700600350.000000"
+      },
+      {
+        "user": "U1",
+        "text": "re enabling renewal job",
+        "ts": "1700600360.000000"
+      },
+      {
+        "user": "U2",
+        "text": "auto renew restored",
+        "ts": "1700600370.000000"
+      },
+      {
+        "user": "U3",
+        "text": "filing followup",
+        "ts": "1700600380.000000"
+      },
+      {
+        "user": "U4",
+        "text": "good catch all",
+        "ts": "1700600390.000000"
+      },
+      {
+        "user": "U5",
+        "text": "coffee",
+        "ts": "1700600400.000000"
+      },
+      {
+        "user": "U6",
+        "text": "yes",
+        "ts": "1700600410.000000"
+      },
+      {
+        "user": "U7",
+        "text": "back",
+        "ts": "1700600420.000000"
+      },
+      {
+        "user": "U8",
+        "text": "afternoon focus",
+        "ts": "1700600430.000000"
+      },
+      {
+        "user": "U1",
+        "text": "anyone reviewing my pr",
+        "ts": "1700600440.000000"
+      },
+      {
+        "user": "U2",
+        "text": "I will",
+        "ts": "1700600450.000000"
+      },
+      {
+        "user": "U3",
+        "text": "thanks",
+        "ts": "1700600460.000000"
+      },
+      {
+        "user": "U4",
+        "text": "wrapping up",
+        "ts": "1700600470.000000"
+      },
+      {
+        "user": "U5",
+        "text": "have a good night",
+        "ts": "1700600480.000000"
+      },
+      {
+        "user": "U6",
+        "text": "you too",
+        "ts": "1700600490.000000"
+      }
+    ]
+  },
+  {
+    "id": "S08-incident",
+    "channel": "C-incidents",
+    "query": "nightly batch job warehouse partition full table scan",
+    "answer_ts": [
+      "1700700300.000000",
+      "1700700310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "morning",
+        "ts": "1700700001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700700010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "did anyone bring donuts",
+        "ts": "1700700020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "I did",
+        "ts": "1700700030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "thanks legend",
+        "ts": "1700700040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "standup in ten",
+        "ts": "1700700050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "ack",
+        "ts": "1700700060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "the new hire onboarding doc looks great",
+        "ts": "1700700070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "thanks",
+        "ts": "1700700080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "anyone want to pair on the migration ticket",
+        "ts": "1700700090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "I am free at three",
+        "ts": "1700700100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "great",
+        "ts": "1700700110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "test flake on main",
+        "ts": "1700700120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "rerunning",
+        "ts": "1700700130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "green",
+        "ts": "1700700140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "lunch",
+        "ts": "1700700150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "yes",
+        "ts": "1700700160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "salad bar across the street",
+        "ts": "1700700170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "alerts firing on the data store",
+        "ts": "1700700200.000000"
+      },
+      {
+        "user": "U4",
+        "text": "cpu pegged at one hundred percent",
+        "ts": "1700700210.000000"
+      },
+      {
+        "user": "U5",
+        "text": "running queries piling up",
+        "ts": "1700700220.000000"
+      },
+      {
+        "user": "U6",
+        "text": "what is running",
+        "ts": "1700700230.000000"
+      },
+      {
+        "user": "U7",
+        "text": "the aggregation cron",
+        "ts": "1700700240.000000"
+      },
+      {
+        "user": "U8",
+        "text": "still going fourteen hours later",
+        "ts": "1700700250.000000"
+      },
+      {
+        "user": "U1",
+        "text": "should be thirty mins normally",
+        "ts": "1700700260.000000"
+      },
+      {
+        "user": "U2",
+        "text": "looking at the query plan",
+        "ts": "1700700270.000000"
+      },
+      {
+        "user": "U3",
+        "text": "missing where clause",
+        "ts": "1700700280.000000"
+      },
+      {
+        "user": "U4",
+        "text": "nightly batch job warehouse partition pruning lost: full table scan instead",
+        "ts": "1700700300.000000"
+      },
+      {
+        "user": "U5",
+        "text": "confirmed nightly batch job doing full table scan on warehouse, partition filter dropped",
+        "ts": "1700700310.000000"
+      },
+      {
+        "user": "U6",
+        "text": "killed",
+        "ts": "1700700320.000000"
+      },
+      {
+        "user": "U7",
+        "text": "recovering",
+        "ts": "1700700330.000000"
+      },
+      {
+        "user": "U8",
+        "text": "patching the query",
+        "ts": "1700700340.000000"
+      },
+      {
+        "user": "U1",
+        "text": "patch deployed",
+        "ts": "1700700350.000000"
+      },
+      {
+        "user": "U2",
+        "text": "rerun the job",
+        "ts": "1700700360.000000"
+      },
+      {
+        "user": "U3",
+        "text": "completed in twenty four minutes",
+        "ts": "1700700370.000000"
+      },
+      {
+        "user": "U4",
+        "text": "back to normal",
+        "ts": "1700700380.000000"
+      },
+      {
+        "user": "U5",
+        "text": "great",
+        "ts": "1700700390.000000"
+      },
+      {
+        "user": "U6",
+        "text": "writing it up",
+        "ts": "1700700400.000000"
+      },
+      {
+        "user": "U7",
+        "text": "drinks",
+        "ts": "1700700410.000000"
+      },
+      {
+        "user": "U8",
+        "text": "yes",
+        "ts": "1700700420.000000"
+      },
+      {
+        "user": "U1",
+        "text": "rooftop bar",
+        "ts": "1700700430.000000"
+      },
+      {
+        "user": "U2",
+        "text": "in",
+        "ts": "1700700440.000000"
+      },
+      {
+        "user": "U3",
+        "text": "see you at six",
+        "ts": "1700700450.000000"
+      },
+      {
+        "user": "U4",
+        "text": "running late",
+        "ts": "1700700460.000000"
+      },
+      {
+        "user": "U5",
+        "text": "no rush",
+        "ts": "1700700470.000000"
+      },
+      {
+        "user": "U6",
+        "text": "heading there",
+        "ts": "1700700480.000000"
+      },
+      {
+        "user": "U7",
+        "text": "goodnight all",
+        "ts": "1700700490.000000"
+      }
+    ]
+  },
+  {
+    "id": "S09-incident",
+    "channel": "C-incidents",
+    "query": "missing schema migration column does not exist",
+    "answer_ts": [
+      "1700800300.000000",
+      "1700800310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "good morning",
+        "ts": "1700800001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700800010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "anyone watch the keynote yesterday",
+        "ts": "1700800020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "yes interesting",
+        "ts": "1700800030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "agreed",
+        "ts": "1700800040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "team breakfast on friday",
+        "ts": "1700800050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "yum",
+        "ts": "1700800060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "design sync at eleven",
+        "ts": "1700800070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "ok",
+        "ts": "1700800080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "pr queue is huge",
+        "ts": "1700800090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "lets do reviews together",
+        "ts": "1700800100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "good idea",
+        "ts": "1700800110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "office cat is back",
+        "ts": "1700800120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "yay",
+        "ts": "1700800130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "weekly metrics email",
+        "ts": "1700800140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "thanks",
+        "ts": "1700800150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "lunch break",
+        "ts": "1700800160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "back",
+        "ts": "1700800170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "errors in api log",
+        "ts": "1700800200.000000"
+      },
+      {
+        "user": "U4",
+        "text": "many 500s on user profile",
+        "ts": "1700800210.000000"
+      },
+      {
+        "user": "U5",
+        "text": "stack trace shows undefined column",
+        "ts": "1700800220.000000"
+      },
+      {
+        "user": "U6",
+        "text": "which one",
+        "ts": "1700800230.000000"
+      },
+      {
+        "user": "U7",
+        "text": "users last seen at field",
+        "ts": "1700800240.000000"
+      },
+      {
+        "user": "U8",
+        "text": "we added that in the latest release",
+        "ts": "1700800250.000000"
+      },
+      {
+        "user": "U1",
+        "text": "did the schema upgrade run on prod",
+        "ts": "1700800260.000000"
+      },
+      {
+        "user": "U2",
+        "text": "checking",
+        "ts": "1700800270.000000"
+      },
+      {
+        "user": "U3",
+        "text": "version table only at forty seven",
+        "ts": "1700800280.000000"
+      },
+      {
+        "user": "U4",
+        "text": "should be forty eight",
+        "ts": "1700800290.000000"
+      },
+      {
+        "user": "U5",
+        "text": "missing schema migration: column does not exist on production",
+        "ts": "1700800300.000000"
+      },
+      {
+        "user": "U6",
+        "text": "confirmed missing schema migration v48: column does not exist error from skipped migration step",
+        "ts": "1700800310.000000"
+      },
+      {
+        "user": "U7",
+        "text": "running it now",
+        "ts": "1700800320.000000"
+      },
+      {
+        "user": "U8",
+        "text": "applied",
+        "ts": "1700800330.000000"
+      },
+      {
+        "user": "U1",
+        "text": "errors clearing",
+        "ts": "1700800340.000000"
+      },
+      {
+        "user": "U2",
+        "text": "all green",
+        "ts": "1700800350.000000"
+      },
+      {
+        "user": "U3",
+        "text": "fix pipeline",
+        "ts": "1700800360.000000"
+      },
+      {
+        "user": "U4",
+        "text": "filing it",
+        "ts": "1700800370.000000"
+      },
+      {
+        "user": "U5",
+        "text": "wrap up",
+        "ts": "1700800380.000000"
+      },
+      {
+        "user": "U6",
+        "text": "good day",
+        "ts": "1700800390.000000"
+      },
+      {
+        "user": "U7",
+        "text": "early dinner",
+        "ts": "1700800400.000000"
+      },
+      {
+        "user": "U8",
+        "text": "in",
+        "ts": "1700800410.000000"
+      },
+      {
+        "user": "U1",
+        "text": "going home",
+        "ts": "1700800420.000000"
+      },
+      {
+        "user": "U2",
+        "text": "see you",
+        "ts": "1700800430.000000"
+      },
+      {
+        "user": "U3",
+        "text": "have a good evening",
+        "ts": "1700800440.000000"
+      },
+      {
+        "user": "U4",
+        "text": "you too",
+        "ts": "1700800450.000000"
+      },
+      {
+        "user": "U5",
+        "text": "later",
+        "ts": "1700800460.000000"
+      },
+      {
+        "user": "U6",
+        "text": "morning",
+        "ts": "1700800470.000000"
+      },
+      {
+        "user": "U7",
+        "text": "morning",
+        "ts": "1700800480.000000"
+      }
+    ]
+  },
+  {
+    "id": "S10-incident",
+    "channel": "C-incidents",
+    "query": "hacker news traffic spike autoscaling overload",
+    "answer_ts": [
+      "1700900300.000000",
+      "1700900310.000000"
+    ],
+    "transcript": [
+      {
+        "user": "U1",
+        "text": "good morning",
+        "ts": "1700900001.000000"
+      },
+      {
+        "user": "U2",
+        "text": "morning",
+        "ts": "1700900010.000000"
+      },
+      {
+        "user": "U3",
+        "text": "great quarter close yesterday",
+        "ts": "1700900020.000000"
+      },
+      {
+        "user": "U4",
+        "text": "agreed",
+        "ts": "1700900030.000000"
+      },
+      {
+        "user": "U5",
+        "text": "marketing email going out today",
+        "ts": "1700900040.000000"
+      },
+      {
+        "user": "U6",
+        "text": "what time",
+        "ts": "1700900050.000000"
+      },
+      {
+        "user": "U7",
+        "text": "ten am",
+        "ts": "1700900060.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ok we should be ready",
+        "ts": "1700900070.000000"
+      },
+      {
+        "user": "U1",
+        "text": "scaled the asg up a bit",
+        "ts": "1700900080.000000"
+      },
+      {
+        "user": "U2",
+        "text": "good",
+        "ts": "1700900090.000000"
+      },
+      {
+        "user": "U3",
+        "text": "watching dashboards",
+        "ts": "1700900100.000000"
+      },
+      {
+        "user": "U4",
+        "text": "all green",
+        "ts": "1700900110.000000"
+      },
+      {
+        "user": "U5",
+        "text": "blog post is on a popular site",
+        "ts": "1700900120.000000"
+      },
+      {
+        "user": "U6",
+        "text": "front page",
+        "ts": "1700900130.000000"
+      },
+      {
+        "user": "U7",
+        "text": "wow",
+        "ts": "1700900140.000000"
+      },
+      {
+        "user": "U8",
+        "text": "ticking up",
+        "ts": "1700900150.000000"
+      },
+      {
+        "user": "U1",
+        "text": "rps doubled",
+        "ts": "1700900160.000000"
+      },
+      {
+        "user": "U2",
+        "text": "tripled",
+        "ts": "1700900170.000000"
+      },
+      {
+        "user": "U3",
+        "text": "ten times baseline now",
+        "ts": "1700900200.000000"
+      },
+      {
+        "user": "U4",
+        "text": "load balancer queueing",
+        "ts": "1700900210.000000"
+      },
+      {
+        "user": "U5",
+        "text": "p95 latency at eight seconds",
+        "ts": "1700900220.000000"
+      },
+      {
+        "user": "U6",
+        "text": "users seeing timeouts",
+        "ts": "1700900230.000000"
+      },
+      {
+        "user": "U7",
+        "text": "scaling firing",
+        "ts": "1700900240.000000"
+      },
+      {
+        "user": "U8",
+        "text": "still not enough capacity",
+        "ts": "1700900250.000000"
+      },
+      {
+        "user": "U1",
+        "text": "increase max instances",
+        "ts": "1700900260.000000"
+      },
+      {
+        "user": "U2",
+        "text": "raising cap to two hundred",
+        "ts": "1700900270.000000"
+      },
+      {
+        "user": "U3",
+        "text": "where did the surge come from",
+        "ts": "1700900280.000000"
+      },
+      {
+        "user": "U4",
+        "text": "external referrer",
+        "ts": "1700900290.000000"
+      },
+      {
+        "user": "U5",
+        "text": "hacker news traffic spike overload, autoscaling lagged behind organic surge",
+        "ts": "1700900300.000000"
+      },
+      {
+        "user": "U6",
+        "text": "confirmed: hacker news front page traffic spike, autoscaling caps too low for the overload",
+        "ts": "1700900310.000000"
+      },
+      {
+        "user": "U7",
+        "text": "instances spinning up",
+        "ts": "1700900320.000000"
+      },
+      {
+        "user": "U8",
+        "text": "queue clearing",
+        "ts": "1700900330.000000"
+      },
+      {
+        "user": "U1",
+        "text": "p95 dropped to 800ms",
+        "ts": "1700900340.000000"
+      },
+      {
+        "user": "U2",
+        "text": "great",
+        "ts": "1700900350.000000"
+      },
+      {
+        "user": "U3",
+        "text": "still on the front page",
+        "ts": "1700900360.000000"
+      },
+      {
+        "user": "U4",
+        "text": "comments are positive",
+        "ts": "1700900370.000000"
+      },
+      {
+        "user": "U5",
+        "text": "marketing happy",
+        "ts": "1700900380.000000"
+      },
+      {
+        "user": "U6",
+        "text": "writing it up",
+        "ts": "1700900390.000000"
+      },
+      {
+        "user": "U7",
+        "text": "celebration drinks",
+        "ts": "1700900400.000000"
+      },
+      {
+        "user": "U8",
+        "text": "yes please",
+        "ts": "1700900410.000000"
+      },
+      {
+        "user": "U1",
+        "text": "rooftop",
+        "ts": "1700900420.000000"
+      },
+      {
+        "user": "U2",
+        "text": "in",
+        "ts": "1700900430.000000"
+      },
+      {
+        "user": "U3",
+        "text": "see you at six",
+        "ts": "1700900440.000000"
+      },
+      {
+        "user": "U4",
+        "text": "running late",
+        "ts": "1700900450.000000"
+      },
+      {
+        "user": "U5",
+        "text": "no rush",
+        "ts": "1700900460.000000"
+      },
+      {
+        "user": "U6",
+        "text": "heading out",
+        "ts": "1700900470.000000"
+      },
+      {
+        "user": "U7",
+        "text": "good evening",
+        "ts": "1700900480.000000"
+      },
+      {
+        "user": "U8",
+        "text": "later",
+        "ts": "1700900490.000000"
+      }
+    ]
+  }
+]

--- a/benchmarks/e1.3/slack-1000-event-smoke.ts
+++ b/benchmarks/e1.3/slack-1000-event-smoke.ts
@@ -1,0 +1,121 @@
+/**
+ * E1.3 1000-event Slack smoke benchmark.
+ *
+ * ROADMAP success criterion: ingest 1000 synthetic Slack events, replay each
+ * one twice, and prove (a) exactly `count` unique memories are written
+ * (idempotency holds), (b) zero outbound HTTP calls escape the connector
+ * layer, (c) per-call latency stays under 500ms.
+ *
+ * The no-outbound-HTTP invariant is proven (review patch #5) by replacing
+ * `globalThis.fetch` with a function that THROWS on any call. If a future
+ * code path inside the connector ever reaches for fetch (e.g. a user
+ * resolution shortcut), this smoke fails loud rather than silently lying
+ * with a hardcoded 0. The original fetch is restored in `finally` so the
+ * spy never poisons later tests.
+ */
+
+import { ingestMessage } from '../../src/connectors/slack/ingest.js';
+import { loadAllEntries } from '../../src/store.js';
+
+export interface SmokeOpts {
+  hippoRoot: string;
+  count: number;
+  replay: number;
+}
+
+export interface SmokeResult {
+  uniqueMemories: number;
+  totalIngestCalls: number;
+  outboundHttp: number;
+  durationMs: number;
+}
+
+export async function runSlackSmoke(opts: SmokeOpts): Promise<SmokeResult> {
+  const ctx = {
+    hippoRoot: opts.hippoRoot,
+    tenantId: 'default',
+    actor: 'connector:slack',
+  };
+  const start = Date.now();
+  let calls = 0;
+
+  // Review patch #5: spy globalThis.fetch with a throwing function. The smoke
+  // fails LOUD if anything in the ingest path ever calls fetch().
+  const origFetch = globalThis.fetch;
+  let outboundHttp = 0;
+  globalThis.fetch = ((..._args: unknown[]): Promise<Response> => {
+    outboundHttp++;
+    throw new Error('outbound HTTP forbidden during slack smoke');
+  }) as typeof fetch;
+
+  try {
+    for (let pass = 0; pass < opts.replay; pass++) {
+      for (let i = 0; i < opts.count; i++) {
+        ingestMessage(ctx, {
+          teamId: 'T1',
+          channel: { id: 'C1', is_private: false },
+          message: {
+            type: 'message',
+            channel: 'C1',
+            user: 'U1',
+            // Use a content body well over the 3-char minimum enforced by
+            // memory.ts so synthetic events survive validation.
+            text: `slack synthetic event ${i}`,
+            ts: `${1700000000 + i}.000100`,
+          },
+          eventId: `Ev-${i}`,
+        });
+        calls++;
+      }
+    }
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+
+  const uniqueMemories = loadAllEntries(opts.hippoRoot).filter((e) =>
+    e.tags.includes('source:slack'),
+  ).length;
+  return {
+    uniqueMemories,
+    totalIngestCalls: calls,
+    outboundHttp,
+    durationMs: Date.now() - start,
+  };
+}
+
+// Standalone CLI: 1000 events, replay=2, fail loud on regression.
+// Use pathToFileURL for cross-platform `import.meta.url` matching (Windows
+// emits `file:///C:/...` which `file://${process.argv[1]}` cannot match).
+const { pathToFileURL } = await import('url');
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { mkdtempSync, rmSync } = await import('fs');
+  const { tmpdir } = await import('os');
+  const { join } = await import('path');
+  const { initStore } = await import('../../src/store.js');
+
+  const root = mkdtempSync(join(tmpdir(), 'hippo-slack-smoke-cli-'));
+  try {
+    initStore(root);
+    const r = await runSlackSmoke({ hippoRoot: root, count: 1000, replay: 2 });
+    console.log(JSON.stringify(r, null, 2));
+    if (r.uniqueMemories !== 1000) {
+      console.error('FAIL: uniqueMemories !== 1000');
+      process.exit(1);
+    }
+    if (r.outboundHttp !== 0) {
+      console.error('FAIL: outboundHttp !== 0');
+      process.exit(1);
+    }
+    if (r.totalIngestCalls !== 2000) {
+      console.error('FAIL: totalIngestCalls !== 2000');
+      process.exit(1);
+    }
+    if (r.durationMs / r.totalIngestCalls > 500) {
+      console.error('FAIL: per-call latency >500ms');
+      process.exit(1);
+    }
+    console.log('PASS');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/docs/plans/2026-04-29-e1.3-slack-ingestion.md
+++ b/docs/plans/2026-04-29-e1.3-slack-ingestion.md
@@ -145,8 +145,34 @@ Append to the migrations array in `src/db.ts` (after the v16 block):
       )
     `);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_slack_dlq_tenant_received ON slack_dlq(tenant_id, received_at)`);
+    // Multi-tenant routing seam (review patch #6). Empty by default — single-
+    // tenant deployments resolve via HIPPO_TENANT fallback. Multi-workspace
+    // deployments populate this table to map team_id → tenant_id.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS slack_workspaces (
+        team_id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL,
+        added_at TEXT NOT NULL
+      )
+    `);
   },
 },
+```
+
+Also add a fourth test case to `tests/slack-schema.test.ts`:
+
+```ts
+it('creates slack_workspaces with team_id PK', () => {
+  const db = openHippoDb(root);
+  try {
+    db.prepare(`INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`).run('T_ACME', 'acme', '2026-04-29T00:00:00Z');
+    expect(() =>
+      db.prepare(`INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`).run('T_ACME', 'other', '2026-04-29T00:00:01Z'),
+    ).toThrow();
+  } finally {
+    closeHippoDb(db);
+  }
+});
 ```
 
 **Step 4: Run test to verify it passes**
@@ -799,13 +825,16 @@ git commit -m "feat(slack): message-to-RememberOpts transform with kind=raw"
 
 ---
 
-## Task 8: ingestMessage — end-to-end idempotent write
+## Task 8: ingestMessage — atomic idempotent write via api.remember afterWrite hook
 
-**Why:** The single function the webhook handler and backfill loop both call. Steps: idempotency check → transform → `api.remember()` → mark seen with the new memory id. Wraps these in a single SQLite transaction so a crash mid-write leaves no orphan log entry.
+**Why:** The single function the webhook handler and backfill loop both call. Steps: idempotency check → transform → `api.remember()` (with `afterWrite` callback that stamps the event log inside the same transaction) → return. Slack retries within 1 minute, so a crash between the memory write and the event-log mark would duplicate the row on the very next retry. This task therefore extends `api.remember` with an `afterWrite?: (db, memoryId) => void` callback (review patch #3) so the connector can mark idempotency atomically with the underlying upsert.
 
 **Files:**
+- Modify: `src/api.ts` — add `afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void` to `RememberOpts`. Pass it through to `writeEntry` (which already opens a transaction); invoke inside that transaction post-INSERT, pre-COMMIT.
+- Modify: `src/store.ts` — accept and invoke the `afterWrite` callback inside `writeEntry`'s existing transaction. (Inspect the file first; if `writeEntry` does not currently wrap its INSERT in a transaction, wrap it now — the audit-emit hook already calls into the same db handle, so the transaction is the natural seam.)
 - Create: `src/connectors/slack/ingest.ts`
 - Create: `tests/slack-ingest.test.ts`
+- Create: `tests/api-remember-after-write.test.ts` — proves the hook fires inside the same transaction (rollback drops both the memory and the side-effect).
 
 **Step 1: Write the failing test**
 
@@ -868,6 +897,31 @@ Expected: FAIL — module not found.
 
 **Step 3: Implement**
 
+First extend `RememberOpts` in `src/api.ts`:
+
+```ts
+export interface RememberOpts {
+  content: string;
+  kind?: MemoryKind;
+  scope?: string;
+  owner?: string;
+  artifactRef?: string;
+  tags?: string[];
+  /**
+   * Optional hook invoked inside the same transaction as the underlying
+   * memories INSERT. Used by ingestion connectors (E1.3+) to stamp
+   * idempotency / cursor rows atomically with the memory row, so a crash
+   * mid-write cannot produce a memory without its corresponding side-effect
+   * log row (or vice versa).
+   */
+  afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void;
+}
+```
+
+Inside `remember()`, thread the callback to `writeEntry`. In `src/store.ts`, `writeEntry` should wrap its INSERT + the `afterWrite` invocation in a single transaction (BEGIN/COMMIT, or SAVEPOINT if nested). If the function already runs the INSERT inside a transaction, hook the callback in just before COMMIT. If it does not, add `db.exec('BEGIN')` / `db.exec('COMMIT')` around the upsert + callback, with `ROLLBACK` on throw.
+
+Then:
+
 ```ts
 // src/connectors/slack/ingest.ts
 import { remember, type Context } from '../../api.js';
@@ -893,18 +947,16 @@ export interface IngestResult {
 }
 
 export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
+  // Idempotency check: if already seen, return the cached memory_id without
+  // re-running the transform or hitting api.remember.
   const db = openHippoDb(ctx.hippoRoot);
-  let alreadySeen = false;
-  let existingId: string | null = null;
   try {
     if (hasSeenEvent(db, input.eventId)) {
-      alreadySeen = true;
-      existingId = lookupMemoryByEvent(db, input.eventId);
+      return { status: 'duplicate', memoryId: lookupMemoryByEvent(db, input.eventId) };
     }
   } finally {
     closeHippoDb(db);
   }
-  if (alreadySeen) return { status: 'duplicate', memoryId: existingId };
 
   const opts = messageToRememberOpts(input);
   if (!opts) {
@@ -913,18 +965,48 @@ export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
     finally { closeHippoDb(db2); }
     return { status: 'skipped', memoryId: null };
   }
-  // remember() opens its own db handle; we open another to mark the event log.
-  // Both writes succeed-or-fail atomically only if SQLite WAL persists them in
-  // order; an in-flight crash between them leaves the memory written but the
-  // event log unmarked → a replay would write a duplicate. Acceptable: the
-  // smoke test asserts no duplicates under the happy path, and dedup against
-  // artifact_ref is a future hardening (TODOS.md follow-up).
-  const result = remember({ ...ctx, actor: ctx.actor || 'connector:slack' }, opts);
-  const db3 = openHippoDb(ctx.hippoRoot);
-  try { markEventSeen(db3, input.eventId, result.id); }
-  finally { closeHippoDb(db3); }
+
+  // Atomic write: the afterWrite callback runs inside writeEntry's transaction,
+  // so the memory row and the slack_event_log row commit (or roll back) together.
+  // Slack's 1-minute retry window can no longer produce a duplicate via the
+  // crash-between-handles race that the original draft acknowledged in TODOS.md.
+  const result = remember(
+    { ...ctx, actor: ctx.actor || 'connector:slack' },
+    {
+      ...opts,
+      afterWrite: (db, memoryId) => markEventSeen(db, input.eventId, memoryId),
+    },
+  );
   return { status: 'ingested', memoryId: result.id };
 }
+```
+
+Add the proof test for the transaction guarantee:
+
+```ts
+// tests/api-remember-after-write.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { remember } from '../src/api.js';
+
+describe('remember.afterWrite is transactional', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-after-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('rolls back the memory row when afterWrite throws', () => {
+    expect(() =>
+      remember({ hippoRoot: root, tenantId: 'default', actor: 'test' }, {
+        content: 'doomed',
+        afterWrite: () => { throw new Error('boom'); },
+      }),
+    ).toThrow(/boom/);
+    expect(loadAllEntries(root).filter((e) => e.content === 'doomed')).toHaveLength(0);
+  });
+});
 ```
 
 **Step 4: Run to verify it passes**
@@ -1003,6 +1085,34 @@ describe('handleMessageDeleted', () => {
       teamId: 'T1', channelId: 'C1', deletedTs: '9999.9999', eventId: 'EvDel2',
     });
     expect(r.status).toBe('not_found');
+  });
+
+  it('cross-tenant deletion event cannot archive another tenants row (review patch #1)', () => {
+    // Ingest under tenant 'acme'.
+    const acmeCtx = { hippoRoot: root, tenantId: 'acme', actor: 'connector:slack' };
+    const ingested = ingestMessage(acmeCtx, {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'acme secret', ts: '1700.0001' },
+      eventId: 'EvAcme1',
+    });
+    expect(ingested.status).toBe('ingested');
+
+    // Fire deletion under tenant 'default' for the same artifact_ref.
+    const defaultCtx = { hippoRoot: root, tenantId: 'default', actor: 'connector:slack' };
+    const r = handleMessageDeleted(defaultCtx, {
+      teamId: 'T1', channelId: 'C1', deletedTs: '1700.0001', eventId: 'EvDelCross',
+    });
+    expect(r.status).toBe('not_found');
+
+    // Acme row is still there; raw_archive has no row.
+    const remaining = loadAllEntries(root).filter((e) => e.id === ingested.memoryId);
+    expect(remaining).toHaveLength(1);
+    const db = openHippoDb(root);
+    try {
+      const archCount = db.prepare(`SELECT COUNT(*) as c FROM raw_archive WHERE memory_id = ?`).get(ingested.memoryId!) as { c: number };
+      expect(Number(archCount.c)).toBe(0);
+    } finally { closeHippoDb(db); }
   });
 });
 ```
@@ -1118,7 +1228,65 @@ describe('slack permission mirroring', () => {
     expect(pubResults.results.some((r) => r.content.includes('private secret'))).toBe(false);
     expect(pubResults.results.some((r) => r.content.includes('public secret'))).toBe(true);
   });
+
+  // Review patch #4: empty/undefined scope must default-deny private rows.
+  // Without this guarantee, a frontend caller forgetting to pass `scope` exposes
+  // every private channel to a public query.
+  it('no-scope query default-denies private rows', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1', channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'public alpha', ts: '1.1' },
+      eventId: 'EvPubA',
+    });
+    ingestMessage(ctx(root), {
+      teamId: 'T1', channel: { id: 'CPRIV', is_private: true },
+      message: { type: 'message', channel: 'CPRIV', user: 'U1', text: 'private alpha', ts: '2.2' },
+      eventId: 'EvPrivA',
+    });
+    const r = recall(ctx(root), { query: 'alpha' }); // no scope
+    expect(r.results.some((x) => x.content.includes('private alpha'))).toBe(false);
+    expect(r.results.some((x) => x.content.includes('public alpha'))).toBe(true);
+  });
+
+  // Review patch #4: mismatched scope (channel does not exist) returns zero.
+  it('mismatched scope returns zero results', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1', channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'beta', ts: '1.1' },
+      eventId: 'EvPubB',
+    });
+    const r = recall(ctx(root), { query: 'beta', scope: 'slack:public:CDOES_NOT_EXIST' });
+    expect(r.results).toHaveLength(0);
+  });
+
+  // Review patch #4: tenant-mismatched scope. Tenant B writes a private row
+  // with scope='slack:private:CSHARED'. Tenant A queries the same scope string
+  // and must get nothing — recall is tenant-scoped before scope-scoped.
+  it('tenant-mismatched scope does not leak across tenants', () => {
+    const ctxA = (r: string) => ({ hippoRoot: r, tenantId: 'tenantA', actor: 'cli' });
+    const ctxB = (r: string) => ({ hippoRoot: r, tenantId: 'tenantB', actor: 'cli' });
+    ingestMessage(ctxB(root), {
+      teamId: 'T1', channel: { id: 'CSHARED', is_private: true },
+      message: { type: 'message', channel: 'CSHARED', user: 'U1', text: 'tenantB secret', ts: '3.3' },
+      eventId: 'EvShared',
+    });
+    const r = recall(ctxA(root), { query: 'secret', scope: 'slack:private:CSHARED' });
+    expect(r.results).toHaveLength(0);
+  });
 });
+```
+
+The default-deny rule in the first new test is load-bearing: implement `recall()` so the absence of `opts.scope` filters OUT any row whose scope starts with `'slack:private:'`. Sketch:
+
+```ts
+const all = loadSearchEntries(ctx.hippoRoot, opts.query, undefined, ctx.tenantId);
+let entries = all;
+if (opts.scope !== undefined && opts.scope !== '') {
+  entries = all.filter((e) => e.scope === opts.scope);
+} else {
+  // Default-deny: a no-scope caller cannot see private slack channels.
+  entries = all.filter((e) => !(e.scope ?? '').startsWith('slack:private:'));
+}
 ```
 
 **Step 2: Run to verify it fails**
@@ -1163,13 +1331,18 @@ git commit -m "feat(api): scope filter on recall for permission mirroring"
 
 ---
 
-## Task 11: Webhook route + URL verification
+## Task 11: Webhook route + URL verification + tenant-routing seam + lockdown test
 
-**Why:** Slack POSTs events to a single URL. The route must (a) handle the one-time `url_verification` handshake, (b) verify the HMAC signature on every other request, (c) parse the envelope, (d) call `ingestMessage` or `handleMessageDeleted`, (e) on parse failure write to DLQ and STILL ack 200 (otherwise Slack retries forever). All under the 1MB body cap that A1 already enforces.
+**Why:** Slack POSTs events to a single URL. The route must (a) handle the one-time `url_verification` handshake, (b) verify the HMAC signature on every other request, (c) resolve `body.team_id` → tenant via the `slack_workspaces` table (review patch #6) with a fallback to `HIPPO_TENANT`, (d) parse the envelope, (e) call `ingestMessage` or `handleMessageDeleted`, (f) on parse failure write to DLQ and STILL ack 200 (otherwise Slack retries forever). All under the 1MB body cap that A1 already enforces.
+
+**Critical auth shape (review patch #2):** the Slack route is the FIRST and ONLY public `/v1/*` route. Without an explicit allow-list, a future global Bearer middleware silently breaks it (or, worse, the gate gets removed because "Slack needs to be public" — bypass surface). This task introduces a `PUBLIC_ROUTES` constant in `server.ts` and a lockdown test asserting every other `/v1/*` route returns 401 without Bearer (so a future regression that drops the Bearer gate can't ship green).
 
 **Files:**
-- Modify: `src/server.ts` — add the route, import the connector helpers.
+- Modify: `src/server.ts` — add the route, import the connector helpers, add `PUBLIC_ROUTES` constant, route Slack lookups through `resolveTenantForTeam`.
+- Create: `src/connectors/slack/tenant-routing.ts` — `resolveTenantForTeam(db, teamId): string | null` helper. Falls back to null when no row; caller uses `HIPPO_TENANT` then.
 - Create: `tests/slack-webhook-route.test.ts`
+- Create: `tests/slack-tenant-routing.test.ts` — proves `slack_workspaces` rows route, empty table falls back.
+- Create: `tests/server-bearer-lockdown.test.ts` — proves every `/v1/*` route except `/v1/connectors/slack/events` returns 401 with no Bearer when the loopback fallback is disabled.
 
 **Step 1: Write the failing test**
 
@@ -1261,8 +1434,82 @@ describe('POST /v1/connectors/slack/events', () => {
       expect(Number(row.c)).toBe(1);
     } finally { closeHippoDb(db); }
   });
+
+  // Review patch #7: missing secret returns 404 (route appears unmounted), not 503.
+  it('returns 404 when SLACK_SIGNING_SECRET is unset (no config leak)', async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    const body = '{}';
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body,
+    });
+    expect(res.status).toBe(404);
+    process.env.SLACK_SIGNING_SECRET = SECRET;
+  });
+
+  // Review patch #2 positive case: route accepts requests with valid signature
+  // and NO Authorization header (because it's in PUBLIC_ROUTES).
+  it('accepts valid signature with no Bearer (PUBLIC_ROUTES allow-list)', async () => {
+    const body = JSON.stringify({
+      type: 'event_callback', team_id: 'T1', event_id: 'EvNoBearer', event_time: Math.floor(Date.now() / 1000),
+      event: { type: 'message', channel: 'C1', user: 'U1', text: 'no-bearer ok', ts: '1700000001.000200' },
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      // No Authorization header on purpose.
+      headers: { 'content-type': 'application/json', 'x-slack-request-timestamp': ts, 'x-slack-signature': sign(ts, body) },
+      body,
+    });
+    expect(res.status).toBe(200);
+  });
 });
 ```
+
+Add the lockdown test in `tests/server-bearer-lockdown.test.ts`. It mints an API key, then asserts every other `/v1/*` route returns 401 without Bearer (when loopback-no-auth is disabled via `HIPPO_REQUIRE_AUTH=1` or equivalent — inspect existing server.ts auth shape and pick the smallest existing knob; if none exists, set a request-time `X-Hippo-Force-Auth` header that the server respects in tests).
+
+```ts
+// tests/server-bearer-lockdown.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { serve } from '../src/server.js';
+
+describe('server Bearer lockdown', () => {
+  let root: string;
+  let handle: { stop: () => Promise<void>; port: number };
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-lockdown-'));
+    initStore(root);
+    process.env.HIPPO_REQUIRE_AUTH = '1';
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+  });
+  afterEach(async () => { delete process.env.HIPPO_REQUIRE_AUTH; await handle.stop(); rmSync(root, { recursive: true, force: true }); });
+
+  const v1Routes: Array<{ method: string; path: string; body?: string }> = [
+    { method: 'POST', path: '/v1/memories', body: '{"content":"x"}' },
+    { method: 'GET', path: '/v1/memories?q=x' },
+    { method: 'POST', path: '/v1/auth/keys', body: '{}' },
+    { method: 'GET', path: '/v1/auth/keys' },
+    { method: 'GET', path: '/v1/audit' },
+  ];
+
+  it('all /v1/* routes except slack require Bearer', async () => {
+    for (const r of v1Routes) {
+      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, {
+        method: r.method,
+        headers: { 'content-type': 'application/json' },
+        body: r.body,
+      });
+      expect(res.status, `${r.method} ${r.path}`).toBe(401);
+    }
+  });
+});
+```
+
+Note: if `server.ts` does not yet expose a way to disable the loopback-no-auth fallback for tests, this task ALSO adds that knob (ideally `HIPPO_REQUIRE_AUTH=1`). It's a one-liner but it's load-bearing for the lockdown invariant.
 
 **Step 2: Run to verify it fails**
 
@@ -1271,42 +1518,76 @@ Expected: FAIL — route returns 404 for all four cases.
 
 **Step 3: Implement**
 
-In `src/server.ts`, after the `/v1/audit` block and before the MCP routes, add:
+First, write the tenant-routing helper:
+
+```ts
+// src/connectors/slack/tenant-routing.ts
+import type { DatabaseSyncLike } from '../../db.js';
+
+/**
+ * Look up the tenant_id for a Slack team_id. Returns null when no row exists,
+ * which signals "use the deployment's HIPPO_TENANT fallback". Multi-workspace
+ * deployments populate slack_workspaces; single-workspace deployments leave
+ * the table empty and rely on the env fallback.
+ */
+export function resolveTenantForTeam(db: DatabaseSyncLike, teamId: string): string | null {
+  const row = db.prepare(`SELECT tenant_id FROM slack_workspaces WHERE team_id = ?`).get(teamId) as
+    | { tenant_id?: string }
+    | undefined;
+  return row?.tenant_id ?? null;
+}
+```
+
+Add a small test (`tests/slack-tenant-routing.test.ts`) asserting (a) populated row routes to that tenant, (b) empty table returns null, (c) lookup is exact-match (no prefix bleed).
+
+Then in `src/server.ts`, near the top of the file (alongside the existing route constants), add:
+
+```ts
+// Review patch #2: explicit allow-list for unauthenticated /v1/* routes.
+// New unauth routes MUST be added here AND get a corresponding entry in
+// tests/server-bearer-lockdown.test.ts. Do not gate by `path.startsWith`
+// match elsewhere — pattern-positional auth is bypass-by-accident.
+const PUBLIC_ROUTES: ReadonlySet<string> = new Set(['POST /v1/connectors/slack/events']);
+```
+
+Adjust the existing Bearer enforcement seam (`buildContextWithAuth` or whichever helper currently runs auth) to consult `PUBLIC_ROUTES` and skip the Bearer requirement when `${method} ${path}` is in the set. The Slack route still verifies its own HMAC signature — auth is replaced, not removed.
+
+Then, after the `/v1/audit` block and before the MCP routes, add the route itself:
 
 ```ts
 // POST /v1/connectors/slack/events — Slack Events API webhook.
 //
-// Verifies HMAC signature, handles url_verification handshake, dispatches
-// event_callback envelopes to ingestMessage / handleMessageDeleted, and
-// parks malformed payloads in slack_dlq. Always ACKs 200 on signed requests
-// (apart from URL verification which echoes the challenge) so Slack does
-// not enter the retry storm. Auth is signature-based, NOT Bearer — a Slack
-// signing secret is the only credential. Bearer enforcement here would
-// require Slack to mint a bearer per workspace, which it can't.
+// Verifies HMAC signature, handles url_verification handshake, resolves
+// team_id → tenantId via slack_workspaces (falls back to HIPPO_TENANT),
+// dispatches event_callback envelopes to ingestMessage / handleMessageDeleted,
+// and parks malformed payloads in slack_dlq. Always ACKs 200 on signed
+// requests (apart from URL verification which echoes the challenge) so
+// Slack does not enter the retry storm. Auth is signature-based, NOT
+// Bearer — a Slack signing secret is the only credential.
 if (method === 'POST' && path === '/v1/connectors/slack/events') {
   const rawBody = await readBody(req);
-  const sig = req.headers['x-slack-signature'];
-  const tsHdr = req.headers['x-slack-request-timestamp'];
   const secret = process.env.SLACK_SIGNING_SECRET;
   if (!secret) {
-    throw new HttpError(503, 'SLACK_SIGNING_SECRET not configured');
+    // Review patch #7: 404 (route appears unmounted) instead of 503,
+    // so a probe cannot distinguish "route gated off by config" from
+    // "route does not exist on this build".
+    res.writeHead(404, JSON_HEADERS);
+    res.end(JSON.stringify({ error: 'not found' }));
+    return;
   }
+  const sig = req.headers['x-slack-signature'];
+  const tsHdr = req.headers['x-slack-request-timestamp'];
   if (typeof sig !== 'string' || typeof tsHdr !== 'string' ||
       !verifySlackSignature({ rawBody, timestamp: tsHdr, signature: sig, signingSecret: secret })) {
     throw new HttpError(401, 'invalid Slack signature');
   }
-  // After signature verification, build a tenant context. Single-tenant
-  // deployments use HIPPO_TENANT; multi-tenant routing by team_id is a
-  // v2 follow-up (TODOS.md).
-  const ctx = {
-    hippoRoot: opts.hippoRoot,
-    tenantId: process.env.HIPPO_TENANT ?? 'default',
-    actor: 'connector:slack',
-  };
+  // Resolve tenant: parse the body once to peek at team_id, then look up
+  // slack_workspaces. We re-use the parsed body below for routing, so we
+  // don't pay the JSON.parse cost twice.
   let body: unknown;
   try { body = JSON.parse(rawBody); } catch {
-    const db = openHippoDb(ctx.hippoRoot);
-    try { writeToDlq(db, { tenantId: ctx.tenantId, rawPayload: rawBody, error: 'invalid JSON' }); }
+    const db = openHippoDb(opts.hippoRoot);
+    try { writeToDlq(db, { tenantId: process.env.HIPPO_TENANT ?? 'default', rawPayload: rawBody, error: 'invalid JSON' }); }
     finally { closeHippoDb(db); }
     sendJson(res, 200, { ok: true, status: 'dlq' });
     return;
@@ -1315,6 +1596,19 @@ if (method === 'POST' && path === '/v1/connectors/slack/events') {
     sendJson(res, 200, { challenge: String((body as Record<string, unknown>).challenge ?? '') });
     return;
   }
+  let resolvedTenant = process.env.HIPPO_TENANT ?? 'default';
+  if (isSlackEventEnvelope(body)) {
+    const db = openHippoDb(opts.hippoRoot);
+    try {
+      const mapped = resolveTenantForTeam(db, body.team_id);
+      if (mapped) resolvedTenant = mapped;
+    } finally { closeHippoDb(db); }
+  }
+  const ctx = {
+    hippoRoot: opts.hippoRoot,
+    tenantId: resolvedTenant,
+    actor: 'connector:slack',
+  };
   if (!isSlackEventEnvelope(body)) {
     const db = openHippoDb(ctx.hippoRoot);
     try { writeToDlq(db, { tenantId: ctx.tenantId, rawPayload: rawBody, error: 'not an event_callback envelope' }); }
@@ -1359,6 +1653,7 @@ import { isSlackEventEnvelope, isSlackMessageEvent } from './connectors/slack/ty
 import { ingestMessage } from './connectors/slack/ingest.js';
 import { handleMessageDeleted } from './connectors/slack/deletion.js';
 import { writeToDlq } from './connectors/slack/dlq.js';
+import { resolveTenantForTeam } from './connectors/slack/tenant-routing.js';
 ```
 
 **Step 4: Run to verify it passes**
@@ -1906,20 +2201,33 @@ export async function runSlackSmoke(opts: SmokeOpts): Promise<SmokeResult> {
   const ctx = { hippoRoot: opts.hippoRoot, tenantId: 'default', actor: 'connector:slack' };
   const start = Date.now();
   let calls = 0;
-  // No outbound HTTP: this drives ingestMessage directly. The success criterion
-  // is that the connector layer never reaches for fetch() on the happy path.
-  const outboundHttp = 0;
-  for (let pass = 0; pass < opts.replay; pass++) {
-    for (let i = 0; i < opts.count; i++) {
-      ingestMessage(ctx, {
-        teamId: 'T1',
-        channel: { id: 'C1', is_private: false },
-        message: { type: 'message', channel: 'C1', user: 'U1', text: `msg ${i}`, ts: `${1700000000 + i}.000100` },
-        eventId: `Ev-${i}`,
-      });
-      calls++;
+
+  // Review patch #5: spy globalThis.fetch and throw on any call. This proves
+  // the no-outbound-HTTP invariant for real, instead of hardcoding a 0 that
+  // would silently lie if a future code path added a fetch() call.
+  const origFetch = globalThis.fetch;
+  let outboundHttp = 0;
+  globalThis.fetch = ((..._args: unknown[]) => {
+    outboundHttp++;
+    throw new Error('outbound HTTP forbidden during slack smoke');
+  }) as typeof fetch;
+
+  try {
+    for (let pass = 0; pass < opts.replay; pass++) {
+      for (let i = 0; i < opts.count; i++) {
+        ingestMessage(ctx, {
+          teamId: 'T1',
+          channel: { id: 'C1', is_private: false },
+          message: { type: 'message', channel: 'C1', user: 'U1', text: `msg ${i}`, ts: `${1700000000 + i}.000100` },
+          eventId: `Ev-${i}`,
+        });
+        calls++;
+      }
     }
+  } finally {
+    globalThis.fetch = origFetch;
   }
+
   const uniqueMemories = loadAllEntries(opts.hippoRoot).filter((e) => e.tags.includes('source:slack')).length;
   return { uniqueMemories, totalIngestCalls: calls, outboundHttp, durationMs: Date.now() - start };
 }
@@ -2040,25 +2348,24 @@ export async function runIncidentRecallEval(opts: { hippoRoot: string }): Promis
   const ctx: Context = { hippoRoot: opts.hippoRoot, tenantId: 'default', actor: 'eval:slack' };
   const results: Array<{ id: string; recallPrecision: number; baselinePrecision: number; beat: boolean }> = [];
   for (const sc of scenarios) {
-    // Ingest the transcript.
+    // Review patch #8: stamp a per-message sentinel so recall-result matching
+    // is deterministic. The sentinel `[s:<scenario>:<ts>]` is unique across
+    // the entire eval corpus — content equality + ambient phrase repetition
+    // can no longer produce false positives.
+    const sentinel = (m: { ts: string }) => `[s:${sc.id}:${m.ts}]`;
     for (const m of sc.transcript) {
       ingestMessage(ctx, {
         teamId: 'T1', channel: { id: sc.channel, is_private: false },
-        message: { type: 'message', channel: sc.channel, user: m.user, text: m.text, ts: m.ts },
+        message: { type: 'message', channel: sc.channel, user: m.user, text: `${m.text} ${sentinel(m)}`, ts: m.ts },
         eventId: `${sc.id}:${m.ts}`,
       });
     }
-    // Recall.
     const r = recall(ctx, { query: sc.query, limit: 10, scope: `slack:public:${sc.channel}` });
-    const recalledTs = new Set(r.results.map((x) => {
-      // artifact_ref → ts (last segment). The recall result doesn't carry artifact_ref; look up via memories table is fine, but for V1 we approximate by
-      // storing ts in the tags is simpler. To keep eval honest, fetch via api/store directly.
-      return x.id; // placeholder — real impl reads artifact_ref via openHippoDb
-    }));
-    void recalledTs; // see TODO below
-    const recallHit = sc.answer_ts.filter((ts) => sc.transcript.some((m) => m.ts === ts && r.results.some((res) => res.content === m.text))).length;
+    const recallHit = sc.answer_ts.filter((ts) =>
+      r.results.some((res) => res.content.includes(sentinel({ ts }))),
+    ).length;
     const recallPrecision = recallHit / sc.answer_ts.length;
-    // Baseline: last 10 messages.
+    // Baseline: last 10 messages of the raw transcript (before sentinel stamping).
     const tail = sc.transcript.slice(-10);
     const baselineHit = sc.answer_ts.filter((ts) => tail.some((m) => m.ts === ts)).length;
     const baselinePrecision = baselineHit / sc.answer_ts.length;
@@ -2068,7 +2375,7 @@ export async function runIncidentRecallEval(opts: { hippoRoot: string }): Promis
 }
 ```
 
-Note: the `recall` result currently returns `content` and `id`, not artifact_ref. The eval matches by content for V1; if A6/F-track work changes content shape, the eval needs to switch to artifact_ref lookup. Document this in the file.
+The sentinel approach (review patch #8) is intentionally low-tech: zero changes to `api.recall`'s response shape, deterministic, and faster than a second SQL round-trip to look up artifact_ref. Document the sentinel format in `scenarios.json`'s schema header so the corpus stays portable.
 
 Compose 10 realistic incident scenarios. Each scenario gets ~100-line transcripts where the answer messages are buried in the middle so the tail-baseline misses them.
 
@@ -2127,22 +2434,26 @@ git commit -m "docs(slack): wrap up E1.3 — relabel pass + CHANGELOG + README"
 
 A reviewer accepting this work checks:
 
-1. `npx vitest run` — all 17 new test files green plus the existing suite untouched.
-2. `node dist/benchmarks/e1.3/slack-1000-event-smoke.js` — prints `PASS` (1000 unique memories, zero outbound HTTP, <500ms/event).
-3. `npx vitest run tests/slack-incident-recall.test.ts` — recall beats tail baseline on ≥7/10 staged scenarios.
+1. `npx vitest run` — every new test file green (schema, types, signature, idempotency, dlq, scope, transform, ingest, deletion, permission-mirror, webhook-route, tenant-routing, bearer-lockdown, ratelimit, backfill, cli, web-client, smoke-1000, incident-recall, api-remember-after-write) plus the existing suite untouched.
+2. `node dist/benchmarks/e1.3/slack-1000-event-smoke.js` — prints `PASS` (1000 unique memories, **zero outbound HTTP proven by globalThis.fetch spy**, <500ms/event).
+3. `npx vitest run tests/slack-incident-recall.test.ts` — recall beats tail baseline on ≥7/10 staged scenarios using the per-message sentinel match (review patch #8).
 4. `grep -rn "kind: 'raw'" src/connectors/slack/` — exactly one hit (in `transform.ts`).
 5. `grep -rn "archiveRawMemory\|archiveRaw" src/connectors/slack/` — exactly one call (in `deletion.ts` via `api.archiveRaw`).
-6. Schema migration v17 runs on a fresh db and on a v16 db without errors.
-7. Webhook route refuses requests with bad / missing signatures (manual `curl` plus the route test).
-8. `hippo slack dlq list` prints rows; `hippo slack backfill --channel C0000` errors clearly when `SLACK_BOT_TOKEN` is unset.
-9. `TODOS.md` updated with the relabel item removed and the v2 follow-ups added.
-10. The CHANGELOG entry says what shipped, not what was tried.
+6. Schema migration v17 runs on a fresh db and on a v16 db without errors. Tables created: `slack_event_log`, `slack_cursors`, `slack_dlq`, `slack_workspaces` (review patch #6).
+7. Webhook route returns 404 with `SLACK_SIGNING_SECRET` unset (review patch #7), 401 on bad/missing signatures, 200 on valid signature with no Bearer (review patch #2 PUBLIC_ROUTES).
+8. `tests/server-bearer-lockdown.test.ts` proves every other `/v1/*` route returns 401 without Bearer (review patch #2).
+9. `tests/api-remember-after-write.test.ts` proves the `afterWrite` hook is transactional (review patch #3 — rollback drops the memory).
+10. `tests/slack-deletion.test.ts` includes the cross-tenant case (review patch #1 — tenant A cannot archive tenant B's row).
+11. `tests/slack-permission-mirror.test.ts` covers no-scope default-deny, mismatched-scope-zero, and tenant-mismatched-scope (review patch #4).
+12. `hippo slack dlq list` prints rows; `hippo slack backfill --channel C0000` errors clearly when `SLACK_BOT_TOKEN` is unset.
+13. `TODOS.md` updated with the relabel item removed and the v2 follow-ups added.
+14. The CHANGELOG entry says what shipped, not what was tried.
 
 ## Out of scope (track for v2)
 
-- Per-`team_id` tenant routing (today the route uses `HIPPO_TENANT`; a multi-tenant deployment needs a `slack_workspaces` table mapping team_id → tenant_id).
 - Slash-command write-backs (`/hippo remember <text>`). V1 is read-only.
 - Thread-aware ranking (treat `thread_ts` as a parent boost).
 - DLQ replay command (`hippo slack dlq retry <id>`).
-- Eval scoring by `artifact_ref` instead of `content` match.
+- Eval scoring by `artifact_ref` instead of sentinel match (the sentinel is fine for the synthetic corpus; real-traffic evals may want artifact_ref, which would extend `RecallResultItem`).
 - Incremental real-time backfill (today's loop drains the channel; for live workspaces add a "stop at cursor" mode).
+- Operator UI for `slack_workspaces` (today's table is populated via direct SQL; v2 adds `hippo slack workspaces add --team T --tenant t`).

--- a/docs/plans/2026-04-29-e1.3-slack-ingestion.md
+++ b/docs/plans/2026-04-29-e1.3-slack-ingestion.md
@@ -1,0 +1,2148 @@
+# E1.3 Slack Append-Only Ingestion Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stream Slack workspace events into hippo as `kind='raw'` rows with full provenance, idempotency, cursor-based backfill, source-deletion sync, permission mirroring, and a dead-letter queue. The first end-to-end ingestion connector built on the A3+A5+A1 stack.
+
+**Architecture:** The Slack adapter is a thin module under `src/connectors/slack/` that translates Slack events (webhooks + Web API backfill) into `api.remember()` calls with `kind='raw'`, `source='slack'`, `artifact_ref='slack://team/channel/ts'`, and a `scope` derived from channel privacy. A new HTTP route `POST /v1/connectors/slack/events` verifies Slack's HMAC signature, deduplicates against a `slack_event_log` table, and routes deletions through `archiveRawMemory()` to honour the append-only invariant. Backfill paginates the conversations.history API with a per-channel cursor stored in `slack_cursors`; rate-limit (429) responses pause and resume. Malformed events land in `slack_dlq` for offline review.
+
+**Tech Stack:** TypeScript, node:sqlite, node:http (existing A1 server), Node's built-in `crypto` (HMAC-SHA256 timing-safe), real DB tests via vitest (no mocks), `WebClient`-shaped fetch interface so the test harness can inject canned responses without a network.
+
+**Non-goals (V1):**
+- No write-back to Slack (zero source-system writes). Read-only adapter.
+- No worker queue. Webhook handler is synchronous; Slack's 3s budget is plenty for an idempotency check + one `INSERT`.
+- No browser-automation fallback. Slack's Events API + Web API are both first-class.
+- No rich-text rendering. The connector stores the message text verbatim and lets `recall` rank it.
+
+**ROADMAP success criterion:** 1000-event smoke test with no source-system writes; recall surfaces incident context faster than transcript replay on 10 staged scenarios. Both must pass before tagging this work shipped.
+
+---
+
+## Background reading (do this BEFORE Task 1)
+
+Read these in order. Each links into a downstream task — skipping = drift.
+
+- `ROADMAP-RESEARCH.md` lines 240-249, 123-129 — the E1.3 spec and the per-connector test invariants this plan must hit.
+- `src/api.ts` (full file, ~457 lines) — domain layer. Tasks 7-11 call into `remember()`, `archiveRaw()`, and `auditList()` exactly as written. Don't reinvent.
+- `src/raw-archive.ts` — the only legitimate way to delete `kind='raw'` rows. Source-deletion (Task 11) routes through here.
+- `src/db.ts` migrations 14-16 — A3 envelope (kind/scope/owner/artifact_ref) and the append-only trigger on `kind='raw'`. Task 1 adds migration 17 alongside.
+- `src/server.ts` lines 312-595 — the route table and `buildContextWithAuth` helper. Task 12 inserts `/v1/connectors/slack/events` here.
+- `src/importers.ts` lines 86-92 — explicit comment marking E1.x connectors as the boundary that must use `kind='raw'`. Task 7 honours that.
+- Slack docs: <https://api.slack.com/events-api> (signed envelope shape), <https://api.slack.com/authentication/verifying-requests-from-slack> (signature algorithm), <https://api.slack.com/methods/conversations.history> (backfill pagination, `cursor` + `response_metadata.next_cursor`).
+
+---
+
+## Task 1: Schema v17 — slack_event_log, slack_cursors, slack_dlq
+
+**Why:** Three durable tables: idempotency (one row per Slack event_id), backfill cursors (per-channel resume point), and a DLQ for events that can't be parsed. All three live in the hippo SQLite db so a single backup captures connector state.
+
+**Files:**
+- Modify: `src/db.ts` — append migration block to the migrations array (the version field is the next integer after 16).
+- Create: `tests/slack-schema.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-schema.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+describe('schema v17 — slack ingestion tables', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-schema-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('creates slack_event_log with PRIMARY KEY on event_id', () => {
+    const db = openHippoDb(root);
+    try {
+      const cols = db.prepare(`PRAGMA table_info(slack_event_log)`).all() as Array<Record<string, unknown>>;
+      const eventIdCol = cols.find((c) => c.name === 'event_id');
+      expect(eventIdCol).toBeDefined();
+      expect(eventIdCol!.pk).toBe(1);
+      // Re-insert same event_id must throw (PK uniqueness).
+      db.prepare(`INSERT INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`).run('E1', '2026-04-29T00:00:00Z', 'm1');
+      expect(() =>
+        db.prepare(`INSERT INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`).run('E1', '2026-04-29T00:00:01Z', 'm2'),
+      ).toThrow();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates slack_cursors keyed on (tenant_id, channel_id)', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(`INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?, ?, ?, ?)`).run('default', 'C1', '1700000000.000000', '2026-04-29T00:00:00Z');
+      // Same composite key collides; INSERT OR REPLACE supported.
+      expect(() =>
+        db.prepare(`INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?, ?, ?, ?)`).run('default', 'C1', '1700000001.000000', '2026-04-29T00:00:01Z'),
+      ).toThrow();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates slack_dlq with autoincrementing id and received_at', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(`INSERT INTO slack_dlq (tenant_id, raw_payload, error, received_at) VALUES (?, ?, ?, ?)`).run('default', '{}', 'parse error', '2026-04-29T00:00:00Z');
+      const row = db.prepare(`SELECT id FROM slack_dlq LIMIT 1`).get() as { id: number };
+      expect(row.id).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/slack-schema.test.ts`
+Expected: FAIL with `no such table: slack_event_log`.
+
+**Step 3: Implement migration v17**
+
+Append to the migrations array in `src/db.ts` (after the v16 block):
+
+```ts
+{
+  version: 17,
+  up: (db) => {
+    // E1.3 Slack ingestion: idempotency log, per-channel backfill cursors, DLQ.
+    // See docs/plans/2026-04-29-e1.3-slack-ingestion.md.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS slack_event_log (
+        event_id TEXT PRIMARY KEY,
+        ingested_at TEXT NOT NULL,
+        memory_id TEXT
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_slack_event_log_memory ON slack_event_log(memory_id) WHERE memory_id IS NOT NULL`);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS slack_cursors (
+        tenant_id TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        latest_ts TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, channel_id)
+      )
+    `);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS slack_dlq (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tenant_id TEXT NOT NULL,
+        raw_payload TEXT NOT NULL,
+        error TEXT NOT NULL,
+        received_at TEXT NOT NULL,
+        retried_at TEXT
+      )
+    `);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_slack_dlq_tenant_received ON slack_dlq(tenant_id, received_at)`);
+  },
+},
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/slack-schema.test.ts`
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/db.ts tests/slack-schema.test.ts
+git commit -m "feat(slack): schema v17 for ingestion idempotency, cursors, DLQ"
+```
+
+---
+
+## Task 2: Slack types
+
+**Why:** A small typed surface for the Slack event shapes the adapter consumes. Centralised so future changes to Slack's payload shape are one file, not eight.
+
+**Files:**
+- Create: `src/connectors/slack/types.ts`
+- Create: `tests/slack-types.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-types.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  isSlackEventEnvelope,
+  isSlackMessageEvent,
+  type SlackEventEnvelope,
+  type SlackMessageEvent,
+} from '../src/connectors/slack/types.js';
+
+describe('slack types', () => {
+  it('accepts a well-formed event envelope', () => {
+    const envelope: SlackEventEnvelope = {
+      type: 'event_callback',
+      team_id: 'T1',
+      event_id: 'Ev1',
+      event_time: 1700000000,
+      event: { type: 'message', channel: 'C1', user: 'U1', text: 'hi', ts: '1700000000.000100' },
+    };
+    expect(isSlackEventEnvelope(envelope)).toBe(true);
+  });
+
+  it('accepts a message_deleted subtype', () => {
+    const evt = {
+      type: 'message',
+      subtype: 'message_deleted',
+      channel: 'C1',
+      deleted_ts: '1700000000.000100',
+      ts: '1700000001.000200',
+    };
+    expect(isSlackMessageEvent(evt)).toBe(true);
+    expect((evt as SlackMessageEvent).subtype).toBe('message_deleted');
+  });
+
+  it('rejects malformed envelopes', () => {
+    expect(isSlackEventEnvelope({ type: 'event_callback' })).toBe(false);
+    expect(isSlackEventEnvelope(null)).toBe(false);
+    expect(isSlackEventEnvelope({ event_id: 'Ev1', event: {} })).toBe(false);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-types.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/types.ts
+/**
+ * Slack Events API envelope shapes used by the ingestion connector.
+ * Spec: https://api.slack.com/events-api
+ */
+
+export interface SlackUrlVerification {
+  type: 'url_verification';
+  challenge: string;
+  token?: string;
+}
+
+export interface SlackMessageEvent {
+  type: 'message';
+  subtype?: 'message_deleted' | 'message_changed' | 'channel_join' | string;
+  channel: string;
+  channel_type?: 'channel' | 'group' | 'im' | 'mpim';
+  user?: string;
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  /** Present on subtype='message_deleted'. */
+  deleted_ts?: string;
+}
+
+export interface SlackEventEnvelope {
+  type: 'event_callback';
+  team_id: string;
+  event_id: string;
+  event_time: number;
+  event: SlackMessageEvent | { type: string; [k: string]: unknown };
+}
+
+export type SlackInbound = SlackEventEnvelope | SlackUrlVerification;
+
+export function isSlackEventEnvelope(x: unknown): x is SlackEventEnvelope {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return (
+    o.type === 'event_callback' &&
+    typeof o.team_id === 'string' &&
+    typeof o.event_id === 'string' &&
+    typeof o.event_time === 'number' &&
+    !!o.event &&
+    typeof o.event === 'object' &&
+    typeof (o.event as Record<string, unknown>).type === 'string'
+  );
+}
+
+export function isSlackMessageEvent(x: unknown): x is SlackMessageEvent {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return o.type === 'message' && typeof o.channel === 'string' && typeof o.ts === 'string';
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-types.test.ts`
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/types.ts tests/slack-types.test.ts
+git commit -m "feat(slack): event envelope and message types"
+```
+
+---
+
+## Task 3: HMAC signature verification
+
+**Why:** Every Slack webhook arrives with `X-Slack-Signature` and `X-Slack-Request-Timestamp`. The signature is `v0=<hex>` where `<hex>` is `HMAC-SHA256(signingSecret, "v0:<ts>:<rawBody>")`. We verify it with `crypto.timingSafeEqual` and reject requests older than 5 minutes (replay defence). Without this, anyone who guesses the URL can write into our memory store.
+
+**Files:**
+- Create: `src/connectors/slack/signature.ts`
+- Create: `tests/slack-signature.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-signature.test.ts
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+import { verifySlackSignature } from '../src/connectors/slack/signature.js';
+
+const SECRET = 'shhh';
+
+function sign(ts: string, body: string): string {
+  const mac = createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex');
+  return `v0=${mac}`;
+}
+
+describe('verifySlackSignature', () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  it('accepts a valid signature within the 5min window', () => {
+    const body = '{"hello":"world"}';
+    const ts = String(now);
+    const sig = sign(ts, body);
+    expect(verifySlackSignature({ rawBody: body, timestamp: ts, signature: sig, signingSecret: SECRET, now })).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    const ts = String(now);
+    const sig = sign(ts, '{"hello":"world"}');
+    expect(verifySlackSignature({ rawBody: '{"hello":"evil"}', timestamp: ts, signature: sig, signingSecret: SECRET, now })).toBe(false);
+  });
+
+  it('rejects a stale timestamp (>5min skew)', () => {
+    const stale = String(now - 6 * 60);
+    const body = '{}';
+    const sig = sign(stale, body);
+    expect(verifySlackSignature({ rawBody: body, timestamp: stale, signature: sig, signingSecret: SECRET, now })).toBe(false);
+  });
+
+  it('rejects a malformed signature header', () => {
+    expect(verifySlackSignature({ rawBody: '{}', timestamp: String(now), signature: 'garbage', signingSecret: SECRET, now })).toBe(false);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-signature.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/signature.ts
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export interface VerifyOpts {
+  rawBody: string;
+  timestamp: string;
+  signature: string;
+  signingSecret: string;
+  /** Current unix seconds. Injectable for tests. */
+  now?: number;
+  /** Max allowed skew in seconds. Default 5 minutes (Slack's recommendation). */
+  skewSeconds?: number;
+}
+
+export function verifySlackSignature(opts: VerifyOpts): boolean {
+  const { rawBody, timestamp, signature, signingSecret } = opts;
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const skew = opts.skewSeconds ?? 5 * 60;
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(now - ts) > skew) return false;
+  if (!signature.startsWith('v0=')) return false;
+  const expected = `v0=${createHmac('sha256', signingSecret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`;
+  const a = Buffer.from(signature, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-signature.test.ts`
+Expected: 4 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/signature.ts tests/slack-signature.test.ts
+git commit -m "feat(slack): HMAC-SHA256 signature verification with replay window"
+```
+
+---
+
+## Task 4: Idempotency log helpers
+
+**Why:** Slack retries unacknowledged webhooks up to 3 times within 1 minute. The same `event_id` must not produce two memories. `slack_event_log` records every event we've seen; on replay we early-return without re-writing.
+
+**Files:**
+- Create: `src/connectors/slack/idempotency.ts`
+- Create: `tests/slack-idempotency.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-idempotency.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { hasSeenEvent, markEventSeen, lookupMemoryByEvent } from '../src/connectors/slack/idempotency.js';
+
+describe('slack idempotency', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-idem-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('hasSeenEvent returns false then true after marking', () => {
+    const db = openHippoDb(root);
+    try {
+      expect(hasSeenEvent(db, 'Ev1')).toBe(false);
+      markEventSeen(db, 'Ev1', 'm123');
+      expect(hasSeenEvent(db, 'Ev1')).toBe(true);
+      expect(lookupMemoryByEvent(db, 'Ev1')).toBe('m123');
+    } finally { closeHippoDb(db); }
+  });
+
+  it('markEventSeen is a no-op on duplicate (INSERT OR IGNORE)', () => {
+    const db = openHippoDb(root);
+    try {
+      markEventSeen(db, 'Ev1', 'm123');
+      // Second call must not throw and must not overwrite the original memory_id.
+      markEventSeen(db, 'Ev1', 'mDIFFERENT');
+      expect(lookupMemoryByEvent(db, 'Ev1')).toBe('m123');
+    } finally { closeHippoDb(db); }
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-idempotency.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/idempotency.ts
+import type { DatabaseSyncLike } from '../../db.js';
+
+export function hasSeenEvent(db: DatabaseSyncLike, eventId: string): boolean {
+  const row = db.prepare(`SELECT 1 FROM slack_event_log WHERE event_id = ?`).get(eventId);
+  return !!row;
+}
+
+export function markEventSeen(db: DatabaseSyncLike, eventId: string, memoryId: string | null): void {
+  db.prepare(`INSERT OR IGNORE INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`)
+    .run(eventId, new Date().toISOString(), memoryId);
+}
+
+export function lookupMemoryByEvent(db: DatabaseSyncLike, eventId: string): string | null {
+  const row = db.prepare(`SELECT memory_id FROM slack_event_log WHERE event_id = ?`).get(eventId) as
+    | { memory_id: string | null }
+    | undefined;
+  return row?.memory_id ?? null;
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-idempotency.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/idempotency.ts tests/slack-idempotency.test.ts
+git commit -m "feat(slack): idempotency log helpers"
+```
+
+---
+
+## Task 5: Dead-letter queue helpers
+
+**Why:** A webhook with a malformed body (Slack-side bug, future API change, signature passes but JSON is wrong) must not crash the route or get retried forever. Park the raw payload + error in `slack_dlq`, ack 200, move on. Operators inspect via CLI later.
+
+**Files:**
+- Create: `src/connectors/slack/dlq.ts`
+- Create: `tests/slack-dlq.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-dlq.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { writeToDlq, listDlq, markDlqRetried } from '../src/connectors/slack/dlq.js';
+
+describe('slack DLQ', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-dlq-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('captures raw payload + error and lists oldest-first', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{"a":1}', error: 'parse fail' });
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{"b":2}', error: 'unknown event type' });
+      const items = listDlq(db, { tenantId: 'default' });
+      expect(items).toHaveLength(2);
+      expect(items[0].error).toBe('parse fail');
+      expect(items[0].retriedAt).toBeNull();
+    } finally { closeHippoDb(db); }
+  });
+
+  it('markDlqRetried sets retried_at', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{}', error: 'boom' });
+      const [item] = listDlq(db, { tenantId: 'default' });
+      markDlqRetried(db, item.id);
+      const [after] = listDlq(db, { tenantId: 'default' });
+      expect(after.retriedAt).not.toBeNull();
+    } finally { closeHippoDb(db); }
+  });
+
+  it('listDlq scopes by tenantId', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{}', error: 'a' });
+      writeToDlq(db, { tenantId: 'acme', rawPayload: '{}', error: 'b' });
+      expect(listDlq(db, { tenantId: 'default' })).toHaveLength(1);
+      expect(listDlq(db, { tenantId: 'acme' })).toHaveLength(1);
+    } finally { closeHippoDb(db); }
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-dlq.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/dlq.ts
+import type { DatabaseSyncLike } from '../../db.js';
+
+export interface DlqItem {
+  id: number;
+  tenantId: string;
+  rawPayload: string;
+  error: string;
+  receivedAt: string;
+  retriedAt: string | null;
+}
+
+export interface WriteDlqOpts {
+  tenantId: string;
+  rawPayload: string;
+  error: string;
+}
+
+export function writeToDlq(db: DatabaseSyncLike, opts: WriteDlqOpts): number {
+  const result = db
+    .prepare(`INSERT INTO slack_dlq (tenant_id, raw_payload, error, received_at) VALUES (?, ?, ?, ?)`)
+    .run(opts.tenantId, opts.rawPayload, opts.error, new Date().toISOString());
+  return Number(result.lastInsertRowid);
+}
+
+export function listDlq(db: DatabaseSyncLike, opts: { tenantId: string; limit?: number }): DlqItem[] {
+  const rows = db
+    .prepare(`SELECT id, tenant_id, raw_payload, error, received_at, retried_at FROM slack_dlq WHERE tenant_id = ? ORDER BY received_at ASC LIMIT ?`)
+    .all(opts.tenantId, opts.limit ?? 100) as Array<Record<string, unknown>>;
+  return rows.map((r) => ({
+    id: Number(r.id),
+    tenantId: String(r.tenant_id),
+    rawPayload: String(r.raw_payload),
+    error: String(r.error),
+    receivedAt: String(r.received_at),
+    retriedAt: r.retried_at == null ? null : String(r.retried_at),
+  }));
+}
+
+export function markDlqRetried(db: DatabaseSyncLike, id: number): void {
+  db.prepare(`UPDATE slack_dlq SET retried_at = ? WHERE id = ?`).run(new Date().toISOString(), id);
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-dlq.test.ts`
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/dlq.ts tests/slack-dlq.test.ts
+git commit -m "feat(slack): dead-letter queue helpers"
+```
+
+---
+
+## Task 6: Channel privacy → scope mapping
+
+**Why:** Permission mirroring is the second-most-important invariant after idempotency. Public-channel messages get `scope='slack:public:<Cxxx>'`; private channels and DMs get `scope='slack:private:<Cxxx>'`. Recall scope filtering (already wired in `loadSearchEntries` per-row scope column) then keeps private content out of public-scoped queries.
+
+**Files:**
+- Create: `src/connectors/slack/scope.ts`
+- Create: `tests/slack-scope.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-scope.test.ts
+import { describe, it, expect } from 'vitest';
+import { scopeFromChannel } from '../src/connectors/slack/scope.js';
+
+describe('scopeFromChannel', () => {
+  it('public channel → slack:public:<id>', () => {
+    expect(scopeFromChannel({ id: 'C123', is_private: false, is_im: false, is_mpim: false })).toBe('slack:public:C123');
+  });
+  it('private channel → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'C456', is_private: true })).toBe('slack:private:C456');
+  });
+  it('DM (im) → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'D1', is_im: true })).toBe('slack:private:D1');
+  });
+  it('group DM (mpim) → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'G1', is_mpim: true })).toBe('slack:private:G1');
+  });
+  it('unknown → defaults to private (fail closed)', () => {
+    expect(scopeFromChannel({ id: 'X1' })).toBe('slack:private:X1');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-scope.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/scope.ts
+
+export interface ChannelMeta {
+  id: string;
+  is_private?: boolean;
+  is_im?: boolean;
+  is_mpim?: boolean;
+}
+
+/**
+ * Map a Slack channel into a hippo scope string.
+ *
+ * Default to private when privacy is undetermined. The cost of leaking a
+ * public channel into private scope (recall returns nothing) is far smaller
+ * than the cost of leaking a private channel into public scope (data exposed
+ * to a tenant that should not see it).
+ */
+export function scopeFromChannel(ch: ChannelMeta): string {
+  const isPublic = ch.is_private === false && !ch.is_im && !ch.is_mpim;
+  return isPublic ? `slack:public:${ch.id}` : `slack:private:${ch.id}`;
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-scope.test.ts`
+Expected: 5 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/scope.ts tests/slack-scope.test.ts
+git commit -m "feat(slack): channel privacy to scope mapping (fail-closed)"
+```
+
+---
+
+## Task 7: Message → MemoryEntry transform
+
+**Why:** The shape conversion from a Slack `SlackMessageEvent` to the `RememberOpts` consumed by `api.remember()`. Crucial that this stamps `kind='raw'`, `source='slack'`, `artifact_ref='slack://<team>/<channel>/<ts>'`, and the scope from Task 6. The artifact_ref doubles as the lookup key for source-deletion (Task 11).
+
+**Files:**
+- Create: `src/connectors/slack/transform.ts`
+- Create: `tests/slack-transform.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-transform.test.ts
+import { describe, it, expect } from 'vitest';
+import { messageToRememberOpts } from '../src/connectors/slack/transform.js';
+
+describe('messageToRememberOpts', () => {
+  it('produces kind=raw + slack:// artifact_ref + scope from channel privacy', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'incident at 3pm', ts: '1700000000.000100' },
+    });
+    expect(opts.kind).toBe('raw');
+    expect(opts.scope).toBe('slack:public:C1');
+    expect(opts.artifactRef).toBe('slack://T1/C1/1700000000.000100');
+    expect(opts.content).toBe('incident at 3pm');
+    expect(opts.tags).toEqual(expect.arrayContaining(['source:slack', 'channel:C1']));
+  });
+
+  it('skips empty bodies (returns null)', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C1' },
+      message: { type: 'message', channel: 'C1', ts: '1700000000.000100' },
+    });
+    expect(opts).toBeNull();
+  });
+
+  it('private channel → slack:private:<id>', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C2', is_private: true },
+      message: { type: 'message', channel: 'C2', user: 'U1', text: 'secret', ts: '1700000000.000100' },
+    });
+    expect(opts!.scope).toBe('slack:private:C2');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-transform.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/transform.ts
+import type { RememberOpts } from '../../api.js';
+import { scopeFromChannel, type ChannelMeta } from './scope.js';
+import type { SlackMessageEvent } from './types.js';
+
+export interface TransformInput {
+  teamId: string;
+  channel: ChannelMeta;
+  message: SlackMessageEvent;
+}
+
+/**
+ * Convert a SlackMessageEvent into RememberOpts for api.remember(). Returns
+ * null when the message has no usable body (e.g. system events, bot reactions
+ * without text). Caller treats null as "skip but mark idempotency seen".
+ */
+export function messageToRememberOpts(input: TransformInput): RememberOpts | null {
+  const text = input.message.text?.trim();
+  if (!text) return null;
+  const artifactRef = `slack://${input.teamId}/${input.channel.id}/${input.message.ts}`;
+  const tags = [
+    'source:slack',
+    `channel:${input.channel.id}`,
+    ...(input.message.user ? [`user:${input.message.user}`] : []),
+    ...(input.message.thread_ts ? [`thread:${input.message.thread_ts}`] : []),
+  ];
+  return {
+    content: text,
+    kind: 'raw',
+    scope: scopeFromChannel(input.channel),
+    artifactRef,
+    tags,
+  };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-transform.test.ts`
+Expected: 3 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/transform.ts tests/slack-transform.test.ts
+git commit -m "feat(slack): message-to-RememberOpts transform with kind=raw"
+```
+
+---
+
+## Task 8: ingestMessage — end-to-end idempotent write
+
+**Why:** The single function the webhook handler and backfill loop both call. Steps: idempotency check → transform → `api.remember()` → mark seen with the new memory id. Wraps these in a single SQLite transaction so a crash mid-write leaves no orphan log entry.
+
+**Files:**
+- Create: `src/connectors/slack/ingest.ts`
+- Create: `tests/slack-ingest.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-ingest.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('ingestMessage', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-ingest-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('writes a kind=raw memory and is idempotent on replay', () => {
+    const evt = {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message' as const, channel: 'C1', user: 'U1', text: 'hello', ts: '1700.0001' },
+      eventId: 'Ev1',
+    };
+    const r1 = ingestMessage(ctx(root), evt);
+    expect(r1.status).toBe('ingested');
+    expect(r1.memoryId).toBeDefined();
+
+    const r2 = ingestMessage(ctx(root), evt);
+    expect(r2.status).toBe('duplicate');
+    expect(r2.memoryId).toBe(r1.memoryId);
+
+    const entries = loadAllEntries(root);
+    const slackEntries = entries.filter((e) => e.source === 'slack' || e.tags.includes('source:slack'));
+    expect(slackEntries).toHaveLength(1);
+    expect(slackEntries[0].kind).toBe('raw');
+  });
+
+  it('marks empty-body messages as skipped without writing', () => {
+    const evt = {
+      teamId: 'T1',
+      channel: { id: 'C1' },
+      message: { type: 'message' as const, channel: 'C1', ts: '1700.0001' },
+      eventId: 'Ev2',
+    };
+    const r = ingestMessage(ctx(root), evt);
+    expect(r.status).toBe('skipped');
+    // Replay still returns duplicate, not skipped, because seen is marked.
+    expect(ingestMessage(ctx(root), evt).status).toBe('duplicate');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-ingest.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/ingest.ts
+import { remember, type Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { hasSeenEvent, markEventSeen, lookupMemoryByEvent } from './idempotency.js';
+import { messageToRememberOpts } from './transform.js';
+import type { ChannelMeta } from './scope.js';
+import type { SlackMessageEvent } from './types.js';
+
+export interface IngestInput {
+  teamId: string;
+  channel: ChannelMeta;
+  message: SlackMessageEvent;
+  /** Slack event_id for the envelope (or for backfill, a synthesized stable id). */
+  eventId: string;
+}
+
+export type IngestStatus = 'ingested' | 'duplicate' | 'skipped';
+
+export interface IngestResult {
+  status: IngestStatus;
+  memoryId: string | null;
+}
+
+export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
+  const db = openHippoDb(ctx.hippoRoot);
+  let alreadySeen = false;
+  let existingId: string | null = null;
+  try {
+    if (hasSeenEvent(db, input.eventId)) {
+      alreadySeen = true;
+      existingId = lookupMemoryByEvent(db, input.eventId);
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+  if (alreadySeen) return { status: 'duplicate', memoryId: existingId };
+
+  const opts = messageToRememberOpts(input);
+  if (!opts) {
+    const db2 = openHippoDb(ctx.hippoRoot);
+    try { markEventSeen(db2, input.eventId, null); }
+    finally { closeHippoDb(db2); }
+    return { status: 'skipped', memoryId: null };
+  }
+  // remember() opens its own db handle; we open another to mark the event log.
+  // Both writes succeed-or-fail atomically only if SQLite WAL persists them in
+  // order; an in-flight crash between them leaves the memory written but the
+  // event log unmarked → a replay would write a duplicate. Acceptable: the
+  // smoke test asserts no duplicates under the happy path, and dedup against
+  // artifact_ref is a future hardening (TODOS.md follow-up).
+  const result = remember({ ...ctx, actor: ctx.actor || 'connector:slack' }, opts);
+  const db3 = openHippoDb(ctx.hippoRoot);
+  try { markEventSeen(db3, input.eventId, result.id); }
+  finally { closeHippoDb(db3); }
+  return { status: 'ingested', memoryId: result.id };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-ingest.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/ingest.ts tests/slack-ingest.test.ts
+git commit -m "feat(slack): idempotent ingestMessage with skip handling"
+```
+
+---
+
+## Task 9: Source-deletion sync (handleMessageDeleted)
+
+**Why:** GDPR. When a Slack user deletes a message, hippo must invalidate the corresponding memory or stand accused of being a parallel store-of-record. The deletion arrives as a `subtype='message_deleted'` event with `deleted_ts`. We resolve `slack://<team>/<channel>/<deleted_ts>` to a memory_id via `artifact_ref` lookup, then route through `archiveRawMemory()` (the only legal path for `kind='raw'`).
+
+**Files:**
+- Create: `src/connectors/slack/deletion.ts`
+- Create: `tests/slack-deletion.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-deletion.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+import { handleMessageDeleted } from '../src/connectors/slack/deletion.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('handleMessageDeleted', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-del-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('archives the matching kind=raw row via archiveRawMemory', () => {
+    const ingested = ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'doomed', ts: '1700.0001' },
+      eventId: 'Ev1',
+    });
+    expect(ingested.status).toBe('ingested');
+
+    const result = handleMessageDeleted(ctx(root), {
+      teamId: 'T1',
+      channelId: 'C1',
+      deletedTs: '1700.0001',
+      eventId: 'EvDel1',
+    });
+    expect(result.status).toBe('archived');
+
+    const remaining = loadAllEntries(root).filter((e) => e.id === ingested.memoryId);
+    expect(remaining).toHaveLength(0);
+
+    // raw_archive table now has the row.
+    const db = openHippoDb(root);
+    try {
+      const arch = db.prepare(`SELECT memory_id, reason FROM raw_archive WHERE memory_id = ?`).get(ingested.memoryId!) as Record<string, unknown>;
+      expect(arch).toBeDefined();
+      expect(String(arch.reason)).toContain('source_deleted');
+    } finally { closeHippoDb(db); }
+  });
+
+  it('returns not_found for unknown artifact_ref (idempotent on replay)', () => {
+    const r = handleMessageDeleted(ctx(root), {
+      teamId: 'T1', channelId: 'C1', deletedTs: '9999.9999', eventId: 'EvDel2',
+    });
+    expect(r.status).toBe('not_found');
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-deletion.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/deletion.ts
+import { archiveRaw, type Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { markEventSeen, hasSeenEvent } from './idempotency.js';
+
+export interface DeletionInput {
+  teamId: string;
+  channelId: string;
+  deletedTs: string;
+  eventId: string;
+}
+
+export type DeletionStatus = 'archived' | 'not_found' | 'duplicate';
+
+export interface DeletionResult {
+  status: DeletionStatus;
+  memoryId: string | null;
+}
+
+export function handleMessageDeleted(ctx: Context, input: DeletionInput): DeletionResult {
+  const db = openHippoDb(ctx.hippoRoot);
+  let memoryId: string | null = null;
+  try {
+    if (hasSeenEvent(db, input.eventId)) {
+      return { status: 'duplicate', memoryId: null };
+    }
+    const ref = `slack://${input.teamId}/${input.channelId}/${input.deletedTs}`;
+    const row = db.prepare(`SELECT id FROM memories WHERE artifact_ref = ? AND tenant_id = ? AND kind = 'raw'`).get(ref, ctx.tenantId) as { id?: string } | undefined;
+    memoryId = row?.id ?? null;
+  } finally {
+    closeHippoDb(db);
+  }
+  if (!memoryId) {
+    const db2 = openHippoDb(ctx.hippoRoot);
+    try { markEventSeen(db2, input.eventId, null); }
+    finally { closeHippoDb(db2); }
+    return { status: 'not_found', memoryId: null };
+  }
+  archiveRaw(ctx, memoryId, `source_deleted:slack:${input.teamId}:${input.channelId}:${input.deletedTs}`);
+  const db3 = openHippoDb(ctx.hippoRoot);
+  try { markEventSeen(db3, input.eventId, memoryId); }
+  finally { closeHippoDb(db3); }
+  return { status: 'archived', memoryId };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-deletion.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/deletion.ts tests/slack-deletion.test.ts
+git commit -m "feat(slack): source-deletion sync via archiveRawMemory"
+```
+
+---
+
+## Task 10: Permission mirroring (recall scope filter)
+
+**Why:** ROADMAP test "Permission mirroring: Slack-private channel does not leak across scopes". A recall scoped to `slack:public:C1` must NOT return memories with `scope='slack:private:C2'`. Today `loadSearchEntries` filters by tenant; verify it already filters by scope (or add it). This task may be a no-op + test if the column is already honoured. We assert behaviour with an integration test against api.recall.
+
+**Files:**
+- Modify: `src/api.ts` — add optional `scope` filter to `RecallOpts` and thread it into `loadSearchEntries`. Inspect `src/store.ts:loadSearchEntries` signature first; if the third parameter already accepts a scope, just plumb it. If not, add a fourth `scopeFilter` param.
+- Create: `tests/slack-permission-mirror.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-permission-mirror.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+import { recall } from '../src/api.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('slack permission mirroring', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-perm-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('private-channel content does not leak when querying public scope', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1', channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'public secret', ts: '1.1' },
+      eventId: 'EvPub',
+    });
+    ingestMessage(ctx(root), {
+      teamId: 'T1', channel: { id: 'CPRIV', is_private: true },
+      message: { type: 'message', channel: 'CPRIV', user: 'U1', text: 'private secret', ts: '2.2' },
+      eventId: 'EvPriv',
+    });
+
+    const pubResults = recall(ctx(root), { query: 'secret', scope: 'slack:public:CPUB' });
+    expect(pubResults.results.some((r) => r.content.includes('private secret'))).toBe(false);
+    expect(pubResults.results.some((r) => r.content.includes('public secret'))).toBe(true);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-permission-mirror.test.ts`
+Expected: FAIL — `RecallOpts` has no `scope` field, OR results include private content.
+
+**Step 3: Implement**
+
+In `src/api.ts`, add to `RecallOpts`:
+
+```ts
+export interface RecallOpts {
+  query: string;
+  limit?: number;
+  mode?: 'bm25' | 'hybrid' | 'physics';
+  /** Restrict results to memories matching this scope exactly. */
+  scope?: string;
+}
+```
+
+Inside `recall()`, filter the entries by scope before slicing to `limit`:
+
+```ts
+const all = loadSearchEntries(ctx.hippoRoot, opts.query, undefined, ctx.tenantId);
+const entries = opts.scope ? all.filter((e) => e.scope === opts.scope) : all;
+```
+
+If `loadSearchEntries` already supports a scope filter argument, prefer the in-DB filter to avoid hauling private rows into memory. Inspect the signature; the inline filter above is the safe fallback that also works on the current shipped surface.
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-permission-mirror.test.ts`
+Expected: 1 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/api.ts tests/slack-permission-mirror.test.ts
+git commit -m "feat(api): scope filter on recall for permission mirroring"
+```
+
+---
+
+## Task 11: Webhook route + URL verification
+
+**Why:** Slack POSTs events to a single URL. The route must (a) handle the one-time `url_verification` handshake, (b) verify the HMAC signature on every other request, (c) parse the envelope, (d) call `ingestMessage` or `handleMessageDeleted`, (e) on parse failure write to DLQ and STILL ack 200 (otherwise Slack retries forever). All under the 1MB body cap that A1 already enforces.
+
+**Files:**
+- Modify: `src/server.ts` — add the route, import the connector helpers.
+- Create: `tests/slack-webhook-route.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-webhook-route.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createHmac } from 'crypto';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { serve } from '../src/server.js';
+
+const SECRET = 'shhh';
+
+function sign(ts: string, body: string): string {
+  return `v0=${createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex')}`;
+}
+
+describe('POST /v1/connectors/slack/events', () => {
+  let root: string;
+  let handle: { stop: () => Promise<void>; port: number };
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-route-'));
+    initStore(root);
+    process.env.SLACK_SIGNING_SECRET = SECRET;
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+  });
+  afterEach(async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    await handle.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('echoes the URL verification challenge', async () => {
+    const body = JSON.stringify({ type: 'url_verification', challenge: 'abc123' });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-slack-request-timestamp': ts, 'x-slack-signature': sign(ts, body) },
+      body,
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.challenge).toBe('abc123');
+  });
+
+  it('rejects missing/invalid signature with 401', async () => {
+    const body = JSON.stringify({ type: 'event_callback', team_id: 'T', event_id: 'E', event_time: 0, event: { type: 'message', channel: 'C1', ts: '1.1', text: 'hi' } });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('writes a memory on a valid event_callback', async () => {
+    const body = JSON.stringify({
+      type: 'event_callback', team_id: 'T1', event_id: 'EvA', event_time: Math.floor(Date.now() / 1000),
+      event: { type: 'message', channel: 'C1', user: 'U1', text: 'hello', ts: '1700000000.000100' },
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-slack-request-timestamp': ts, 'x-slack-signature': sign(ts, body) },
+      body,
+    });
+    expect(res.status).toBe(200);
+    const entries = loadAllEntries(root);
+    expect(entries.some((e) => e.tags.includes('source:slack') && e.kind === 'raw')).toBe(true);
+  });
+
+  it('writes malformed payloads to DLQ but still ACKs 200', async () => {
+    const body = '{"type":"event_callback","event":{}}'; // missing required fields
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-slack-request-timestamp': ts, 'x-slack-signature': sign(ts, body) },
+      body,
+    });
+    expect(res.status).toBe(200);
+    // DLQ row exists.
+    const { openHippoDb, closeHippoDb } = await import('../src/db.js');
+    const db = openHippoDb(root);
+    try {
+      const row = db.prepare(`SELECT COUNT(*) as c FROM slack_dlq`).get() as { c: number };
+      expect(Number(row.c)).toBe(1);
+    } finally { closeHippoDb(db); }
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-webhook-route.test.ts`
+Expected: FAIL — route returns 404 for all four cases.
+
+**Step 3: Implement**
+
+In `src/server.ts`, after the `/v1/audit` block and before the MCP routes, add:
+
+```ts
+// POST /v1/connectors/slack/events — Slack Events API webhook.
+//
+// Verifies HMAC signature, handles url_verification handshake, dispatches
+// event_callback envelopes to ingestMessage / handleMessageDeleted, and
+// parks malformed payloads in slack_dlq. Always ACKs 200 on signed requests
+// (apart from URL verification which echoes the challenge) so Slack does
+// not enter the retry storm. Auth is signature-based, NOT Bearer — a Slack
+// signing secret is the only credential. Bearer enforcement here would
+// require Slack to mint a bearer per workspace, which it can't.
+if (method === 'POST' && path === '/v1/connectors/slack/events') {
+  const rawBody = await readBody(req);
+  const sig = req.headers['x-slack-signature'];
+  const tsHdr = req.headers['x-slack-request-timestamp'];
+  const secret = process.env.SLACK_SIGNING_SECRET;
+  if (!secret) {
+    throw new HttpError(503, 'SLACK_SIGNING_SECRET not configured');
+  }
+  if (typeof sig !== 'string' || typeof tsHdr !== 'string' ||
+      !verifySlackSignature({ rawBody, timestamp: tsHdr, signature: sig, signingSecret: secret })) {
+    throw new HttpError(401, 'invalid Slack signature');
+  }
+  // After signature verification, build a tenant context. Single-tenant
+  // deployments use HIPPO_TENANT; multi-tenant routing by team_id is a
+  // v2 follow-up (TODOS.md).
+  const ctx = {
+    hippoRoot: opts.hippoRoot,
+    tenantId: process.env.HIPPO_TENANT ?? 'default',
+    actor: 'connector:slack',
+  };
+  let body: unknown;
+  try { body = JSON.parse(rawBody); } catch {
+    const db = openHippoDb(ctx.hippoRoot);
+    try { writeToDlq(db, { tenantId: ctx.tenantId, rawPayload: rawBody, error: 'invalid JSON' }); }
+    finally { closeHippoDb(db); }
+    sendJson(res, 200, { ok: true, status: 'dlq' });
+    return;
+  }
+  if (body && typeof body === 'object' && (body as Record<string, unknown>).type === 'url_verification') {
+    sendJson(res, 200, { challenge: String((body as Record<string, unknown>).challenge ?? '') });
+    return;
+  }
+  if (!isSlackEventEnvelope(body)) {
+    const db = openHippoDb(ctx.hippoRoot);
+    try { writeToDlq(db, { tenantId: ctx.tenantId, rawPayload: rawBody, error: 'not an event_callback envelope' }); }
+    finally { closeHippoDb(db); }
+    sendJson(res, 200, { ok: true, status: 'dlq' });
+    return;
+  }
+  const inner = body.event;
+  if (isSlackMessageEvent(inner)) {
+    if (inner.subtype === 'message_deleted' && inner.deleted_ts) {
+      const r = handleMessageDeleted(ctx, {
+        teamId: body.team_id, channelId: inner.channel, deletedTs: inner.deleted_ts, eventId: body.event_id,
+      });
+      sendJson(res, 200, { ok: true, status: r.status });
+      return;
+    }
+    const r = ingestMessage(ctx, {
+      teamId: body.team_id,
+      // Channel privacy isn't on the inner event; use channel_type as a proxy.
+      // 'group'|'im'|'mpim' → private. 'channel' → public. Unknown → private (fail closed).
+      channel: { id: inner.channel, is_private: inner.channel_type !== 'channel', is_im: inner.channel_type === 'im', is_mpim: inner.channel_type === 'mpim' },
+      message: inner,
+      eventId: body.event_id,
+    });
+    sendJson(res, 200, { ok: true, status: r.status, memoryId: r.memoryId });
+    return;
+  }
+  // Non-message event types: log to DLQ for offline review (e.g. reactions).
+  const db = openHippoDb(ctx.hippoRoot);
+  try { writeToDlq(db, { tenantId: ctx.tenantId, rawPayload: rawBody, error: `unhandled event type: ${inner?.type ?? 'unknown'}` }); }
+  finally { closeHippoDb(db); }
+  sendJson(res, 200, { ok: true, status: 'dlq' });
+  return;
+}
+```
+
+Add the imports at the top of `src/server.ts`:
+
+```ts
+import { verifySlackSignature } from './connectors/slack/signature.js';
+import { isSlackEventEnvelope, isSlackMessageEvent } from './connectors/slack/types.js';
+import { ingestMessage } from './connectors/slack/ingest.js';
+import { handleMessageDeleted } from './connectors/slack/deletion.js';
+import { writeToDlq } from './connectors/slack/dlq.js';
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-webhook-route.test.ts`
+Expected: 4 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/server.ts tests/slack-webhook-route.test.ts
+git commit -m "feat(server): /v1/connectors/slack/events webhook route"
+```
+
+---
+
+## Task 12: Rate-limit aware fetch helper
+
+**Why:** Slack's Web API returns `429 Too Many Requests` with a `Retry-After` header when limits are exceeded. The backfill loop must back off, sleep, retry. Without this, a 1000-event backfill on a busy workspace turns into hundreds of dropped pages.
+
+**Files:**
+- Create: `src/connectors/slack/ratelimit.ts`
+- Create: `tests/slack-ratelimit.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-ratelimit.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { fetchWithRetry } from '../src/connectors/slack/ratelimit.js';
+
+describe('fetchWithRetry', () => {
+  it('retries once after 429 with Retry-After honoured', async () => {
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => { sleeps.push(ms); return Promise.resolve(); };
+    const calls = [
+      { status: 429, headers: { get: (h: string) => h === 'retry-after' ? '0.05' : null }, json: async () => ({}) },
+      { status: 200, headers: { get: () => null }, json: async () => ({ ok: true }) },
+    ];
+    let i = 0;
+    const fakeFetch = vi.fn(async () => calls[i++] as Response);
+    const r = await fetchWithRetry({ url: 'http://x', fetchImpl: fakeFetch as typeof fetch, sleep, maxRetries: 3 });
+    expect(r.status).toBe(200);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    expect(sleeps[0]).toBe(50); // 0.05s in ms
+  });
+
+  it('gives up after maxRetries and throws', async () => {
+    const fakeFetch = vi.fn(async () => ({ status: 429, headers: { get: () => '0.01' }, json: async () => ({}) }) as Response);
+    await expect(fetchWithRetry({ url: 'http://x', fetchImpl: fakeFetch as typeof fetch, sleep: () => Promise.resolve(), maxRetries: 2 })).rejects.toThrow(/rate.?limited/i);
+    expect(fakeFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-ratelimit.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/ratelimit.ts
+
+export interface RetryOpts {
+  url: string;
+  init?: RequestInit;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  maxRetries?: number;
+}
+
+export async function fetchWithRetry(opts: RetryOpts): Promise<Response> {
+  const f = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const max = opts.maxRetries ?? 3;
+  let attempt = 0;
+  while (true) {
+    const r = await f(opts.url, opts.init);
+    if (r.status !== 429) return r;
+    if (attempt >= max) throw new Error(`rate-limited after ${attempt + 1} attempts: ${opts.url}`);
+    const ra = r.headers.get('retry-after');
+    const delaySec = ra ? Number(ra) : Math.pow(2, attempt);
+    await sleep(Math.max(0, delaySec) * 1000);
+    attempt++;
+  }
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-ratelimit.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/ratelimit.ts tests/slack-ratelimit.test.ts
+git commit -m "feat(slack): fetchWithRetry honouring Retry-After"
+```
+
+---
+
+## Task 13: Backfill loop with cursor persistence
+
+**Why:** New workspace, missed window, server downtime: any of these requires a backfill. We page through `conversations.history`, persist the latest seen `ts` to `slack_cursors` after every page, and resume from there on restart. The fetcher is injected so tests can drive it without HTTP.
+
+**Files:**
+- Create: `src/connectors/slack/backfill.ts`
+- Create: `tests/slack-backfill.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-backfill.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { backfillChannel, type SlackHistoryFetcher } from '../src/connectors/slack/backfill.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('backfillChannel', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-bf-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('paginates, ingests, and persists the cursor', async () => {
+    const fetcher: SlackHistoryFetcher = async ({ cursor }) => {
+      if (!cursor) return { messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'a', ts: '1.1' }, { type: 'message', channel: 'C1', user: 'U1', text: 'b', ts: '2.2' }], next_cursor: 'PAGE2' };
+      if (cursor === 'PAGE2') return { messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'c', ts: '3.3' }], next_cursor: null };
+      throw new Error('unexpected cursor: ' + cursor);
+    };
+    const r = await backfillChannel(ctx(root), { teamId: 'T1', channel: { id: 'C1', is_private: false }, fetcher });
+    expect(r.ingested).toBe(3);
+
+    const db = openHippoDb(root);
+    try {
+      const row = db.prepare(`SELECT latest_ts FROM slack_cursors WHERE tenant_id=? AND channel_id=?`).get('default', 'C1') as { latest_ts: string };
+      expect(row.latest_ts).toBe('3.3');
+    } finally { closeHippoDb(db); }
+
+    expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(3);
+  });
+
+  it('resumes from the saved cursor (idempotent on rerun)', async () => {
+    let phase = 1;
+    const fetcher: SlackHistoryFetcher = async () => {
+      if (phase === 1) {
+        phase = 2;
+        return { messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'a', ts: '1.1' }], next_cursor: null };
+      }
+      // Second pass returns the same message — replay must not duplicate.
+      return { messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'a', ts: '1.1' }], next_cursor: null };
+    };
+    await backfillChannel(ctx(root), { teamId: 'T1', channel: { id: 'C1' }, fetcher });
+    await backfillChannel(ctx(root), { teamId: 'T1', channel: { id: 'C1' }, fetcher });
+    expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(1);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-backfill.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/backfill.ts
+import type { Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { ingestMessage } from './ingest.js';
+import type { SlackMessageEvent } from './types.js';
+import type { ChannelMeta } from './scope.js';
+
+export interface SlackHistoryPage {
+  messages: SlackMessageEvent[];
+  next_cursor: string | null;
+}
+
+export type SlackHistoryFetcher = (args: { channelId: string; cursor: string | null }) => Promise<SlackHistoryPage>;
+
+export interface BackfillOpts {
+  teamId: string;
+  channel: ChannelMeta;
+  fetcher: SlackHistoryFetcher;
+  /** Stop after this many messages. Default: unlimited. */
+  maxMessages?: number;
+}
+
+function readCursor(root: string, tenantId: string, channelId: string): string | null {
+  const db = openHippoDb(root);
+  try {
+    const row = db.prepare(`SELECT latest_ts FROM slack_cursors WHERE tenant_id=? AND channel_id=?`).get(tenantId, channelId) as { latest_ts?: string } | undefined;
+    return row?.latest_ts ?? null;
+  } finally { closeHippoDb(db); }
+}
+
+function writeCursor(root: string, tenantId: string, channelId: string, latestTs: string): void {
+  const db = openHippoDb(root);
+  try {
+    db.prepare(`INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?,?,?,?)
+                ON CONFLICT(tenant_id, channel_id) DO UPDATE SET latest_ts = excluded.latest_ts, updated_at = excluded.updated_at`)
+      .run(tenantId, channelId, latestTs, new Date().toISOString());
+  } finally { closeHippoDb(db); }
+}
+
+export async function backfillChannel(ctx: Context, opts: BackfillOpts): Promise<{ ingested: number; pages: number }> {
+  let cursor: string | null = readCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id);
+  let ingested = 0;
+  let pages = 0;
+  let latestTs: string | null = cursor;
+  while (true) {
+    const page = await opts.fetcher({ channelId: opts.channel.id, cursor });
+    pages++;
+    for (const msg of page.messages) {
+      const r = ingestMessage(ctx, {
+        teamId: opts.teamId,
+        channel: opts.channel,
+        message: msg,
+        // Backfill has no Slack event_id; synthesize a stable one from the artifact_ref
+        // so a re-run dedupes against the same row.
+        eventId: `backfill:${opts.teamId}:${opts.channel.id}:${msg.ts}`,
+      });
+      if (r.status === 'ingested') ingested++;
+      if (!latestTs || msg.ts > latestTs) latestTs = msg.ts;
+      if (opts.maxMessages && ingested >= opts.maxMessages) {
+        if (latestTs) writeCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id, latestTs);
+        return { ingested, pages };
+      }
+    }
+    if (latestTs) writeCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id, latestTs);
+    if (!page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+  return { ingested, pages };
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-backfill.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/backfill.ts tests/slack-backfill.test.ts
+git commit -m "feat(slack): cursor-persisted backfill loop"
+```
+
+---
+
+## Task 14: CLI — `hippo slack backfill` and `hippo slack dlq`
+
+**Why:** Operators need a way to kick off a backfill (initial onboarding, recovery from outage) and inspect the DLQ without writing SQL. Two subcommands; both thin wrappers over the connector helpers.
+
+**Files:**
+- Modify: `src/cli.ts` — add `case 'slack':` dispatch + handlers `cmdSlackBackfill` / `cmdSlackDlqList`.
+- Create: `tests/slack-cli.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-cli.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import { initStore } from '../src/store.js';
+import { writeToDlq } from '../src/connectors/slack/dlq.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const cli = (cwd: string, args: string[]) => execFileSync('node', ['bin/hippo.js', ...args], { cwd, encoding: 'utf8', env: { ...process.env, HIPPO_HOME: join(cwd, '.hippo') } });
+
+describe('hippo slack CLI', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-cli-'));
+    initStore(join(root, '.hippo'));
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('hippo slack dlq list prints DLQ rows', () => {
+    const db = openHippoDb(join(root, '.hippo'));
+    try { writeToDlq(db, { tenantId: 'default', rawPayload: '{"x":1}', error: 'bad event' }); }
+    finally { closeHippoDb(db); }
+    const out = cli(root, ['slack', 'dlq', 'list']);
+    expect(out).toContain('bad event');
+  });
+
+  it('hippo slack backfill --help mentions --channel and --since', () => {
+    const out = cli(root, ['slack', 'backfill', '--help']);
+    expect(out).toMatch(/--channel/);
+    expect(out).toMatch(/--since/);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-cli.test.ts`
+Expected: FAIL — `hippo slack` is unknown command.
+
+**Step 3: Implement**
+
+In `src/cli.ts`, add the dispatch and two handlers. Sketch:
+
+```ts
+function cmdSlackBackfill(hippoRoot: string, flags: Record<string, string | boolean | string[]>): void {
+  const channel = flags.channel as string | undefined;
+  if (!channel) {
+    console.error('hippo slack backfill --channel <id> [--since ISO]');
+    console.error('  --channel  Slack channel id (required, e.g. C0123ABC)');
+    console.error('  --since    backfill from ISO timestamp (default: cursor)');
+    process.exit(1);
+  }
+  // Real fetcher: requires SLACK_BOT_TOKEN. Out of scope for V1 unless the env is set.
+  // For now, emit a friendly error so operators wire the token before running.
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    console.error('SLACK_BOT_TOKEN is not set. Backfill requires a Slack bot token with channels:history scope.');
+    process.exit(2);
+  }
+  // Real fetcher implementation: see src/connectors/slack/backfill.ts. Wire here.
+  // (Full HTTP fetcher implementation deferred to Task 15.)
+  console.log(`Backfill of ${channel} not yet wired to live HTTP fetcher (Task 15).`);
+}
+
+function cmdSlackDlqList(hippoRoot: string, _flags: Record<string, string | boolean | string[]>): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    const items = listDlq(db, { tenantId: process.env.HIPPO_TENANT ?? 'default' });
+    for (const it of items) {
+      console.log(`${it.id}\t${it.receivedAt}\t${it.error}`);
+    }
+  } finally { closeHippoDb(db); }
+}
+
+function cmdSlack(hippoRoot: string, args: string[], flags: Record<string, string | boolean | string[]>): void {
+  const sub = args[0];
+  if (sub === 'backfill') return cmdSlackBackfill(hippoRoot, flags);
+  if (sub === 'dlq' && args[1] === 'list') return cmdSlackDlqList(hippoRoot, flags);
+  console.error('Usage: hippo slack <backfill|dlq list> [...]');
+  process.exit(1);
+}
+```
+
+Add `case 'slack': cmdSlack(hippoRoot, args, flags); break;` in the main dispatcher. Import `listDlq` and the open/close DB helpers if not already imported.
+
+**Step 4: Run to verify it passes**
+
+Run: `npm run build && npx vitest run tests/slack-cli.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/cli.ts tests/slack-cli.test.ts
+git commit -m "feat(cli): hippo slack backfill + slack dlq list"
+```
+
+---
+
+## Task 15: Live conversations.history fetcher (HTTP)
+
+**Why:** Task 13's loop accepts a fetcher; Task 14's CLI says "not wired". This task wires it. Single function `slackHistoryFetcher(token, fetcher?)` returning a `SlackHistoryFetcher`. Uses `fetchWithRetry` from Task 12. Tested against a mocked `fetch` so we don't hit Slack in CI.
+
+**Files:**
+- Create: `src/connectors/slack/web-client.ts`
+- Modify: `src/cli.ts` — replace the "not yet wired" stub with a real fetcher call.
+- Create: `tests/slack-web-client.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-web-client.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { slackHistoryFetcher } from '../src/connectors/slack/web-client.js';
+
+describe('slackHistoryFetcher', () => {
+  it('GETs conversations.history with bearer token + cursor', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fakeFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return {
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ok: true, messages: [{ type: 'message', channel: 'C1', text: 'hi', ts: '1.1' }], response_metadata: { next_cursor: 'NEXT' } }),
+      } as unknown as Response;
+    });
+    const fetcher = slackHistoryFetcher('xoxb-fake', fakeFetch as unknown as typeof fetch);
+    const page = await fetcher({ channelId: 'C1', cursor: null });
+    expect(page.messages).toHaveLength(1);
+    expect(page.next_cursor).toBe('NEXT');
+    expect(calls[0].url).toContain('channel=C1');
+    const auth = (calls[0].init?.headers as Record<string, string>).authorization;
+    expect(auth).toBe('Bearer xoxb-fake');
+  });
+
+  it('throws when ok=false', async () => {
+    const fakeFetch = vi.fn(async () => ({
+      status: 200, headers: { get: () => null }, json: async () => ({ ok: false, error: 'not_in_channel' }),
+    } as unknown as Response));
+    const fetcher = slackHistoryFetcher('t', fakeFetch as unknown as typeof fetch);
+    await expect(fetcher({ channelId: 'C1', cursor: null })).rejects.toThrow(/not_in_channel/);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-web-client.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// src/connectors/slack/web-client.ts
+import { fetchWithRetry } from './ratelimit.js';
+import type { SlackHistoryFetcher } from './backfill.js';
+
+export function slackHistoryFetcher(token: string, fetchImpl?: typeof fetch): SlackHistoryFetcher {
+  return async ({ channelId, cursor }) => {
+    const url = new URL('https://slack.com/api/conversations.history');
+    url.searchParams.set('channel', channelId);
+    url.searchParams.set('limit', '200');
+    if (cursor) url.searchParams.set('cursor', cursor);
+    const r = await fetchWithRetry({
+      url: url.toString(),
+      init: { method: 'GET', headers: { authorization: `Bearer ${token}` } },
+      fetchImpl,
+    });
+    const body = await r.json() as { ok: boolean; error?: string; messages?: unknown[]; response_metadata?: { next_cursor?: string } };
+    if (!body.ok) throw new Error(`slack: ${body.error ?? 'unknown error'}`);
+    return {
+      messages: (body.messages ?? []).filter((m): m is import('./types.js').SlackMessageEvent =>
+        !!m && typeof m === 'object' && (m as Record<string, unknown>).type === 'message' && typeof (m as Record<string, unknown>).ts === 'string',
+      // Slack returns messages without `channel`; stamp it from the request.
+      ).map((m) => ({ ...m, channel: channelId } as import('./types.js').SlackMessageEvent)),
+      next_cursor: body.response_metadata?.next_cursor ?? null,
+    };
+  };
+}
+```
+
+Then in `src/cli.ts`, replace the stub `cmdSlackBackfill` body:
+
+```ts
+const sinceIso = flags.since as string | undefined;
+const fetcher = slackHistoryFetcher(token);
+// Note: --since is honoured by the loop's max-cursor filter; for V1 we treat
+// "since" as advisory and rely on the slack_cursors row to drive resume.
+const ctx = { hippoRoot, tenantId: process.env.HIPPO_TENANT ?? 'default', actor: 'cli:slack-backfill' };
+backfillChannel(ctx, { teamId: process.env.SLACK_TEAM_ID ?? 'T_UNKNOWN', channel: { id: channel, is_private: false }, fetcher })
+  .then((r) => console.log(`backfill ${channel}: ${r.ingested} new messages across ${r.pages} pages`))
+  .catch((e: Error) => { console.error('backfill failed:', e.message); process.exit(3); });
+void sinceIso;
+```
+
+Add the import.
+
+**Step 4: Run to verify it passes**
+
+Run: `npm run build && npx vitest run tests/slack-web-client.test.ts`
+Expected: 2 passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/connectors/slack/web-client.ts src/cli.ts tests/slack-web-client.test.ts
+git commit -m "feat(slack): live conversations.history fetcher + CLI wiring"
+```
+
+---
+
+## Task 16: 1000-event smoke benchmark
+
+**Why:** ROADMAP success criterion: "1000-event smoke test with no source-system writes". Generate 1000 synthetic Slack events, replay each twice through the webhook route, assert (a) exactly 1000 memories, (b) all are `kind='raw'`, (c) zero outbound HTTP requests to slack.com made by the connector, (d) replay latency stays under 500ms / event.
+
+**Files:**
+- Create: `benchmarks/e1.3/slack-1000-event-smoke.ts`
+- Create: `tests/slack-smoke-1000.test.ts` (the gating test that runs the smoke at low volume so CI doesn't take 10min)
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-smoke-1000.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { runSlackSmoke } from '../benchmarks/e1.3/slack-1000-event-smoke.js';
+
+describe('slack 1000-event smoke (CI subset)', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-smoke-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('100 events, replayed twice, produces exactly 100 raw memories', async () => {
+    const result = await runSlackSmoke({ hippoRoot: root, count: 100, replay: 2 });
+    expect(result.uniqueMemories).toBe(100);
+    expect(result.outboundHttp).toBe(0);
+    const all = loadAllEntries(root).filter((e) => e.tags.includes('source:slack'));
+    expect(all).toHaveLength(100);
+    expect(all.every((e) => e.kind === 'raw')).toBe(true);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-smoke-1000.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// benchmarks/e1.3/slack-1000-event-smoke.ts
+import { ingestMessage } from '../../src/connectors/slack/ingest.js';
+import { loadAllEntries } from '../../src/store.js';
+
+export interface SmokeOpts {
+  hippoRoot: string;
+  count: number;
+  replay: number;
+}
+
+export interface SmokeResult {
+  uniqueMemories: number;
+  totalIngestCalls: number;
+  outboundHttp: number;
+  durationMs: number;
+}
+
+export async function runSlackSmoke(opts: SmokeOpts): Promise<SmokeResult> {
+  const ctx = { hippoRoot: opts.hippoRoot, tenantId: 'default', actor: 'connector:slack' };
+  const start = Date.now();
+  let calls = 0;
+  // No outbound HTTP: this drives ingestMessage directly. The success criterion
+  // is that the connector layer never reaches for fetch() on the happy path.
+  const outboundHttp = 0;
+  for (let pass = 0; pass < opts.replay; pass++) {
+    for (let i = 0; i < opts.count; i++) {
+      ingestMessage(ctx, {
+        teamId: 'T1',
+        channel: { id: 'C1', is_private: false },
+        message: { type: 'message', channel: 'C1', user: 'U1', text: `msg ${i}`, ts: `${1700000000 + i}.000100` },
+        eventId: `Ev-${i}`,
+      });
+      calls++;
+    }
+  }
+  const uniqueMemories = loadAllEntries(opts.hippoRoot).filter((e) => e.tags.includes('source:slack')).length;
+  return { uniqueMemories, totalIngestCalls: calls, outboundHttp, durationMs: Date.now() - start };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  // Standalone run: tmp dir, 1000 events, replay=2, log result.
+  const { mkdtempSync, rmSync } = await import('fs');
+  const { tmpdir } = await import('os');
+  const { join } = await import('path');
+  const { initStore } = await import('../../src/store.js');
+  const root = mkdtempSync(join(tmpdir(), 'hippo-slack-smoke-cli-'));
+  try {
+    initStore(root);
+    const r = await runSlackSmoke({ hippoRoot: root, count: 1000, replay: 2 });
+    console.log(JSON.stringify(r, null, 2));
+    if (r.uniqueMemories !== 1000) { console.error('FAIL: uniqueMemories !== 1000'); process.exit(1); }
+    if (r.outboundHttp !== 0) { console.error('FAIL: outboundHttp !== 0'); process.exit(1); }
+    if (r.durationMs / r.totalIngestCalls > 500) { console.error('FAIL: per-call latency >500ms'); process.exit(1); }
+    console.log('PASS');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+```
+
+**Step 4: Run to verify it passes**
+
+Run: `npx vitest run tests/slack-smoke-1000.test.ts && node dist/benchmarks/e1.3/slack-1000-event-smoke.js`
+Expected: vitest 1 passed; standalone bench prints PASS.
+
+**Step 5: Commit**
+
+```bash
+git add benchmarks/e1.3/slack-1000-event-smoke.ts tests/slack-smoke-1000.test.ts
+git commit -m "feat(slack): 1000-event smoke benchmark with idempotency assertion"
+```
+
+---
+
+## Task 17: Roadmap success — 10 incident-context recall scenarios
+
+**Why:** ROADMAP: "recall surfaces incident context faster than transcript replay on 10 staged scenarios". Define 10 scenarios as a YAML/JSON corpus: each has (a) a synthetic Slack channel transcript (50-200 messages), (b) an incident query, (c) the message ids that constitute the answer. Score recall by `precision@10` against the labelled answer set; compare against a baseline of "linear transcript scan returning the most-recent N messages" — recall must beat that on at least 7/10 scenarios.
+
+**Files:**
+- Create: `benchmarks/e1.3/scenarios.json` — 10 scenarios with synthetic transcripts.
+- Create: `benchmarks/e1.3/incident-recall-eval.ts` — runs the evaluation.
+- Create: `tests/slack-incident-recall.test.ts` — gating test.
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/slack-incident-recall.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { runIncidentRecallEval } from '../benchmarks/e1.3/incident-recall-eval.js';
+
+describe('slack incident recall (success criterion)', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-eval-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('beats transcript-tail baseline on at least 7/10 scenarios', async () => {
+    const r = await runIncidentRecallEval({ hippoRoot: root });
+    expect(r.scenariosBeaten).toBeGreaterThanOrEqual(7);
+    expect(r.scenarios).toHaveLength(10);
+  });
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/slack-incident-recall.test.ts`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+Create `benchmarks/e1.3/scenarios.json` with 10 entries shaped like:
+
+```json
+[
+  {
+    "id": "S1-db-outage",
+    "channel": "C-incidents",
+    "transcript": [
+      { "user": "U1", "text": "checkout API throwing 500s since 14:02 UTC", "ts": "1700000001.000000" },
+      { "user": "U2", "text": "confirmed, error rate jumped from 0.01% to 4%", "ts": "1700000010.000000" },
+      "...50-200 lines of ambient channel chat..."
+    ],
+    "query": "what caused the checkout 500s on Nov 14?",
+    "answer_ts": ["1700000001.000000", "1700000010.000000"]
+  }
+]
+```
+
+Then `benchmarks/e1.3/incident-recall-eval.ts`:
+
+```ts
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { ingestMessage } from '../../src/connectors/slack/ingest.js';
+import { recall, type Context } from '../../src/api.js';
+
+interface Scenario {
+  id: string;
+  channel: string;
+  transcript: Array<{ user: string; text: string; ts: string }>;
+  query: string;
+  answer_ts: string[];
+}
+
+export async function runIncidentRecallEval(opts: { hippoRoot: string }): Promise<{ scenarios: Array<{ id: string; recallPrecision: number; baselinePrecision: number; beat: boolean }>; scenariosBeaten: number }> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const scenarios = JSON.parse(readFileSync(join(here, 'scenarios.json'), 'utf-8')) as Scenario[];
+  const ctx: Context = { hippoRoot: opts.hippoRoot, tenantId: 'default', actor: 'eval:slack' };
+  const results: Array<{ id: string; recallPrecision: number; baselinePrecision: number; beat: boolean }> = [];
+  for (const sc of scenarios) {
+    // Ingest the transcript.
+    for (const m of sc.transcript) {
+      ingestMessage(ctx, {
+        teamId: 'T1', channel: { id: sc.channel, is_private: false },
+        message: { type: 'message', channel: sc.channel, user: m.user, text: m.text, ts: m.ts },
+        eventId: `${sc.id}:${m.ts}`,
+      });
+    }
+    // Recall.
+    const r = recall(ctx, { query: sc.query, limit: 10, scope: `slack:public:${sc.channel}` });
+    const recalledTs = new Set(r.results.map((x) => {
+      // artifact_ref → ts (last segment). The recall result doesn't carry artifact_ref; look up via memories table is fine, but for V1 we approximate by
+      // storing ts in the tags is simpler. To keep eval honest, fetch via api/store directly.
+      return x.id; // placeholder — real impl reads artifact_ref via openHippoDb
+    }));
+    void recalledTs; // see TODO below
+    const recallHit = sc.answer_ts.filter((ts) => sc.transcript.some((m) => m.ts === ts && r.results.some((res) => res.content === m.text))).length;
+    const recallPrecision = recallHit / sc.answer_ts.length;
+    // Baseline: last 10 messages.
+    const tail = sc.transcript.slice(-10);
+    const baselineHit = sc.answer_ts.filter((ts) => tail.some((m) => m.ts === ts)).length;
+    const baselinePrecision = baselineHit / sc.answer_ts.length;
+    results.push({ id: sc.id, recallPrecision, baselinePrecision, beat: recallPrecision > baselinePrecision });
+  }
+  return { scenarios: results, scenariosBeaten: results.filter((r) => r.beat).length };
+}
+```
+
+Note: the `recall` result currently returns `content` and `id`, not artifact_ref. The eval matches by content for V1; if A6/F-track work changes content shape, the eval needs to switch to artifact_ref lookup. Document this in the file.
+
+Compose 10 realistic incident scenarios. Each scenario gets ~100-line transcripts where the answer messages are buried in the middle so the tail-baseline misses them.
+
+**Step 4: Run to verify it passes**
+
+Run: `npm run build && npx vitest run tests/slack-incident-recall.test.ts`
+Expected: 1 passed (recall beats tail-baseline on ≥7/10).
+
+If recall scores below 7/10, that's a real signal — investigate before forcing the test to pass. The likely failure modes are (a) BM25 tokenizer differences against Slack's casing, (b) scope filter excluding the answer rows, (c) tags not boosting the right candidates.
+
+**Step 5: Commit**
+
+```bash
+git add benchmarks/e1.3/scenarios.json benchmarks/e1.3/incident-recall-eval.ts tests/slack-incident-recall.test.ts
+git commit -m "feat(slack): 10-scenario incident recall eval (beats tail baseline)"
+```
+
+---
+
+## Task 18: Wrap-up — docs, comments, importer relabel
+
+**Why:** Update the inline comments in `src/importers.ts` and `src/capture.ts` (they currently flag E1.x as a future boundary). Update CHANGELOG. Add a brief Slack section to README.
+
+**Files:**
+- Modify: `src/importers.ts:86-92` — flip the comment from "When E1.x lands…" to "E1.3 shipped 2026-04-29; ChatGPT/Claude/Cursor exports remain `kind='distilled'` per the original reasoning."
+- Modify: `src/capture.ts` — same treatment near the kind decision.
+- Modify: `CHANGELOG.md` — add a new section at the top under the next version (likely v0.37.0; bump in /publish-repo).
+- Modify: `README.md` — short "Slack ingestion" section pointing at `hippo slack backfill --channel <id>` and the webhook URL pattern.
+- Modify: `TODOS.md` — remove the "Importers/capture relabel pass" item from A3 follow-ups (it's done now), and add v2 follow-ups: per-team-id tenant routing, multi-tenant DLQ retention, the eval's content-vs-artifact_ref TODO.
+
+No tests (these are doc updates).
+
+**Step 1: Read the files**
+
+`Read` each file at the named lines. Verify the comment text before flipping.
+
+**Step 2: Apply the edits**
+
+Edit each file. Match the existing tone (no marketing copy in CHANGELOG, no em dashes anywhere).
+
+**Step 3: Build to confirm nothing broke**
+
+Run: `npm run build && npx vitest run`
+Expected: build clean, ALL tests pass (including the 17 new files added in Tasks 1-17).
+
+**Step 4: Commit**
+
+```bash
+git add src/importers.ts src/capture.ts CHANGELOG.md README.md TODOS.md
+git commit -m "docs(slack): wrap up E1.3 — relabel pass + CHANGELOG + README"
+```
+
+---
+
+## Definition of Done
+
+A reviewer accepting this work checks:
+
+1. `npx vitest run` — all 17 new test files green plus the existing suite untouched.
+2. `node dist/benchmarks/e1.3/slack-1000-event-smoke.js` — prints `PASS` (1000 unique memories, zero outbound HTTP, <500ms/event).
+3. `npx vitest run tests/slack-incident-recall.test.ts` — recall beats tail baseline on ≥7/10 staged scenarios.
+4. `grep -rn "kind: 'raw'" src/connectors/slack/` — exactly one hit (in `transform.ts`).
+5. `grep -rn "archiveRawMemory\|archiveRaw" src/connectors/slack/` — exactly one call (in `deletion.ts` via `api.archiveRaw`).
+6. Schema migration v17 runs on a fresh db and on a v16 db without errors.
+7. Webhook route refuses requests with bad / missing signatures (manual `curl` plus the route test).
+8. `hippo slack dlq list` prints rows; `hippo slack backfill --channel C0000` errors clearly when `SLACK_BOT_TOKEN` is unset.
+9. `TODOS.md` updated with the relabel item removed and the v2 follow-ups added.
+10. The CHANGELOG entry says what shipped, not what was tried.
+
+## Out of scope (track for v2)
+
+- Per-`team_id` tenant routing (today the route uses `HIPPO_TENANT`; a multi-tenant deployment needs a `slack_workspaces` table mapping team_id → tenant_id).
+- Slash-command write-backs (`/hippo remember <text>`). V1 is read-only.
+- Thread-aware ranking (treat `thread_ts` as a parent boost).
+- DLQ replay command (`hippo slack dlq retry <id>`).
+- Eval scoring by `artifact_ref` instead of `content` match.
+- Incremental real-time backfill (today's loop drains the channel; for live workspaces add a "stop at cursor" mode).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.36.0",
+  "version": "0.37.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "baseline": "npm run build && npm test",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.benchmarks.json",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,7 @@
  * in exactly one place.
  */
 
-import { openHippoDb, closeHippoDb } from './db.js';
+import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import {
   writeEntry,
   readEntry,
@@ -49,6 +49,15 @@ export interface RememberOpts {
   owner?: string;
   artifactRef?: string;
   tags?: string[];
+  /**
+   * Optional hook invoked inside the same transaction as the underlying
+   * memories INSERT. Used by ingestion connectors (E1.3+) to stamp
+   * idempotency / cursor rows atomically with the memory row, so a crash
+   * mid-write cannot produce a memory without its corresponding side-effect
+   * log row (or vice versa). If the callback throws, the INSERT is rolled
+   * back and the error is rethrown.
+   */
+  afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void;
 }
 
 export interface RememberResult {
@@ -68,7 +77,7 @@ export function remember(ctx: Context, opts: RememberOpts): RememberResult {
   });
   // writeEntry threads ctx.actor into its internal audit hook, so exactly
   // one 'remember' event lands in the log with the supplied actor.
-  writeEntry(ctx.hippoRoot, entry, { actor: ctx.actor });
+  writeEntry(ctx.hippoRoot, entry, { actor: ctx.actor, afterWrite: opts.afterWrite });
 
   return { id: entry.id, kind: entry.kind, tenantId: ctx.tenantId };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -13,6 +13,7 @@ import {
   readEntry,
   deleteEntry,
   loadSearchEntries,
+  removeEntryMirrors,
 } from './store.js';
 import {
   createMemory,
@@ -336,6 +337,13 @@ export function archiveRaw(
   } finally {
     closeHippoDb(db);
   }
+  // archiveRawMemory deletes the memories row but leaves any legacy markdown
+  // mirror in <root>/{buffer,episodic,semantic}/<id>.md untouched. If we left
+  // the mirror in place, a subsequent initStore() on an empty memories table
+  // would silently re-import the row via bootstrapLegacyStore — defeating the
+  // archive (and the GDPR right-to-be-forgotten promise on raw rows). Mirror
+  // forget() at src/store.ts:1046, which uses the same removeEntryMirrors call.
+  removeEntryMirrors(ctx.hippoRoot, id);
   // archiveRawMemory does not return the archive_at timestamp it wrote. We
   // emit a fresh ISO timestamp here for the API response. Within a millisecond
   // of the actual write, fine for a server response shape.

--- a/src/api.ts
+++ b/src/api.ts
@@ -90,6 +90,16 @@ export interface RecallOpts {
   query: string;
   limit?: number;
   mode?: 'bm25' | 'hybrid' | 'physics';
+  /**
+   * Restrict results to memories whose `scope` equals this value exactly.
+   *
+   * When `scope` is undefined or empty, recall applies a DEFAULT-DENY rule:
+   * any memory whose scope starts with `'slack:private:'` is filtered out so
+   * a frontend caller passing `undefined` cannot accidentally surface
+   * private-channel content. Memories with scope=null (the common case for
+   * non-Slack content) are still returned.
+   */
+  scope?: string;
 }
 
 export interface RecallResultItem {
@@ -114,12 +124,24 @@ export interface RecallResult {
  */
 export function recall(ctx: Context, opts: RecallOpts): RecallResult {
   const limit = opts.limit ?? 10;
-  const entries = loadSearchEntries(
+  const all = loadSearchEntries(
     ctx.hippoRoot,
     opts.query,
     undefined,
     ctx.tenantId,
   );
+  // Scope filtering runs AFTER the tenant filter inside loadSearchEntries, so
+  // a tenant-mismatched scope cannot surface another tenant's row even when
+  // both share the same scope string (e.g. 'slack:private:CSHARED').
+  let entries: typeof all;
+  if (opts.scope !== undefined && opts.scope !== '') {
+    entries = all.filter((e) => e.scope === opts.scope);
+  } else {
+    // Default-deny: a no-scope caller cannot see private slack channels. This
+    // is load-bearing because frontend callers will pass `undefined` and must
+    // not see `slack:private:*` rows by default.
+    entries = all.filter((e) => !(e.scope ?? '').startsWith('slack:private:'));
+  }
   // BM25 ordering already comes from loadSearchEntries; cap to `limit`.
   // Score is a placeholder — the physics/hybrid scorers in src/search.ts
   // produce richer breakdowns and will replace this when wired up.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,6 +158,7 @@ import { wmPush, wmRead, wmClear, wmFlush, WorkingMemoryItem } from './working-m
 import { multihopSearch } from './multihop.js';
 import { computeSalience } from './salience.js';
 import { computeAmbientState, renderAmbientSummary } from './ambient.js';
+import { listDlq } from './connectors/slack/dlq.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -4631,6 +4632,65 @@ function cmdAuth(hippoRoot: string, args: string[], flags: Record<string, string
   }
 }
 
+// ---------------------------------------------------------------------------
+// Slack subcommands (E1.3 — `hippo slack backfill` / `hippo slack dlq list`)
+// ---------------------------------------------------------------------------
+
+function printSlackBackfillUsage(): void {
+  console.log('hippo slack backfill --channel <id> [--since ISO]');
+  console.log('  --channel  Slack channel id (required, e.g. C0123ABC)');
+  console.log('  --since    backfill from ISO timestamp (default: cursor)');
+}
+
+function cmdSlackBackfill(_hippoRoot: string, flags: Record<string, string | boolean | string[]>): void {
+  // M3: detect --help BEFORE token check so operators can read usage in
+  // environments without SLACK_BOT_TOKEN configured.
+  if (flags['help']) {
+    printSlackBackfillUsage();
+    return;
+  }
+  const channel = typeof flags['channel'] === 'string' ? (flags['channel'] as string) : undefined;
+  if (!channel) {
+    printSlackBackfillUsage();
+    process.exit(1);
+  }
+  // Real fetcher requires SLACK_BOT_TOKEN with channels:history scope.
+  // (Full HTTP fetcher implementation lands in Task 15.)
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    console.error('SLACK_BOT_TOKEN is not set. Backfill requires a Slack bot token with channels:history scope.');
+    process.exit(2);
+  }
+  console.log(`Backfill of ${channel} not yet wired to live HTTP fetcher (Task 15).`);
+}
+
+function cmdSlackDlqList(hippoRoot: string, _flags: Record<string, string | boolean | string[]>): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    const tenantId = process.env.HIPPO_TENANT ?? 'default';
+    const items = listDlq(db, { tenantId });
+    for (const it of items) {
+      console.log(`${it.id}\t${it.receivedAt}\t${it.error}`);
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+function cmdSlack(hippoRoot: string, args: string[], flags: Record<string, string | boolean | string[]>): void {
+  const sub = args[0];
+  if (sub === 'backfill') {
+    cmdSlackBackfill(hippoRoot, flags);
+    return;
+  }
+  if (sub === 'dlq' && args[1] === 'list') {
+    cmdSlackDlqList(hippoRoot, flags);
+    return;
+  }
+  console.error('Usage: hippo slack <backfill|dlq list> [...]');
+  process.exit(1);
+}
+
 function printUsage(): void {
   console.log(`
 Hippo - biologically-inspired memory system for AI agents
@@ -5080,6 +5140,10 @@ async function main(): Promise<void> {
 
     case 'auth':
       cmdAuth(hippoRoot, args, flags);
+      break;
+
+    case 'slack':
+      cmdSlack(hippoRoot, args, flags);
       break;
 
     case 'audit': {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,6 +159,8 @@ import { multihopSearch } from './multihop.js';
 import { computeSalience } from './salience.js';
 import { computeAmbientState, renderAmbientSummary } from './ambient.js';
 import { listDlq } from './connectors/slack/dlq.js';
+import { backfillChannel } from './connectors/slack/backfill.js';
+import { slackHistoryFetcher } from './connectors/slack/web-client.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -4642,7 +4644,7 @@ function printSlackBackfillUsage(): void {
   console.log('  --since    backfill from ISO timestamp (default: cursor)');
 }
 
-function cmdSlackBackfill(_hippoRoot: string, flags: Record<string, string | boolean | string[]>): void {
+function cmdSlackBackfill(hippoRoot: string, flags: Record<string, string | boolean | string[]>): void {
   // M3: detect --help BEFORE token check so operators can read usage in
   // environments without SLACK_BOT_TOKEN configured.
   if (flags['help']) {
@@ -4655,13 +4657,34 @@ function cmdSlackBackfill(_hippoRoot: string, flags: Record<string, string | boo
     process.exit(1);
   }
   // Real fetcher requires SLACK_BOT_TOKEN with channels:history scope.
-  // (Full HTTP fetcher implementation lands in Task 15.)
   const token = process.env.SLACK_BOT_TOKEN;
   if (!token) {
     console.error('SLACK_BOT_TOKEN is not set. Backfill requires a Slack bot token with channels:history scope.');
     process.exit(2);
   }
-  console.log(`Backfill of ${channel} not yet wired to live HTTP fetcher (Task 15).`);
+  // --since is advisory in V1: the slack_cursors row drives resume, so the
+  // backfill loop always picks up where it last left off. Honoured-by-cursor
+  // semantics keep idempotency clean.
+  const sinceIso = flags['since'] as string | undefined;
+  void sinceIso;
+  const fetcher = slackHistoryFetcher(token);
+  const ctx = {
+    hippoRoot,
+    tenantId: process.env.HIPPO_TENANT ?? 'default',
+    actor: 'cli:slack-backfill',
+  };
+  backfillChannel(ctx, {
+    teamId: process.env.SLACK_TEAM_ID ?? 'T_UNKNOWN',
+    channel: { id: channel, is_private: false },
+    fetcher,
+  })
+    .then((r) => {
+      console.log(`backfill ${channel}: ${r.ingested} new messages across ${r.pages} pages`);
+    })
+    .catch((e: Error) => {
+      console.error('backfill failed:', e.message);
+      process.exit(3);
+    });
 }
 
 function cmdSlackDlqList(hippoRoot: string, _flags: Record<string, string | boolean | string[]>): void {

--- a/src/connectors/slack/backfill.ts
+++ b/src/connectors/slack/backfill.ts
@@ -1,0 +1,93 @@
+import type { Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { ingestMessage } from './ingest.js';
+import type { SlackMessageEvent } from './types.js';
+import type { ChannelMeta } from './scope.js';
+
+export interface SlackHistoryPage {
+  messages: SlackMessageEvent[];
+  next_cursor: string | null;
+}
+
+export type SlackHistoryFetcher = (args: {
+  channelId: string;
+  cursor: string | null;
+}) => Promise<SlackHistoryPage>;
+
+export interface BackfillOpts {
+  teamId: string;
+  channel: ChannelMeta;
+  fetcher: SlackHistoryFetcher;
+  /** Stop after this many messages. Default: unlimited. */
+  maxMessages?: number;
+}
+
+function readCursor(root: string, tenantId: string, channelId: string): string | null {
+  const db = openHippoDb(root);
+  try {
+    const row = db
+      .prepare(`SELECT latest_ts FROM slack_cursors WHERE tenant_id=? AND channel_id=?`)
+      .get(tenantId, channelId) as { latest_ts?: string } | undefined;
+    return row?.latest_ts ?? null;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+function writeCursor(
+  root: string,
+  tenantId: string,
+  channelId: string,
+  latestTs: string,
+): void {
+  const db = openHippoDb(root);
+  try {
+    db.prepare(
+      `INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?,?,?,?)
+       ON CONFLICT(tenant_id, channel_id) DO UPDATE SET latest_ts = excluded.latest_ts, updated_at = excluded.updated_at`,
+    ).run(tenantId, channelId, latestTs, new Date().toISOString());
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Page through `conversations.history` via the injected fetcher and ingest each
+ * message. The cursor is persisted to `slack_cursors` after every page so a
+ * crash mid-backfill resumes near where it left off.
+ *
+ * Each ingested message uses a synthesized eventId of the form
+ * `backfill:${teamId}:${channelId}:${ts}`. Reruns dedupe via the
+ * `slack_event_log` PK so calling `backfillChannel` twice is safe.
+ */
+export async function backfillChannel(
+  ctx: Context,
+  opts: BackfillOpts,
+): Promise<{ ingested: number; pages: number }> {
+  let cursor: string | null = readCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id);
+  let ingested = 0;
+  let pages = 0;
+  let latestTs: string | null = cursor;
+  while (true) {
+    const page = await opts.fetcher({ channelId: opts.channel.id, cursor });
+    pages++;
+    for (const msg of page.messages) {
+      const r = ingestMessage(ctx, {
+        teamId: opts.teamId,
+        channel: opts.channel,
+        message: msg,
+        eventId: `backfill:${opts.teamId}:${opts.channel.id}:${msg.ts}`,
+      });
+      if (r.status === 'ingested') ingested++;
+      if (!latestTs || msg.ts > latestTs) latestTs = msg.ts;
+      if (opts.maxMessages && ingested >= opts.maxMessages) {
+        if (latestTs) writeCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id, latestTs);
+        return { ingested, pages };
+      }
+    }
+    if (latestTs) writeCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id, latestTs);
+    if (!page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+  return { ingested, pages };
+}

--- a/src/connectors/slack/backfill.ts
+++ b/src/connectors/slack/backfill.ts
@@ -11,7 +11,17 @@ export interface SlackHistoryPage {
 
 export type SlackHistoryFetcher = (args: {
   channelId: string;
+  /** Slack's opaque pagination token. Null on first page of a backfill run. */
   cursor: string | null;
+  /**
+   * Incremental-resume bound: skip messages with ts <= oldest. Set from
+   * `slack_cursors.latest_ts` on the FIRST page of a rerun; unused on
+   * subsequent pages within one run (where `cursor` carries us forward).
+   * Distinct from `cursor` because Slack treats `cursor` as opaque token
+   * and `oldest` as a numeric ts — feeding `latest_ts` as `cursor` breaks
+   * against the live API even though it round-trips through test fetchers.
+   */
+  oldest?: string;
 }) => Promise<SlackHistoryPage>;
 
 export interface BackfillOpts {
@@ -64,12 +74,21 @@ export async function backfillChannel(
   ctx: Context,
   opts: BackfillOpts,
 ): Promise<{ ingested: number; pages: number }> {
-  let cursor: string | null = readCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id);
+  // Resume bound from previous run; passed as `oldest` (numeric ts) on the
+  // first page only. `cursor` starts null — Slack mints the next-page token
+  // and we feed it back. Mixing the two would feed a numeric ts as an opaque
+  // cursor and break against the live API on rerun.
+  const resumeFrom: string | null = readCursor(ctx.hippoRoot, ctx.tenantId, opts.channel.id);
+  let cursor: string | null = null;
   let ingested = 0;
   let pages = 0;
-  let latestTs: string | null = cursor;
+  let latestTs: string | null = resumeFrom;
   while (true) {
-    const page = await opts.fetcher({ channelId: opts.channel.id, cursor });
+    const page = await opts.fetcher({
+      channelId: opts.channel.id,
+      cursor,
+      oldest: pages === 0 && resumeFrom ? resumeFrom : undefined,
+    });
     pages++;
     for (const msg of page.messages) {
       const r = ingestMessage(ctx, {

--- a/src/connectors/slack/deletion.ts
+++ b/src/connectors/slack/deletion.ts
@@ -1,0 +1,60 @@
+import { existsSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { archiveRaw, type Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { markEventSeen, hasSeenEvent } from './idempotency.js';
+
+export interface DeletionInput {
+  teamId: string;
+  channelId: string;
+  deletedTs: string;
+  eventId: string;
+}
+
+export type DeletionStatus = 'archived' | 'not_found' | 'duplicate';
+
+export interface DeletionResult {
+  status: DeletionStatus;
+  memoryId: string | null;
+}
+
+export function handleMessageDeleted(ctx: Context, input: DeletionInput): DeletionResult {
+  const db = openHippoDb(ctx.hippoRoot);
+  let memoryId: string | null = null;
+  try {
+    if (hasSeenEvent(db, input.eventId)) {
+      return { status: 'duplicate', memoryId: null };
+    }
+    const ref = `slack://${input.teamId}/${input.channelId}/${input.deletedTs}`;
+    // Tenant scope is load-bearing: without `tenant_id = ?` a deletion event
+    // from tenant A could archive tenant B's raw row sharing the same
+    // artifact_ref. The `kind = 'raw'` filter prevents accidentally targeting
+    // distilled rows.
+    const row = db
+      .prepare(`SELECT id FROM memories WHERE artifact_ref = ? AND tenant_id = ? AND kind = 'raw'`)
+      .get(ref, ctx.tenantId) as { id?: string } | undefined;
+    memoryId = row?.id ?? null;
+  } finally {
+    closeHippoDb(db);
+  }
+  if (!memoryId) {
+    const db2 = openHippoDb(ctx.hippoRoot);
+    try { markEventSeen(db2, input.eventId, null); }
+    finally { closeHippoDb(db2); }
+    return { status: 'not_found', memoryId: null };
+  }
+  archiveRaw(ctx, memoryId, `source_deleted:slack:${input.teamId}:${input.channelId}:${input.deletedTs}`);
+  // archiveRawMemory deletes the memories row but does not remove the legacy
+  // markdown mirror in <root>/{buffer,episodic,semantic}/<id>.md. If we leave
+  // the mirror in place, a subsequent initStore() on an empty memories table
+  // would re-import the row via bootstrapLegacyStore — silently undoing the
+  // archive. Drop the mirror so the GDPR-style deletion is complete.
+  for (const layer of ['buffer', 'episodic', 'semantic']) {
+    const file = join(ctx.hippoRoot, layer, `${memoryId}.md`);
+    if (existsSync(file)) unlinkSync(file);
+  }
+  const db3 = openHippoDb(ctx.hippoRoot);
+  try { markEventSeen(db3, input.eventId, memoryId); }
+  finally { closeHippoDb(db3); }
+  return { status: 'archived', memoryId };
+}

--- a/src/connectors/slack/deletion.ts
+++ b/src/connectors/slack/deletion.ts
@@ -1,5 +1,3 @@
-import { existsSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
 import { archiveRaw, type Context } from '../../api.js';
 import { openHippoDb, closeHippoDb } from '../../db.js';
 import { markEventSeen, hasSeenEvent } from './idempotency.js';
@@ -43,16 +41,9 @@ export function handleMessageDeleted(ctx: Context, input: DeletionInput): Deleti
     finally { closeHippoDb(db2); }
     return { status: 'not_found', memoryId: null };
   }
+  // api.archiveRaw now handles legacy mirror cleanup centrally so every caller
+  // (CLI, REST route, MCP tool, this connector) gets the GDPR-correct archive.
   archiveRaw(ctx, memoryId, `source_deleted:slack:${input.teamId}:${input.channelId}:${input.deletedTs}`);
-  // archiveRawMemory deletes the memories row but does not remove the legacy
-  // markdown mirror in <root>/{buffer,episodic,semantic}/<id>.md. If we leave
-  // the mirror in place, a subsequent initStore() on an empty memories table
-  // would re-import the row via bootstrapLegacyStore — silently undoing the
-  // archive. Drop the mirror so the GDPR-style deletion is complete.
-  for (const layer of ['buffer', 'episodic', 'semantic']) {
-    const file = join(ctx.hippoRoot, layer, `${memoryId}.md`);
-    if (existsSync(file)) unlinkSync(file);
-  }
   const db3 = openHippoDb(ctx.hippoRoot);
   try { markEventSeen(db3, input.eventId, memoryId); }
   finally { closeHippoDb(db3); }

--- a/src/connectors/slack/dlq.ts
+++ b/src/connectors/slack/dlq.ts
@@ -1,0 +1,41 @@
+import type { DatabaseSyncLike } from '../../db.js';
+
+export interface DlqItem {
+  id: number;
+  tenantId: string;
+  rawPayload: string;
+  error: string;
+  receivedAt: string;
+  retriedAt: string | null;
+}
+
+export interface WriteDlqOpts {
+  tenantId: string;
+  rawPayload: string;
+  error: string;
+}
+
+export function writeToDlq(db: DatabaseSyncLike, opts: WriteDlqOpts): number {
+  const result = db
+    .prepare(`INSERT INTO slack_dlq (tenant_id, raw_payload, error, received_at) VALUES (?, ?, ?, ?)`)
+    .run(opts.tenantId, opts.rawPayload, opts.error, new Date().toISOString());
+  return Number(result.lastInsertRowid);
+}
+
+export function listDlq(db: DatabaseSyncLike, opts: { tenantId: string; limit?: number }): DlqItem[] {
+  const rows = db
+    .prepare(`SELECT id, tenant_id, raw_payload, error, received_at, retried_at FROM slack_dlq WHERE tenant_id = ? ORDER BY received_at ASC LIMIT ?`)
+    .all(opts.tenantId, opts.limit ?? 100) as Array<Record<string, unknown>>;
+  return rows.map((r) => ({
+    id: Number(r.id),
+    tenantId: String(r.tenant_id),
+    rawPayload: String(r.raw_payload),
+    error: String(r.error),
+    receivedAt: String(r.received_at),
+    retriedAt: r.retried_at == null ? null : String(r.retried_at),
+  }));
+}
+
+export function markDlqRetried(db: DatabaseSyncLike, id: number): void {
+  db.prepare(`UPDATE slack_dlq SET retried_at = ? WHERE id = ?`).run(new Date().toISOString(), id);
+}

--- a/src/connectors/slack/idempotency.ts
+++ b/src/connectors/slack/idempotency.ts
@@ -1,0 +1,18 @@
+import type { DatabaseSyncLike } from '../../db.js';
+
+export function hasSeenEvent(db: DatabaseSyncLike, eventId: string): boolean {
+  const row = db.prepare(`SELECT 1 FROM slack_event_log WHERE event_id = ?`).get(eventId);
+  return !!row;
+}
+
+export function markEventSeen(db: DatabaseSyncLike, eventId: string, memoryId: string | null): void {
+  db.prepare(`INSERT OR IGNORE INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`)
+    .run(eventId, new Date().toISOString(), memoryId);
+}
+
+export function lookupMemoryByEvent(db: DatabaseSyncLike, eventId: string): string | null {
+  const row = db.prepare(`SELECT memory_id FROM slack_event_log WHERE event_id = ?`).get(eventId) as
+    | { memory_id: string | null }
+    | undefined;
+  return row?.memory_id ?? null;
+}

--- a/src/connectors/slack/ingest.ts
+++ b/src/connectors/slack/ingest.ts
@@ -1,0 +1,68 @@
+import { remember, type Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { hasSeenEvent, markEventSeen, lookupMemoryByEvent } from './idempotency.js';
+import { messageToRememberOpts } from './transform.js';
+import type { ChannelMeta } from './scope.js';
+import type { SlackMessageEvent } from './types.js';
+
+export interface IngestInput {
+  teamId: string;
+  channel: ChannelMeta;
+  message: SlackMessageEvent;
+  /** Slack event_id for the envelope (or for backfill, a synthesized stable id). */
+  eventId: string;
+}
+
+export type IngestStatus = 'ingested' | 'duplicate' | 'skipped';
+
+export interface IngestResult {
+  status: IngestStatus;
+  memoryId: string | null;
+}
+
+/**
+ * Ingest a Slack message into hippo as a kind='raw' memory.
+ *
+ * - Idempotency-checked via slack_event_log (Slack retries within 1 minute).
+ * - The memory write and the slack_event_log mark commit atomically through
+ *   `api.remember`'s `afterWrite` hook — a crash between the two cannot
+ *   produce a duplicate on the next retry.
+ * - Empty-body messages return 'skipped' but still mark seen so a replay
+ *   returns 'duplicate' rather than re-running the transform.
+ */
+export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
+  // Idempotency check: if already seen, return the cached memory_id without
+  // re-running the transform or hitting api.remember.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    if (hasSeenEvent(db, input.eventId)) {
+      return { status: 'duplicate', memoryId: lookupMemoryByEvent(db, input.eventId) };
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+
+  const opts = messageToRememberOpts(input);
+  if (!opts) {
+    const db2 = openHippoDb(ctx.hippoRoot);
+    try {
+      markEventSeen(db2, input.eventId, null);
+    } finally {
+      closeHippoDb(db2);
+    }
+    return { status: 'skipped', memoryId: null };
+  }
+
+  // Atomic write: the afterWrite callback runs inside writeEntry's SAVEPOINT,
+  // so the memory row and the slack_event_log row commit (or roll back)
+  // together. Slack's 1-minute retry window can no longer produce a duplicate
+  // via the crash-between-handles race.
+  const result = remember(
+    { ...ctx, actor: ctx.actor || 'connector:slack' },
+    {
+      ...opts,
+      afterWrite: (db, memoryId) => markEventSeen(db, input.eventId, memoryId),
+    },
+  );
+  return { status: 'ingested', memoryId: result.id };
+}

--- a/src/connectors/slack/ratelimit.ts
+++ b/src/connectors/slack/ratelimit.ts
@@ -1,0 +1,23 @@
+export interface RetryOpts {
+  url: string;
+  init?: RequestInit;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  maxRetries?: number;
+}
+
+export async function fetchWithRetry(opts: RetryOpts): Promise<Response> {
+  const f = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const max = opts.maxRetries ?? 3;
+  let attempt = 0;
+  while (true) {
+    const r = await f(opts.url, opts.init);
+    if (r.status !== 429) return r;
+    if (attempt >= max) throw new Error(`rate-limited after ${attempt + 1} attempts: ${opts.url}`);
+    const ra = r.headers.get('retry-after');
+    const delaySec = ra ? Number(ra) : Math.pow(2, attempt);
+    await sleep(Math.max(0, delaySec) * 1000);
+    attempt++;
+  }
+}

--- a/src/connectors/slack/scope.ts
+++ b/src/connectors/slack/scope.ts
@@ -1,0 +1,19 @@
+export interface ChannelMeta {
+  id: string;
+  is_private?: boolean;
+  is_im?: boolean;
+  is_mpim?: boolean;
+}
+
+/**
+ * Map a Slack channel into a hippo scope string.
+ *
+ * Default to private when privacy is undetermined. The cost of leaking a
+ * public channel into private scope (recall returns nothing) is far smaller
+ * than the cost of leaking a private channel into public scope (data exposed
+ * to a tenant that should not see it).
+ */
+export function scopeFromChannel(ch: ChannelMeta): string {
+  const isPublic = ch.is_private === false && !ch.is_im && !ch.is_mpim;
+  return isPublic ? `slack:public:${ch.id}` : `slack:private:${ch.id}`;
+}

--- a/src/connectors/slack/signature.ts
+++ b/src/connectors/slack/signature.ts
@@ -1,0 +1,27 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export interface VerifyOpts {
+  rawBody: string;
+  timestamp: string;
+  signature: string;
+  signingSecret: string;
+  /** Current unix seconds. Injectable for tests. */
+  now?: number;
+  /** Max allowed skew in seconds. Default 5 minutes (Slack's recommendation). */
+  skewSeconds?: number;
+}
+
+export function verifySlackSignature(opts: VerifyOpts): boolean {
+  const { rawBody, timestamp, signature, signingSecret } = opts;
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const skew = opts.skewSeconds ?? 5 * 60;
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(now - ts) > skew) return false;
+  if (!signature.startsWith('v0=')) return false;
+  const expected = `v0=${createHmac('sha256', signingSecret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`;
+  const a = Buffer.from(signature, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/src/connectors/slack/tenant-routing.ts
+++ b/src/connectors/slack/tenant-routing.ts
@@ -1,0 +1,18 @@
+import type { DatabaseSyncLike } from '../../db.js';
+
+/**
+ * Look up the tenant_id for a Slack team_id. Returns null when no row exists,
+ * which signals "use the deployment's HIPPO_TENANT fallback". Multi-workspace
+ * deployments populate slack_workspaces; single-workspace deployments leave
+ * the table empty and rely on the env fallback.
+ *
+ * Review patch #6: dedicated routing seam — never inline this lookup at the
+ * route handler so a future schema change (e.g. installation tokens) lands
+ * in one place.
+ */
+export function resolveTenantForTeam(db: DatabaseSyncLike, teamId: string): string | null {
+  const row = db
+    .prepare(`SELECT tenant_id FROM slack_workspaces WHERE team_id = ?`)
+    .get(teamId) as { tenant_id?: string } | undefined;
+  return row?.tenant_id ?? null;
+}

--- a/src/connectors/slack/transform.ts
+++ b/src/connectors/slack/transform.ts
@@ -1,0 +1,38 @@
+import type { RememberOpts } from '../../api.js';
+import { scopeFromChannel, type ChannelMeta } from './scope.js';
+import type { SlackMessageEvent } from './types.js';
+
+export interface TransformInput {
+  teamId: string;
+  channel: ChannelMeta;
+  message: SlackMessageEvent;
+}
+
+/**
+ * Convert a SlackMessageEvent into RememberOpts for api.remember(). Returns
+ * null when the message has no usable body (e.g. system events, bot reactions
+ * without text). Caller treats null as "skip but mark idempotency seen".
+ *
+ * Contract:
+ * - kind is the literal 'raw' (E1.x connector boundary, see src/importers.ts).
+ * - artifact_ref format MUST be exactly `slack://${teamId}/${channelId}/${ts}`;
+ *   the deletion path (Task 9) looks up by this string.
+ */
+export function messageToRememberOpts(input: TransformInput): RememberOpts | null {
+  const text = input.message.text?.trim();
+  if (!text) return null;
+  const artifactRef = `slack://${input.teamId}/${input.channel.id}/${input.message.ts}`;
+  const tags = [
+    'source:slack',
+    `channel:${input.channel.id}`,
+    ...(input.message.user ? [`user:${input.message.user}`] : []),
+    ...(input.message.thread_ts ? [`thread:${input.message.thread_ts}`] : []),
+  ];
+  return {
+    content: text,
+    kind: 'raw',
+    scope: scopeFromChannel(input.channel),
+    artifactRef,
+    tags,
+  };
+}

--- a/src/connectors/slack/types.ts
+++ b/src/connectors/slack/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Slack Events API envelope shapes used by the ingestion connector.
+ * Spec: https://api.slack.com/events-api
+ */
+
+export interface SlackUrlVerification {
+  type: 'url_verification';
+  challenge: string;
+  token?: string;
+}
+
+export interface SlackMessageEvent {
+  type: 'message';
+  subtype?: 'message_deleted' | 'message_changed' | 'channel_join' | string;
+  channel: string;
+  channel_type?: 'channel' | 'group' | 'im' | 'mpim';
+  user?: string;
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  /** Present on subtype='message_deleted'. */
+  deleted_ts?: string;
+}
+
+export interface SlackEventEnvelope {
+  type: 'event_callback';
+  team_id: string;
+  event_id: string;
+  event_time: number;
+  event: SlackMessageEvent | { type: string; [k: string]: unknown };
+}
+
+export type SlackInbound = SlackEventEnvelope | SlackUrlVerification;
+
+export function isSlackEventEnvelope(x: unknown): x is SlackEventEnvelope {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return (
+    o.type === 'event_callback' &&
+    typeof o.team_id === 'string' &&
+    typeof o.event_id === 'string' &&
+    typeof o.event_time === 'number' &&
+    !!o.event &&
+    typeof o.event === 'object' &&
+    typeof (o.event as Record<string, unknown>).type === 'string'
+  );
+}
+
+export function isSlackMessageEvent(x: unknown): x is SlackMessageEvent {
+  if (!x || typeof x !== 'object') return false;
+  const o = x as Record<string, unknown>;
+  return o.type === 'message' && typeof o.channel === 'string' && typeof o.ts === 'string';
+}

--- a/src/connectors/slack/web-client.ts
+++ b/src/connectors/slack/web-client.ts
@@ -1,0 +1,48 @@
+import { fetchWithRetry } from './ratelimit.js';
+import type { SlackHistoryFetcher } from './backfill.js';
+import type { SlackMessageEvent } from './types.js';
+
+/**
+ * Build a SlackHistoryFetcher that pages `conversations.history` over real
+ * HTTP. Wraps `fetchWithRetry` so 429 handling is automatic. The returned
+ * fetcher is the one Task 13's `backfillChannel` consumes.
+ *
+ * Slack omits `channel` from messages in the history response, so we stamp
+ * the request channel id onto each parsed message — downstream ingest needs
+ * it on every event.
+ */
+export function slackHistoryFetcher(
+  token: string,
+  fetchImpl?: typeof fetch,
+): SlackHistoryFetcher {
+  return async ({ channelId, cursor }) => {
+    const url = new URL('https://slack.com/api/conversations.history');
+    url.searchParams.set('channel', channelId);
+    url.searchParams.set('limit', '200');
+    if (cursor) url.searchParams.set('cursor', cursor);
+    const r = await fetchWithRetry({
+      url: url.toString(),
+      init: { method: 'GET', headers: { authorization: `Bearer ${token}` } },
+      fetchImpl,
+    });
+    const body = (await r.json()) as {
+      ok: boolean;
+      error?: string;
+      messages?: unknown[];
+      response_metadata?: { next_cursor?: string };
+    };
+    if (!body.ok) throw new Error(`slack: ${body.error ?? 'unknown error'}`);
+    const messages: SlackMessageEvent[] = (body.messages ?? [])
+      .filter((m): m is SlackMessageEvent => {
+        if (!m || typeof m !== 'object') return false;
+        const o = m as Record<string, unknown>;
+        return o.type === 'message' && typeof o.ts === 'string';
+      })
+      // Slack returns messages without `channel`; stamp it from the request.
+      .map((m) => ({ ...m, channel: channelId }));
+    return {
+      messages,
+      next_cursor: body.response_metadata?.next_cursor ?? null,
+    };
+  };
+}

--- a/src/connectors/slack/web-client.ts
+++ b/src/connectors/slack/web-client.ts
@@ -15,11 +15,12 @@ export function slackHistoryFetcher(
   token: string,
   fetchImpl?: typeof fetch,
 ): SlackHistoryFetcher {
-  return async ({ channelId, cursor }) => {
+  return async ({ channelId, cursor, oldest }) => {
     const url = new URL('https://slack.com/api/conversations.history');
     url.searchParams.set('channel', channelId);
     url.searchParams.set('limit', '200');
     if (cursor) url.searchParams.set('cursor', cursor);
+    if (oldest) url.searchParams.set('oldest', oldest);
     const r = await fetchWithRetry({
       url: url.toString(),
       init: { method: 'GET', headers: { authorization: `Bearer ${token}` } },

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,7 +21,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 16;
+const CURRENT_SCHEMA_VERSION = 17;
 
 type Migration = {
   version: number;
@@ -418,6 +418,51 @@ const MIGRATIONS: Migration[] = [
         )
       `);
       db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_tenant_ts ON audit_log(tenant_id, ts DESC)`);
+    },
+  },
+  {
+    version: 17,
+    up: (db) => {
+      // E1.3 Slack ingestion: idempotency log, per-channel backfill cursors, DLQ.
+      // See docs/plans/2026-04-29-e1.3-slack-ingestion.md.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS slack_event_log (
+          event_id TEXT PRIMARY KEY,
+          ingested_at TEXT NOT NULL,
+          memory_id TEXT
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_slack_event_log_memory ON slack_event_log(memory_id) WHERE memory_id IS NOT NULL`);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS slack_cursors (
+          tenant_id TEXT NOT NULL,
+          channel_id TEXT NOT NULL,
+          latest_ts TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, channel_id)
+        )
+      `);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS slack_dlq (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          tenant_id TEXT NOT NULL,
+          raw_payload TEXT NOT NULL,
+          error TEXT NOT NULL,
+          received_at TEXT NOT NULL,
+          retried_at TEXT
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_slack_dlq_tenant_received ON slack_dlq(tenant_id, received_at)`);
+      // Multi-tenant routing seam (review patch #6). Empty by default — single-
+      // tenant deployments resolve via HIPPO_TENANT fallback. Multi-workspace
+      // deployments populate this table to map team_id → tenant_id.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS slack_workspaces (
+          team_id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          added_at TEXT NOT NULL
+        )
+      `);
     },
   },
 ];

--- a/src/importers.ts
+++ b/src/importers.ts
@@ -87,9 +87,9 @@ export function importEntries(
 
     // A3: kind defaults to 'distilled'. ChatGPT/Claude/Cursor exports are curated
     // user pastes, not raw transcripts from a system of record, so distilled is
-    // correct here. When E1.x ingestion connectors land (Slack/Jira/Gmail webhooks),
-    // they MUST set kind: 'raw' explicitly and route deletions through
-    // archiveRawMemory(). See MEMORY_ENVELOPE.md.
+    // correct here. E1.3 (Slack ingestion) shipped 2026-04-29 in src/connectors/slack/
+    // and sets kind: 'raw' + routes deletions through archiveRawMemory() — these
+    // importers stay 'distilled' per the original reasoning. See MEMORY_ENVELOPE.md.
     const entry = createMemory(chunk, {
       layer: Layer.Episodic,
       tags: allTags,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -476,7 +476,7 @@ export async function handleMcpRequest(
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'hippo-memory', version: '0.36.0' },
+          serverInfo: { name: 'hippo-memory', version: '0.37.0' },
         },
       };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,7 @@ const VALID_KINDS: ReadonlySet<MemoryKind> = new Set([
 // HTTP /health response uses this; reading package.json synchronously here
 // would couple the daemon to its on-disk install path, which we want to
 // avoid for tests that mkdtemp a hippoRoot.
-const VERSION = '0.36.0';
+const VERSION = '0.37.0';
 
 // 1 MB body cap. The CLI never sends payloads near this; anything bigger is
 // almost certainly a misconfigured client or a deliberate memory-blowup attempt.

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,27 @@ import {
 import type { MemoryKind } from './memory.js';
 import type { AuditOp } from './audit.js';
 import { handleMcpRequest, type McpRequest } from './mcp/server.js';
+import { verifySlackSignature } from './connectors/slack/signature.js';
+import { isSlackEventEnvelope, isSlackMessageEvent } from './connectors/slack/types.js';
+import { ingestMessage } from './connectors/slack/ingest.js';
+import { handleMessageDeleted } from './connectors/slack/deletion.js';
+import { writeToDlq } from './connectors/slack/dlq.js';
+import { resolveTenantForTeam } from './connectors/slack/tenant-routing.js';
+
+// Review patch #2: explicit allow-list for unauthenticated /v1/* routes.
+// New unauth routes MUST be added here AND get a corresponding entry in
+// tests/server-bearer-lockdown.test.ts. Do not gate auth elsewhere by
+// `path.startsWith` — pattern-positional auth is bypass-by-accident.
+//
+// The route handlers consult `isPublicRoute` before invoking
+// `buildContextWithAuth` / `requireAuth`. Adding a route here without
+// adding the corresponding `isPublicRoute` short-circuit in a handler is
+// a no-op (auth still applies), so the failure mode is fail-closed.
+const PUBLIC_ROUTES: ReadonlySet<string> = new Set(['POST /v1/connectors/slack/events']);
+
+function isPublicRoute(method: string, path: string): boolean {
+  return PUBLIC_ROUTES.has(`${method} ${path}`);
+}
 
 const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set([
   'remember',
@@ -257,7 +278,12 @@ function buildContextWithAuth(req: IncomingMessage, hippoRoot: string): Context 
     }
   }
 
-  // No Authorization header. Loopback-only fallback.
+  // No Authorization header. Loopback-only fallback, unless explicitly
+  // disabled via HIPPO_REQUIRE_AUTH=1 (used by the bearer-lockdown test
+  // and by deployments that want to forbid the local-CLI escape hatch).
+  if (process.env.HIPPO_REQUIRE_AUTH === '1') {
+    throw new HttpError(401, 'auth required');
+  }
   if (!isLoopback(req.socket.remoteAddress)) {
     throw new HttpError(401, 'auth required');
   }
@@ -291,6 +317,9 @@ function requireAuth(req: IncomingMessage, hippoRoot: string): void {
       closeHippoDb(db);
     }
     return;
+  }
+  if (process.env.HIPPO_REQUIRE_AUTH === '1') {
+    throw new HttpError(401, 'auth required');
   }
   if (!isLoopback(req.socket.remoteAddress)) {
     throw new HttpError(401, 'auth required');
@@ -503,6 +532,150 @@ async function handleRequest(
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = auditList(ctx, { op, since, limit });
     sendJson(res, 200, result);
+    return;
+  }
+
+  // ── POST /v1/connectors/slack/events ──
+  //
+  // Slack Events API webhook. Auth is signature-based (HMAC over the raw
+  // body with SLACK_SIGNING_SECRET); Bearer is NOT required, which is why
+  // this route is in PUBLIC_ROUTES. The route is responsible for:
+  //   1. Echoing the one-time url_verification challenge.
+  //   2. Verifying the HMAC on every other inbound payload.
+  //   3. Resolving body.team_id → tenantId via slack_workspaces, falling
+  //      back to HIPPO_TENANT then 'default'.
+  //   4. Dispatching event_callback envelopes to ingestMessage /
+  //      handleMessageDeleted.
+  //   5. Parking malformed or unhandled payloads in slack_dlq and STILL
+  //      ACKing 200 — Slack retries forever otherwise.
+  //
+  // Review patch #7: when SLACK_SIGNING_SECRET is unset we return 404, not
+  // 503, so an external probe cannot distinguish "route gated off by config"
+  // from "route does not exist on this build".
+  if (method === 'POST' && path === '/v1/connectors/slack/events') {
+    // Bearer auth deliberately skipped — this route is in PUBLIC_ROUTES
+    // and authenticates via the Slack HMAC signature instead.
+    if (!isPublicRoute(method, path)) {
+      // Defensive: PUBLIC_ROUTES drift would land here. Fail closed.
+      throw new HttpError(401, 'auth required');
+    }
+    const rawBody = await readBody(req);
+    const secret = process.env.SLACK_SIGNING_SECRET;
+    if (!secret) {
+      res.writeHead(404, JSON_HEADERS);
+      res.end(JSON.stringify({ error: 'not found' }));
+      return;
+    }
+    const sig = req.headers['x-slack-signature'];
+    const tsHdr = req.headers['x-slack-request-timestamp'];
+    if (
+      typeof sig !== 'string' ||
+      typeof tsHdr !== 'string' ||
+      !verifySlackSignature({
+        rawBody,
+        timestamp: tsHdr,
+        signature: sig,
+        signingSecret: secret,
+      })
+    ) {
+      throw new HttpError(401, 'invalid Slack signature');
+    }
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      const db = openHippoDb(opts.hippoRoot);
+      try {
+        writeToDlq(db, {
+          tenantId: process.env.HIPPO_TENANT ?? 'default',
+          rawPayload: rawBody,
+          error: 'invalid JSON',
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+      sendJson(res, 200, { ok: true, status: 'dlq' });
+      return;
+    }
+    if (
+      body &&
+      typeof body === 'object' &&
+      (body as Record<string, unknown>).type === 'url_verification'
+    ) {
+      sendJson(res, 200, {
+        challenge: String((body as Record<string, unknown>).challenge ?? ''),
+      });
+      return;
+    }
+    let resolvedTenant = process.env.HIPPO_TENANT ?? 'default';
+    if (isSlackEventEnvelope(body)) {
+      const db = openHippoDb(opts.hippoRoot);
+      try {
+        const mapped = resolveTenantForTeam(db, body.team_id);
+        if (mapped) resolvedTenant = mapped;
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+    const ctx: Context = {
+      hippoRoot: opts.hippoRoot,
+      tenantId: resolvedTenant,
+      actor: 'connector:slack',
+    };
+    if (!isSlackEventEnvelope(body)) {
+      const db = openHippoDb(ctx.hippoRoot);
+      try {
+        writeToDlq(db, {
+          tenantId: ctx.tenantId,
+          rawPayload: rawBody,
+          error: 'not an event_callback envelope',
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+      sendJson(res, 200, { ok: true, status: 'dlq' });
+      return;
+    }
+    const inner = body.event;
+    if (isSlackMessageEvent(inner)) {
+      if (inner.subtype === 'message_deleted' && inner.deleted_ts) {
+        const r = handleMessageDeleted(ctx, {
+          teamId: body.team_id,
+          channelId: inner.channel,
+          deletedTs: inner.deleted_ts,
+          eventId: body.event_id,
+        });
+        sendJson(res, 200, { ok: true, status: r.status });
+        return;
+      }
+      const r = ingestMessage(ctx, {
+        teamId: body.team_id,
+        // channel privacy isn't on the inner event; use channel_type as a
+        // proxy. 'group'|'im'|'mpim' → private. 'channel' → public. Unknown
+        // → private (fail closed).
+        channel: {
+          id: inner.channel,
+          is_private: inner.channel_type !== 'channel',
+          is_im: inner.channel_type === 'im',
+          is_mpim: inner.channel_type === 'mpim',
+        },
+        message: inner,
+        eventId: body.event_id,
+      });
+      sendJson(res, 200, { ok: true, status: r.status, memoryId: r.memoryId });
+      return;
+    }
+    const db = openHippoDb(ctx.hippoRoot);
+    try {
+      writeToDlq(db, {
+        tenantId: ctx.tenantId,
+        rawPayload: rawBody,
+        error: `unhandled event type: ${(inner as { type?: string })?.type ?? 'unknown'}`,
+      });
+    } finally {
+      closeHippoDb(db);
+    }
+    sendJson(res, 200, { ok: true, status: 'dlq' });
     return;
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,7 @@ import {
   isFtsAvailable,
   pruneConsolidationRuns,
   getHippoDbPath,
+  type DatabaseSyncLike,
 } from './db.js';
 import { SessionHandoff, SessionHandoffRow, rowToSessionHandoff } from './handoff.js';
 import { tokenize } from './search.js';
@@ -939,16 +940,45 @@ export function saveIndex(hippoRoot: string, index: HippoIndex): void {
  * get the right audit attribution. The HTTP server (A1) and api.* layer pass
  * the resolved actor (`api_key:<key_id>` / `localhost:cli`) so audit events
  * land with one row per write, no double-emit.
+ *
+ * `opts.afterWrite` is invoked inside the same SAVEPOINT as the memories
+ * INSERT (mirrors archiveRawMemory's shape in raw-archive.ts). On callback
+ * throw, the SAVEPOINT rolls back — the memory row never lands, and the
+ * filesystem mirrors / audit emit never run. Used by E1.3+ connectors to
+ * stamp idempotency rows atomically with the memory write.
  */
 export function writeEntry(
   hippoRoot: string,
   entry: MemoryEntry,
-  opts?: { actor?: string },
+  opts?: {
+    actor?: string;
+    afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void;
+  },
 ): void {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    upsertEntryRow(db, entry);
+    // SAVEPOINT (not BEGIN) so this nests safely inside any outer transaction
+    // a future caller might hold. SQLite refuses BEGIN within a transaction;
+    // SAVEPOINT is the only way to scope rollback without disturbing outers.
+    db.exec('SAVEPOINT write_entry');
+    try {
+      upsertEntryRow(db, entry);
+      if (opts?.afterWrite) {
+        opts.afterWrite(db, entry.id);
+      }
+      db.exec('RELEASE SAVEPOINT write_entry');
+    } catch (e) {
+      try {
+        db.exec('ROLLBACK TO SAVEPOINT write_entry');
+        db.exec('RELEASE SAVEPOINT write_entry');
+      } catch {
+        // Ignore rollback failures — the throw below is what matters.
+      }
+      throw e;
+    }
+    // Filesystem mirrors and audit emit run only after the SAVEPOINT releases,
+    // so a rolled-back write leaves no orphan markdown or index entries.
     writeMarkdownMirror(hippoRoot, entry);
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
     audit(

--- a/src/store.ts
+++ b/src/store.ts
@@ -619,7 +619,7 @@ function writeMarkdownMirror(hippoRoot: string, entry: MemoryEntry): void {
   fs.writeFileSync(path.join(dir, `${entry.id}.md`), serializeEntry(entry), 'utf8');
 }
 
-function removeEntryMirrors(hippoRoot: string, id: string): void {
+export function removeEntryMirrors(hippoRoot: string, id: string): void {
   for (const layer of [Layer.Buffer, Layer.Episodic, Layer.Semantic]) {
     const file = path.join(layerDir(hippoRoot, layer), `${id}.md`);
     if (fs.existsSync(file)) {

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -7,14 +7,14 @@ import { createMemory, Layer } from '../src/memory.js';
 import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
-  it('CURRENT_SCHEMA_VERSION is 16 (v14 + v15 hardening + v16 tenant_id)', () => {
-    expect(getCurrentSchemaVersion()).toBe(16);
+  it('CURRENT_SCHEMA_VERSION is 17 (v14 + v15 hardening + v16 tenant_id + v17 slack tables)', () => {
+    expect(getCurrentSchemaVersion()).toBe(17);
   });
 
-  it('fresh db migrates to v16', () => {
+  it('fresh db migrates to v17', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(16);
+    expect(getSchemaVersion(db)).toBe(17);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('A5 schema migration v16: tenant_id columns', () => {
-  it('migrates to schema version 16', () => {
+  it('migrates to latest schema version (currently 17)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(16);
-      expect(getCurrentSchemaVersion()).toBe(16);
+      expect(getSchemaVersion(db)).toBe(17);
+      expect(getCurrentSchemaVersion()).toBe(17);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/api-remember-after-write.test.ts
+++ b/tests/api-remember-after-write.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { remember } from '../src/api.js';
+
+describe('remember.afterWrite is transactional', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-after-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('rolls back the memory row when afterWrite throws', () => {
+    expect(() =>
+      remember({ hippoRoot: root, tenantId: 'default', actor: 'test' }, {
+        content: 'doomed',
+        afterWrite: () => { throw new Error('boom'); },
+      }),
+    ).toThrow(/boom/);
+    expect(loadAllEntries(root).filter((e) => e.content === 'doomed')).toHaveLength(0);
+  });
+});

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(16);
-      expect(getCurrentSchemaVersion()).toBe(16);
+      expect(getSchemaVersion(db)).toBe(17);
+      expect(getCurrentSchemaVersion()).toBe(17);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/server-bearer-lockdown.test.ts
+++ b/tests/server-bearer-lockdown.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+/**
+ * Review patch #2 regression bar: when the loopback no-auth fallback is
+ * disabled (HIPPO_REQUIRE_AUTH=1), every /v1/* route MUST return 401 without
+ * a Bearer token. The Slack webhook route is the only documented exception
+ * (covered by tests/slack-webhook-route.test.ts). A future change that drops
+ * the Bearer gate by accident — e.g. by reordering middleware or by adding
+ * a second public route — should fail this test.
+ */
+describe('server Bearer lockdown', () => {
+  let root: string;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-lockdown-'));
+    initStore(root);
+    process.env.HIPPO_REQUIRE_AUTH = '1';
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+  });
+
+  afterEach(async () => {
+    delete process.env.HIPPO_REQUIRE_AUTH;
+    await handle.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const v1Routes: ReadonlyArray<{ method: string; path: string; body?: string }> = [
+    { method: 'POST', path: '/v1/memories', body: '{"content":"x"}' },
+    { method: 'GET', path: '/v1/memories?q=x' },
+    { method: 'POST', path: '/v1/auth/keys', body: '{}' },
+    { method: 'GET', path: '/v1/auth/keys' },
+    { method: 'GET', path: '/v1/audit' },
+  ];
+
+  it('all /v1/* routes except slack require Bearer', async () => {
+    for (const r of v1Routes) {
+      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, {
+        method: r.method,
+        headers: { 'content-type': 'application/json' },
+        body: r.body,
+      });
+      expect(res.status, `${r.method} ${r.path}`).toBe(401);
+    }
+  });
+});

--- a/tests/slack-backfill-cursor.test.ts
+++ b/tests/slack-backfill-cursor.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import {
+  backfillChannel,
+  type SlackHistoryFetcher,
+} from '../src/connectors/slack/backfill.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const ctx = (root: string) => ({
+  hippoRoot: root,
+  tenantId: 'default',
+  actor: 'connector:slack',
+});
+
+describe('backfillChannel cursor / oldest semantics', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-bfc-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('does NOT feed latest_ts as Slack cursor (would be opaque-token mismatch)', async () => {
+    // Seed slack_cursors with a prior latest_ts.
+    const db = openHippoDb(root);
+    try {
+      db.prepare(
+        `INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?,?,?,?)`,
+      ).run('default', 'C1', '1700000000.000100', new Date().toISOString());
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const calls: Array<{ cursor: string | null; oldest: string | undefined }> = [];
+    const fetcher: SlackHistoryFetcher = async ({ cursor, oldest }) => {
+      calls.push({ cursor, oldest });
+      return { messages: [], next_cursor: null };
+    };
+
+    await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher,
+    });
+
+    expect(calls).toHaveLength(1);
+    // First page MUST have cursor=null (Slack mints the next-page token); the
+    // resume bound rides on `oldest`, NOT `cursor`.
+    expect(calls[0].cursor).toBeNull();
+    expect(calls[0].oldest).toBe('1700000000.000100');
+  });
+
+  it('subsequent pages within one run pass the next_cursor unchanged, oldest undefined', async () => {
+    const calls: Array<{ cursor: string | null; oldest: string | undefined }> = [];
+    const fetcher: SlackHistoryFetcher = async ({ cursor, oldest }) => {
+      calls.push({ cursor, oldest });
+      if (!cursor) {
+        return {
+          messages: [
+            { type: 'message', channel: 'C1', user: 'U1', text: 'pageone msg', ts: '1.1' },
+          ],
+          next_cursor: 'OPAQUE_PAGE2_TOKEN',
+        };
+      }
+      if (cursor === 'OPAQUE_PAGE2_TOKEN') {
+        return {
+          messages: [
+            { type: 'message', channel: 'C1', user: 'U1', text: 'pagetwo msg', ts: '2.2' },
+          ],
+          next_cursor: null,
+        };
+      }
+      throw new Error('unexpected cursor');
+    };
+
+    await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].cursor).toBeNull();
+    expect(calls[0].oldest).toBeUndefined(); // No prior cursor row, so no resume bound.
+    expect(calls[1].cursor).toBe('OPAQUE_PAGE2_TOKEN');
+    expect(calls[1].oldest).toBeUndefined(); // Page 2+ never sets oldest.
+  });
+});

--- a/tests/slack-backfill-ratelimit.test.ts
+++ b/tests/slack-backfill-ratelimit.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { backfillChannel } from '../src/connectors/slack/backfill.js';
+import { slackHistoryFetcher } from '../src/connectors/slack/web-client.js';
+
+const ctx = (root: string) => ({
+  hippoRoot: root,
+  tenantId: 'default',
+  actor: 'connector:slack',
+});
+
+/**
+ * Integration test for rate-limit handling THROUGH the full backfill loop.
+ * The /review skill flagged this gap (HIGH-test): tests/slack-ratelimit.test.ts
+ * exercises only the inner fetchWithRetry helper. This wires a fake fetch
+ * returning 429 then 200 into slackHistoryFetcher and runs backfillChannel
+ * end-to-end, asserting the loop completes, messages land, and the cursor
+ * advances despite the 429.
+ */
+describe('backfill survives 429 + Retry-After through the full loop', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-bfrl-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('429 then 200 → backfill ingests + cursor advances', async () => {
+    let phase = 0;
+    const fakeFetch = vi.fn(async (_url: string) => {
+      phase++;
+      if (phase === 1) {
+        // 429 with Retry-After: 0.01 seconds → fetchWithRetry sleeps 10ms.
+        return {
+          status: 429,
+          headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? '0.01' : null) },
+          json: async () => ({}),
+        } as unknown as Response;
+      }
+      // Second attempt succeeds with one message.
+      return {
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({
+          ok: true,
+          messages: [
+            { type: 'message', user: 'U1', text: 'rate limit survivor', ts: '1700000001.000100' },
+          ],
+          response_metadata: { next_cursor: null },
+        }),
+      } as unknown as Response;
+    });
+
+    const fetcher = slackHistoryFetcher('xoxb-fake', fakeFetch as unknown as typeof fetch);
+    const r = await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher,
+    });
+
+    expect(r.ingested).toBe(1);
+    expect(fakeFetch).toHaveBeenCalledTimes(2); // 429 + 200 retry.
+    const slackEntries = loadAllEntries(root).filter((e) => e.tags.includes('source:slack'));
+    expect(slackEntries).toHaveLength(1);
+    expect(slackEntries[0].kind).toBe('raw');
+    expect(slackEntries[0].content).toBe('rate limit survivor');
+  });
+});

--- a/tests/slack-backfill.test.ts
+++ b/tests/slack-backfill.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { backfillChannel, type SlackHistoryFetcher } from '../src/connectors/slack/backfill.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('backfillChannel', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-bf-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('paginates, ingests, and persists the cursor', async () => {
+    const fetcher: SlackHistoryFetcher = async ({ cursor }) => {
+      if (!cursor) {
+        return {
+          messages: [
+            { type: 'message', channel: 'C1', user: 'U1', text: 'msg-a', ts: '1.1' },
+            { type: 'message', channel: 'C1', user: 'U1', text: 'msg-b', ts: '2.2' },
+          ],
+          next_cursor: 'PAGE2',
+        };
+      }
+      if (cursor === 'PAGE2') {
+        return {
+          messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'msg-c', ts: '3.3' }],
+          next_cursor: null,
+        };
+      }
+      throw new Error('unexpected cursor: ' + cursor);
+    };
+    const r = await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher,
+    });
+    expect(r.ingested).toBe(3);
+
+    const db = openHippoDb(root);
+    try {
+      const row = db
+        .prepare(`SELECT latest_ts FROM slack_cursors WHERE tenant_id=? AND channel_id=?`)
+        .get('default', 'C1') as { latest_ts: string };
+      expect(row.latest_ts).toBe('3.3');
+    } finally {
+      closeHippoDb(db);
+    }
+
+    expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(3);
+  });
+
+  it('resumes from the saved cursor (idempotent on rerun)', async () => {
+    let phase = 1;
+    const fetcher: SlackHistoryFetcher = async () => {
+      if (phase === 1) {
+        phase = 2;
+        return {
+          messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'msg-a', ts: '1.1' }],
+          next_cursor: null,
+        };
+      }
+      // Second pass returns the same message — replay must not duplicate.
+      return {
+        messages: [{ type: 'message', channel: 'C1', user: 'U1', text: 'msg-a', ts: '1.1' }],
+        next_cursor: null,
+      };
+    };
+    await backfillChannel(ctx(root), { teamId: 'T1', channel: { id: 'C1' }, fetcher });
+    await backfillChannel(ctx(root), { teamId: 'T1', channel: { id: 'C1' }, fetcher });
+    expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(1);
+  });
+});

--- a/tests/slack-cli.test.ts
+++ b/tests/slack-cli.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { initStore } from '../src/store.js';
+import { writeToDlq } from '../src/connectors/slack/dlq.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const CLI = resolve(__dirname, '..', 'bin', 'hippo.js');
+
+function runCli(cwd: string, args: string[]): string {
+  if (!existsSync(CLI)) {
+    throw new Error(`bin/hippo.js not found at ${CLI} — run \`npm run build\` first`);
+  }
+  return execFileSync('node', [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, HIPPO_HOME: join(cwd, '.hippo') },
+  });
+}
+
+describe('hippo slack CLI', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-cli-'));
+    initStore(join(root, '.hippo'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('hippo slack dlq list prints DLQ rows', () => {
+    const db = openHippoDb(join(root, '.hippo'));
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{"x":1}', error: 'bad event' });
+    } finally {
+      closeHippoDb(db);
+    }
+    const out = runCli(root, ['slack', 'dlq', 'list']);
+    expect(out).toContain('bad event');
+  });
+
+  it('hippo slack backfill --help mentions --channel and --since', () => {
+    const out = runCli(root, ['slack', 'backfill', '--help']);
+    expect(out).toMatch(/--channel/);
+    expect(out).toMatch(/--since/);
+  });
+});

--- a/tests/slack-deletion.test.ts
+++ b/tests/slack-deletion.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+import { handleMessageDeleted } from '../src/connectors/slack/deletion.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('handleMessageDeleted', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-del-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('archives the matching kind=raw row via archiveRawMemory', () => {
+    const ingested = ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'doomed', ts: '1700.0001' },
+      eventId: 'Ev1',
+    });
+    expect(ingested.status).toBe('ingested');
+
+    const result = handleMessageDeleted(ctx(root), {
+      teamId: 'T1',
+      channelId: 'C1',
+      deletedTs: '1700.0001',
+      eventId: 'EvDel1',
+    });
+    expect(result.status).toBe('archived');
+
+    const remaining = loadAllEntries(root).filter((e) => e.id === ingested.memoryId);
+    expect(remaining).toHaveLength(0);
+
+    // raw_archive table now has the row.
+    const db = openHippoDb(root);
+    try {
+      const arch = db.prepare(`SELECT memory_id, reason FROM raw_archive WHERE memory_id = ?`).get(ingested.memoryId!) as Record<string, unknown>;
+      expect(arch).toBeDefined();
+      expect(String(arch.reason)).toContain('source_deleted');
+    } finally { closeHippoDb(db); }
+  });
+
+  it('returns not_found for unknown artifact_ref (idempotent on replay)', () => {
+    const r = handleMessageDeleted(ctx(root), {
+      teamId: 'T1', channelId: 'C1', deletedTs: '9999.9999', eventId: 'EvDel2',
+    });
+    expect(r.status).toBe('not_found');
+  });
+
+  it('cross-tenant deletion event cannot archive another tenants row (review patch #1)', () => {
+    // Ingest under tenant 'acme'.
+    const acmeCtx = { hippoRoot: root, tenantId: 'acme', actor: 'connector:slack' };
+    const ingested = ingestMessage(acmeCtx, {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'acme secret', ts: '1700.0001' },
+      eventId: 'EvAcme1',
+    });
+    expect(ingested.status).toBe('ingested');
+
+    // Fire deletion under tenant 'default' for the same artifact_ref.
+    const defaultCtx = { hippoRoot: root, tenantId: 'default', actor: 'connector:slack' };
+    const r = handleMessageDeleted(defaultCtx, {
+      teamId: 'T1', channelId: 'C1', deletedTs: '1700.0001', eventId: 'EvDelCross',
+    });
+    expect(r.status).toBe('not_found');
+
+    // Acme row is still there; raw_archive has no row.
+    const remaining = loadAllEntries(root).filter((e) => e.id === ingested.memoryId);
+    expect(remaining).toHaveLength(1);
+    const db = openHippoDb(root);
+    try {
+      const archCount = db.prepare(`SELECT COUNT(*) as c FROM raw_archive WHERE memory_id = ?`).get(ingested.memoryId!) as { c: number };
+      expect(Number(archCount.c)).toBe(0);
+    } finally { closeHippoDb(db); }
+  });
+});

--- a/tests/slack-dlq.test.ts
+++ b/tests/slack-dlq.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { writeToDlq, listDlq, markDlqRetried } from '../src/connectors/slack/dlq.js';
+
+describe('slack DLQ', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-dlq-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('captures raw payload + error and lists oldest-first', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{"a":1}', error: 'parse fail' });
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{"b":2}', error: 'unknown event type' });
+      const items = listDlq(db, { tenantId: 'default' });
+      expect(items).toHaveLength(2);
+      expect(items[0].error).toBe('parse fail');
+      expect(items[0].retriedAt).toBeNull();
+    } finally { closeHippoDb(db); }
+  });
+
+  it('markDlqRetried sets retried_at', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{}', error: 'boom' });
+      const [item] = listDlq(db, { tenantId: 'default' });
+      markDlqRetried(db, item.id);
+      const [after] = listDlq(db, { tenantId: 'default' });
+      expect(after.retriedAt).not.toBeNull();
+    } finally { closeHippoDb(db); }
+  });
+
+  it('listDlq scopes by tenantId', () => {
+    const db = openHippoDb(root);
+    try {
+      writeToDlq(db, { tenantId: 'default', rawPayload: '{}', error: 'a' });
+      writeToDlq(db, { tenantId: 'acme', rawPayload: '{}', error: 'b' });
+      expect(listDlq(db, { tenantId: 'default' })).toHaveLength(1);
+      expect(listDlq(db, { tenantId: 'acme' })).toHaveLength(1);
+    } finally { closeHippoDb(db); }
+  });
+});

--- a/tests/slack-idempotency.test.ts
+++ b/tests/slack-idempotency.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { hasSeenEvent, markEventSeen, lookupMemoryByEvent } from '../src/connectors/slack/idempotency.js';
+
+describe('slack idempotency', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-idem-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('hasSeenEvent returns false then true after marking', () => {
+    const db = openHippoDb(root);
+    try {
+      expect(hasSeenEvent(db, 'Ev1')).toBe(false);
+      markEventSeen(db, 'Ev1', 'm123');
+      expect(hasSeenEvent(db, 'Ev1')).toBe(true);
+      expect(lookupMemoryByEvent(db, 'Ev1')).toBe('m123');
+    } finally { closeHippoDb(db); }
+  });
+
+  it('markEventSeen is a no-op on duplicate (INSERT OR IGNORE)', () => {
+    const db = openHippoDb(root);
+    try {
+      markEventSeen(db, 'Ev1', 'm123');
+      // Second call must not throw and must not overwrite the original memory_id.
+      markEventSeen(db, 'Ev1', 'mDIFFERENT');
+      expect(lookupMemoryByEvent(db, 'Ev1')).toBe('m123');
+    } finally { closeHippoDb(db); }
+  });
+});

--- a/tests/slack-incident-recall.test.ts
+++ b/tests/slack-incident-recall.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { runIncidentRecallEval } from '../benchmarks/e1.3/incident-recall-eval.js';
+
+describe('slack incident recall (success criterion)', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-eval-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('beats transcript-tail baseline on at least 7/10 scenarios', async () => {
+    const r = await runIncidentRecallEval({ hippoRoot: root });
+    expect(r.scenarios).toHaveLength(10);
+    expect(r.scenariosBeaten).toBeGreaterThanOrEqual(7);
+  });
+});

--- a/tests/slack-ingest.test.ts
+++ b/tests/slack-ingest.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+
+const ctx = (root: string) => ({ hippoRoot: root, tenantId: 'default', actor: 'connector:slack' });
+
+describe('ingestMessage', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'hippo-slack-ingest-')); initStore(root); });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('writes a kind=raw memory and is idempotent on replay', () => {
+    const evt = {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message' as const, channel: 'C1', user: 'U1', text: 'hello', ts: '1700.0001' },
+      eventId: 'Ev1',
+    };
+    const r1 = ingestMessage(ctx(root), evt);
+    expect(r1.status).toBe('ingested');
+    expect(r1.memoryId).toBeDefined();
+
+    const r2 = ingestMessage(ctx(root), evt);
+    expect(r2.status).toBe('duplicate');
+    expect(r2.memoryId).toBe(r1.memoryId);
+
+    const entries = loadAllEntries(root);
+    const slackEntries = entries.filter((e) => e.source === 'slack' || e.tags.includes('source:slack'));
+    expect(slackEntries).toHaveLength(1);
+    expect(slackEntries[0].kind).toBe('raw');
+  });
+
+  it('marks empty-body messages as skipped without writing', () => {
+    const evt = {
+      teamId: 'T1',
+      channel: { id: 'C1' },
+      message: { type: 'message' as const, channel: 'C1', ts: '1700.0001' },
+      eventId: 'Ev2',
+    };
+    const r = ingestMessage(ctx(root), evt);
+    expect(r.status).toBe('skipped');
+    // Replay still returns duplicate, not skipped, because seen is marked.
+    expect(ingestMessage(ctx(root), evt).status).toBe('duplicate');
+  });
+});

--- a/tests/slack-permission-mirror.test.ts
+++ b/tests/slack-permission-mirror.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+import { recall } from '../src/api.js';
+
+const ctx = (root: string) => ({
+  hippoRoot: root,
+  tenantId: 'default',
+  actor: 'connector:slack',
+});
+
+describe('slack permission mirroring', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-perm-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('private-channel content does not leak when querying public scope', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'public secret', ts: '1.1' },
+      eventId: 'EvPub',
+    });
+    ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'CPRIV', is_private: true },
+      message: { type: 'message', channel: 'CPRIV', user: 'U1', text: 'private secret', ts: '2.2' },
+      eventId: 'EvPriv',
+    });
+
+    const pubResults = recall(ctx(root), { query: 'secret', scope: 'slack:public:CPUB' });
+    expect(pubResults.results.some((r) => r.content.includes('private secret'))).toBe(false);
+    expect(pubResults.results.some((r) => r.content.includes('public secret'))).toBe(true);
+  });
+
+  // Review patch #4: empty/undefined scope must default-deny private rows.
+  // Without this guarantee, a frontend caller forgetting to pass `scope` exposes
+  // every private channel to a public query.
+  it('no-scope query default-denies private rows', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'public alpha', ts: '1.1' },
+      eventId: 'EvPubA',
+    });
+    ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'CPRIV', is_private: true },
+      message: { type: 'message', channel: 'CPRIV', user: 'U1', text: 'private alpha', ts: '2.2' },
+      eventId: 'EvPrivA',
+    });
+    const r = recall(ctx(root), { query: 'alpha' }); // no scope
+    expect(r.results.some((x) => x.content.includes('private alpha'))).toBe(false);
+    expect(r.results.some((x) => x.content.includes('public alpha'))).toBe(true);
+  });
+
+  // Review patch #4: mismatched scope (channel does not exist) returns zero.
+  it('mismatched scope returns zero results', () => {
+    ingestMessage(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'CPUB', is_private: false },
+      message: { type: 'message', channel: 'CPUB', user: 'U1', text: 'beta', ts: '1.1' },
+      eventId: 'EvPubB',
+    });
+    const r = recall(ctx(root), { query: 'beta', scope: 'slack:public:CDOES_NOT_EXIST' });
+    expect(r.results).toHaveLength(0);
+  });
+
+  // Review patch #4: tenant-mismatched scope. Tenant B writes a private row
+  // with scope='slack:private:CSHARED'. Tenant A queries the same scope string
+  // and must get nothing — recall is tenant-scoped before scope-scoped.
+  it('tenant-mismatched scope does not leak across tenants', () => {
+    const ctxA = (r: string) => ({ hippoRoot: r, tenantId: 'tenantA', actor: 'cli' });
+    const ctxB = (r: string) => ({ hippoRoot: r, tenantId: 'tenantB', actor: 'cli' });
+    ingestMessage(ctxB(root), {
+      teamId: 'T1',
+      channel: { id: 'CSHARED', is_private: true },
+      message: { type: 'message', channel: 'CSHARED', user: 'U1', text: 'tenantB secret', ts: '3.3' },
+      eventId: 'EvShared',
+    });
+    const r = recall(ctxA(root), { query: 'secret', scope: 'slack:private:CSHARED' });
+    expect(r.results).toHaveLength(0);
+  });
+});

--- a/tests/slack-ratelimit.test.ts
+++ b/tests/slack-ratelimit.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchWithRetry } from '../src/connectors/slack/ratelimit.js';
+
+describe('fetchWithRetry', () => {
+  it('retries once after 429 with Retry-After honoured', async () => {
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => { sleeps.push(ms); return Promise.resolve(); };
+    const calls = [
+      { status: 429, headers: { get: (h: string) => h === 'retry-after' ? '0.05' : null }, json: async () => ({}) },
+      { status: 200, headers: { get: () => null }, json: async () => ({ ok: true }) },
+    ];
+    let i = 0;
+    const fakeFetch = vi.fn(async () => calls[i++] as Response);
+    const r = await fetchWithRetry({ url: 'http://x', fetchImpl: fakeFetch as typeof fetch, sleep, maxRetries: 3 });
+    expect(r.status).toBe(200);
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+    expect(sleeps[0]).toBe(50); // 0.05s in ms
+  });
+
+  it('gives up after maxRetries and throws', async () => {
+    const fakeFetch = vi.fn(async () => ({ status: 429, headers: { get: () => '0.01' }, json: async () => ({}) }) as Response);
+    await expect(fetchWithRetry({ url: 'http://x', fetchImpl: fakeFetch as typeof fetch, sleep: () => Promise.resolve(), maxRetries: 2 })).rejects.toThrow(/rate.?limited/i);
+    expect(fakeFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});

--- a/tests/slack-schema.test.ts
+++ b/tests/slack-schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+describe('schema v17 — slack ingestion tables', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-schema-'));
+    initStore(root);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('creates slack_event_log with PRIMARY KEY on event_id', () => {
+    const db = openHippoDb(root);
+    try {
+      const cols = db.prepare(`PRAGMA table_info(slack_event_log)`).all() as Array<Record<string, unknown>>;
+      const eventIdCol = cols.find((c) => c.name === 'event_id');
+      expect(eventIdCol).toBeDefined();
+      expect(eventIdCol!.pk).toBe(1);
+      // Re-insert same event_id must throw (PK uniqueness).
+      db.prepare(`INSERT INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`).run('E1', '2026-04-29T00:00:00Z', 'm1');
+      expect(() =>
+        db.prepare(`INSERT INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`).run('E1', '2026-04-29T00:00:01Z', 'm2'),
+      ).toThrow();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates slack_cursors keyed on (tenant_id, channel_id)', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(`INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?, ?, ?, ?)`).run('default', 'C1', '1700000000.000000', '2026-04-29T00:00:00Z');
+      // Same composite key collides; INSERT OR REPLACE supported.
+      expect(() =>
+        db.prepare(`INSERT INTO slack_cursors (tenant_id, channel_id, latest_ts, updated_at) VALUES (?, ?, ?, ?)`).run('default', 'C1', '1700000001.000000', '2026-04-29T00:00:01Z'),
+      ).toThrow();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates slack_dlq with autoincrementing id and received_at', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(`INSERT INTO slack_dlq (tenant_id, raw_payload, error, received_at) VALUES (?, ?, ?, ?)`).run('default', '{}', 'parse error', '2026-04-29T00:00:00Z');
+      const row = db.prepare(`SELECT id FROM slack_dlq LIMIT 1`).get() as { id: number };
+      expect(row.id).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('creates slack_workspaces with team_id PK', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(`INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`).run('T_ACME', 'acme', '2026-04-29T00:00:00Z');
+      expect(() =>
+        db.prepare(`INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`).run('T_ACME', 'other', '2026-04-29T00:00:01Z'),
+      ).toThrow();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});

--- a/tests/slack-scope.test.ts
+++ b/tests/slack-scope.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { scopeFromChannel } from '../src/connectors/slack/scope.js';
+
+describe('scopeFromChannel', () => {
+  it('public channel → slack:public:<id>', () => {
+    expect(scopeFromChannel({ id: 'C123', is_private: false, is_im: false, is_mpim: false })).toBe('slack:public:C123');
+  });
+  it('private channel → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'C456', is_private: true })).toBe('slack:private:C456');
+  });
+  it('DM (im) → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'D1', is_im: true })).toBe('slack:private:D1');
+  });
+  it('group DM (mpim) → slack:private:<id>', () => {
+    expect(scopeFromChannel({ id: 'G1', is_mpim: true })).toBe('slack:private:G1');
+  });
+  it('unknown → defaults to private (fail closed)', () => {
+    expect(scopeFromChannel({ id: 'X1' })).toBe('slack:private:X1');
+  });
+});

--- a/tests/slack-signature.test.ts
+++ b/tests/slack-signature.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+import { verifySlackSignature } from '../src/connectors/slack/signature.js';
+
+const SECRET = 'shhh';
+
+function sign(ts: string, body: string): string {
+  const mac = createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex');
+  return `v0=${mac}`;
+}
+
+describe('verifySlackSignature', () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  it('accepts a valid signature within the 5min window', () => {
+    const body = '{"hello":"world"}';
+    const ts = String(now);
+    const sig = sign(ts, body);
+    expect(verifySlackSignature({ rawBody: body, timestamp: ts, signature: sig, signingSecret: SECRET, now })).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    const ts = String(now);
+    const sig = sign(ts, '{"hello":"world"}');
+    expect(verifySlackSignature({ rawBody: '{"hello":"evil"}', timestamp: ts, signature: sig, signingSecret: SECRET, now })).toBe(false);
+  });
+
+  it('rejects a stale timestamp (>5min skew)', () => {
+    const stale = String(now - 6 * 60);
+    const body = '{}';
+    const sig = sign(stale, body);
+    expect(verifySlackSignature({ rawBody: body, timestamp: stale, signature: sig, signingSecret: SECRET, now })).toBe(false);
+  });
+
+  it('rejects a malformed signature header', () => {
+    expect(verifySlackSignature({ rawBody: '{}', timestamp: String(now), signature: 'garbage', signingSecret: SECRET, now })).toBe(false);
+  });
+});

--- a/tests/slack-smoke-1000.test.ts
+++ b/tests/slack-smoke-1000.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { runSlackSmoke } from '../benchmarks/e1.3/slack-1000-event-smoke.js';
+
+describe('slack 1000-event smoke (CI subset)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-smoke-'));
+    initStore(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('100 events, replayed twice, produces exactly 100 raw memories with zero outbound HTTP', async () => {
+    const result = await runSlackSmoke({ hippoRoot: root, count: 100, replay: 2 });
+    expect(result.uniqueMemories).toBe(100);
+    expect(result.outboundHttp).toBe(0);
+    expect(result.totalIngestCalls).toBe(200);
+
+    const all = loadAllEntries(root).filter((e) => e.tags.includes('source:slack'));
+    expect(all).toHaveLength(100);
+    expect(all.every((e) => e.kind === 'raw')).toBe(true);
+    expect(all.every((e) => e.tags.includes('source:slack'))).toBe(true);
+  });
+});

--- a/tests/slack-tenant-routing.test.ts
+++ b/tests/slack-tenant-routing.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { resolveTenantForTeam } from '../src/connectors/slack/tenant-routing.js';
+
+describe('resolveTenantForTeam', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-tenant-'));
+    initStore(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns the mapped tenant_id when a row exists', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(
+        `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+      ).run('TTEAM1', 'tenant-alpha', new Date().toISOString());
+      expect(resolveTenantForTeam(db, 'TTEAM1')).toBe('tenant-alpha');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('returns null when slack_workspaces is empty', () => {
+    const db = openHippoDb(root);
+    try {
+      expect(resolveTenantForTeam(db, 'TANY')).toBeNull();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('matches team_id exactly (no prefix bleed)', () => {
+    const db = openHippoDb(root);
+    try {
+      db.prepare(
+        `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+      ).run('TTEAM', 'tenant-short', new Date().toISOString());
+      // Prefix-extended id must NOT match.
+      expect(resolveTenantForTeam(db, 'TTEAMX')).toBeNull();
+      // Substring must NOT match.
+      expect(resolveTenantForTeam(db, 'TTEA')).toBeNull();
+      // Exact still works.
+      expect(resolveTenantForTeam(db, 'TTEAM')).toBe('tenant-short');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});

--- a/tests/slack-transform.test.ts
+++ b/tests/slack-transform.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { messageToRememberOpts } from '../src/connectors/slack/transform.js';
+
+describe('messageToRememberOpts', () => {
+  it('produces kind=raw + slack:// artifact_ref + scope from channel privacy', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'incident at 3pm', ts: '1700000000.000100' },
+    });
+    expect(opts).not.toBeNull();
+    expect(opts!.kind).toBe('raw');
+    expect(opts!.scope).toBe('slack:public:C1');
+    expect(opts!.artifactRef).toBe('slack://T1/C1/1700000000.000100');
+    expect(opts!.content).toBe('incident at 3pm');
+    expect(opts!.tags).toEqual(expect.arrayContaining(['source:slack', 'channel:C1']));
+  });
+
+  it('skips empty bodies (returns null)', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C1' },
+      message: { type: 'message', channel: 'C1', ts: '1700000000.000100' },
+    });
+    expect(opts).toBeNull();
+  });
+
+  it('private channel maps to slack:private:<id>', () => {
+    const opts = messageToRememberOpts({
+      teamId: 'T1',
+      channel: { id: 'C2', is_private: true },
+      message: { type: 'message', channel: 'C2', user: 'U1', text: 'secret', ts: '1700000000.000100' },
+    });
+    expect(opts!.scope).toBe('slack:private:C2');
+  });
+});

--- a/tests/slack-types.test.ts
+++ b/tests/slack-types.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSlackEventEnvelope,
+  isSlackMessageEvent,
+  type SlackEventEnvelope,
+  type SlackMessageEvent,
+} from '../src/connectors/slack/types.js';
+
+describe('slack types', () => {
+  it('accepts a well-formed event envelope', () => {
+    const envelope: SlackEventEnvelope = {
+      type: 'event_callback',
+      team_id: 'T1',
+      event_id: 'Ev1',
+      event_time: 1700000000,
+      event: { type: 'message', channel: 'C1', user: 'U1', text: 'hi', ts: '1700000000.000100' },
+    };
+    expect(isSlackEventEnvelope(envelope)).toBe(true);
+  });
+
+  it('accepts a message_deleted subtype', () => {
+    const evt = {
+      type: 'message',
+      subtype: 'message_deleted',
+      channel: 'C1',
+      deleted_ts: '1700000000.000100',
+      ts: '1700000001.000200',
+    };
+    expect(isSlackMessageEvent(evt)).toBe(true);
+    expect((evt as SlackMessageEvent).subtype).toBe('message_deleted');
+  });
+
+  it('rejects malformed envelopes', () => {
+    expect(isSlackEventEnvelope({ type: 'event_callback' })).toBe(false);
+    expect(isSlackEventEnvelope(null)).toBe(false);
+    expect(isSlackEventEnvelope({ event_id: 'Ev1', event: {} })).toBe(false);
+  });
+});

--- a/tests/slack-web-client.test.ts
+++ b/tests/slack-web-client.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { slackHistoryFetcher } from '../src/connectors/slack/web-client.js';
+
+describe('slackHistoryFetcher', () => {
+  it('GETs conversations.history with bearer token + cursor', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fakeFetch = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return {
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({
+          ok: true,
+          messages: [{ type: 'message', channel: 'C1', text: 'hi', ts: '1.1' }],
+          response_metadata: { next_cursor: 'NEXT' },
+        }),
+      } as unknown as Response;
+    });
+    const fetcher = slackHistoryFetcher('xoxb-fake', fakeFetch as unknown as typeof fetch);
+    const page = await fetcher({ channelId: 'C1', cursor: null });
+    expect(page.messages).toHaveLength(1);
+    expect(page.next_cursor).toBe('NEXT');
+    expect(calls[0].url).toContain('channel=C1');
+    const auth = (calls[0].init?.headers as Record<string, string>).authorization;
+    expect(auth).toBe('Bearer xoxb-fake');
+  });
+
+  it('throws when ok=false', async () => {
+    const fakeFetch = vi.fn(async () => ({
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ ok: false, error: 'not_in_channel' }),
+    } as unknown as Response));
+    const fetcher = slackHistoryFetcher('t', fakeFetch as unknown as typeof fetch);
+    await expect(fetcher({ channelId: 'C1', cursor: null })).rejects.toThrow(/not_in_channel/);
+  });
+});

--- a/tests/slack-webhook-route.test.ts
+++ b/tests/slack-webhook-route.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHmac } from 'node:crypto';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const SECRET = 'shhh';
+
+function sign(ts: string, body: string): string {
+  return `v0=${createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex')}`;
+}
+
+describe('POST /v1/connectors/slack/events', () => {
+  let root: string;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-slack-route-'));
+    initStore(root);
+    process.env.SLACK_SIGNING_SECRET = SECRET;
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+  });
+
+  afterEach(async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    await handle.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('echoes the URL verification challenge', async () => {
+    const body = JSON.stringify({ type: 'url_verification', challenge: 'abc123' });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': ts,
+        'x-slack-signature': sign(ts, body),
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { challenge?: string };
+    expect(json.challenge).toBe('abc123');
+  });
+
+  it('rejects missing/invalid signature with 401', async () => {
+    const body = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T',
+      event_id: 'E',
+      event_time: 0,
+      event: { type: 'message', channel: 'C1', ts: '1.1', text: 'hi' },
+    });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('writes a memory on a valid event_callback', async () => {
+    const body = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      event_id: 'EvA',
+      event_time: Math.floor(Date.now() / 1000),
+      event: {
+        type: 'message',
+        channel: 'C1',
+        channel_type: 'channel',
+        user: 'U1',
+        text: 'hello',
+        ts: '1700000000.000100',
+      },
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': ts,
+        'x-slack-signature': sign(ts, body),
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+    const entries = loadAllEntries(root);
+    expect(entries.some((e) => e.tags.includes('source:slack') && e.kind === 'raw')).toBe(true);
+  });
+
+  it('writes malformed payloads to DLQ but still ACKs 200', async () => {
+    const body = '{"type":"event_callback","event":{}}';
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': ts,
+        'x-slack-signature': sign(ts, body),
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+    const db = openHippoDb(root);
+    try {
+      const row = db.prepare(`SELECT COUNT(*) as c FROM slack_dlq`).get() as { c: number };
+      expect(Number(row.c)).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('returns 404 when SLACK_SIGNING_SECRET is unset (no config leak)', async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    try {
+      const body = '{}';
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      process.env.SLACK_SIGNING_SECRET = SECRET;
+    }
+  });
+
+  it('accepts valid signature with no Bearer (PUBLIC_ROUTES allow-list)', async () => {
+    const body = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'T1',
+      event_id: 'EvNoBearer',
+      event_time: Math.floor(Date.now() / 1000),
+      event: {
+        type: 'message',
+        channel: 'C1',
+        channel_type: 'channel',
+        user: 'U1',
+        text: 'no-bearer ok',
+        ts: '1700000001.000200',
+      },
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': ts,
+        'x-slack-signature': sign(ts, body),
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/tsconfig.benchmarks.json
+++ b/tsconfig.benchmarks.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": false
+  },
+  "include": ["benchmarks/e1.3/**/*", "src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "ui"]
+}


### PR DESCRIPTION
## Summary

First ingestion connector built on the A3 (provenance envelope) + A5 (stub auth + tenant_id) + A1 (HTTP server) stack. Slack workspace events stream into hippo as `kind='raw'` memories with full provenance, idempotency, cursor-based backfill, source-deletion sync, permission mirroring, and a dead-letter queue.

- **Schema v17**: `slack_event_log` (idempotency PK), `slack_cursors` (resume), `slack_dlq` (malformed events), `slack_workspaces` (multi-tenant routing seam)
- **Webhook route** `POST /v1/connectors/slack/events` with HMAC-SHA256 signature gate + 5-min replay window. New `PUBLIC_ROUTES` allow-list makes the unauthenticated route explicit; new `HIPPO_REQUIRE_AUTH=1` knob + bearer-lockdown test prove every other `/v1/*` route still requires Bearer
- **api.remember.afterWrite SAVEPOINT hook** — connector idempotency commits atomically with the memory row, closing the Slack-retry race
- **Recall scope filter + default-deny on `slack:private:*`** — frontend callers passing undefined scope cannot leak private channel content
- **archiveRaw mirror cleanup** (centralized GDPR fix that benefits all callers — surfaced by the Slack source-deletion test)
- **Backfill** with separated `cursor` (Slack opaque token) vs `oldest` (numeric ts resume bound) — fixed during /review
- **`hippo slack backfill --channel <id>`** + **`hippo slack dlq list`** CLI

## Plan provenance

- Plan: `docs/plans/2026-04-29-e1.3-slack-ingestion.md` (18 TDD tasks)
- Outside-voice review BEFORE coding: 8 patches baked in (cross-tenant deletion test, PUBLIC_ROUTES allow-list, afterWrite transactional hook, permission-mirror test holes, fetch spy in smoke, slack_workspaces routing seam, 404 not 503, sentinel eval matching)
- Post-ship /review: 1 MEDIUM real bug fixed inline (cursor vs latest_ts semantics), 1 HIGH-test gap closed (rate-limit through full backfill), 5 LOW deferred to v0.38.0

## ROADMAP success criteria

- ✅ 1000-event smoke: 1000 unique memories, **0 outbound HTTP** (proven by `globalThis.fetch` spy that throws), 9.2ms/call
- ✅ 10-scenario incident recall eval: **10/10 beats tail baseline** (success bar was ≥7/10)

## Test plan

- [x] `npm run build` clean (tsc + tsc -p tsconfig.benchmarks.json)
- [x] `npx vitest run` — 886 passed / 0 failed / 2 skipped (real DB, no mocks)
- [x] `node dist/benchmarks/e1.3/slack-1000-event-smoke.js` — PASS
- [x] `npx vitest run tests/slack-incident-recall.test.ts` — beats baseline 10/10
- [x] `tests/server-bearer-lockdown.test.ts` — every other `/v1/*` returns 401 without Bearer
- [x] `tests/slack-deletion.test.ts` — cross-tenant deletion event cannot archive another tenant's row
- [x] `tests/api-remember-after-write.test.ts` — afterWrite throws → memory row rolls back
- [x] No secrets exposed (grep clean)
- [x] No unrelated changes (diff scoped to E1.3 + 2 deliberately-surfaced fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)