### PR TITLE
feat(v0.39): security hardening + GDPR Path A

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Privacy (BREAKING data shape)
 - **GDPR Path A on raw_archive:** archived memories no longer retain content in `raw_archive.payload_json`. Stored shape is `{redacted:true, archived_at, tenant_id, kind, reason}`. Migration v20 redacts existing rows in place. Compliance audit trail preserved via `audit_log`.
+- **Recall audit hashes the query:** `audit_log` rows for op='recall' now store `query_hash` (sha256, first 16 hex chars) and `query_length` instead of the truncated query text. Prevents canary content from persisting in audit_log when a caller queries with text matching an archived (RTBF) memory.
+- **Mirror reaper post-migration:** `openHippoDb()` runs `cleanupArchivedMirrors` after migrations to delete `<hippoRoot>/{episodic,buffer,semantic}/<id>.md` for every `raw_archive` row. Closes the gap where pre-v0.39 archives left their original-content markdown mirrors on disk. Idempotent via the `gdpr_v20_mirror_cleanup` meta flag (one-shot per DB). `archiveRaw` mirror cleanup is wrapped in try/catch; orphan files self-heal on a future scheduled scan if the unlink ever fails.
 
 ### Hardening
 - MCP HTTP handlers route through `src/api.ts` so audit + cross-tenant guards apply uniformly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.39.0 (2026-04-30)
+
+### Security (CRITICAL)
+- **Cross-tenant authorization:** `promote()` now verifies memory belongs to ctx.tenantId before promoteToGlobal. `authCreate` ignores body.tenantId and forces ctx.tenantId at HTTP layer.
+- **Supersede CAS race:** `supersede()` wraps the transition in BEGIN IMMEDIATE with `WHERE superseded_by IS NULL`; concurrent attempts now throw CONFLICT instead of producing double chains.
+- **MCP cross-tenant outcome poisoning:** `lastRecalledIds` now keyed by per-client `clientKey` (HTTP: hash(bearer + remote IP), stdio: 'stdio-${pid}'). Outcome from client B cannot touch client A's recall set.
+- **Slack unknown-team fallback:** when `slack_workspaces` is non-empty and the incoming `team_id` is unmapped, the event is sent to DLQ as `unroutable` instead of silently ingesting into the env-default tenant. Escape hatch: `SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1`.
+
+### Privacy (BREAKING data shape)
+- **GDPR Path A on raw_archive:** archived memories no longer retain content in `raw_archive.payload_json`. Stored shape is `{redacted:true, archived_at, tenant_id, kind, reason}`. Migration v20 redacts existing rows in place. Compliance audit trail preserved via `audit_log`.
+
+### Hardening
+- MCP HTTP handlers route through `src/api.ts` so audit + cross-tenant guards apply uniformly
+- Bearer lockdown test parameterized over the full 12-route table
+- Auth timing leak reduced: `DUMMY_HASH` precomputed at module load; miss path runs scrypt
+- `/mcp/stream` re-validates bearer on a 60s heartbeat; new `MCP_SSE_MAX_AGE_SEC` (default 3600s) caps stream age
+- Graceful shutdown awaits `server.stop()` before `process.exit`
+- Slack ingest race closed via `afterWrite` hook (atomic event_log + memory)
+- Slack deletion idempotency closed via new `afterArchive` hook in `archiveRawMemory`
+- Slack DLQ: schema additions (team_id, bucket, retry_count, signature, slack_timestamp); `hippo slack dlq replay <id>` command
+- Slack signing-secret rotation: accept `SLACK_SIGNING_SECRET_PREVIOUS` during rollover
+
+### Schema
+- Migration v19: slack_dlq columns (team_id, bucket, retry_count, signature, slack_timestamp)
+- Migration v20: raw_archive.payload_json redacted in place (Path A backfill)
+
+### Retracted
+- v0.36 <50ms p99 latency target. v0.36 ships at 58.4ms (sequential single-thread). No current target; revisit in v0.40+ if a real user asks.
+
+### Deferred to v0.40
+- Tenant-guard audit on remaining MCP tools (context, status, learn, conflicts, resolve, peers) + any unscoped readEntry/loadSearchEntries call sites in CLI/dashboard/refine
+- Request-level rate limit on /v1/* to bound key-id enumeration
+- p99 hardening
+- 24h soak harness as a real release gate (currently scaffold)
+- B3 dlPFC follow-ups (sequential-learning adapter contract, etc.)
+
 ## 0.38.0 (2026-04-29)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v0.39.0
+
+- Security hardening release: 5 CRITICAL cross-tenant fixes (CVE candidates), GDPR Path A on archive (true RTBF), MCP per-client isolation, Slack ingestion race + idempotency hardening, auth timing leak reduction.
+
 ### What's new in v0.38.0
 
 - **B3 dlPFC persistent goal stack (depth 3).** Schema v18 adds `goal_stack`, `retrieval_policy`, `goal_recall_log`. New CLI subcommands: `hippo goal push|list|complete|suspend|resume`. With `HIPPO_SESSION_ID` set, `hippo recall` auto-boosts memories tagged with the active goal (final multiplier hard-capped at 3.0x). Retrieval policies (`error-prioritized`, `schema-fit-biased`, `recency-first`, `hybrid`) further shape ranking.

--- a/TODOS.md
+++ b/TODOS.md
@@ -181,17 +181,55 @@ ranking improvements; none are correctness blockers.
 
 ---
 
-## v0.37.0 — A1 p99 latency hardening
+## v0.40.0 — Security + hardening follow-ups
 
-A1 (v0.36.0) ships `hippo serve` with a 10k-store p99 above the ROADMAP
-target. The architecture lands; the latency target slips to v0.37.0.
+From the v0.39 security hardening release. Items consciously deferred so
+v0.39 could ship the CRITICAL cross-tenant fixes without scope creep.
 
-- [ ] **A1 p99 latency hardening — current p99 = 58.42ms, target < 50ms.**
+- [ ] **Tenant-guard audit on remaining MCP tools.** v0.39 hardened
+  recall/remember/outcome/share via `src/api.ts`. The remaining MCP tools
+  (context, status, learn, conflicts, resolve, peers) plus any unscoped
+  `readEntry` / `loadSearchEntries` call sites in CLI / dashboard /
+  refine still need a tenant-isolation pass.
+
+- [ ] **Request-level rate limit on /v1/*.** The reduced auth-timing
+  leak in v0.39 narrows but does not eliminate key-id enumeration.
+  Bound enumeration attempts with a per-IP rate limit on /v1/* (token
+  bucket, configurable via `HIPPO_V1_RPS`).
+
+- [ ] **p99 hardening (long-term, no current target).** The v0.36 <50ms
+  target was retracted in v0.39 (CHANGELOG). v0.36 ships at 58.4ms
+  (sequential single-thread on a 10k store). No active target until a
+  real user asks. When/if revived, server-mode concurrent measurement
+  is the right baseline, not the current single-thread harness.
+
+- [ ] **24h soak harness as a real release gate.** `benchmarks/a1/soak.ts`
+  is scaffold-only in v0.39. Promote to a CI-integrated, evidence-bearing
+  release gate (RSS / heap / FD / WAL drift bounds) before claiming
+  "soak-tested" anywhere user-facing.
+
+- [ ] **B3 dlPFC stretch items.**
+  - Sequential-learning adapter contract (pushGoal/completeGoal hooks
+    on `benchmarks/sequential-learning/adapters/interface.mjs`).
+  - vlPFC interference suppression companion to dlPFC depth.
+  - `--no-propagate` flag on `goal complete` (close without strength
+    side-effects on recalled memories).
+  - Refactor `enforceDepthCap` helper to remove duplication between
+    `pushGoalWithDb` and `resumeGoal`.
+  - `goal_recall_log` compaction policy (table grows unbounded today).
+  - `paired_ab.py` for paired-comparison goal-stack evaluations.
+
+---
+
+## Long-term — no current target
+
+- [ ] **A1 p99 latency hardening — current p99 = 58.42ms, retracted target.**
   Measured via `benchmarks/a1/p99-recall.ts` on a 10k synthetic store
   (1000 BM25 queries, cold cache, single SQLite connection, full HTTP
   round trip). p50 = 39.5ms / p95 = 54.9ms / p99 = 58.4ms / mean = 41.0ms.
-  Distribution is tight (stddev 6.6ms) so the bottleneck is structural,
-  not tail flakes. Likely candidates to profile:
+  v0.39 retracted the <50ms target; the harness is sequential single-thread
+  and not representative of server-mode concurrent load. Likely candidates
+  if/when revived:
     1. FTS5 candidate load in `loadSearchEntries` — current path scans
        all rows then ranks; a tighter `MATCH` query plan + LIMIT inside
        the FTS subquery should shave the tail.
@@ -203,8 +241,10 @@ target. The architecture lands; the latency target slips to v0.37.0.
     4. Hybrid embeddings: ROADMAP pins "hybrid ON" but `src/api.ts:recall`
        is BM25-only today. Wiring hybrid will likely make p99 worse, not
        better — re-baseline after that lands.
-  Re-run the bench after each candidate fix; gate ship of v0.37.0 on
-  p99 < 50ms.
+
+---
+
+## v0.37.0 — server hardening follow-ups
 
 - [ ] **H1 — stale-pidfile + PID-reuse-with-different-port.** A
   detectServer caller can read a pidfile whose pid was reused by an

--- a/benchmarks/a1/p99-recall.ts
+++ b/benchmarks/a1/p99-recall.ts
@@ -1,6 +1,10 @@
 /**
  * p99 recall benchmark — A1 ROADMAP success criterion.
  *
+ * v0.39 (2026-04-30): the <50ms p99 target stated in v0.36 plan is retracted.
+ * Measured ~58.4ms on 10k store, sequential single-thread.
+ * Server-mode concurrent measurement is a v0.40+ effort.
+ *
  * Pinned spec:
  *   - Query mix: top-10 BM25 against tier-1 micro-eval queries
  *   - Cold cache (fresh server start, no warmup)

--- a/benchmarks/a1/soak.ts
+++ b/benchmarks/a1/soak.ts
@@ -1,6 +1,9 @@
 /**
  * 24h soak harness — A1 ROADMAP success criterion.
  *
+ * v0.39: scaffold for 24h soak runs. NOT a release gate. Operators can run
+ * manually; no CI integration. Real-soak-as-evidence is a v0.40+ effort.
+ *
  * Drives the server with a steady-state mixed workload (recall/remember/forget)
  * for N hours and tracks RSS, heap, FD count, SQLite WAL size, and request
  * latency in 60s windows. The actual 24h run is manual / scheduled; this

--- a/docs/plans/2026-04-30-v0.39-security-hardening.md
+++ b/docs/plans/2026-04-30-v0.39-security-hardening.md
@@ -1,0 +1,1165 @@
+# v0.39.0 Security Hardening + GDPR Path A Implementation Plan (v2)
+
+> **For Claude:** Subagent-driven execution. Codex on the v2 plan first to verify code-shape grounding.
+
+**Goal:** Apply 21 fixes across v0.36/v0.37 retrospective + B3 review residue, ship as v0.39.0 security hardening release.
+
+**Source:** Retroactive `/codex` on v0.36 A1 (4 P1 + 6 P2 + 2 NIT). Retroactive `/codex` on v0.37 E1.3 (2 P1 + 7 P2 + 2 NIT). User decision: **all fixed, Path A on GDPR archive.**
+
+**Branch:** `feat/v0.39-security-hardening` (branched from master @ 35da47a, working tree clean).
+
+**Tech Stack:** TypeScript, node:sqlite, vitest. Same constraints as B3.
+
+---
+
+## Revision log
+
+- **v1 (2026-04-30):** Initial plan from retrospective findings. Codex flagged 6 P1 + 6 P2 + 1 NIT — all root-caused to speculative code shapes (plan didn't read actual signatures).
+- **v2 (2026-04-30):** Grounded every fix against actual code:
+  - `supersede()` (api.ts:260) uses 2× `writeEntry` with own DB handles; CAS approach revised to do the UPDATE-with-WHERE directly via a fresh db handle, then `writeEntryDbOnly(db, newEntry)` inside the SAME transaction (introduced in commit 1 fix 1.0), then `writeEntryMirrors` after COMMIT.
+  - `archiveRaw()` (api.ts:318) ALREADY tenant-checks at line 333. Removed redundant fix; promote/forget still need it.
+  - `archiveRawMemory(db, id, opts)` (raw-archive.ts:26) ALREADY uses SAVEPOINT + FTS purge + audit. Path A is a one-line change at line 41 (redacted JSON instead of full row).
+  - `validateApiKey(db, plaintext)` (auth.ts:61) is the real surface; key format is `scrypt$saltHex$hashHex` over the FULL plaintext key. Timing fix: precompute `DUMMY_HASH` once at module load via existing `hashKey()`, route miss path through `verifyKey(plaintext, DUMMY_HASH)` so scrypt always runs.
+  - Real route paths: `/v1/memories/:id/archive`, `/v1/memories/:id/supersede`, `/v1/memories/:id/promote`, `/v1/memories/:id`, `/v1/auth/keys/:keyId`, `/v1/audit`, etc. Enumerated from server.ts:409-494.
+  - `McpContext` (mcp/server.ts:76) has only `hippoRoot, tenantId, actor`. Add optional `clientKey?: string` field; HTTP server builds it from `hash(bearer + remoteAddr)`; stdio defaults to `'stdio-${pid}'`.
+  - Slack DLQ replay needs original signature/timestamp stored. Migration v19 adds `signature TEXT, slack_timestamp TEXT` columns alongside `team_id, bucket, retry_count`.
+  - `writeEntry` opens its own DB. Single-tx fix for Slack ingest race: use `afterWrite` hook (already exists from B3 in remember()) to do the `INSERT OR IGNORE slack_event_log` atomically inside writeEntry's transaction. The hook receives the open db handle.
+  - Test design: replace `Promise.all` race tests with direct CAS-SQL assertion tests (verify `WHERE superseded_by IS NULL` returns changes=0 on the second concurrent attempt).
+  - Auth timing claim: "reduced timing signal" not "equalized" — DB lookup branch still differs.
+  - Manifest list explicit in commit 6.
+- **v3 (post-codex round 2):** PROCEED-WITH-FIXES verdict. Applied: (1) supersede dangling-pointer closed via new helper in store.ts; (2) commit 2 MCP scope tightened to actual MCP tools (recall/remember/outcome); (3) commit 3 ingest snippet uses real var name `input.eventId`, explicit changes-check + DuplicateEventError throw; (4) commit 5 bearer route list corrected to actual server.ts routes (12 authed); (5) success criterion 2 mentions v20 backfill.
+- **v4 (post-codex round 3):** Applied writeEntryDbOnly/writeEntryMirrors split, hippo_share fix, Risk 3 reframe, commit 2 message refresh, TODOS update.
+- **v5 (post-codex round 4):** PROCEED-WITH-FIXES verdict. Applied: (1) supersede actually calls `writeEntryMirrors` after COMMIT (was missing in v4); (2) shareMemory signature is now `{ force?: boolean; tenantId?: string }` (tenantId optional for backward compat with existing `{ force: true }` callers; MCP/REST/CLI callers MUST pass it); (3) added Fix 2.5 — hippo_outcome's readEntry call gains tenant filter; (4) v0.40 deferred section no longer mentions writeEntry-with-db (done in v0.39); (5) audit-order change documented as a correctness improvement (audit committed atomically with row, not after mirrors).
+
+---
+
+## Success criteria (verifiable)
+
+1. All 5 CRITICAL findings closed with regression tests proving cross-tenant attack is blocked.
+2. Path A on `archiveRawMemory`: archived rows have `payload_json = JSON.stringify({redacted:true, archived_at, tenant_id, kind, reason})`. Migration v20 backfill redacts existing rows, extracting `tenant_id`/`kind` from the existing `payload_json` before overwriting. (v19 lands slack_dlq columns; v20 lands the Path A backfill.)
+3. Bearer lockdown test parameterized over the full route table from `src/server.ts:parseRequest`.
+4. Auth timing leak reduced: precomputed `DUMMY_HASH` at module init, miss path runs `verifyKey(plaintext, DUMMY_HASH)`. (Documented as "reduced timing signal" — DB hit/miss still measurable in cache.)
+5. MCP `hippo_recall`, `hippo_remember`, `hippo_outcome` route through `src/api.ts` (audit + cross-tenant guards uniform); `hippo_share` gets a tenant guard via Fix 2.4. Other MCP tools (context, status, learn, conflicts, resolve, peers) keep their existing lower-level call sites in v0.39 — full audit deferred to v0.40.
+6. SSE auth-rebind on a heartbeat (default 60s) + `MCP_SSE_MAX_AGE_SEC` (default 3600).
+7. Slack ingest race closed via `afterWrite` hook — INSERT OR IGNORE slack_event_log + UPDATE memory_id all run inside writeEntry's transaction.
+8. Slack deletion idempotency: extend `archiveRawMemory` with optional `afterArchive` hook that runs inside the same SAVEPOINT.
+9. Slack DLQ records `team_id`, `bucket`, `retry_count`, `signature`, `slack_timestamp`. CLI `hippo slack dlq replay <id>` re-validates signature using stored values, then re-runs ingest.
+10. Default-deny lower-level loader: documented + tested via MCP recall (after MCP-via-api lands).
+11. Slack web-client `oldest` URL param test.
+12. Slack signing-secret rotation: accept `SLACK_SIGNING_SECRET_PREVIOUS` during rollover.
+13. PUBLIC_ROUTES regression tests (trailing slash, encoded slash, wrong method, query string).
+14. Graceful shutdown: signal handler awaits `stop()` before `process.exit(0)`.
+15. p99 latency claim retracted in CHANGELOG/TODOS (Path C — cheap and honest; revisit in v0.40+ if a real user asks).
+16. Soak harness documented as scaffold-only, not a release gate.
+17. All 931 tests still pass + ~25 new regression tests = ~956 total.
+18. Schema migration v19 idempotent on existing v18 hippo databases.
+
+## Out of scope (defer to v0.40.0)
+
+- B3 dlPFC follow-ups (sequential-learning adapter contract, MCP/REST session_id plumbing — separate from MCP clientKey added here, vlPFC interference, --no-propagate, enforceDepthCap refactor, goal_recall_log compaction, paired_ab.py)
+- New features
+- A2 HTTP API hardening polish
+- Hitting <50ms p99 (claim retracted, not solved)
+
+---
+
+## Task layout
+
+Six commits, ordered by surface area. Each independently testable.
+
+- **Commit 1:** api.ts cross-tenant + supersede CAS (CRITICAL #1, #2, #4 + tests)
+- **Commit 2:** MCP cross-tenant outcome + MCP-via-api (CRITICAL #3 + MEDIUM #9)
+- **Commit 3:** Slack ingestion hardening (CRITICAL #5 + MEDIUM #11-15 + NITs)
+- **Commit 4:** Migration v20 + GDPR Path A redaction (HIGH #7) — slack_dlq schema additions land in commit 3's migration v19, see sequencing note below
+- **Commit 5:** Server hardening (HIGH #6, #8 + MEDIUM #10 + NITs)
+- **Commit 6:** Benchmark honesty + docs + version bump 0.39.0
+
+**Note on commit 3 / 4 sequencing:** commit 3 lands code that *uses* new slack_dlq columns (signature, team_id, bucket); commit 4 lands the migration that adds those columns. To keep tests passing at every commit boundary, **migration v19 lands in commit 3** alongside the slack code, and commit 4 only adds the Path A redaction logic + a v20 backfill UPDATE for raw_archive. Sequence: commit 3 = code + migration v19; commit 4 = redaction code + migration v20 (backfill-only, redacts existing rows).
+
+Revised commit list:
+- **Commit 3:** Slack ingestion hardening + migration v19 (slack_dlq columns)
+- **Commit 4:** GDPR Path A redaction + migration v20 (raw_archive backfill)
+
+Schema target: v18 → v19 (commit 3) → v20 (commit 4). Then test pin moves 18→20.
+
+---
+
+## Commit 1 — api.ts cross-tenant + supersede CAS
+
+**Files:**
+- Modify: `src/store.ts` (add `writeEntryDbOnly` — composable lower-level variant)
+- Modify: `src/api.ts` (promote, forget, supersede, authCreate)
+- Modify: `src/server.ts` (authCreate route handler at /v1/auth/keys POST)
+- Test: `tests/v039-api-tenant-isolation.test.ts` (create)
+
+**Fixes:** CRITICAL #1 (promote), CRITICAL #2 (authCreate), CRITICAL #4 (supersede + dangling-pointer fix).
+
+### Fix 1.0 — Split writeEntry: DB-only + mirrors (prerequisite for 1.3)
+
+**Location:** `src/store.ts:950` (existing `writeEntry` — verified body at lines 950-1000).
+
+Current `writeEntry(hippoRoot, entry, opts)` does THREE things in order:
+1. **DB write** inside a SAVEPOINT: `upsertEntryRow(db, entry)` + `opts.afterWrite?(db, id)`.
+2. **Filesystem mirrors** AFTER the SAVEPOINT releases: `writeMarkdownMirror(hippoRoot, entry)` + `writeIndexMirror(hippoRoot, buildIndexFromDb(db))`.
+3. **Audit** via `audit(db, 'remember', ...)`.
+
+For supersede's case, the new memory write needs to share the OUTER `BEGIN IMMEDIATE` of the CAS, but mirrors must run AFTER the outer COMMIT (so a rolled-back tx doesn't leave orphan markdown — same invariant the existing code preserves via post-SAVEPOINT placement).
+
+**Refactor: split into two helpers.**
+
+```ts
+// New: DB-only path. Caller owns the open `db` handle. Runs SAVEPOINT +
+// upsert + afterWrite hook + audit. Audit uses the same db. Caller is
+// responsible for: opening db, BEGIN/COMMIT (if wrapping in a larger tx),
+// closing db, AND calling writeEntryMirrors after the larger tx commits.
+export function writeEntryDbOnly(
+  db: DatabaseSyncLike,
+  entry: MemoryEntry,
+  opts?: { actor?: string; afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void },
+): void {
+  db.exec('SAVEPOINT write_entry');
+  try {
+    upsertEntryRow(db, entry);
+    if (opts?.afterWrite) opts.afterWrite(db, entry.id);
+    db.exec('RELEASE SAVEPOINT write_entry');
+  } catch (e) {
+    try {
+      db.exec('ROLLBACK TO SAVEPOINT write_entry');
+      db.exec('RELEASE SAVEPOINT write_entry');
+    } catch {}
+    throw e;
+  }
+  audit(db, 'remember', entry.id, {
+    kind: entry.kind ?? 'distilled',
+    scope: entry.scope ?? null,
+  }, opts?.actor ?? 'cli', entry.tenantId);
+}
+
+// New: filesystem mirrors. Caller passes hippoRoot + an open db (for buildIndexFromDb).
+// Runs AFTER the outer transaction commits.
+export function writeEntryMirrors(hippoRoot: string, db: DatabaseSyncLike, entry: MemoryEntry): void {
+  writeMarkdownMirror(hippoRoot, entry);
+  writeIndexMirror(hippoRoot, buildIndexFromDb(db));
+}
+
+// Refactored: existing public API stays the same.
+export function writeEntry(hippoRoot: string, entry: MemoryEntry, opts?: WriteEntryOpts): void {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    writeEntryDbOnly(db, entry, opts);
+    writeEntryMirrors(hippoRoot, db, entry);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+```
+
+Supersede uses `writeEntryDbOnly` inside the BEGIN IMMEDIATE; calls `writeEntryMirrors` after COMMIT (db handle still open). All existing tests pass — `writeEntry` semantics unchanged for callers.
+
+**Audit-order note (codex round 4):** Original `writeEntry` runs audit AFTER mirrors (src/store.ts:982-984). The refactor moves audit INSIDE `writeEntryDbOnly` (before mirrors). This is a *correctness improvement*, not a regression: audit now commits atomically with the row INSERT, so a mirror failure cannot leave a recorded audit entry without a corresponding DB row. Document the change in CHANGELOG under "Hardening" rather than "BREAKING" since the user-visible audit trail still matches reality.
+
+### Fix 1.1 — promote() tenant check
+
+**Location:** `src/api.ts:224` (existing function body).
+
+Read the existing promote function. Add at the top of the body (before `promoteToGlobal`):
+
+```ts
+const ownerDb = openHippoDb(ctx.hippoRoot);
+try {
+  const row = ownerDb.prepare(
+    `SELECT tenant_id FROM memories WHERE id = ?`,
+  ).get(opts.id) as { tenant_id: string } | undefined;
+  // Match archiveRaw's not-found semantics: don't leak whether the id exists in another tenant.
+  if (!row || row.tenant_id !== ctx.tenantId) {
+    throw new Error(`memory not found: ${opts.id}`);
+  }
+} finally {
+  closeHippoDb(ownerDb);
+}
+```
+
+Apply the same pattern to `forget()` (api.ts:190) — current forget calls `forgetEntry(ctx.hippoRoot, id, ctx.tenantId)` which DOES tenant-filter at the SQL level (verify by reading src/store.ts:forgetEntry). If forgetEntry already filters by tenantId and returns "not found" on cross-tenant access, leave it alone — no fix needed. Reading is mandatory before modifying.
+
+### Fix 1.2 — authCreate force ctx.tenantId
+
+**Location:** `src/api.ts:374` + `src/server.ts:/v1/auth/keys POST handler`.
+
+The plan's v1 said `AuthCreateOpts.tenantId` exists. Verify by reading the actual interface. If `tenantId` is in `AuthCreateOpts`:
+- Remove the field from the interface
+- Body of `authCreate` already used `ctx.tenantId` (verify); just stop passing the body field
+- HTTP route handler in src/server.ts: ignore `body.tenantId`, pass only `{ label }` to `authCreate(ctx, { label })`
+
+If `AuthCreateOpts.tenantId` does NOT exist (the body might already be using ctx.tenantId via Context propagation), find where the HTTP handler reads `body.tenantId` and verify it's not silently allowing override. Mark fix as already-fixed in that case.
+
+### Fix 1.3 — supersede CAS
+
+**Location:** `src/api.ts:260` (existing function body — readEntry + 2× writeEntry).
+
+The shape: readEntry returns the old memory; supersede mutates `old.superseded_by = newEntry.id`; calls writeEntry twice (each opens its own DB handle); then writes audit on a third DB.
+
+The race: between readEntry's "is this not yet superseded?" check and writeEntry of old, another process can supersede the same row. Both win, two new memories chain off the same old.
+
+**Fix approach (single-handle CAS via `writeEntryDbOnly` from fix 1.0):** open a fresh db handle in api.ts:supersede; do BEGIN IMMEDIATE; do the CAS as direct SQL UPDATE with WHERE clause; if changes=0 throw CONFLICT; call `writeEntryDbOnly(db, newEntry)` so the new memory upsert + afterWrite + audit run inside the SAME transaction; append the user-facing `supersede` audit row; COMMIT. After COMMIT, call `writeEntryMirrors(ctx.hippoRoot, db, newEntry)` for the markdown/index mirrors (matching existing writeEntry's post-savepoint mirror invariant). The old memory's strength/last_retrieved/etc. are NOT updated — only the superseded_by pointer changed via the CAS UPDATE.
+
+```ts
+export function supersede(
+  ctx: Context,
+  oldId: string,
+  newContent: string,
+): { ok: true; oldId: string; newId: string } {
+  // Read old (tenant-scoped). readEntry already filters by tenantId.
+  const old: MemoryEntry | null = readEntry(ctx.hippoRoot, oldId, ctx.tenantId);
+  if (!old) {
+    throw new Error(`Memory not found: ${oldId}`);
+  }
+  // Guard: not already superseded. The CAS below races-safely closes the
+  // window between this read and the write; this check just gives a clearer
+  // error message in the common single-writer case.
+  if (old.superseded_by) {
+    throw new Error(
+      `Memory ${oldId} is already superseded by ${old.superseded_by}. Supersede that one instead.`,
+    );
+  }
+
+  const newEntry = createMemory(newContent, {
+    layer: old.layer ?? Layer.Episodic,
+    tags: [...old.tags],
+    pinned: old.pinned,
+    source: old.source,
+    confidence: 'verified',
+    tenantId: ctx.tenantId,
+  });
+
+  // Race-safe transition: open a fresh db handle, BEGIN IMMEDIATE, run all
+  // three steps (CAS on old + writeEntryDbOnly(new) + supersede audit row) atomically.
+  // Two concurrent supersedes: exactly one CAS wins (changes=1), the other
+  // gets changes=0 and throws.
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      // 1. CAS: only succeed if old.superseded_by IS NULL.
+      const result = db.prepare(`
+        UPDATE memories
+        SET superseded_by = ?
+        WHERE id = ? AND tenant_id = ? AND superseded_by IS NULL
+      `).run(newEntry.id, oldId, ctx.tenantId);
+      if ((result.changes ?? 0) === 0) {
+        db.exec('ROLLBACK');
+        throw new Error(`Memory ${oldId} already superseded by another writer`);
+      }
+      // 2. Write new memory inside same tx via writeEntryDbOnly (DB-only path).
+      writeEntryDbOnly(db, newEntry, { actor: ctx.actor });
+      // 3. Audit row inside same tx so chain is committed atomically.
+      appendAuditEvent(db, {
+        tenantId: ctx.tenantId,
+        actor: ctx.actor,
+        op: 'supersede',
+        targetId: oldId,
+        metadata: { newId: newEntry.id },
+      });
+      db.exec('COMMIT');
+    } catch (err) {
+      try { db.exec('ROLLBACK'); } catch {}
+      throw err;
+    }
+    // Mirrors after COMMIT, while db handle is still open (read-only at this point).
+    // Same invariant as existing writeEntry: mirror failure leaves disk MISSING
+    // the markdown for the new memory (self-heals on next backfill via
+    // writeIndexMirror reading the DB). DOES NOT desync DB or rollback the supersede.
+    try {
+      writeEntryMirrors(ctx.hippoRoot, db, newEntry);
+    } catch (mirrorErr) {
+      console.error('supersede: mirror write failed (non-fatal, will self-heal):', mirrorErr);
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+
+  // Write the new memory inside the SAME transaction as the CAS — no
+  // dangling-pointer window. Requires writeEntryDbOnly (added in this commit
+  // to src/store.ts) which takes an external db handle and does NOT open
+  // its own. The original writeEntry stays as the public single-handle API
+  // for ergonomic callers; writeEntryDbOnly is the lower-level variant that
+  // composable transactions use.
+  // (See src/store.ts:writeEntryDbOnly — exposed in this commit.)
+  // The full sequence inside BEGIN IMMEDIATE: CAS update on old → 
+  // writeEntryDbOnly(new) → supersede audit row → COMMIT. (Note: writeEntryDbOnly
+  // emits its OWN 'remember' audit for the new memory; the explicit appendAuditEvent
+  // for op='supersede' carries the user-facing intent + chain pointer.) If any
+  // step throws, the entire chain rolls back. Closes the dangling-pointer hole.
+
+  return { ok: true, oldId, newId: newEntry.id };
+}
+```
+
+**No dangling-pointer trade-off:** writeEntryDbOnly (fix 1.0) lets the new memory write join the BEGIN IMMEDIATE transaction. CAS + audit + new memory all commit atomically OR all roll back. Codex round-2 P1 closed.
+
+### Tests (commit 1)
+
+`tests/v039-api-tenant-isolation.test.ts`:
+
+1. **promote: cross-tenant denied.** Tenant A pushes memory m1; tenant B promote(m1) → throws "memory not found".
+2. **forget: cross-tenant denied.** Same shape; verify forget already enforces (might be "no fix needed, but test to lock invariant").
+3. **archiveRaw: cross-tenant denied.** Verify the existing fix at api.ts:333.
+4. **authCreate: body tenantId ignored.** HTTP POST /v1/auth/keys with bearer=tenantA-key, body=`{tenantId:'B', label:'x'}`. Resulting key belongs to A.
+5. **supersede CAS: direct SQL race.** Open the test DB, manually pre-set `superseded_by = 'pre-existing'` on the row, call supersede() → throws "already superseded by another writer". Asserts the CAS UPDATE returns changes=0.
+6. **supersede CAS: clean path.** Normal supersede → throws nothing, both rows land, chain is correct.
+7. **supersede CAS: tenant-scoped CAS.** Tenant A's supersede attempt on tenant B's row → throws "Memory not found" (readEntry returns null at the top).
+
+### Commit message
+```
+fix(api): cross-tenant authorization + supersede CAS + writeEntryDbOnly
+
+- store.ts: factor writeEntryDbOnly (composable variant taking external db);
+  writeEntry becomes a thin wrapper. Public semantics unchanged.
+- api.ts promote: verify memory belongs to ctx.tenantId before promoteToGlobal
+- api.ts forget: confirm tenant scoping (already enforced via forgetEntry)
+- api.ts authCreate: ignore body.tenantId, force ctx.tenantId at HTTP layer
+- api.ts supersede: BEGIN IMMEDIATE wrapping CAS-update on old + writeEntryDbOnly
+  for new + audit row, all atomic. No dangling-pointer window.
+- 7 regression tests for each cross-tenant attack path + CAS race
+```
+
+---
+
+## Commit 2 — MCP cross-tenant + MCP-via-api
+
+**Files:**
+- Modify: `src/mcp/server.ts` (McpContext + lastRecalledIds keying + handlers via api.ts)
+- Modify: `src/server.ts` (build clientKey when constructing McpContext for HTTP)
+- Test: `tests/v039-mcp-tenant-isolation.test.ts` (create)
+
+**Fixes:** CRITICAL #3, MEDIUM #9.
+
+### Fix 2.1 — McpContext.clientKey + tenant-keyed lastRecalledIds
+
+**Location:** `src/mcp/server.ts:76` (interface) + module scope (lastRecalledIds).
+
+```ts
+export interface McpContext {
+  hippoRoot: string;
+  tenantId: string;
+  actor: string;
+  /**
+   * Per-client key for state isolation under HTTP-MCP. For stdio: 'stdio-${pid}'
+   * (one process = one client). For HTTP-SSE / HTTP MCP: hash(bearer + remoteAddr)
+   * built by src/server.ts when constructing McpContext for the request.
+   * Optional for backwards compatibility; defaults to `${tenantId}:default`.
+   */
+  clientKey?: string;
+}
+```
+
+Replace `let lastRecalledIds: string[] = []` with `const lastRecalledIds = new Map<string, string[]>()` keyed by `ctx.clientKey ?? \`${ctx.tenantId}:default\``. Update both writers (the recall handler that sets it) and readers (the outcome handler).
+
+### Fix 2.2 — clientKey construction in server.ts for HTTP MCP
+
+**Location:** `src/server.ts:/mcp` route handler.
+
+Find where the MCP request is dispatched in src/server.ts (search for `handleMcpRequest`). Where the McpContext is constructed for the HTTP request, add:
+
+```ts
+import { createHash } from 'node:crypto';
+
+function buildMcpClientKey(req: IncomingMessage): string {
+  const auth = readAuthHeader(req);
+  const tokenHash = auth.kind === 'bearer'
+    ? createHash('sha256').update(auth.token).digest('hex').slice(0, 16)
+    : 'noauth';
+  const addr = req.socket.remoteAddress ?? 'unknown';
+  return `http:${tokenHash}:${addr}`;
+}
+
+// when building McpContext for HTTP:
+const mcpCtx: McpContext = {
+  hippoRoot,
+  tenantId,
+  actor: 'mcp',
+  clientKey: buildMcpClientKey(req),
+};
+```
+
+For stdio (the existing fall-through path that doesn't pass McpContext), default `clientKey` to `'stdio-' + process.pid` inside mcp/server.ts when `ctx.clientKey` is undefined.
+
+### Fix 2.3 — MCP handlers route through src/api.ts (scoped)
+
+**Location:** `src/mcp/server.ts` tool dispatch (cases at :259 hippo_recall, :276 hippo_remember, :311 hippo_outcome).
+
+**Scope (codex round-2 P1):** MCP only exposes 10 tools today (recall, remember, outcome, context, status, learn, conflicts, resolve, share, peers). Of those, only `hippo_recall`, `hippo_remember`, `hippo_outcome` have api.ts counterparts that route through cross-tenant guards + audit. The rest call lower-level helpers directly (e.g., hippo_share → shareMemory, hippo_resolve → conflict helpers, hippo_context/status/learn → store/search helpers).
+
+**This commit:** route `hippo_recall`, `hippo_remember`, `hippo_outcome` through `recall(ctx, ...)`, `remember(ctx, ...)`, and the existing outcome flow (which `lastRecalledIds` keying already protects per Fix 2.1). Build `Context` from `McpContext`: `{ hippoRoot: mcpCtx.hippoRoot, tenantId: mcpCtx.tenantId, actor: 'mcp' }`.
+
+**Critical exception — hippo_share (codex round-3 P1):** `shareMemory(localRoot, id)` at src/shared.ts:282 calls `readEntry(localRoot, id)` WITHOUT tenant filter. MCP `hippo_share` tool exposes this to any bearer. Tenant A can copy tenant B's memory to global. Real cross-tenant exfiltration. **Must fix in v0.39 (Fix 2.4 below).**
+
+**v0.40 follow-up (added to TODOS in commit 6):** for the remaining 6 MCP tools (context, status, learn, conflicts, resolve, peers), audit each readEntry/loadSearchEntries call site for tenant filtering. Some already pass tenantId (verified: search* helpers at src/shared.ts:96-97, 172-173 do); others may not. Full audit + guard pass deferred to v0.40 — none of the remaining 6 are as direct an exfil path as share.
+
+**Negative scope:** the original v1 plan said "MCP forget cross-tenant denied" test — there is no MCP forget tool. Drop that test. The cross-tenant guard for forget is exercised by the api.ts test in commit 1.
+
+### Fix 2.4 — hippo_share cross-tenant guard
+
+**Location:** `src/shared.ts:282` (shareMemory) + MCP handler at `src/mcp/server.ts:436` (case 'hippo_share').
+
+**Bug:** `shareMemory(localRoot, id)` reads via `readEntry(localRoot, id)` (line 277) — no tenant filter. Bearer for tenant A calling MCP `hippo_share` with tenant B's id reads + copies tenant B's memory to the global store.
+
+**Fix (path a — fix at the source, backward-compat):**
+
+```ts
+// src/shared.ts: extend signature; tenantId is OPTIONAL so existing
+// callers passing only { force: true } still compile. Callers that pass
+// tenantId get tenant-scoped readEntry; callers that don't get the legacy
+// unscoped path. MCP/REST hosts MUST pass tenantId.
+export function shareMemory(
+  localRoot: string,
+  id: string,
+  options: { force?: boolean; tenantId?: string } = {},
+): MemoryEntry | null {
+  const entry = readEntry(localRoot, id, options.tenantId);  // tenantId may be undefined → unscoped legacy path
+  if (!entry) throw new Error(`Memory not found: ${id}`);
+  // ...rest unchanged
+}
+```
+
+`readEntry(hippoRoot, id, tenantId?)` already supports the optional tenantId at src/store.ts:1007 — passing it filters by tenant, returning null on cross-tenant attempts; passing undefined returns first match (legacy behavior).
+
+**Required call-site updates (must pass tenantId):**
+- `src/mcp/server.ts:436` (`case 'hippo_share'`): pass `ctx.tenantId`.
+- `src/server.ts` if there's a REST share endpoint (verify; if exists, pass `tenantId`).
+- `src/cli.ts:5758` (`hippo share` command): pass resolved tenantId.
+
+**Acceptable legacy unscoped sites (v0.40 audit):**
+- `src/shared.ts:370` internal call — review whether this is local-only single-tenant context or a real exfil path.
+
+The "Memory not found" error matches archiveRaw's not-found semantics, doesn't leak existence.
+
+### Fix 2.5 — hippo_outcome readEntry tenant filter
+
+**Location:** `src/mcp/server.ts:317` (case 'hippo_outcome' calls readEntry).
+
+Codex round 4 spotted: `readEntry(hippoRoot, id)` without tenantId. Even though `lastRecalledIds` keying (Fix 2.1) protects against cross-client outcome poisoning, the readEntry call itself can leak whether a memory exists in another tenant via timing/error-message difference.
+
+**Fix:** pass `ctx.tenantId` to readEntry. Same shape as fix 2.4.
+
+### Tests (commit 2)
+
+`tests/v039-mcp-tenant-isolation.test.ts`:
+
+1. **lastRecalledIds keyed by clientKey.** Two simulated clients with different clientKey values both recall against the same tenant. Each client's outcome only touches its own recalled set.
+2. **MCP recall produces audit_log with actor='mcp'.** Proves the api.ts route reaches audit.
+3. **MCP remember produces audit_log with actor='mcp'.** Same shape — the remember tool now routes through api.ts.
+4. **stdio backward-compat.** McpContext with no clientKey provided → uses `stdio-${pid}` fallback, no errors.
+5. **Cross-tenant outcome blocked under HTTP-MCP.** Two HTTP-MCP simulated clients with different bearers but same tenant — outcome from client B doesn't touch client A's recall set (already covered by #1, but exercise via the actual buildMcpClientKey path).
+6. **hippo_share cross-tenant denied.** Tenant A pushes memory m1; tenant B's MCP context calls `hippo_share` with id=m1 → throws "Memory not found"; global store does NOT receive m1.
+
+### Commit message
+```
+fix(mcp): client-key isolation + recall/remember/outcome via api.ts + hippo_share guard
+
+- McpContext gains optional clientKey; HTTP-MCP builds hash(bearer + remote addr),
+  stdio defaults to 'stdio-${pid}'
+- lastRecalledIds becomes Map<clientKey, string[]> — outcome from client B
+  cannot touch client A's recall set
+- hippo_recall/hippo_remember route through src/api.ts (audit + guards uniform)
+- shareMemory accepts tenantId, passes through readEntry filter — closes
+  hippo_share cross-tenant exfiltration via MCP
+- 6 regression tests including hippo_share cross-tenant denied
+- v0.40 follow-up: tenant-guard audit on remaining MCP tools (context/status/
+  learn/conflicts/resolve/peers)
+```
+
+---
+
+## Commit 3 — Slack ingestion hardening + migration v19
+
+**Files:**
+- Modify: `src/connectors/slack/tenant-routing.ts` (fail-closed on unknown team)
+- Modify: `src/connectors/slack/ingest.ts` (use afterWrite hook for atomic event_log + memory)
+- Modify: `src/connectors/slack/deletion.ts` (use afterArchive hook — added in raw-archive.ts)
+- Modify: `src/raw-archive.ts` (extend with optional afterArchive hook callback)
+- Modify: `src/connectors/slack/dlq.ts` (write team_id, bucket, signature, slack_timestamp)
+- Modify: `src/connectors/slack/signature.ts` (rotation: read SLACK_SIGNING_SECRET_PREVIOUS too)
+- Modify: `src/server.ts` (slack-events handler uses fail-closed routing + DLQ team_id capture)
+- Modify: `src/cli.ts` (cmdSlack `dlq replay` subcommand)
+- Modify: `src/db.ts` (migration v19: slack_dlq columns)
+- Test: `tests/v039-slack-hardening.test.ts` (create)
+
+**Fixes:** CRITICAL #5, MEDIUM #11-15, NITs (web-client `oldest`, signing rotation).
+
+### Fix 3.1 — Migration v19: slack_dlq columns
+
+**Location:** `src/db.ts` MIGRATIONS array.
+
+Append after v18:
+
+```ts
+{
+  version: 19,
+  up: (db) => {
+    if (!tableHasColumn(db, 'slack_dlq', 'team_id')) {
+      db.exec(`ALTER TABLE slack_dlq ADD COLUMN team_id TEXT`);
+    }
+    if (!tableHasColumn(db, 'slack_dlq', 'bucket')) {
+      db.exec(`ALTER TABLE slack_dlq ADD COLUMN bucket TEXT NOT NULL DEFAULT 'parse_error'`);
+      // SQLite ALTER TABLE cannot add CHECK; bucket value enforcement is app-level.
+    }
+    if (!tableHasColumn(db, 'slack_dlq', 'retry_count')) {
+      db.exec(`ALTER TABLE slack_dlq ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`);
+    }
+    if (!tableHasColumn(db, 'slack_dlq', 'signature')) {
+      db.exec(`ALTER TABLE slack_dlq ADD COLUMN signature TEXT`);
+    }
+    if (!tableHasColumn(db, 'slack_dlq', 'slack_timestamp')) {
+      db.exec(`ALTER TABLE slack_dlq ADD COLUMN slack_timestamp TEXT`);
+    }
+  },
+}
+```
+
+Bump `CURRENT_SCHEMA_VERSION = 19`. Update test pins (b3, a3, a5, pr2) from 18 → 19.
+
+### Fix 3.2 — Unknown team_id fail-closed (CRITICAL #5)
+
+**Location:** `src/connectors/slack/tenant-routing.ts`.
+
+Replace `resolveTenantForTeam` to count slack_workspaces rows and fail closed:
+
+```ts
+export function resolveTenantForTeam(db: DatabaseSyncLike, teamId: string): string | null {
+  const row = db.prepare(`SELECT tenant_id FROM slack_workspaces WHERE team_id = ?`).get(teamId) as { tenant_id: string } | undefined;
+  if (row) return row.tenant_id;
+
+  const total = (db.prepare(`SELECT COUNT(*) AS c FROM slack_workspaces`).get() as { c: number }).c;
+  if (total === 0) {
+    // Single-workspace install: env fallback is safe.
+    return process.env.HIPPO_TENANT?.trim() || 'default';
+  }
+
+  if (process.env.SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK === '1') {
+    return process.env.HIPPO_TENANT?.trim() || 'default';
+  }
+
+  return null; // fail closed
+}
+```
+
+In `src/server.ts` slack-events route handler: if `resolveTenantForTeam` returns null, write to DLQ with `bucket='unroutable'` (capturing team_id from raw body), respond 200 OK to Slack (mandatory ACK), do NOT ingest.
+
+### Fix 3.3 — afterArchive hook in raw-archive.ts
+
+**Location:** `src/raw-archive.ts:26`.
+
+Extend `ArchiveOpts` and the function body:
+
+```ts
+export interface ArchiveOpts {
+  reason: string;
+  who: string;
+  /**
+   * Optional hook invoked inside the same SAVEPOINT as the archive INSERT/DELETE.
+   * Used by Slack deletion to mark the deletion event seen atomically — a crash
+   * mid-archive must not leave the deletion event untracked. Throwing rolls back
+   * the entire archive.
+   */
+  afterArchive?: (db: DatabaseSyncLike, archivedMemoryId: string) => void;
+}
+
+// in the function body, after the audit append + before RELEASE SAVEPOINT:
+if (opts.afterArchive) {
+  opts.afterArchive(db, id);
+}
+```
+
+In `src/connectors/slack/deletion.ts`, pass `afterArchive` that calls `markEventSeen(db, eventId, archivedMemoryId)` using the SAME `db` handle.
+
+### Fix 3.4 — Ingest race fix via afterWrite
+
+**Location:** `src/connectors/slack/ingest.ts`.
+
+The B3 work added an `afterWrite` hook to `remember()` (api.ts:RememberOpts.afterWrite, threaded into store.ts:writeEntry SAVEPOINT). Current ingest.ts already uses it at line 64 to call `markEventSeen(db, input.eventId, memoryId)` — but `markEventSeen` is a plain `INSERT OR IGNORE` that silently succeeds on duplicate, leaving the second worker's memory write committed.
+
+**Fix:** replace the silent INSERT OR IGNORE with an explicit changes-check that throws on duplicate:
+
+```ts
+// In ingest.ts ingestMessage afterWrite (replacing the markEventSeen call):
+afterWrite: (db, memoryId) => {
+  const inserted = db.prepare(
+    `INSERT OR IGNORE INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`,
+  ).run(input.eventId, new Date().toISOString(), memoryId);
+  if ((inserted.changes ?? 0) === 0) {
+    // Two-worker race: another writer reserved this event_id between the
+    // pre-check and the write. Throw to roll back the SAVEPOINT in writeEntry
+    // — the memory row gets discarded, idempotency holds.
+    throw new DuplicateEventError(input.eventId);
+  }
+},
+```
+
+`input.eventId` (camelCase) — verified actual variable name at src/connectors/slack/ingest.ts:13 + :38. Wrap the outer `remember()` call in try/catch mapping `DuplicateEventError` to `{status: 'skipped_duplicate'}`. Other errors propagate.
+
+The pre-check `hasSeenEvent` at ingest.ts:38 stays as a fast-path optimisation (avoids opening the SAVEPOINT for known duplicates), but is no longer load-bearing for correctness — the afterWrite throw is.
+
+### Fix 3.5 — DLQ writes capture team_id, bucket, signature, slack_timestamp
+
+**Location:** `src/connectors/slack/dlq.ts:writeToDlq`.
+
+Extend the function signature:
+
+```ts
+export interface DlqWriteOpts {
+  tenantId: string | null;  // null = unroutable
+  teamId?: string;
+  rawPayload: string;
+  error: string;
+  bucket: 'parse_error' | 'unroutable' | 'signature_fail';
+  signature?: string;
+  slackTimestamp?: string;
+}
+
+export function writeToDlq(db: DatabaseSyncLike, opts: DlqWriteOpts): number {
+  const result = db.prepare(`
+    INSERT INTO slack_dlq
+      (tenant_id, team_id, raw_payload, error, received_at, bucket, signature, slack_timestamp)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    opts.tenantId ?? '__unroutable__',
+    opts.teamId ?? null,
+    opts.rawPayload,
+    opts.error,
+    new Date().toISOString(),
+    opts.bucket,
+    opts.signature ?? null,
+    opts.slackTimestamp ?? null,
+  );
+  return Number(result.lastInsertRowid);
+}
+```
+
+In `src/server.ts` slack-events handler, capture `signature` from `X-Slack-Signature` header and `slackTimestamp` from `X-Slack-Request-Timestamp`. On parse error, attempt to extract `team_id` from the raw body via cheap regex `/"team_id"\s*:\s*"([^"]+)"/` — if found, populate `teamId`. On signature failure, write to bucket=`signature_fail`. On unknown team, bucket=`unroutable`.
+
+### Fix 3.6 — DLQ replay CLI
+
+**Location:** `src/cli.ts:cmdSlack` (existing dispatch).
+
+Add subcommand `replay`:
+
+```bash
+hippo slack dlq replay <id> [--force]
+```
+
+Behavior:
+1. SELECT row by id from slack_dlq.
+2. If `signature` and `slack_timestamp` are present, re-run signature verification using the current `SLACK_SIGNING_SECRET` (not previous — replay uses current state). If fails AND `--force` is false, error out.
+3. Re-parse the raw_payload, run through the normal ingest path.
+4. On success: UPDATE slack_dlq SET retried_at = ?, retry_count = retry_count + 1.
+5. On failure: UPDATE retry_count only; leave the row.
+
+### Fix 3.7 — Signing-secret rotation
+
+**Location:** `src/connectors/slack/signature.ts`.
+
+```ts
+export function verifySlackSignature(
+  rawBody: string,
+  signature: string,
+  timestamp: string,
+  signingSecret: string,
+  previousSecret?: string,
+): boolean {
+  if (verifyOne(rawBody, signature, timestamp, signingSecret)) return true;
+  if (previousSecret && verifyOne(rawBody, signature, timestamp, previousSecret)) return true;
+  return false;
+}
+```
+
+In server.ts handler, read both `SLACK_SIGNING_SECRET` and `SLACK_SIGNING_SECRET_PREVIOUS` from env; pass both. Document the rotation flow in CHANGELOG: deploy with current+previous, verify both work, drop previous after rollover.
+
+### Fix 3.8 — Web-client oldest test
+
+Already covered in tests below. See test 9.
+
+### Tests (commit 3)
+
+`tests/v039-slack-hardening.test.ts`:
+
+1. **Migration v19 schema additions.** Schema version is 19; slack_dlq has team_id/bucket/retry_count/signature/slack_timestamp columns.
+2. **Unknown team + empty workspaces → fallback.** No slack_workspaces rows; unknown team_id → resolves to env tenant.
+3. **Unknown team + non-empty workspaces → fail closed.** One slack_workspaces row registered to team_X; event from team_Y → resolveTenantForTeam returns null.
+4. **Escape hatch.** Same as #3 with `SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1` → resolves to env tenant.
+5. **Server slack-events: unroutable goes to DLQ.** Same as #3 via the HTTP route; assert slack_dlq has bucket='unroutable' and team_id captured.
+6. **Ingest race: duplicate event_id.** Manually call ingestMessage twice with same event_id → second returns `skipped_duplicate`, slack_event_log has 1 row, memories has 1 row.
+7. **Deletion afterArchive atomic.** Mock raw-archive to throw inside afterArchive callback → archive rolls back, memory still exists, slack_event_log not marked.
+8. **DLQ replay clean path.** Seed a parse_error row with valid signature; replay → retry_count=1, ingest succeeds, memory created.
+9. **Web-client emits `oldest` on first-page resume only.** Spy fetch → first call URL contains `oldest=<latest_ts>`; subsequent cursor pages do not have `oldest`.
+10. **Signing-secret rotation.** Verify signature signed with previous secret passes when both env vars set; signature signed with random fails.
+11. **DLQ team_id captured from malformed body.** Send malformed envelope with valid team_id field → DLQ row has team_id populated.
+
+### Commit message
+```
+fix(slack): hardening + migration v19
+
+- tenant-routing fail-closed when slack_workspaces non-empty + unknown team
+  (escape hatch SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1)
+- ingest race closed via afterWrite hook (atomic event_log + memory)
+- deletion idempotency closed via new afterArchive hook in raw-archive.ts
+- DLQ schema: team_id, bucket, retry_count, signature, slack_timestamp
+- hippo slack dlq replay <id> command
+- signing-secret rotation: SLACK_SIGNING_SECRET_PREVIOUS during rollover
+- 11 regression tests including web-client oldest URL param
+```
+
+---
+
+## Commit 4 — GDPR Path A redaction + migration v20
+
+**Files:**
+- Modify: `src/raw-archive.ts:41` (redact payload_json)
+- Modify: `src/db.ts` (migration v20: backfill existing raw_archive rows)
+- Test: `tests/v039-gdpr-path-a.test.ts` (create)
+
+**Fixes:** HIGH #7.
+
+### Fix 4.1 — archiveRawMemory writes redacted payload
+
+**Location:** `src/raw-archive.ts:41`.
+
+Read the existing function. The current line is:
+
+```ts
+).run(id, new Date().toISOString(), opts.reason, opts.who, JSON.stringify(row, bigintSafeReplacer));
+```
+
+Replace with:
+
+```ts
+const redactedPayload = JSON.stringify({
+  redacted: true,
+  archived_at: new Date().toISOString(),
+  tenant_id: row.tenant_id ?? 'default',
+  kind: row.kind,
+  reason: opts.reason,
+  // Note: original content is NOT stored. Path A semantics — true RTBF.
+  // The audit_log row appended below carries op='archive_raw' for compliance audit.
+});
+).run(id, new Date().toISOString(), opts.reason, opts.who, redactedPayload);
+```
+
+Existing audit (line 62-69) and FTS purge (line 49-56) remain unchanged. The audit row IS the compliance record; raw_archive is now metadata-only.
+
+### Fix 4.2 — Migration v20: backfill redact existing rows
+
+**Location:** `src/db.ts` migration v20.
+
+```ts
+{
+  version: 20,
+  up: (db) => {
+    // Path A backfill: redact every existing raw_archive.payload_json so
+    // historical archives match the new metadata-only contract. Read each
+    // row, parse the existing JSON to extract tenant_id and kind (best
+    // effort), then UPDATE with the redacted shape. Rows with unparseable
+    // legacy JSON get redacted with tenant_id='unknown', kind='unknown'.
+    const rows = db.prepare(`SELECT id, archived_at, reason, payload_json FROM raw_archive`).all() as Array<{
+      id: number;
+      archived_at: string;
+      reason: string;
+      payload_json: string;
+    }>;
+    const update = db.prepare(`UPDATE raw_archive SET payload_json = ? WHERE id = ?`);
+    for (const row of rows) {
+      let tenant = 'unknown';
+      let kind = 'unknown';
+      try {
+        const parsed = JSON.parse(row.payload_json) as { tenant_id?: string; kind?: string };
+        tenant = parsed.tenant_id ?? 'unknown';
+        kind = parsed.kind ?? 'unknown';
+      } catch {
+        // Unparseable legacy payload — redact with unknowns.
+      }
+      const redacted = JSON.stringify({
+        redacted: true,
+        archived_at: row.archived_at,
+        tenant_id: tenant,
+        kind,
+        reason: row.reason,
+        migration: 'v20_redact',
+      });
+      update.run(redacted, row.id);
+    }
+  },
+}
+```
+
+Bump `CURRENT_SCHEMA_VERSION = 20`. Update test pins (b3, a3, a5, pr2, the v19 test from commit 3) from 19 → 20.
+
+### Tests (commit 4)
+
+`tests/v039-gdpr-path-a.test.ts`:
+
+1. **Schema v20.** Test pins on master files updated to 20.
+2. **Fresh archive Path A.** Push a kind='raw' memory; archiveRaw it; SELECT raw_archive — payload_json contains `{"redacted":true,...}` and NOT the original content.
+3. **Migration v20 backfill.** Seed a v18 DB by hand-inserting a raw_archive row with full content payload; open the DB (triggering migrations); SELECT — payload now redacted, tenant_id and kind preserved.
+4. **Migration v20 with malformed legacy payload.** Seed a row with payload_json = 'not-json'; migrate; redacted with unknowns.
+5. **Audit row preserved.** archiveRaw still writes audit_log entry with op='archive_raw' (compliance record), even though raw_archive content is gone.
+6. **No re-recall after archive.** Already covered in B3 tests, but verify under Path A — the memory is gone, raw_archive is metadata-only, recall returns nothing.
+
+### Commit message
+```
+feat(gdpr): Path A archive redaction - true RTBF on raw_archive
+
+BREAKING (data shape, not API): raw_archive.payload_json now stores
+{redacted:true, archived_at, tenant_id, kind, reason} instead of full
+memory content. Migration v20 redacts existing rows in place, preserving
+tenant_id and kind from the legacy payload when parseable.
+
+Compliance audit trail remains via audit_log (op='archive_raw').
+6 regression tests including legacy-payload-malformed migration path.
+```
+
+---
+
+## Commit 5 — Server hardening
+
+**Files:**
+- Modify: `src/server.ts` (signal-await, SSE rebind + max-age)
+- Modify: `src/auth.ts` (DUMMY_HASH, miss-path runs verifyKey)
+- Modify: `tests/server-bearer-lockdown.test.ts` (route parity, parameterized)
+- Test: `tests/v039-server-hardening.test.ts` (create — PUBLIC_ROUTES regression, default-deny lower-level, SSE)
+
+**Fixes:** HIGH #6, #8, MEDIUM #10, NITs (PUBLIC_ROUTES, signal race).
+
+### Fix 5.1 — Bearer lockdown route parity
+
+**Location:** `tests/server-bearer-lockdown.test.ts:33`.
+
+The actual route table from src/server.ts (verified by reading lines 349-742):
+
+- `GET /health` — public (no auth)
+- `POST /v1/memories` — authed (remember)
+- `GET /v1/memories` — authed (recall)
+- `POST /v1/memories/:id/archive` — authed
+- `POST /v1/memories/:id/supersede` — authed
+- `POST /v1/memories/:id/promote` — authed
+- `DELETE /v1/memories/:id` — authed (forget)
+- `POST /v1/auth/keys` — authed (authCreate)
+- `GET /v1/auth/keys` — authed (list)
+- `DELETE /v1/auth/keys/:keyId` — authed (revoke)
+- `GET /v1/audit` — authed
+- `POST /v1/connectors/slack/events` — public (HMAC-verified, NOT bearer-authed; covered by separate Slack tests)
+- `POST /mcp` — authed (MCP request)
+- `GET /mcp/stream` — authed (SSE)
+
+No `GET /mcp` route. Codex round-2 corrected v1's invented routes.
+
+Parameterize the test:
+
+```ts
+const AUTHED_ROUTES: Array<{ method: string; path: string; body?: object }> = [
+  { method: 'POST', path: '/v1/memories', body: { content: 'x' } },
+  { method: 'GET', path: '/v1/memories?q=test' },
+  { method: 'POST', path: '/v1/memories/abc/archive', body: { reason: 'x' } },
+  { method: 'POST', path: '/v1/memories/abc/supersede', body: { content: 'y' } },
+  { method: 'POST', path: '/v1/memories/abc/promote' },
+  { method: 'DELETE', path: '/v1/memories/abc' },
+  { method: 'POST', path: '/v1/auth/keys', body: { label: 'x' } },
+  { method: 'GET', path: '/v1/auth/keys' },
+  { method: 'DELETE', path: '/v1/auth/keys/hk_xyz' },
+  { method: 'GET', path: '/v1/audit' },
+  { method: 'POST', path: '/mcp', body: { jsonrpc: '2.0', method: 'tools/list', id: 1 } },
+  { method: 'GET', path: '/mcp/stream' },
+];
+```
+
+12 authed routes total. `/v1/connectors/slack/events` is public-by-design (HMAC-verified) — covered separately in Slack hardening tests. `/health` is public — no test needed.
+
+Per route: assert HTTP 401 with `HIPPO_REQUIRE_AUTH=1` and missing/bad bearer.
+
+### Fix 5.2 — Auth timing leak via DUMMY_HASH
+
+**Location:** `src/auth.ts`.
+
+```ts
+// Constant dummy hash precomputed once at module load — used to equalize
+// scrypt cost on the miss path so key-id existence cannot be timed.
+// Stored format identical to real hashes: scrypt$saltHex$hashHex.
+const DUMMY_PLAINTEXT = 'hk_dummy_constant_padding_for_timing.dummy_secret_padding_for_timing_x';
+const DUMMY_HASH = hashKey(DUMMY_PLAINTEXT);
+
+export function validateApiKey(db: DatabaseSyncLike, plaintext: string): ValidateResult {
+  const dot = plaintext.indexOf('.');
+  if (dot < 0) {
+    // Still run verifyKey to keep timing similar even on malformed input.
+    verifyKey('hk_xxx.yyy', DUMMY_HASH);
+    return { valid: false };
+  }
+  const keyId = plaintext.slice(0, dot);
+  const row = db
+    .prepare(`SELECT key_hash, tenant_id, revoked_at FROM api_keys WHERE key_id = ?`)
+    .get(keyId) as { key_hash: string; tenant_id: string; revoked_at: string | null } | undefined;
+
+  // Always run verifyKey — on miss/revoked, against DUMMY_HASH so scrypt cost is paid.
+  // This reduces timing signal between hit and miss, but the DB lookup itself can
+  // still leak via cache effects. v0.40 follow-up: add request-level rate limit on
+  // /v1/* to bound enumeration.
+  const target = (row && !row.revoked_at) ? row.key_hash : DUMMY_HASH;
+  const matches = verifyKey(plaintext, target);
+  if (!row || row.revoked_at || !matches) return { valid: false };
+  return { valid: true, tenantId: row.tenant_id, keyId };
+}
+```
+
+### Fix 5.3 — SSE auth-rebind + max-age
+
+**Location:** `src/server.ts:/mcp/stream` handler.
+
+Add a heartbeat interval (default 60s) that re-validates the bearer. If revoked or fails, close the stream with reason. Also enforce `MCP_SSE_MAX_AGE_SEC` (default 3600). Document in CHANGELOG.
+
+```ts
+const SSE_HEARTBEAT_MS = 60 * 1000;
+const SSE_MAX_AGE_MS = (parseInt(process.env.MCP_SSE_MAX_AGE_SEC ?? '3600', 10) || 3600) * 1000;
+
+// inside the SSE handler, after initial auth check:
+const startedAt = Date.now();
+const heartbeat = setInterval(() => {
+  if (Date.now() - startedAt >= SSE_MAX_AGE_MS) {
+    res.write(`event: closed\ndata: {"reason":"max_age_exceeded"}\n\n`);
+    res.end();
+    clearInterval(heartbeat);
+    return;
+  }
+  // Re-validate bearer
+  try {
+    requireAuth(req, hippoRoot);
+    res.write(`: heartbeat\n\n`);
+  } catch {
+    res.write(`event: closed\ndata: {"reason":"auth_revoked"}\n\n`);
+    res.end();
+    clearInterval(heartbeat);
+  }
+}, SSE_HEARTBEAT_MS);
+
+req.on('close', () => clearInterval(heartbeat));
+```
+
+### Fix 5.4 — Graceful shutdown signal-await
+
+**Location:** `src/server.ts:846, 855`.
+
+Replace synchronous signal handlers with async-aware:
+
+```ts
+let shuttingDown = false;
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.error(`Received ${signal}, shutting down...`);
+  try {
+    await server.stop();
+  } catch (err) {
+    console.error('Error during stop:', err);
+  } finally {
+    process.exit(0);
+  }
+}
+
+process.on('SIGTERM', () => { void gracefulShutdown('SIGTERM'); });
+process.on('SIGINT', () => { void gracefulShutdown('SIGINT'); });
+```
+
+### Fix 5.5 — PUBLIC_ROUTES regression tests
+
+`tests/v039-server-hardening.test.ts`:
+
+```ts
+describe('PUBLIC_ROUTES — bypass attempts', () => {
+  it('trailing slash on slack events does not bypass (still checks HMAC)', async () => {
+    // POST /v1/connectors/slack/events/  with no signature → 401 (HMAC required)
+  });
+  it('encoded slash variant does not bypass', async () => {
+    // POST /v1/connectors/slack%2Fevents → 401 (route mismatch, falls through to authed handler)
+  });
+  it('wrong method on public route requires auth', async () => {
+    // GET /v1/connectors/slack/events without bearer → 401 (only POST is public)
+  });
+  it('query string on public route does not affect routing', async () => {
+    // POST /v1/connectors/slack/events?bypass=1 → still HMAC-verified
+  });
+});
+```
+
+### Fix 5.6 — Default-deny lower-level loader test
+
+After commit 2 lands MCP-via-api, add a test:
+
+```ts
+it('MCP recall with no scope hides slack:private:* memories (default-deny)', async () => {
+  // Push a memory with scope='slack:private:CXXX'
+  // Call MCP recall with no scope
+  // Assert no slack:private memory in results
+});
+```
+
+### Tests (commit 5)
+
+In addition to PUBLIC_ROUTES + default-deny above:
+
+1. **Bearer lockdown parameterized** — every authed route returns 401 without bearer (HIPPO_REQUIRE_AUTH=1).
+2. **Auth timing reduced.** Measure verifyKey time on hit vs. miss-with-DUMMY_HASH; assert within 30% of each other (loose bound — exact-equal is fragile in CI).
+3. **SSE max-age closes stream.** Set MCP_SSE_MAX_AGE_SEC=2; open stream; wait 3s; assert stream closed with reason='max_age_exceeded'.
+4. **SSE auth revoked closes stream.** Open stream with bearer; revoke key via DELETE /v1/auth/keys/:keyId; trigger heartbeat; assert stream closed with reason='auth_revoked'.
+5. **Graceful shutdown.** Start server, send SIGTERM mid-request, verify request completes before exit (mock with a slow handler).
+
+### Commit message
+```
+fix(server): bearer route parity, auth timing reduction, SSE rebind, signal handler
+
+- bearer lockdown test parameterized over 12 authed routes
+- auth.ts: DUMMY_HASH precomputed at module load; miss path runs verifyKey
+  against DUMMY_HASH so scrypt cost is paid (reduced timing signal — DB
+  lookup still differs, v0.40 rate limit follow-up)
+- /mcp/stream: 60s heartbeat re-validates bearer; MCP_SSE_MAX_AGE_SEC limit
+- SIGTERM/SIGINT: await server.stop() before process.exit
+- 5 PUBLIC_ROUTES regression tests + default-deny lower-level test
+```
+
+---
+
+## Commit 6 — Benchmark honesty + docs + version bump 0.39.0
+
+**Files:**
+- Modify: `benchmarks/a1/p99-recall.ts` (retract <50ms claim, document current state)
+- Modify: `benchmarks/a1/soak.ts` README (document as scaffold-only)
+- Modify: `CHANGELOG.md`, `README.md`, `RESEARCH.md`, `TODOS.md`
+- Modify: `package.json`, `package-lock.json`, `openclaw.plugin.json`, `extensions/openclaw-plugin/openclaw.plugin.json`, `extensions/openclaw-plugin/package.json`, `src/server.ts:VERSION`, `src/mcp/server.ts:serverInfo.version` (bump to 0.39.0)
+- No new tests; full suite must pass.
+
+### Fix 6.1 — p99 retraction (Path C from prior plan)
+
+In `benchmarks/a1/p99-recall.ts` README/header comment: add note:
+> v0.39: the <50ms p99 target stated in v0.36 plan is retracted. Measured 58.4ms on 10k store, sequential single-thread. Server-mode concurrent measurement is a v0.40+ effort.
+
+In `TODOS.md` v0.39 section: remove "A1 p99 latency hardening (58.4ms → <50ms)" line OR move to "long-term, no current target".
+
+### Fix 6.2 — Soak harness scaffold
+
+In `benchmarks/a1/soak.ts` header comment: add note:
+> Scaffold for 24h soak runs. Not currently a release gate. Operators can run manually; no CI integration in v0.39.
+
+In CHANGELOG: do not claim "soak run results" as evidence.
+
+### Fix 6.3 — Version bump
+
+Bump every manifest from 0.38.0 → 0.39.0:
+- `package.json` (root)
+- `package-lock.json` (sync via npm install)
+- `openclaw.plugin.json`
+- `extensions/openclaw-plugin/openclaw.plugin.json`
+- `extensions/openclaw-plugin/package.json`
+- `src/server.ts` `VERSION` const
+- `src/mcp/server.ts` serverInfo.version
+
+Verify with grep: `grep -rn '"version".*"0.38.0"' --include='*.json' . | grep -v node_modules | grep -v package-lock` → zero hits.
+
+### Fix 6.4 — Docs
+
+**CHANGELOG.md** (top):
+
+```markdown
+## 0.39.0 (2026-04-30)
+
+### Security (CRITICAL)
+- **Cross-tenant authorization:** `promote()` now verifies memory belongs to ctx.tenantId before promoteToGlobal. `authCreate` ignores body.tenantId and forces ctx.tenantId at HTTP layer.
+- **Supersede CAS race:** `supersede()` wraps the transition in BEGIN IMMEDIATE with `WHERE superseded_by IS NULL`; concurrent attempts now throw CONFLICT instead of producing double chains.
+- **MCP cross-tenant outcome poisoning:** `lastRecalledIds` now keyed by per-client `clientKey` (HTTP: hash(bearer + remote IP), stdio: 'stdio-${pid}'). Outcome from client B cannot touch client A's recall set.
+- **Slack unknown-team fallback:** when `slack_workspaces` is non-empty and the incoming `team_id` is unmapped, the event is sent to DLQ as `unroutable` instead of silently ingesting into the env-default tenant. Escape hatch: `SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1`.
+
+### Privacy (BREAKING data shape)
+- **GDPR Path A on raw_archive:** archived memories no longer retain content in `raw_archive.payload_json`. Stored shape is `{redacted:true, archived_at, tenant_id, kind, reason}`. Migration v20 redacts existing rows in place. Compliance audit trail preserved via `audit_log`.
+
+### Hardening
+- MCP HTTP handlers route through `src/api.ts` so audit + cross-tenant guards apply uniformly
+- Bearer lockdown test parameterized over the full 12-route table
+- Auth timing leak reduced: `DUMMY_HASH` precomputed at module load; miss path runs scrypt
+- `/mcp/stream` re-validates bearer on a 60s heartbeat; new `MCP_SSE_MAX_AGE_SEC` (default 3600s) caps stream age
+- Graceful shutdown awaits `server.stop()` before `process.exit`
+- Slack ingest race closed via `afterWrite` hook (atomic event_log + memory)
+- Slack deletion idempotency closed via new `afterArchive` hook in `archiveRawMemory`
+- Slack DLQ: schema additions (team_id, bucket, retry_count, signature, slack_timestamp); `hippo slack dlq replay <id>` command
+- Slack signing-secret rotation: accept `SLACK_SIGNING_SECRET_PREVIOUS` during rollover
+
+### Schema
+- Migration v19: slack_dlq columns (team_id, bucket, retry_count, signature, slack_timestamp)
+- Migration v20: raw_archive.payload_json redacted in place (Path A backfill)
+
+### Retracted
+- v0.36 <50ms p99 latency target. v0.36 ships at 58.4ms (sequential single-thread). No current target; revisit in v0.40+ if a real user asks.
+
+### Deferred to v0.40
+- Tenant-guard audit on remaining MCP tools (context, status, learn, conflicts, resolve, peers) + any unscoped readEntry/loadSearchEntries call sites in CLI/dashboard/refine
+- Request-level rate limit on /v1/* to bound key-id enumeration
+- p99 hardening
+- 24h soak harness as a real release gate (currently scaffold)
+- B3 dlPFC follow-ups (sequential-learning adapter contract, etc.)
+```
+
+**README.md:** add "What's new in v0.39.0" entry: "Security hardening release: 5 CRITICAL cross-tenant fixes (CVE candidates), GDPR Path A on archive (true RTBF), MCP per-client isolation, Slack ingestion race + idempotency hardening, auth timing leak reduction." No new feature receipts.
+
+**RESEARCH.md:** unchanged unless an architectural note is needed.
+
+**TODOS.md:** clear v0.38.x security follow-ups (now done). Add v0.40 follow-ups: tenant-guard audit on remaining MCP tools (context, status, learn, conflicts, resolve, peers — share is fixed in this release per fix 2.4); request-level rate limit on /v1/* to bound key-id enumeration; p99 hardening; 24h soak as a real release gate (currently scaffold); B3 dlPFC stretch items.
+
+### Final test pass
+
+`npm run build` clean. `npx vitest run` → 931 + ~25 new = ~956 passing.
+
+### Commit message
+```
+chore: bump to v0.39.0 - security hardening release
+
+5 CRITICAL cross-tenant fixes + GDPR Path A redaction + MCP isolation
++ Slack ingestion hardening + auth timing reduction + SSE rebind
++ graceful shutdown. Migration v19 (slack_dlq) + v20 (raw_archive backfill).
+~25 new regression tests, full suite at ~956.
+```
+
+---
+
+## Risks (v2)
+
+**Risk 1: Migration v20 redaction destroys existing raw_archive content.**
+Path A is intentional. CHANGELOG must call this out as BREAKING data shape. If any user actually wanted retention semantics, they need to roll back to v0.38 OR copy raw_archive content out before upgrading. Rollback path: down-migration not provided — v0.39 is forward-only on this column.
+
+**Risk 2: MCP-via-api refactor breaks an MCP client silently.**
+Mitigation: end-to-end test with both stdio (existing test path) and HTTP-MCP (new test path). If we don't have an HTTP-MCP test client in tests/, add a minimal one that issues a tools/list + tools/call request.
+
+**Risk 3: Supersede mirror failure post-COMMIT.**
+The DB transaction (CAS + new memory upsert + audit) commits atomically. Filesystem mirrors run AFTER COMMIT — if writeMarkdownMirror or writeIndexMirror throws, the DB is already committed but disk lacks the markdown for the new memory. This matches the existing `writeEntry` invariant and self-heals on next backfill. NOT a dangling-pointer DB inconsistency — that hole is closed in v0.39 via `writeEntryDbOnly` joining the CAS transaction.
+
+**Risk 4: Auth timing fix is "reduced" not "fixed".**
+Documented honestly. DB hit/miss branch still measurable via cache. v0.40: add request-level rate limit on /v1/* to bound enumeration attempts. Plus encourage operators to run behind a reverse-proxy with rate limiting today.
+
+**Risk 5: SSE max-age default 3600s breaks long-lived MCP clients.**
+Configurable via env. Document in CHANGELOG. Most Claude Code / openclaw MCP sessions are bounded; long-lived agents that stay connected >1h are unusual but supported via env override.
+
+**Risk 6: DLQ replay using current SLACK_SIGNING_SECRET fails on old rows signed with rotated-out secret.**
+Acceptable: replay is best-effort; if the signature can no longer be verified, replay must fail unless `--force` is passed. Document in CLI help.
+
+**Risk 7: Slack ingest race fix re-uses B3 afterWrite hook.**
+The afterWrite hook is an existing extension point from B3, well-tested. Risk surface is the new throw-on-duplicate semantic — verify the catch in ingestMessage maps `DuplicateEventError` cleanly.
+
+**Risk 8: SSE heartbeat re-validation under load.**
+Every 60s, every active stream. With 100 streams: 100 DB queries / 60s = manageable. Document the cost; v0.40 can cache validations briefly.
+
+---
+
+## Execution
+
+1. /codex on this v2 plan FIRST — verify no new defects vs the actual code shapes referenced.
+2. If codex says PROCEED: dispatch subagents per commit, in order:
+   - commit 1 → /review of commit 1 diff → commit 2 → /review of commit 2 → ...
+   - Each subagent dispatch is one commit's work; /review between commits catches drift early.
+3. After commit 6: full /review on the merged-branch diff → /self-review → /ship-check.
+4. Squash merge → npm publish v0.39.0 → tag → global install verify → hippo capture.
+
+If any commit's tests fail and the fix isn't obvious in 2 iterations, STOP and report rather than escalate. /full-power authorizes rigour, not shortcuts.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.38.0",
+  "version": "0.39.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -422,10 +422,20 @@ export function supersede(
  * helpers hardcode actor='cli'). Instead we pass `ctx.actor` through as `who`,
  * and raw-archive.ts uses that for the audit row.
  */
+export interface ArchiveRawOpts {
+  /**
+   * Connector idempotency hook (v0.39 commit 3). Runs inside the same
+   * SAVEPOINT as the archive — throwing rolls the archive back. Used by the
+   * Slack deletion connector to mark the deletion event seen atomically.
+   */
+  afterArchive?: (db: DatabaseSyncLike, archivedMemoryId: string) => void;
+}
+
 export function archiveRaw(
   ctx: Context,
   id: string,
   reason: string,
+  opts: ArchiveRawOpts = {},
 ): { ok: true; archivedAt: string } {
   const db = openHippoDb(ctx.hippoRoot);
   try {
@@ -440,7 +450,11 @@ export function archiveRaw(
     if (!row || row.tenant_id !== ctx.tenantId) {
       throw new Error(`memory not found: ${id}`);
     }
-    archiveRawMemory(db, id, { reason, who: ctx.actor });
+    archiveRawMemory(db, id, {
+      reason,
+      who: ctx.actor,
+      afterArchive: opts.afterArchive,
+    });
   } finally {
     closeHippoDb(db);
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,8 @@
 import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import {
   writeEntry,
+  writeEntryDbOnly,
+  writeEntryMirrors,
   readEntry,
   deleteEntry,
   loadSearchEntries,
@@ -225,6 +227,24 @@ export function promote(
   ctx: Context,
   id: string,
 ): { ok: true; sourceId: string; globalId: string } {
+  // Tenant scope: promoteToGlobal reads the entry from the local root via
+  // readEntry without a tenant filter, so a Bearer for tenant A could
+  // promote tenant B's row by guessing or leaking the id. Pre-check the
+  // row's tenant_id and deny cross-tenant access with the same not-found
+  // wording archiveRaw uses (no info leak about whether the id exists in
+  // another tenant).
+  const ownerDb = openHippoDb(ctx.hippoRoot);
+  try {
+    const row = ownerDb
+      .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+      .get(id) as { tenant_id?: string } | undefined;
+    if (!row || row.tenant_id !== ctx.tenantId) {
+      throw new Error(`memory not found: ${id}`);
+    }
+  } finally {
+    closeHippoDb(ownerDb);
+  }
+
   // promoteToGlobal threads ctx.actor into the writeEntry call on the global
   // db, which emits a 'remember' audit row. We then add the user-facing
   // 'promote' event on the global db so the audit trail keeps the intent
@@ -262,10 +282,16 @@ export function supersede(
   oldId: string,
   newContent: string,
 ): { ok: true; oldId: string; newId: string } {
+  // Read old (tenant-scoped). readEntry filters by tenantId, so a Bearer for
+  // tenant A on tenant B's id throws "Memory not found" here without any
+  // info leak.
   const old: MemoryEntry | null = readEntry(ctx.hippoRoot, oldId, ctx.tenantId);
   if (!old) {
     throw new Error(`Memory not found: ${oldId}`);
   }
+  // Guard: not already superseded. The CAS UPDATE below race-safely closes
+  // the window between this read and the write; this check just produces a
+  // clearer error in the common single-writer case.
   if (old.superseded_by) {
     throw new Error(
       `Memory ${oldId} is already superseded by ${old.superseded_by}. Supersede that one instead.`,
@@ -280,21 +306,62 @@ export function supersede(
     confidence: 'verified',
     tenantId: ctx.tenantId,
   });
-  old.superseded_by = newEntry.id;
-  writeEntry(ctx.hippoRoot, old, { actor: ctx.actor });
-  writeEntry(ctx.hippoRoot, newEntry, { actor: ctx.actor });
 
-  // The two writeEntry calls above emit 'remember' audit rows; the 'supersede'
-  // event below carries the user-facing intent and the chained newId.
+  // Race-safe transition: open a fresh db handle, BEGIN IMMEDIATE, run all
+  // three steps (CAS on old + writeEntryDbOnly(new) + supersede audit row)
+  // inside the same transaction. Two concurrent supersedes: exactly one CAS
+  // wins (changes=1), the other gets changes=0 and throws CONFLICT. No
+  // dangling-pointer window: the new memory's row commits atomically with
+  // the old.superseded_by pointer.
   const db = openHippoDb(ctx.hippoRoot);
   try {
-    appendAuditEvent(db, {
-      tenantId: ctx.tenantId,
-      actor: ctx.actor,
-      op: 'supersede',
-      targetId: oldId,
-      metadata: { newId: newEntry.id },
-    });
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      // 1. CAS update: only succeed if old.superseded_by IS NULL AND the
+      //    row still belongs to ctx.tenantId. Tenant filter is belt-and-
+      //    braces with the readEntry above — it costs nothing and closes
+      //    a hypothetical window where ownership changes between read and
+      //    update.
+      const result = db.prepare(`
+        UPDATE memories
+        SET superseded_by = ?
+        WHERE id = ? AND tenant_id = ? AND superseded_by IS NULL
+      `).run(newEntry.id, oldId, ctx.tenantId);
+      if ((result.changes ?? 0) === 0) {
+        db.exec('ROLLBACK');
+        throw new Error(`Memory ${oldId} already superseded by another writer`);
+      }
+      // 2. Write new memory inside same tx via writeEntryDbOnly (DB-only
+      //    path). This emits its OWN 'remember' audit row for the new
+      //    memory inside the SAVEPOINT — atomic with the row INSERT.
+      writeEntryDbOnly(db, newEntry, { actor: ctx.actor });
+      // 3. User-facing 'supersede' audit row inside the same tx so the
+      //    chain pointer + audit trail commit atomically.
+      appendAuditEvent(db, {
+        tenantId: ctx.tenantId,
+        actor: ctx.actor,
+        op: 'supersede',
+        targetId: oldId,
+        metadata: { newId: newEntry.id },
+      });
+      db.exec('COMMIT');
+    } catch (err) {
+      try { db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+      throw err;
+    }
+    // Mirrors after COMMIT, while the db handle is still open. Same
+    // invariant as the original writeEntry: a mirror failure leaves disk
+    // MISSING the markdown for the new memory (self-heals on next backfill
+    // via writeIndexMirror reading the DB) but DOES NOT desync the DB or
+    // roll back the supersede. Logged + swallowed, non-fatal.
+    try {
+      writeEntryMirrors(ctx.hippoRoot, db, newEntry);
+    } catch (mirrorErr) {
+      console.error(
+        'supersede: mirror write failed (non-fatal, will self-heal):',
+        mirrorErr,
+      );
+    }
   } finally {
     closeHippoDb(db);
   }
@@ -356,8 +423,6 @@ export function archiveRaw(
 
 export interface AuthCreateOpts {
   label?: string;
-  /** Override the calling tenant (e.g. admin minting a key for tenant B). */
-  tenantId?: string;
 }
 
 export interface AuthCreateResult {
@@ -367,16 +432,22 @@ export interface AuthCreateResult {
 }
 
 /**
- * Mint a new API key. Per A5 v2 follow-ups (TODOS.md), `auth_create` is currently
- * unaudited — we intentionally match that behavior here for consistency. When A5
- * v2 lands and adds the audit op, this function should mirror the cli handler.
+ * Mint a new API key. The new key is ALWAYS bound to `ctx.tenantId`. Callers
+ * cannot override the tenant via the opts bag — a previous `tenantId` field
+ * was removed because the HTTP layer would happily forward `body.tenantId`,
+ * letting tenant A mint a key for tenant B. The HTTP route handler at
+ * `src/server.ts` POST /v1/auth/keys mirrors this: it ignores any body
+ * `tenantId` and uses the resolved Bearer's tenant exclusively.
+ *
+ * Per A5 v2 follow-ups (TODOS.md), `auth_create` is currently unaudited —
+ * we intentionally match that behavior here for consistency. When A5 v2
+ * lands and adds the audit op, this function should mirror the cli handler.
  */
 export function authCreate(ctx: Context, opts: AuthCreateOpts): AuthCreateResult {
-  const tenantId = opts.tenantId ?? ctx.tenantId;
   const db = openHippoDb(ctx.hippoRoot);
   try {
-    const result = createApiKey(db, { tenantId, label: opts.label });
-    return { keyId: result.keyId, plaintext: result.plaintext, tenantId };
+    const result = createApiKey(db, { tenantId: ctx.tenantId, label: opts.label });
+    return { keyId: result.keyId, plaintext: result.plaintext, tenantId: ctx.tenantId };
   } finally {
     closeHippoDb(db);
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,6 +19,7 @@ import {
 } from './store.js';
 import {
   createMemory,
+  applyOutcome,
   type MemoryKind,
   type MemoryEntry,
   Layer,
@@ -173,6 +174,45 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
   }
 
   return { results: ranked, total: entries.length, tokens };
+}
+
+// ---------------------------------------------------------------------------
+// outcome
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a positive/negative outcome to a list of recently-recalled memory ids.
+ * Used by the MCP `hippo_outcome` tool. Tenant-scoped: ids that don't belong
+ * to ctx.tenantId are silently skipped (matches the prior MCP semantics —
+ * a stale id from another tenant doesn't crash the call). Each successful
+ * outcome emits one audit_log row with op='outcome' tagged with ctx.actor.
+ */
+export function outcome(
+  ctx: Context,
+  ids: ReadonlyArray<string>,
+  good: boolean,
+): { applied: number } {
+  let applied = 0;
+  const db = openHippoDb(ctx.hippoRoot);
+  try {
+    for (const id of ids) {
+      const entry = readEntry(ctx.hippoRoot, id, ctx.tenantId);
+      if (!entry) continue;
+      const updated = applyOutcome(entry, good);
+      writeEntry(ctx.hippoRoot, updated, { actor: ctx.actor });
+      appendAuditEvent(db, {
+        tenantId: ctx.tenantId,
+        actor: ctx.actor,
+        op: 'outcome',
+        targetId: id,
+        metadata: { good },
+      });
+      applied++;
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+  return { applied };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,7 @@
  * in exactly one place.
  */
 
+import { createHash } from 'node:crypto';
 import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import {
   writeEntry,
@@ -163,11 +164,20 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
   // duplicate exists today, but we keep the same shape for symmetry.
   const db = openHippoDb(ctx.hippoRoot);
   try {
+    // GDPR Path A: store a sha256 hash (16 hex chars) of the query text
+    // instead of the truncated query itself. If a caller queries with content
+    // that matches an archived (RTBF) memory, the original text must not
+    // persist in audit_log. query_length is preserved for debugging
+    // long-prompt patterns and compliance metrics.
     appendAuditEvent(db, {
       tenantId: ctx.tenantId,
       actor: ctx.actor,
       op: 'recall',
-      metadata: { query: opts.query.slice(0, 200), results: ranked.length },
+      metadata: {
+        query_hash: createHash('sha256').update(opts.query).digest('hex').slice(0, 16),
+        query_length: opts.query.length,
+        results: ranked.length,
+      },
     });
   } finally {
     closeHippoDb(db);
@@ -464,7 +474,19 @@ export function archiveRaw(
   // would silently re-import the row via bootstrapLegacyStore — defeating the
   // archive (and the GDPR right-to-be-forgotten promise on raw rows). Mirror
   // forget() at src/store.ts:1046, which uses the same removeEntryMirrors call.
-  removeEntryMirrors(ctx.hippoRoot, id);
+  // The DB transaction has already committed; if filesystem unlink fails here
+  // we log and continue. The mirror reaper in openHippoDb will catch it on
+  // next DB open (the row is in raw_archive, so the reaper will revisit it
+  // if the meta flag is reset; for v0.39 the reaper is one-shot post-v20 and
+  // will not auto-retry, so the orphan persists until a v0.40+ scheduled scan).
+  try {
+    removeEntryMirrors(ctx.hippoRoot, id);
+  } catch (mirrorErr) {
+    console.error(
+      `archiveRaw: mirror cleanup failed for ${id} (will retry on next DB open):`,
+      mirrorErr,
+    );
+  }
   // archiveRawMemory does not return the archive_at timestamp it wrote. We
   // emit a fresh ISO timestamp here for the API response. Within a millisecond
   // of the actual write, fine for a server response shape.

--- a/src/api.ts
+++ b/src/api.ts
@@ -448,6 +448,7 @@ export function archiveRaw(
   opts: ArchiveRawOpts = {},
 ): { ok: true; archivedAt: string } {
   const db = openHippoDb(ctx.hippoRoot);
+  let mirrorOk = false;
   try {
     // Tenant scope: archiveRawMemory looks up the row by id alone, so a
     // Bearer for tenant A could archive tenant B's raw row without this
@@ -465,27 +466,35 @@ export function archiveRaw(
       who: ctx.actor,
       afterArchive: opts.afterArchive,
     });
+    // archiveRawMemory deletes the memories row but leaves any legacy markdown
+    // mirror in <root>/{buffer,episodic,semantic}/<id>.md untouched. If we left
+    // the mirror in place, a subsequent initStore() on an empty memories table
+    // would silently re-import the row via bootstrapLegacyStore — defeating the
+    // archive (and the GDPR right-to-be-forgotten promise on raw rows). Mirror
+    // forget() at src/store.ts:1046, which uses the same removeEntryMirrors call.
+    // The DB transaction has already committed; if filesystem unlink fails here
+    // we log and continue. The mirror reaper in openHippoDb will catch it on
+    // next DB open: raw_archive.mirror_cleaned_at stays NULL until every layer
+    // mirror for this id is gone, so the reaper genuinely retries.
+    try {
+      removeEntryMirrors(ctx.hippoRoot, id);
+      mirrorOk = true;
+    } catch (mirrorErr) {
+      console.error(
+        `archiveRaw: mirror cleanup failed for ${id} (will retry via reaper on next openHippoDb):`,
+        mirrorErr,
+      );
+    }
+    if (mirrorOk) {
+      // Stamp mirror_cleaned_at now so the next openHippoDb reaper SELECT
+      // returns empty for this row. NULL stays untouched on failure -> retry.
+      db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
+        new Date().toISOString(),
+        id,
+      );
+    }
   } finally {
     closeHippoDb(db);
-  }
-  // archiveRawMemory deletes the memories row but leaves any legacy markdown
-  // mirror in <root>/{buffer,episodic,semantic}/<id>.md untouched. If we left
-  // the mirror in place, a subsequent initStore() on an empty memories table
-  // would silently re-import the row via bootstrapLegacyStore — defeating the
-  // archive (and the GDPR right-to-be-forgotten promise on raw rows). Mirror
-  // forget() at src/store.ts:1046, which uses the same removeEntryMirrors call.
-  // The DB transaction has already committed; if filesystem unlink fails here
-  // we log and continue. The mirror reaper in openHippoDb will catch it on
-  // next DB open (the row is in raw_archive, so the reaper will revisit it
-  // if the meta flag is reset; for v0.39 the reaper is one-shot post-v20 and
-  // will not auto-retry, so the orphan persists until a v0.40+ scheduled scan).
-  try {
-    removeEntryMirrors(ctx.hippoRoot, id);
-  } catch (mirrorErr) {
-    console.error(
-      `archiveRaw: mirror cleanup failed for ${id} (will retry on next DB open):`,
-      mirrorErr,
-    );
   }
   // archiveRawMemory does not return the archive_at timestamp it wrote. We
   // emit a fresh ISO timestamp here for the API response. Within a millisecond

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -134,7 +134,8 @@ export type AuditOp =
   | 'supersede'
   | 'forget'
   | 'archive_raw'
-  | 'auth_revoke';
+  | 'auth_revoke'
+  | 'outcome';
 
 export interface AppendAuditOpts {
   tenantId: string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -22,6 +22,15 @@ function hashKey(plaintext: string): string {
   return `scrypt$${salt.toString('hex')}$${hash.toString('hex')}`;
 }
 
+// Constant dummy hash precomputed once at module load. Used by validateApiKey
+// to pay the scrypt cost on the miss path (unknown / revoked / malformed key)
+// so the timing signal between hit and miss is reduced. The DB lookup branch
+// itself can still leak via cache effects — v0.40 follow-up: request-level
+// rate limit on /v1/* to bound key-id enumeration. Stored format identical to
+// real hashes: scrypt$saltHex$hashHex.
+const DUMMY_PLAINTEXT = 'hk_dummy_constant_padding_for_timing.dummy_secret_padding_for_timing_x';
+const DUMMY_HASH = hashKey(DUMMY_PLAINTEXT);
+
 function verifyKey(plaintext: string, stored: string): boolean {
   const parts = stored.split('$');
   if (parts.length !== 3 || parts[0] !== 'scrypt') return false;
@@ -60,13 +69,24 @@ export interface ValidateResult {
 
 export function validateApiKey(db: DatabaseSyncLike, plaintext: string): ValidateResult {
   const dot = plaintext.indexOf('.');
-  if (dot < 0) return { valid: false };
+  if (dot < 0) {
+    // Malformed input still pays the scrypt cost so caller cannot distinguish
+    // "no dot" from "unknown key_id" by timing.
+    verifyKey(DUMMY_PLAINTEXT, DUMMY_HASH);
+    return { valid: false };
+  }
   const keyId = plaintext.slice(0, dot);
   const row = db
     .prepare(`SELECT key_hash, tenant_id, revoked_at FROM api_keys WHERE key_id = ?`)
     .get(keyId) as { key_hash: string; tenant_id: string; revoked_at: string | null } | undefined;
-  if (!row || row.revoked_at) return { valid: false };
-  if (!verifyKey(plaintext, row.key_hash)) return { valid: false };
+
+  // Always run verifyKey — on miss/revoked, against DUMMY_HASH so scrypt cost
+  // is paid. This reduces timing signal between hit and miss, but the DB
+  // lookup itself can still leak via cache effects. v0.40 follow-up: add
+  // request-level rate limit on /v1/* to bound enumeration.
+  const target = (row && !row.revoked_at) ? row.key_hash : DUMMY_HASH;
+  const matches = verifyKey(plaintext, target);
+  if (!row || row.revoked_at || !matches) return { valid: false };
   return { valid: true, tenantId: row.tenant_id, keyId };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,7 +161,7 @@ import { wmPush, wmRead, wmClear, wmFlush, WorkingMemoryItem } from './working-m
 import { multihopSearch } from './multihop.js';
 import { computeSalience } from './salience.js';
 import { computeAmbientState, renderAmbientSummary } from './ambient.js';
-import { listDlq } from './connectors/slack/dlq.js';
+import { listDlq, replayDlqEntry } from './connectors/slack/dlq.js';
 import { backfillChannel } from './connectors/slack/backfill.js';
 import { slackHistoryFetcher } from './connectors/slack/web-client.js';
 
@@ -5086,6 +5086,41 @@ function cmdSlackDlqList(hippoRoot: string, _flags: Record<string, string | bool
   }
 }
 
+function cmdSlackDlqReplay(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>,
+): void {
+  const idArg = args[2];
+  if (!idArg) {
+    console.error('Usage: hippo slack dlq replay <id> [--force]');
+    process.exit(1);
+  }
+  const id = Number(idArg);
+  if (!Number.isFinite(id) || !Number.isInteger(id) || id < 1) {
+    console.error(`replay: invalid id ${idArg}`);
+    process.exit(1);
+  }
+  const force = flags.force === true;
+  const result = replayDlqEntry(
+    { hippoRoot },
+    id,
+    {
+      force,
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
+    },
+  );
+  if (!result.ok) {
+    console.error(
+      `replay failed: status=${result.status} retry_count=${result.retryCount}${result.reason ? ` reason=${result.reason}` : ''}`,
+    );
+    process.exit(1);
+  }
+  console.log(
+    `replay ok: status=${result.status} memory_id=${result.memoryId ?? '(none)'} retry_count=${result.retryCount}`,
+  );
+}
+
 function cmdSlack(hippoRoot: string, args: string[], flags: Record<string, string | boolean | string[]>): void {
   const sub = args[0];
   if (sub === 'backfill') {
@@ -5096,7 +5131,11 @@ function cmdSlack(hippoRoot: string, args: string[], flags: Record<string, strin
     cmdSlackDlqList(hippoRoot, flags);
     return;
   }
-  console.error('Usage: hippo slack <backfill|dlq list> [...]');
+  if (sub === 'dlq' && args[1] === 'replay') {
+    cmdSlackDlqReplay(hippoRoot, args, flags);
+    return;
+  }
+  console.error('Usage: hippo slack <backfill|dlq list|dlq replay <id> [--force]> [...]');
   process.exit(1);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5760,12 +5760,13 @@ async function main(): Promise<void> {
       } else if (shareId) {
         requireInit(hippoRoot);
         const force = Boolean(flags['force']);
-        const result = shareMemory(hippoRoot, shareId, { force });
+        const tenantId = resolveTenantId({});
+        const result = shareMemory(hippoRoot, shareId, { force, tenantId });
         if (result) {
           console.log(`Shared [${result.id}] to global store.`);
           console.log(`  Source: ${result.source}`);
         } else {
-          const entry = readEntry(hippoRoot, shareId);
+          const entry = readEntry(hippoRoot, shareId, tenantId);
           if (entry) {
             const score = transferScore(entry);
             console.log(`Transfer score too low (${fmt(score)}). This memory looks project-specific.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4558,12 +4558,17 @@ function cmdAuthCreate(hippoRoot: string, flags: Record<string, string | boolean
   const labelFlag = typeof flags['label'] === 'string' ? (flags['label'] as string) : undefined;
   const asJson = Boolean(flags['json']);
 
+  // The CLI's --tenant flag is the only legitimate cross-tenant override
+  // (admin minting a key for another tenant from the local machine). It
+  // flows through ctx.tenantId, NOT through opts — authCreate's opts no
+  // longer accepts a tenantId field, so the HTTP layer cannot smuggle a
+  // body.tenantId across.
   const ctx: api.Context = {
     hippoRoot: root,
-    tenantId: resolveTenantId({}),
+    tenantId: tenantFlag ?? resolveTenantId({}),
     actor: 'cli',
   };
-  const result = api.authCreate(ctx, { tenantId: tenantFlag, label: labelFlag });
+  const result = api.authCreate(ctx, { label: labelFlag });
 
   if (asJson) {
     console.log(JSON.stringify({

--- a/src/connectors/slack/deletion.ts
+++ b/src/connectors/slack/deletion.ts
@@ -16,6 +16,16 @@ export interface DeletionResult {
   memoryId: string | null;
 }
 
+/**
+ * Handle Slack `message_deleted`. v0.39 commit 3 closes the prior race where
+ * the archive committed but `markEventSeen` ran on a second db handle — a
+ * crash between them left the deletion event un-acked, and the next retry
+ * hit a now-archived row and returned `not_found` instead of `duplicate`.
+ *
+ * Fix: pass `afterArchive` to `archiveRaw`, which runs inside the same
+ * SAVEPOINT as the archive itself. The slack_event_log row commits with the
+ * archive or not at all.
+ */
 export function handleMessageDeleted(ctx: Context, input: DeletionInput): DeletionResult {
   const db = openHippoDb(ctx.hippoRoot);
   let memoryId: string | null = null;
@@ -36,16 +46,26 @@ export function handleMessageDeleted(ctx: Context, input: DeletionInput): Deleti
     closeHippoDb(db);
   }
   if (!memoryId) {
+    // No row to archive — still mark the deletion event seen so a retry returns
+    // 'duplicate'. There is nothing to roll back here, so the second-handle
+    // pattern is fine for this branch.
     const db2 = openHippoDb(ctx.hippoRoot);
     try { markEventSeen(db2, input.eventId, null); }
     finally { closeHippoDb(db2); }
     return { status: 'not_found', memoryId: null };
   }
-  // api.archiveRaw now handles legacy mirror cleanup centrally so every caller
-  // (CLI, REST route, MCP tool, this connector) gets the GDPR-correct archive.
-  archiveRaw(ctx, memoryId, `source_deleted:slack:${input.teamId}:${input.channelId}:${input.deletedTs}`);
-  const db3 = openHippoDb(ctx.hippoRoot);
-  try { markEventSeen(db3, input.eventId, memoryId); }
-  finally { closeHippoDb(db3); }
+  // Archive + event-log mark commit together via afterArchive. The hook
+  // receives the same db handle the archive is using, so the INSERT lives
+  // inside the SAVEPOINT.
+  archiveRaw(
+    ctx,
+    memoryId,
+    `source_deleted:slack:${input.teamId}:${input.channelId}:${input.deletedTs}`,
+    {
+      afterArchive: (sameDb, archivedId) => {
+        markEventSeen(sameDb, input.eventId, archivedId);
+      },
+    },
+  );
   return { status: 'archived', memoryId };
 }

--- a/src/connectors/slack/dlq.ts
+++ b/src/connectors/slack/dlq.ts
@@ -1,41 +1,301 @@
 import type { DatabaseSyncLike } from '../../db.js';
+import type { Context } from '../../api.js';
+import { openHippoDb, closeHippoDb } from '../../db.js';
+import { ingestMessage } from './ingest.js';
+import { resolveTenantForTeam } from './tenant-routing.js';
+import { verifySlackSignature } from './signature.js';
+import { isSlackEventEnvelope, isSlackMessageEvent } from './types.js';
+import { handleMessageDeleted } from './deletion.js';
+
+export type DlqBucket = 'parse_error' | 'unroutable' | 'signature_fail';
 
 export interface DlqItem {
   id: number;
   tenantId: string;
+  teamId: string | null;
   rawPayload: string;
   error: string;
   receivedAt: string;
   retriedAt: string | null;
+  bucket: DlqBucket | string;
+  retryCount: number;
+  signature: string | null;
+  slackTimestamp: string | null;
 }
 
+/**
+ * v0.39 commit 3: writeToDlq is now bucket-aware. `bucket` defaults to
+ * 'parse_error' to preserve the legacy single-arg call sites while letting
+ * new callers tag rows for `hippo slack dlq replay` triage.
+ *
+ * `tenantId: null` means "no tenant resolved" (unroutable team). Stored as
+ * the sentinel '__unroutable__' so the column stays NOT NULL — a mismatch
+ * the listing CLI surfaces explicitly.
+ */
 export interface WriteDlqOpts {
-  tenantId: string;
+  tenantId: string | null;
   rawPayload: string;
   error: string;
+  bucket?: DlqBucket;
+  teamId?: string | null;
+  signature?: string | null;
+  slackTimestamp?: string | null;
 }
 
 export function writeToDlq(db: DatabaseSyncLike, opts: WriteDlqOpts): number {
   const result = db
-    .prepare(`INSERT INTO slack_dlq (tenant_id, raw_payload, error, received_at) VALUES (?, ?, ?, ?)`)
-    .run(opts.tenantId, opts.rawPayload, opts.error, new Date().toISOString());
+    .prepare(
+      `INSERT INTO slack_dlq
+        (tenant_id, team_id, raw_payload, error, received_at, bucket, signature, slack_timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      opts.tenantId ?? '__unroutable__',
+      opts.teamId ?? null,
+      opts.rawPayload,
+      opts.error,
+      new Date().toISOString(),
+      opts.bucket ?? 'parse_error',
+      opts.signature ?? null,
+      opts.slackTimestamp ?? null,
+    );
   return Number(result.lastInsertRowid);
 }
 
 export function listDlq(db: DatabaseSyncLike, opts: { tenantId: string; limit?: number }): DlqItem[] {
   const rows = db
-    .prepare(`SELECT id, tenant_id, raw_payload, error, received_at, retried_at FROM slack_dlq WHERE tenant_id = ? ORDER BY received_at ASC LIMIT ?`)
+    .prepare(
+      `SELECT id, tenant_id, team_id, raw_payload, error, received_at, retried_at,
+              bucket, retry_count, signature, slack_timestamp
+         FROM slack_dlq
+        WHERE tenant_id = ?
+        ORDER BY received_at ASC
+        LIMIT ?`,
+    )
     .all(opts.tenantId, opts.limit ?? 100) as Array<Record<string, unknown>>;
-  return rows.map((r) => ({
+  return rows.map(rowToItem);
+}
+
+export function getDlqEntry(db: DatabaseSyncLike, id: number): DlqItem | null {
+  const row = db
+    .prepare(
+      `SELECT id, tenant_id, team_id, raw_payload, error, received_at, retried_at,
+              bucket, retry_count, signature, slack_timestamp
+         FROM slack_dlq
+        WHERE id = ?`,
+    )
+    .get(id) as Record<string, unknown> | undefined;
+  if (!row) return null;
+  return rowToItem(row);
+}
+
+function rowToItem(r: Record<string, unknown>): DlqItem {
+  return {
     id: Number(r.id),
     tenantId: String(r.tenant_id),
+    teamId: r.team_id == null ? null : String(r.team_id),
     rawPayload: String(r.raw_payload),
     error: String(r.error),
     receivedAt: String(r.received_at),
     retriedAt: r.retried_at == null ? null : String(r.retried_at),
-  }));
+    bucket: r.bucket == null ? 'parse_error' : String(r.bucket),
+    retryCount: Number(r.retry_count ?? 0),
+    signature: r.signature == null ? null : String(r.signature),
+    slackTimestamp: r.slack_timestamp == null ? null : String(r.slack_timestamp),
+  };
 }
 
 export function markDlqRetried(db: DatabaseSyncLike, id: number): void {
-  db.prepare(`UPDATE slack_dlq SET retried_at = ? WHERE id = ?`).run(new Date().toISOString(), id);
+  db.prepare(`UPDATE slack_dlq SET retried_at = ?, retry_count = retry_count + 1 WHERE id = ?`)
+    .run(new Date().toISOString(), id);
+}
+
+export interface ReplayDlqOpts {
+  /** Skip signature verification when the row's signature/timestamp are missing or stale. */
+  force?: boolean;
+  /** Current signing secret. If omitted, signature check is skipped (force-only path). */
+  signingSecret?: string;
+  /** Now (unix seconds) override for tests. */
+  now?: number;
+  /** Skew window override for tests. */
+  skewSeconds?: number;
+}
+
+export interface ReplayDlqResult {
+  ok: boolean;
+  status: string;
+  memoryId: string | null;
+  retryCount: number;
+  reason?: string;
+}
+
+/**
+ * Replay a DLQ row through the normal ingest path. Used by `hippo slack dlq
+ * replay <id> [--force]`.
+ *
+ * Behavior:
+ *   1. SELECT the row.
+ *   2. If signature + slack_timestamp are present and `signingSecret` is set,
+ *      re-verify with the CURRENT secret (not previous). Failure → bail unless
+ *      --force. Legacy rows from before v19 may have NULL signature; those
+ *      require --force to replay safely.
+ *   3. Re-parse the raw_payload and dispatch to ingestMessage / handleMessageDeleted.
+ *   4. On success: mark retried_at, increment retry_count.
+ *   5. On failure: increment retry_count only, leave the row.
+ *
+ * The replay always uses the routing the deployment has NOW (current
+ * slack_workspaces table + env), not whatever was in effect when the original
+ * envelope was DLQed. That is intentional: the DLQ exists to be drained after
+ * the operator fixed the routing.
+ */
+export function replayDlqEntry(
+  ctx: Pick<Context, 'hippoRoot'>,
+  id: number,
+  opts: ReplayDlqOpts = {},
+): ReplayDlqResult {
+  const db = openHippoDb(ctx.hippoRoot);
+  let row: DlqItem | null;
+  try {
+    row = getDlqEntry(db, id);
+  } finally {
+    closeHippoDb(db);
+  }
+  if (!row) {
+    return { ok: false, status: 'not_found', memoryId: null, retryCount: 0, reason: `dlq id ${id} not found` };
+  }
+
+  // Signature verification (current secret, not previous).
+  if (!opts.force) {
+    if (!row.signature || !row.slackTimestamp) {
+      return {
+        ok: false,
+        status: 'sig_missing',
+        memoryId: null,
+        retryCount: row.retryCount,
+        reason: 'legacy row without signature/timestamp; pass --force to replay',
+      };
+    }
+    if (opts.signingSecret) {
+      const ok = verifySlackSignature({
+        rawBody: row.rawPayload,
+        signature: row.signature,
+        timestamp: row.slackTimestamp,
+        signingSecret: opts.signingSecret,
+        now: opts.now,
+        // Replays happen long after the fact — give them a wider skew unless overridden.
+        skewSeconds: opts.skewSeconds ?? 60 * 60 * 24 * 365,
+      });
+      if (!ok) {
+        return {
+          ok: false,
+          status: 'sig_fail',
+          memoryId: null,
+          retryCount: row.retryCount,
+          reason: 'signature did not verify against current SLACK_SIGNING_SECRET; pass --force to replay anyway',
+        };
+      }
+    }
+  }
+
+  // Parse + dispatch.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.rawPayload);
+  } catch (e) {
+    bumpRetryCount(ctx.hippoRoot, id);
+    return {
+      ok: false,
+      status: 'parse_error',
+      memoryId: null,
+      retryCount: row.retryCount + 1,
+      reason: `still unparseable: ${(e as Error).message}`,
+    };
+  }
+  if (!isSlackEventEnvelope(parsed)) {
+    bumpRetryCount(ctx.hippoRoot, id);
+    return {
+      ok: false,
+      status: 'unhandled',
+      memoryId: null,
+      retryCount: row.retryCount + 1,
+      reason: 'not an event_callback envelope',
+    };
+  }
+
+  // Resolve tenant against current state. If still unroutable, bail.
+  const db2 = openHippoDb(ctx.hippoRoot);
+  let tenant: string | null;
+  try {
+    tenant = resolveTenantForTeam(db2, parsed.team_id);
+  } finally {
+    closeHippoDb(db2);
+  }
+  if (!tenant) {
+    bumpRetryCount(ctx.hippoRoot, id);
+    return {
+      ok: false,
+      status: 'unroutable',
+      memoryId: null,
+      retryCount: row.retryCount + 1,
+      reason: `team_id ${parsed.team_id} still unroutable`,
+    };
+  }
+
+  const replayCtx: Context = {
+    hippoRoot: ctx.hippoRoot,
+    tenantId: tenant,
+    actor: 'connector:slack:replay',
+  };
+
+  const inner = parsed.event;
+  if (!isSlackMessageEvent(inner)) {
+    bumpRetryCount(ctx.hippoRoot, id);
+    return {
+      ok: false,
+      status: 'unhandled',
+      memoryId: null,
+      retryCount: row.retryCount + 1,
+      reason: `unhandled inner event type`,
+    };
+  }
+
+  if (inner.subtype === 'message_deleted' && inner.deleted_ts) {
+    const r = handleMessageDeleted(replayCtx, {
+      teamId: parsed.team_id,
+      channelId: inner.channel,
+      deletedTs: inner.deleted_ts,
+      eventId: parsed.event_id,
+    });
+    markRetried(ctx.hippoRoot, id);
+    return { ok: true, status: r.status, memoryId: r.memoryId, retryCount: row.retryCount + 1 };
+  }
+
+  const result = ingestMessage(replayCtx, {
+    teamId: parsed.team_id,
+    channel: {
+      id: inner.channel,
+      is_private: inner.channel_type !== 'channel',
+      is_im: inner.channel_type === 'im',
+      is_mpim: inner.channel_type === 'mpim',
+    },
+    message: inner,
+    eventId: parsed.event_id,
+  });
+  markRetried(ctx.hippoRoot, id);
+  return { ok: true, status: result.status, memoryId: result.memoryId, retryCount: row.retryCount + 1 };
+}
+
+function markRetried(hippoRoot: string, id: number): void {
+  const db = openHippoDb(hippoRoot);
+  try { markDlqRetried(db, id); }
+  finally { closeHippoDb(db); }
+}
+
+function bumpRetryCount(hippoRoot: string, id: number): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    db.prepare(`UPDATE slack_dlq SET retry_count = retry_count + 1 WHERE id = ?`).run(id);
+  } finally {
+    closeHippoDb(db);
+  }
 }

--- a/src/connectors/slack/idempotency.ts
+++ b/src/connectors/slack/idempotency.ts
@@ -1,5 +1,22 @@
 import type { DatabaseSyncLike } from '../../db.js';
 
+/**
+ * Thrown by the ingest afterWrite hook when a concurrent worker has already
+ * inserted slack_event_log for the same event_id. The throw propagates out of
+ * writeEntry's SAVEPOINT, rolling back the duplicate memory write so exactly
+ * one memory row exists per Slack event_id even under two-worker races.
+ *
+ * Caller maps to `{status: 'skipped_duplicate'}` at the public API boundary.
+ */
+export class DuplicateEventError extends Error {
+  readonly eventId: string;
+  constructor(eventId: string) {
+    super(`duplicate slack event_id: ${eventId}`);
+    this.name = 'DuplicateEventError';
+    this.eventId = eventId;
+  }
+}
+
 export function hasSeenEvent(db: DatabaseSyncLike, eventId: string): boolean {
   const row = db.prepare(`SELECT 1 FROM slack_event_log WHERE event_id = ?`).get(eventId);
   return !!row;

--- a/src/connectors/slack/ingest.ts
+++ b/src/connectors/slack/ingest.ts
@@ -1,6 +1,11 @@
 import { remember, type Context } from '../../api.js';
 import { openHippoDb, closeHippoDb } from '../../db.js';
-import { hasSeenEvent, markEventSeen, lookupMemoryByEvent } from './idempotency.js';
+import {
+  hasSeenEvent,
+  markEventSeen,
+  lookupMemoryByEvent,
+  DuplicateEventError,
+} from './idempotency.js';
 import { messageToRememberOpts } from './transform.js';
 import type { ChannelMeta } from './scope.js';
 import type { SlackMessageEvent } from './types.js';
@@ -13,7 +18,7 @@ export interface IngestInput {
   eventId: string;
 }
 
-export type IngestStatus = 'ingested' | 'duplicate' | 'skipped';
+export type IngestStatus = 'ingested' | 'duplicate' | 'skipped' | 'skipped_duplicate';
 
 export interface IngestResult {
   status: IngestStatus;
@@ -27,6 +32,12 @@ export interface IngestResult {
  * - The memory write and the slack_event_log mark commit atomically through
  *   `api.remember`'s `afterWrite` hook — a crash between the two cannot
  *   produce a duplicate on the next retry.
+ * - The afterWrite hook uses an explicit `INSERT OR IGNORE` + changes-check:
+ *   if a concurrent worker beat us to slack_event_log between the pre-check
+ *   and the SAVEPOINT, we throw `DuplicateEventError` to roll back the memory
+ *   write. The pre-check `hasSeenEvent` stays as a fast path for the common
+ *   already-seen case, but the afterWrite throw is what makes idempotency
+ *   correct under two-worker concurrency (v0.39 commit 3 fix).
  * - Empty-body messages return 'skipped' but still mark seen so a replay
  *   returns 'duplicate' rather than re-running the transform.
  */
@@ -57,12 +68,40 @@ export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
   // so the memory row and the slack_event_log row commit (or roll back)
   // together. Slack's 1-minute retry window can no longer produce a duplicate
   // via the crash-between-handles race.
-  const result = remember(
-    { ...ctx, actor: ctx.actor || 'connector:slack' },
-    {
-      ...opts,
-      afterWrite: (db, memoryId) => markEventSeen(db, input.eventId, memoryId),
-    },
-  );
-  return { status: 'ingested', memoryId: result.id };
+  try {
+    const result = remember(
+      { ...ctx, actor: ctx.actor || 'connector:slack' },
+      {
+        ...opts,
+        afterWrite: (innerDb, memoryId) => {
+          const inserted = innerDb
+            .prepare(
+              `INSERT OR IGNORE INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`,
+            )
+            .run(input.eventId, new Date().toISOString(), memoryId);
+          if ((Number(inserted.changes ?? 0)) === 0) {
+            // Two-worker race: another writer reserved this event_id between
+            // the pre-check and the write. Throw to roll back the SAVEPOINT
+            // in writeEntry — the memory row gets discarded, idempotency
+            // holds, exactly one memory exists for this event_id.
+            throw new DuplicateEventError(input.eventId);
+          }
+        },
+      },
+    );
+    return { status: 'ingested', memoryId: result.id };
+  } catch (e) {
+    if (e instanceof DuplicateEventError) {
+      // The other worker's memory row is already committed. Return its id
+      // so the caller behaves identically to the fast-path 'duplicate' branch.
+      const db3 = openHippoDb(ctx.hippoRoot);
+      try {
+        const cachedId = lookupMemoryByEvent(db3, input.eventId);
+        return { status: 'skipped_duplicate', memoryId: cachedId };
+      } finally {
+        closeHippoDb(db3);
+      }
+    }
+    throw e;
+  }
 }

--- a/src/connectors/slack/signature.ts
+++ b/src/connectors/slack/signature.ts
@@ -5,23 +5,41 @@ export interface VerifyOpts {
   timestamp: string;
   signature: string;
   signingSecret: string;
+  /**
+   * Previous signing secret during a rotation. v0.39 commit 3: deploy with
+   * both `SLACK_SIGNING_SECRET` (new) and `SLACK_SIGNING_SECRET_PREVIOUS` (old)
+   * set, verify both work, drop previous after rollover. The verifier tries
+   * `signingSecret` first, then `previousSecret` if that fails.
+   */
+  previousSecret?: string;
   /** Current unix seconds. Injectable for tests. */
   now?: number;
   /** Max allowed skew in seconds. Default 5 minutes (Slack's recommendation). */
   skewSeconds?: number;
 }
 
+function verifyOne(
+  rawBody: string,
+  signature: string,
+  timestamp: string,
+  secret: string,
+): boolean {
+  if (!signature.startsWith('v0=')) return false;
+  const expected = `v0=${createHmac('sha256', secret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`;
+  const a = Buffer.from(signature, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
 export function verifySlackSignature(opts: VerifyOpts): boolean {
-  const { rawBody, timestamp, signature, signingSecret } = opts;
+  const { rawBody, timestamp, signature, signingSecret, previousSecret } = opts;
   const now = opts.now ?? Math.floor(Date.now() / 1000);
   const skew = opts.skewSeconds ?? 5 * 60;
   const ts = Number(timestamp);
   if (!Number.isFinite(ts)) return false;
   if (Math.abs(now - ts) > skew) return false;
-  if (!signature.startsWith('v0=')) return false;
-  const expected = `v0=${createHmac('sha256', signingSecret).update(`v0:${timestamp}:${rawBody}`).digest('hex')}`;
-  const a = Buffer.from(signature, 'utf8');
-  const b = Buffer.from(expected, 'utf8');
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
+  if (verifyOne(rawBody, signature, timestamp, signingSecret)) return true;
+  if (previousSecret && verifyOne(rawBody, signature, timestamp, previousSecret)) return true;
+  return false;
 }

--- a/src/connectors/slack/tenant-routing.ts
+++ b/src/connectors/slack/tenant-routing.ts
@@ -1,18 +1,40 @@
 import type { DatabaseSyncLike } from '../../db.js';
 
 /**
- * Look up the tenant_id for a Slack team_id. Returns null when no row exists,
- * which signals "use the deployment's HIPPO_TENANT fallback". Multi-workspace
- * deployments populate slack_workspaces; single-workspace deployments leave
- * the table empty and rely on the env fallback.
+ * Look up the tenant_id for a Slack team_id.
  *
- * Review patch #6: dedicated routing seam — never inline this lookup at the
- * route handler so a future schema change (e.g. installation tokens) lands
- * in one place.
+ * Returns:
+ *   - mapped tenant_id when slack_workspaces has a row for `teamId`
+ *   - the deployment's HIPPO_TENANT fallback (or 'default') when slack_workspaces
+ *     is empty (single-workspace install — env fallback is safe)
+ *   - null when slack_workspaces is non-empty AND `teamId` is unknown
+ *     (multi-workspace install — fail closed; an unknown team is not the
+ *     deployment's tenant). Escape hatch: SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1
+ *     restores the env fallback for emergency rollback only.
+ *
+ * v0.39 commit 3 (CRITICAL #5): the previous version returned null on miss
+ * unconditionally, and the route handler then fell back to HIPPO_TENANT —
+ * which silently routed events from a foreign workspace into the deployment
+ * tenant. The fail-closed contract lives here so every caller (route handler,
+ * CLI replay, future MCP) gets the same protection.
  */
 export function resolveTenantForTeam(db: DatabaseSyncLike, teamId: string): string | null {
   const row = db
     .prepare(`SELECT tenant_id FROM slack_workspaces WHERE team_id = ?`)
     .get(teamId) as { tenant_id?: string } | undefined;
-  return row?.tenant_id ?? null;
+  if (row?.tenant_id) return row.tenant_id;
+
+  const total = (db
+    .prepare(`SELECT COUNT(*) AS c FROM slack_workspaces`)
+    .get() as { c: number | bigint }).c;
+  if (Number(total) === 0) {
+    // Single-workspace install: env fallback is safe.
+    return process.env.HIPPO_TENANT?.trim() || 'default';
+  }
+
+  if (process.env.SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK === '1') {
+    return process.env.HIPPO_TENANT?.trim() || 'default';
+  }
+
+  return null; // fail closed
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,7 +21,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 19;
+const CURRENT_SCHEMA_VERSION = 20;
 
 type Migration = {
   version: number;
@@ -547,6 +547,50 @@ const MIGRATIONS: Migration[] = [
       }
       if (!tableHasColumn(db, 'slack_dlq', 'slack_timestamp')) {
         db.exec(`ALTER TABLE slack_dlq ADD COLUMN slack_timestamp TEXT`);
+      }
+    },
+  },
+  {
+    version: 20,
+    up: (db) => {
+      // v0.39 commit 4 (GDPR Path A backfill): redact every existing
+      // raw_archive.payload_json so historical archives match the new
+      // metadata-only contract from src/raw-archive.ts. Read each row, parse
+      // the existing JSON to extract tenant_id and kind (best effort), then
+      // UPDATE with the redacted shape. Rows with unparseable legacy JSON get
+      // redacted with tenant_id='unknown', kind='unknown'. The audit_log
+      // remains the compliance record.
+      const rows = db
+        .prepare(`SELECT id, archived_at, reason, payload_json FROM raw_archive`)
+        .all() as Array<{
+        id: number;
+        archived_at: string;
+        reason: string;
+        payload_json: string;
+      }>;
+      const update = db.prepare(`UPDATE raw_archive SET payload_json = ? WHERE id = ?`);
+      for (const row of rows) {
+        let tenant = 'unknown';
+        let kind = 'unknown';
+        try {
+          const parsed = JSON.parse(row.payload_json) as {
+            tenant_id?: string;
+            kind?: string;
+          };
+          tenant = parsed.tenant_id ?? 'unknown';
+          kind = parsed.kind ?? 'unknown';
+        } catch {
+          // Unparseable legacy payload — redact with unknowns.
+        }
+        const redacted = JSON.stringify({
+          redacted: true,
+          archived_at: row.archived_at,
+          tenant_id: tenant,
+          kind,
+          reason: row.reason,
+          migration: 'v20_redact',
+        });
+        update.run(redacted, row.id);
       }
     },
   },

--- a/src/db.ts
+++ b/src/db.ts
@@ -22,7 +22,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 20;
+const CURRENT_SCHEMA_VERSION = 21;
 
 type Migration = {
   version: number;
@@ -595,6 +595,20 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 21,
+    up: (db) => {
+      // v0.39 codex round 3: per-row mirror cleanup tracking. Replaces the
+      // global gdpr_v20_mirror_cleanup meta gate (which made the reaper
+      // one-shot and silently swallowed failed unlinks). With this column the
+      // reaper processes only rows WHERE mirror_cleaned_at IS NULL, sets the
+      // timestamp on success, and leaves it NULL on any unlink failure so the
+      // next openHippoDb retries automatically.
+      if (!tableHasColumn(db, 'raw_archive', 'mirror_cleaned_at')) {
+        db.exec(`ALTER TABLE raw_archive ADD COLUMN mirror_cleaned_at TEXT`);
+      }
+    },
+  },
 ];
 
 function tableHasColumn(db: DatabaseSyncLike, tableName: string, columnName: string): boolean {
@@ -622,8 +636,8 @@ export function openHippoDb(hippoRoot: string): DatabaseSyncLike {
     db.exec('PRAGMA foreign_keys = ON');
     runMigrations(db);
     // Path A backfill: delete any orphan markdown mirrors for already-archived
-    // raw_archive rows. Idempotent via gdpr_v20_mirror_cleanup meta flag.
-    // Wrapped in try/catch — a filesystem failure must not prevent DB open.
+    // raw_archive rows. Idempotent via per-row raw_archive.mirror_cleaned_at
+    // (v21). Wrapped in try/catch — a filesystem failure must not prevent DB open.
     try {
       cleanupArchivedMirrors(hippoRoot, db);
     } catch (cleanupErr) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -21,7 +21,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 18;
+const CURRENT_SCHEMA_VERSION = 19;
 
 type Migration = {
   version: number;
@@ -522,6 +522,32 @@ const MIGRATIONS: Migration[] = [
         CREATE UNIQUE INDEX IF NOT EXISTS uniq_goal_recall_log_memory_goal
           ON goal_recall_log(memory_id, goal_id);
       `);
+    },
+  },
+  {
+    version: 19,
+    up: (db) => {
+      // v0.39 commit 3 (Slack hardening): widen slack_dlq with bucketing,
+      // retry tracking, and the signature/timestamp pair that lets `hippo
+      // slack dlq replay` re-verify before re-running ingest. ALTER ADD
+      // COLUMN with DEFAULT is non-destructive — legacy rows take the
+      // default values. Idempotent via tableHasColumn().
+      if (!tableHasColumn(db, 'slack_dlq', 'team_id')) {
+        db.exec(`ALTER TABLE slack_dlq ADD COLUMN team_id TEXT`);
+      }
+      if (!tableHasColumn(db, 'slack_dlq', 'bucket')) {
+        db.exec(`ALTER TABLE slack_dlq ADD COLUMN bucket TEXT NOT NULL DEFAULT 'parse_error'`);
+        // SQLite ALTER TABLE cannot add CHECK; bucket value enforcement is app-level.
+      }
+      if (!tableHasColumn(db, 'slack_dlq', 'retry_count')) {
+        db.exec(`ALTER TABLE slack_dlq ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0`);
+      }
+      if (!tableHasColumn(db, 'slack_dlq', 'signature')) {
+        db.exec(`ALTER TABLE slack_dlq ADD COLUMN signature TEXT`);
+      }
+      if (!tableHasColumn(db, 'slack_dlq', 'slack_timestamp')) {
+        db.exec(`ALTER TABLE slack_dlq ADD COLUMN slack_timestamp TEXT`);
+      }
     },
   },
 ];

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createRequire } from 'module';
 import { createPhysicsTable } from './physics-state.js';
+import { cleanupArchivedMirrors } from './raw-archive-mirror-cleanup.js';
 
 const require = createRequire(import.meta.url);
 
@@ -620,6 +621,14 @@ export function openHippoDb(hippoRoot: string): DatabaseSyncLike {
     db.exec('PRAGMA wal_autocheckpoint = 100');
     db.exec('PRAGMA foreign_keys = ON');
     runMigrations(db);
+    // Path A backfill: delete any orphan markdown mirrors for already-archived
+    // raw_archive rows. Idempotent via gdpr_v20_mirror_cleanup meta flag.
+    // Wrapped in try/catch — a filesystem failure must not prevent DB open.
+    try {
+      cleanupArchivedMirrors(hippoRoot, db);
+    } catch (cleanupErr) {
+      console.error('openHippoDb: cleanupArchivedMirrors failed (non-fatal):', cleanupErr);
+    }
     return db;
   } catch (error) {
     try {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -294,8 +294,13 @@ async function executeTool(
 
       // Existing physics/hybrid scorer continues to drive user-visible
       // ordering and the strength bump on retrieval — unchanged shape for
-      // existing MCP HTTP clients.
-      const entries = loadAllEntries(hippoRoot, tenantId);
+      // existing MCP HTTP clients. v0.39 Fix 5.6: apply the same default-deny
+      // rule as src/api.ts.recall — when the caller passes no scope, drop
+      // `slack:private:*` rows so an MCP client cannot exfiltrate
+      // private-channel content via a bare query. (loadAllEntries is a
+      // tenant-only loader; scope filtering lives at the call site.)
+      const allEntries = loadAllEntries(hippoRoot, tenantId);
+      const entries = allEntries.filter((e) => !(e.scope ?? '').startsWith('slack:private:'));
       const usePhysics = config.physics?.enabled !== false;
       const results = usePhysics
         ? await physicsSearch(query, entries, { budget, hippoRoot, physicsConfig: config.physics })

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,7 @@ import { fetchGitLog, extractLessons, deduplicateLesson, isGitRepo } from '../au
 import { loadConfig } from '../config.js';
 import { resolveConfidence } from '../memory.js';
 import { resolveTenantId } from '../tenant.js';
+import { recall as apiRecall, remember as apiRemember, type Context as ApiContext } from '../api.js';
 
 // ── Find hippo root ──
 
@@ -77,6 +78,13 @@ export interface McpContext {
   hippoRoot: string;
   tenantId: string;
   actor: string;
+  /**
+   * Per-client key for state isolation under HTTP-MCP. For stdio: 'stdio-${pid}'
+   * (one process = one client). For HTTP-SSE / HTTP MCP: hash(bearer + remoteAddr)
+   * built by src/server.ts when constructing McpContext for the request.
+   * Optional for backwards compatibility; defaults to `${tenantId}:default`.
+   */
+  clientKey?: string;
 }
 
 // MCP stdio transport spec: messages are newline-delimited JSON-RPC, no embedded newlines.
@@ -232,7 +240,21 @@ const TOOLS = [
 ];
 
 // ── Track last recalled IDs for outcome feedback ──
-let lastRecalledIds: string[] = [];
+//
+// Keyed per-client so two HTTP-MCP clients hitting the same tenant cannot
+// poison each other's outcome feedback. The key is `ctx.clientKey` when the
+// transport supplies one (HTTP-MCP via src/server.ts builds
+// hash(bearer+remoteAddr)); stdio and any caller without a clientKey falls
+// back to `'stdio-${pid}'` (one process = one client) or
+// `${tenantId}:default` if a McpContext is constructed in tests without a
+// pid-bound transport.
+const lastRecalledIds = new Map<string, string[]>();
+
+function resolveClientKey(ctx: { clientKey?: string; tenantId: string } | undefined): string {
+  if (ctx?.clientKey) return ctx.clientKey;
+  if (ctx?.tenantId) return `stdio-${process.pid}:${ctx.tenantId}`;
+  return `stdio-${process.pid}:default`;
+}
 
 // ── Tool execution ──
 
@@ -259,6 +281,20 @@ async function executeTool(
     case 'hippo_recall': {
       const query = String(args.query || '');
       const budget = Number(args.budget) || config.defaultBudget;
+      // Route through api.ts so audit_log captures actor='mcp' uniformly with
+      // CLI/REST. api.ts.recall handles tenant-scoped BM25 candidate loading;
+      // we re-fetch full entries for ranking + the markRetrieved bookkeeping
+      // that the MCP path has always done.
+      const apiCtx: ApiContext = {
+        hippoRoot,
+        tenantId,
+        actor: 'mcp',
+      };
+      apiRecall(apiCtx, { query, limit: 50 });
+
+      // Existing physics/hybrid scorer continues to drive user-visible
+      // ordering and the strength bump on retrieval — unchanged shape for
+      // existing MCP HTTP clients.
       const entries = loadAllEntries(hippoRoot, tenantId);
       const usePhysics = config.physics?.enabled !== false;
       const results = usePhysics
@@ -268,7 +304,7 @@ async function executeTool(
       // Mark retrieved and persist
       const retrieved = markRetrieved(results.map((r) => r.entry));
       for (const entry of retrieved) writeEntry(hippoRoot, entry);
-      lastRecalledIds = retrieved.map((e) => e.id);
+      lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
       return formatMemories(results, hippoRoot);
     }
@@ -279,19 +315,20 @@ async function executeTool(
       const tags: string[] = [];
       if (args.error) tags.push('error');
       if (args.tag) tags.push(String(args.tag));
-      const existing = loadAllEntries(hippoRoot, tenantId);
-      const schemaFit = computeSchemaFit(text, tags, existing);
-      const entry = createMemory(text, {
-        layer: Layer.Episodic,
-        tags,
-        pinned: Boolean(args.pin),
-        source: 'mcp',
-        confidence: 'verified',
-        baseHalfLifeDays: config.defaultHalfLifeDays,
-        schema_fit: schemaFit,
+      // Route through api.ts so audit_log captures actor='mcp' uniformly with
+      // CLI/REST. api.ts.remember writes the memory + audit row in one
+      // transaction-friendly path; we re-read the entry to surface the
+      // half-life used in the MCP human-readable response.
+      const apiCtx: ApiContext = {
+        hippoRoot,
         tenantId,
+        actor: 'mcp',
+      };
+      const result = apiRemember(apiCtx, {
+        content: text,
+        tags,
       });
-      writeEntry(hippoRoot, entry);
+      const entry = readEntry(hippoRoot, result.id, tenantId);
 
       // Auto-sleep check
       if (config.autoSleep.enabled) {
@@ -305,16 +342,24 @@ async function executeTool(
         }
       }
 
-      return `Remembered [${entry.id}] (half-life: ${entry.half_life_days}d, tags: ${entry.tags.join(', ') || 'none'})`;
+      const halfLife = entry?.half_life_days ?? config.defaultHalfLifeDays;
+      const tagStr = entry?.tags.join(', ') || tags.join(', ') || 'none';
+      return `Remembered [${result.id}] (half-life: ${halfLife}d, tags: ${tagStr})`;
     }
 
     case 'hippo_outcome': {
       const good = Boolean(args.good);
-      if (lastRecalledIds.length === 0) return 'No recent recalls to apply outcome to.';
+      const clientKey = resolveClientKey(ctx);
+      const ids = lastRecalledIds.get(clientKey) ?? [];
+      if (ids.length === 0) return 'No recent recalls to apply outcome to.';
 
       let count = 0;
-      for (const id of lastRecalledIds) {
-        const entry = readEntry(hippoRoot, id);
+      for (const id of ids) {
+        // Pass tenantId so a poisoned lastRecalledIds entry (or a stale one
+        // from a forget/supersede in another tenant) cannot leak existence
+        // via timing/error-path differences. readEntry returns null on
+        // cross-tenant lookups.
+        const entry = readEntry(hippoRoot, id, tenantId);
         if (entry) {
           const updated = applyOutcome(entry, good);
           writeEntry(hippoRoot, updated);
@@ -344,7 +389,7 @@ async function executeTool(
         : await hybridSearch(query, entries, { budget, hippoRoot });
       const retrieved = markRetrieved(results.map((r) => r.entry));
       for (const entry of retrieved) writeEntry(hippoRoot, entry);
-      lastRecalledIds = retrieved.map((e) => e.id);
+      lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
       const snapshot = loadActiveTaskSnapshot(hippoRoot);
       const snapshotText = snapshot
@@ -437,7 +482,11 @@ async function executeTool(
       const shareId = String(args.id || '');
       if (!shareId) return 'Required: id (memory ID to share).';
       const force = Boolean(args.force);
-      const shared = shareMemory(hippoRoot, shareId, { force });
+      // Pass tenantId so shareMemory's readEntry filters by tenant. Without
+      // this, a Bearer for tenant A could call hippo_share with tenant B's
+      // id and copy the row to the global store. The 'Memory not found'
+      // error matches the cross-tenant deny shape elsewhere in the code.
+      const shared = shareMemory(hippoRoot, shareId, { force, tenantId });
       if (!shared) return 'Transfer score too low. Use force=true to override.';
       return `Shared [${shared.id}] to global store. Source: ${shared.source}`;
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,7 +26,7 @@ import { fetchGitLog, extractLessons, deduplicateLesson, isGitRepo } from '../au
 import { loadConfig } from '../config.js';
 import { resolveConfidence } from '../memory.js';
 import { resolveTenantId } from '../tenant.js';
-import { recall as apiRecall, remember as apiRemember, type Context as ApiContext } from '../api.js';
+import { recall as apiRecall, remember as apiRemember, outcome as apiOutcome, type Context as ApiContext } from '../api.js';
 
 // ── Find hippo root ──
 
@@ -353,20 +353,16 @@ async function executeTool(
       const ids = lastRecalledIds.get(clientKey) ?? [];
       if (ids.length === 0) return 'No recent recalls to apply outcome to.';
 
-      let count = 0;
-      for (const id of ids) {
-        // Pass tenantId so a poisoned lastRecalledIds entry (or a stale one
-        // from a forget/supersede in another tenant) cannot leak existence
-        // via timing/error-path differences. readEntry returns null on
-        // cross-tenant lookups.
-        const entry = readEntry(hippoRoot, id, tenantId);
-        if (entry) {
-          const updated = applyOutcome(entry, good);
-          writeEntry(hippoRoot, updated);
-          count++;
-        }
-      }
-      return `Applied ${good ? 'positive' : 'negative'} outcome to ${count} memories`;
+      // Route through src/api.ts so audit_log captures actor='mcp' and
+      // tenant scoping is enforced uniformly (same surface as recall/remember).
+      // outcome() also handles cross-tenant id skip silently.
+      const apiCtx: ApiContext = {
+        hippoRoot,
+        tenantId,
+        actor: 'mcp',
+      };
+      const { applied } = apiOutcome(apiCtx, ids, good);
+      return `Applied ${good ? 'positive' : 'negative'} outcome to ${applied} memories`;
     }
 
     case 'hippo_context': {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -526,7 +526,7 @@ export async function handleMcpRequest(
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'hippo-memory', version: '0.38.0' },
+          serverInfo: { name: 'hippo-memory', version: '0.39.0' },
         },
       };
 

--- a/src/raw-archive-mirror-cleanup.ts
+++ b/src/raw-archive-mirror-cleanup.ts
@@ -1,10 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { DatabaseSyncLike } from './db.js';
-import { getMeta, setMeta } from './db.js';
 
-const META_KEY = 'gdpr_v20_mirror_cleanup';
 const LAYERS = ['episodic', 'buffer', 'semantic'] as const;
+const MAX_WARN_LOGS = 5;
 
 /**
  * Path A backfill cleanup: existing raw_archive rows that were archived BEFORE
@@ -13,27 +12,48 @@ const LAYERS = ['episodic', 'buffer', 'semantic'] as const;
  * this function deletes those filesystem mirrors so RTBF holds for historical
  * archives too.
  *
- * Idempotent via the gdpr_v20_mirror_cleanup meta flag — runs once per DB,
- * even across multiple openHippoDb() calls.
+ * Per-row tracking via raw_archive.mirror_cleaned_at (added in v21):
+ *   - SELECT only rows WHERE mirror_cleaned_at IS NULL.
+ *   - On success (every layer either deleted or didn't exist), UPDATE the row
+ *     with the cleanup timestamp.
+ *   - On any unlink failure, leave mirror_cleaned_at NULL so the next
+ *     openHippoDb call retries. Warn (capped at MAX_WARN_LOGS rows per call).
+ *
+ * Steady-state cost is one SELECT returning empty after every row has been
+ * cleaned successfully.
  */
 export function cleanupArchivedMirrors(hippoRoot: string, db: DatabaseSyncLike): void {
-  if (getMeta(db, META_KEY, '') === 'done') return;
+  const rows = db
+    .prepare(`SELECT memory_id FROM raw_archive WHERE mirror_cleaned_at IS NULL`)
+    .all() as Array<{ memory_id: string }>;
 
-  const rows = db.prepare(`SELECT memory_id FROM raw_archive`).all() as Array<{ memory_id: string }>;
+  if (rows.length === 0) return;
+
+  const update = db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`);
+  const now = new Date().toISOString();
+  let warnCount = 0;
+
   for (const row of rows) {
+    let allOk = true;
     for (const layer of LAYERS) {
       const filePath = path.join(hippoRoot, layer, `${row.memory_id}.md`);
       try {
         if (fs.existsSync(filePath)) {
           fs.unlinkSync(filePath);
         }
-      } catch {
-        // Best-effort: filesystem failure does not block the meta flag.
-        // The next openHippoDb() will skip the loop entirely (flag set below).
-        // If a real concern emerges, run `hippo gdpr scan-mirrors` (v0.40 tool).
+      } catch (err) {
+        allOk = false;
+        if (warnCount < MAX_WARN_LOGS) {
+          console.warn(
+            `cleanupArchivedMirrors: unlink failed for ${filePath} (will retry on next DB open):`,
+            err,
+          );
+          warnCount += 1;
+        }
       }
     }
+    if (allOk) {
+      update.run(now, row.memory_id);
+    }
   }
-
-  setMeta(db, META_KEY, 'done');
 }

--- a/src/raw-archive-mirror-cleanup.ts
+++ b/src/raw-archive-mirror-cleanup.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { DatabaseSyncLike } from './db.js';
+import { getMeta, setMeta } from './db.js';
+
+const META_KEY = 'gdpr_v20_mirror_cleanup';
+const LAYERS = ['episodic', 'buffer', 'semantic'] as const;
+
+/**
+ * Path A backfill cleanup: existing raw_archive rows that were archived BEFORE
+ * commit 70180b5 left their markdown mirrors at <hippoRoot>/<layer>/<id>.md
+ * with original content intact. The DB is already redacted via migration v20;
+ * this function deletes those filesystem mirrors so RTBF holds for historical
+ * archives too.
+ *
+ * Idempotent via the gdpr_v20_mirror_cleanup meta flag — runs once per DB,
+ * even across multiple openHippoDb() calls.
+ */
+export function cleanupArchivedMirrors(hippoRoot: string, db: DatabaseSyncLike): void {
+  if (getMeta(db, META_KEY, '') === 'done') return;
+
+  const rows = db.prepare(`SELECT memory_id FROM raw_archive`).all() as Array<{ memory_id: string }>;
+  for (const row of rows) {
+    for (const layer of LAYERS) {
+      const filePath = path.join(hippoRoot, layer, `${row.memory_id}.md`);
+      try {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+      } catch {
+        // Best-effort: filesystem failure does not block the meta flag.
+        // The next openHippoDb() will skip the loop entirely (flag set below).
+        // If a real concern emerges, run `hippo gdpr scan-mirrors` (v0.40 tool).
+      }
+    }
+  }
+
+  setMeta(db, META_KEY, 'done');
+}

--- a/src/raw-archive.ts
+++ b/src/raw-archive.ts
@@ -15,13 +15,6 @@ export interface ArchiveOpts {
   afterArchive?: (db: DatabaseSyncLike, archivedMemoryId: string) => void;
 }
 
-// JSON.stringify cannot serialize BigInt by default. node:sqlite returns INTEGER
-// columns as bigint when the value exceeds Number.MAX_SAFE_INTEGER. Coerce to
-// string so the audit payload is always serializable.
-function bigintSafeReplacer(_key: string, value: unknown): unknown {
-  return typeof value === 'bigint' ? value.toString() : value;
-}
-
 /**
  * The only legitimate path to remove a `kind='raw'` row from `memories`.
  *
@@ -44,9 +37,21 @@ export function archiveRawMemory(db: DatabaseSyncLike, id: string, opts: Archive
   // transaction. SQLite refuses BEGIN within a transaction; SAVEPOINT nests safely.
   db.exec('SAVEPOINT archive_raw');
   try {
+    // GDPR Path A (v0.39): raw_archive stores ONLY metadata, not the original
+    // memory content. The audit_log row appended below carries op='archive_raw'
+    // for the compliance audit trail. True right-to-be-forgotten — the original
+    // content is unrecoverable from raw_archive after this point.
+    const archivedAt = new Date().toISOString();
+    const redactedPayload = JSON.stringify({
+      redacted: true,
+      archived_at: archivedAt,
+      tenant_id: row.tenant_id ?? 'default',
+      kind: row.kind,
+      reason: opts.reason,
+    });
     db.prepare(
       `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
-    ).run(id, new Date().toISOString(), opts.reason, opts.who, JSON.stringify(row, bigintSafeReplacer));
+    ).run(id, archivedAt, opts.reason, opts.who, redactedPayload);
     // Flip kind to 'archived' so the BEFORE DELETE trigger no longer fires, then delete.
     db.prepare(`UPDATE memories SET kind = 'archived' WHERE id = ?`).run(id);
     db.prepare(`DELETE FROM memories WHERE id = ?`).run(id);

--- a/src/raw-archive.ts
+++ b/src/raw-archive.ts
@@ -5,6 +5,14 @@ import { appendAuditEvent } from './audit.js';
 export interface ArchiveOpts {
   reason: string;
   who: string;
+  /**
+   * Optional hook invoked inside the same SAVEPOINT as the archive INSERT/DELETE,
+   * after the audit row is appended and before RELEASE. Used by the Slack
+   * deletion connector to mark the deletion event seen atomically — a crash
+   * mid-archive must not leave the deletion event untracked. Throwing rolls
+   * back the entire archive (including the audit row).
+   */
+  afterArchive?: (db: DatabaseSyncLike, archivedMemoryId: string) => void;
 }
 
 // JSON.stringify cannot serialize BigInt by default. node:sqlite returns INTEGER
@@ -70,6 +78,14 @@ export function archiveRawMemory(db: DatabaseSyncLike, id: string, opts: Archive
     } catch {
       // Audit must not crash the archive. Failures here mean the audit table
       // is unwritable; the archive itself has already succeeded.
+    }
+    // afterArchive hook (v0.39 commit 3): connector-level idempotency markers
+    // (e.g. slack_event_log) must commit atomically with the archive itself.
+    // Throwing here rolls back the entire SAVEPOINT — both the archive and any
+    // hook side effects. The hook runs INSIDE the SAVEPOINT so its writes
+    // share the archive's transactional fate.
+    if (opts.afterArchive) {
+      opts.afterArchive(db, id);
     }
     db.exec('RELEASE SAVEPOINT archive_raw');
   } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ const VALID_KINDS: ReadonlySet<MemoryKind> = new Set([
 // HTTP /health response uses this; reading package.json synchronously here
 // would couple the daemon to its on-disk install path, which we want to
 // avoid for tests that mkdtemp a hippoRoot.
-const VERSION = '0.38.0';
+const VERSION = '0.39.0';
 
 // 1 MB body cap. The CLI never sends payloads near this; anything bigger is
 // almost certainly a misconfigured client or a deliberate memory-blowup attempt.

--- a/src/server.ts
+++ b/src/server.ts
@@ -457,14 +457,13 @@ async function handleRequest(
     if (labelRaw !== undefined && typeof labelRaw !== 'string') {
       throw new HttpError(400, 'label must be a string');
     }
-    const tenantIdRaw = body['tenantId'];
-    if (tenantIdRaw !== undefined && typeof tenantIdRaw !== 'string') {
-      throw new HttpError(400, 'tenantId must be a string');
-    }
+    // Security: any `tenantId` in the body is IGNORED. The minted key is
+    // bound to the caller's authenticated tenant (ctx.tenantId, resolved
+    // from the Bearer token). Forwarding body.tenantId here would let
+    // tenant A mint a key for tenant B — see authCreate doc comment.
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = authCreate(ctx, {
       label: labelRaw,
-      tenantId: tenantIdRaw,
     });
     sendJson(res, 200, result);
     return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -814,15 +814,53 @@ async function handleRequest(
       connection: 'keep-alive',
     });
     // Initial ping so smoke tests can confirm the stream is live without
-    // waiting 30s for the first keepalive interval.
+    // waiting for the first keepalive interval.
     res.write(': ping\n\n');
+
+    // v0.39 SSE hardening:
+    //   - Heartbeat re-validates the bearer (default 60s). If the key was
+    //     revoked or rotated, close the stream with reason='auth_revoked'.
+    //   - MCP_SSE_MAX_AGE_SEC (default 3600) caps stream lifetime; close
+    //     with reason='max_age_exceeded' when reached.
+    //   - MCP_SSE_HEARTBEAT_MS (default 60000) lets tests run with a short
+    //     interval without waiting a full minute.
+    const heartbeatMs =
+      parseInt(process.env.MCP_SSE_HEARTBEAT_MS ?? '60000', 10) || 60000;
+    const maxAgeMs =
+      (parseInt(process.env.MCP_SSE_MAX_AGE_SEC ?? '3600', 10) || 3600) * 1000;
+    const startedAt = Date.now();
+    let closed = false;
+    const closeWith = (reason: string): void => {
+      if (closed) return;
+      closed = true;
+      try {
+        res.write(`event: closed\ndata: ${JSON.stringify({ reason })}\n\n`);
+      } catch { /* socket already gone */ }
+      try { res.end(); } catch { /* socket already gone */ }
+    };
     const ping = setInterval(() => {
+      if (closed) {
+        clearInterval(ping);
+        return;
+      }
+      if (Date.now() - startedAt >= maxAgeMs) {
+        closeWith('max_age_exceeded');
+        clearInterval(ping);
+        return;
+      }
+      try {
+        requireAuth(req, opts.hippoRoot);
+      } catch {
+        closeWith('auth_revoked');
+        clearInterval(ping);
+        return;
+      }
       try {
         res.write(': ping\n\n');
       } catch {
         clearInterval(ping);
       }
-    }, 30000);
+    }, heartbeatMs);
     // Don't keep the event loop alive just for this timer — the server's
     // listener already does that, and tests want the process to exit cleanly.
     if (typeof ping.unref === 'function') ping.unref();
@@ -919,8 +957,21 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
   // Skip signal handlers under vitest so each test run does not register a
   // stray SIGTERM/SIGINT listener that survives until the runner exits.
   if (!process.env.VITEST) {
-    process.once('SIGTERM', () => { void stop(); });
-    process.once('SIGINT', () => { void stop(); });
+    let shuttingDown = false;
+    const gracefulShutdown = async (signal: string): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.error(`Received ${signal}, shutting down...`);
+      try {
+        await stop();
+      } catch (err) {
+        console.error('Error during stop:', err);
+      } finally {
+        process.exit(0);
+      }
+    };
+    process.once('SIGTERM', () => { void gracefulShutdown('SIGTERM'); });
+    process.once('SIGINT', () => { void gracefulShutdown('SIGINT'); });
   }
 
   return { port: actualPort, url, stop };

--- a/src/server.ts
+++ b/src/server.ts
@@ -586,20 +586,30 @@ async function handleRequest(
       res.end(JSON.stringify({ error: 'not found' }));
       return;
     }
+    const previousSecret = process.env.SLACK_SIGNING_SECRET_PREVIOUS;
     const sig = req.headers['x-slack-signature'];
     const tsHdr = req.headers['x-slack-request-timestamp'];
+    const sigStr = typeof sig === 'string' ? sig : null;
+    const tsStr = typeof tsHdr === 'string' ? tsHdr : null;
     if (
-      typeof sig !== 'string' ||
-      typeof tsHdr !== 'string' ||
+      sigStr === null ||
+      tsStr === null ||
       !verifySlackSignature({
         rawBody,
-        timestamp: tsHdr,
-        signature: sig,
+        timestamp: tsStr,
+        signature: sigStr,
         signingSecret: secret,
+        previousSecret,
       })
     ) {
       throw new HttpError(401, 'invalid Slack signature');
     }
+    // Cheap regex extracts team_id from a (possibly malformed) raw body so the
+    // DLQ row carries it for triage even when JSON.parse fails.
+    const teamIdFromRaw = (() => {
+      const m = rawBody.match(/"team_id"\s*:\s*"([^"]+)"/);
+      return m ? m[1] : null;
+    })();
     let body: unknown;
     try {
       body = JSON.parse(rawBody);
@@ -608,8 +618,12 @@ async function handleRequest(
       try {
         writeToDlq(db, {
           tenantId: process.env.HIPPO_TENANT ?? 'default',
+          teamId: teamIdFromRaw,
           rawPayload: rawBody,
           error: 'invalid JSON',
+          bucket: 'parse_error',
+          signature: sigStr,
+          slackTimestamp: tsStr,
         });
       } finally {
         closeHippoDb(db);
@@ -627,15 +641,39 @@ async function handleRequest(
       });
       return;
     }
-    let resolvedTenant = process.env.HIPPO_TENANT ?? 'default';
+    // Resolve tenant. v0.39 fail-closed: when slack_workspaces is non-empty
+    // and the team_id is unknown, resolveTenantForTeam returns null and we
+    // park the envelope in slack_dlq with bucket='unroutable'. Mandatory ACK
+    // 200 so Slack stops retrying; do NOT call ingest.
+    let resolvedTenant: string | null = null;
     if (isSlackEventEnvelope(body)) {
       const db = openHippoDb(opts.hippoRoot);
       try {
-        const mapped = resolveTenantForTeam(db, body.team_id);
-        if (mapped) resolvedTenant = mapped;
+        resolvedTenant = resolveTenantForTeam(db, body.team_id);
       } finally {
         closeHippoDb(db);
       }
+      if (resolvedTenant === null) {
+        const db2 = openHippoDb(opts.hippoRoot);
+        try {
+          writeToDlq(db2, {
+            tenantId: null, // unroutable — stored as '__unroutable__'
+            teamId: body.team_id,
+            rawPayload: rawBody,
+            error: `unroutable team_id: ${body.team_id}`,
+            bucket: 'unroutable',
+            signature: sigStr,
+            slackTimestamp: tsStr,
+          });
+        } finally {
+          closeHippoDb(db2);
+        }
+        sendJson(res, 200, { ok: true, status: 'dlq' });
+        return;
+      }
+    } else {
+      // Non-envelope payload: use env tenant for the DLQ row's bookkeeping.
+      resolvedTenant = process.env.HIPPO_TENANT ?? 'default';
     }
     const ctx: Context = {
       hippoRoot: opts.hippoRoot,
@@ -647,8 +685,12 @@ async function handleRequest(
       try {
         writeToDlq(db, {
           tenantId: ctx.tenantId,
+          teamId: teamIdFromRaw,
           rawPayload: rawBody,
           error: 'not an event_callback envelope',
+          bucket: 'parse_error',
+          signature: sigStr,
+          slackTimestamp: tsStr,
         });
       } finally {
         closeHippoDb(db);
@@ -689,8 +731,12 @@ async function handleRequest(
     try {
       writeToDlq(db, {
         tenantId: ctx.tenantId,
+        teamId: body.team_id,
         rawPayload: rawBody,
         error: `unhandled event type: ${(inner as { type?: string })?.type ?? 'unknown'}`,
+        bucket: 'parse_error',
+        signature: sigStr,
+        slackTimestamp: tsStr,
       });
     } finally {
       closeHippoDb(db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { createHash } from 'node:crypto';
 import { writePidfile, removePidfile } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { openHippoDb, closeHippoDb } from './db.js';
@@ -246,6 +247,26 @@ function readAuthHeader(req: IncomingMessage): AuthHeader {
   if (scheme.toLowerCase() !== 'bearer') return { kind: 'malformed' };
   if (token.length === 0) return { kind: 'malformed' };
   return { kind: 'bearer', token };
+}
+
+/**
+ * Build a per-client key for MCP state isolation under HTTP-MCP. Used by
+ * mcp/server.ts to scope `lastRecalledIds` to the calling client so two
+ * clients on the same tenant cannot poison each other's outcome feedback.
+ *
+ * Token is hashed (sha256, 16-hex-char prefix) so we never log or persist
+ * the raw bearer. Combined with remoteAddress so two clients sharing a key
+ * (e.g. on a shared Postman environment) are still separable in the common
+ * case. 'noauth' covers loopback no-auth and is acceptable because that
+ * path is single-host single-user.
+ */
+function buildMcpClientKey(req: IncomingMessage): string {
+  const auth = readAuthHeader(req);
+  const tokenHash = auth.kind === 'bearer'
+    ? createHash('sha256').update(auth.token).digest('hex').slice(0, 16)
+    : 'noauth';
+  const addr = req.socket.remoteAddress ?? 'unknown';
+  return `http:${tokenHash}:${addr}`;
 }
 
 /**
@@ -720,6 +741,7 @@ async function handleRequest(
         hippoRoot: ctx.hippoRoot,
         tenantId: ctx.tenantId,
         actor: ctx.actor,
+        clientKey: buildMcpClientKey(req),
       });
     } catch (err) {
       mcpRes = {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -272,9 +272,14 @@ export function transferScore(entry: MemoryEntry): number {
 export function shareMemory(
   localRoot: string,
   id: string,
-  options: { force?: boolean } = {}
+  options: { force?: boolean; tenantId?: string } = {}
 ): MemoryEntry | null {
-  const entry = readEntry(localRoot, id);
+  // tenantId is OPTIONAL for backward compat — autoShare's internal call at
+  // :370 passes only `{ force: true }` in a single-tenant context. MCP/REST
+  // hosts MUST pass tenantId so a Bearer for tenant A cannot share tenant
+  // B's memory to global. readEntry returns null on cross-tenant lookups
+  // when tenantId is provided.
+  const entry = readEntry(localRoot, id, options.tenantId);
   if (!entry) throw new Error(`Memory not found: ${id}`);
 
   const score = transferScore(entry);

--- a/src/store.ts
+++ b/src/store.ts
@@ -958,29 +958,44 @@ export function writeEntry(
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    // SAVEPOINT (not BEGIN) so this nests safely inside any outer transaction
-    // a future caller might hold. SQLite refuses BEGIN within a transaction;
-    // SAVEPOINT is the only way to scope rollback without disturbing outers.
-    db.exec('SAVEPOINT write_entry');
-    try {
-      upsertEntryRow(db, entry);
-      if (opts?.afterWrite) {
-        opts.afterWrite(db, entry.id);
-      }
-      db.exec('RELEASE SAVEPOINT write_entry');
-    } catch (e) {
-      try {
-        db.exec('ROLLBACK TO SAVEPOINT write_entry');
-        db.exec('RELEASE SAVEPOINT write_entry');
-      } catch {
-        // Ignore rollback failures — the throw below is what matters.
-      }
-      throw e;
+    writeEntryDbOnly(db, entry, opts);
+    writeEntryMirrors(hippoRoot, db, entry);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * DB-only write path. Caller owns the open `db` handle. Runs SAVEPOINT +
+ * upsert + afterWrite hook + audit row inside the SAVEPOINT scope. Caller
+ * is responsible for opening `db`, optionally wrapping in a larger BEGIN/
+ * COMMIT (e.g. supersede's BEGIN IMMEDIATE), closing `db`, AND calling
+ * `writeEntryMirrors` after the larger tx commits — mirrors must run
+ * post-commit so a rolled-back tx never leaves orphan markdown.
+ *
+ * Audit-order note: the audit row is emitted INSIDE the SAVEPOINT, so audit
+ * commits atomically with the row INSERT. A subsequent mirror failure cannot
+ * leave a recorded audit entry without its corresponding DB row. This is a
+ * documented hardening over the prior writeEntry-as-monolith ordering.
+ */
+export function writeEntryDbOnly(
+  db: DatabaseSyncLike,
+  entry: MemoryEntry,
+  opts?: {
+    actor?: string;
+    afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void;
+  },
+): void {
+  // SAVEPOINT (not BEGIN) so this nests safely inside any outer transaction
+  // a caller might hold (e.g. supersede's BEGIN IMMEDIATE). SQLite refuses
+  // BEGIN within a transaction; SAVEPOINT is the only way to scope rollback
+  // without disturbing outers.
+  db.exec('SAVEPOINT write_entry');
+  try {
+    upsertEntryRow(db, entry);
+    if (opts?.afterWrite) {
+      opts.afterWrite(db, entry.id);
     }
-    // Filesystem mirrors and audit emit run only after the SAVEPOINT releases,
-    // so a rolled-back write leaves no orphan markdown or index entries.
-    writeMarkdownMirror(hippoRoot, entry);
-    writeIndexMirror(hippoRoot, buildIndexFromDb(db));
     audit(
       db,
       'remember',
@@ -992,9 +1007,31 @@ export function writeEntry(
       opts?.actor ?? 'cli',
       entry.tenantId,
     );
-  } finally {
-    closeHippoDb(db);
+    db.exec('RELEASE SAVEPOINT write_entry');
+  } catch (e) {
+    try {
+      db.exec('ROLLBACK TO SAVEPOINT write_entry');
+      db.exec('RELEASE SAVEPOINT write_entry');
+    } catch {
+      // Ignore rollback failures — the throw below is what matters.
+    }
+    throw e;
   }
+}
+
+/**
+ * Filesystem mirrors path. Caller passes `hippoRoot` + an open `db` handle
+ * (used by `buildIndexFromDb` to derive the index from the source of truth).
+ * MUST be invoked AFTER the outer transaction commits — a mirror write
+ * during a tx that subsequently rolls back would leave orphan markdown.
+ */
+export function writeEntryMirrors(
+  hippoRoot: string,
+  db: DatabaseSyncLike,
+  entry: MemoryEntry,
+): void {
+  writeMarkdownMirror(hippoRoot, entry);
+  writeIndexMirror(hippoRoot, buildIndexFromDb(db));
 }
 
 /**

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -7,14 +7,14 @@ import { createMemory, Layer } from '../src/memory.js';
 import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
-  it('CURRENT_SCHEMA_VERSION is 19 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns)', () => {
-    expect(getCurrentSchemaVersion()).toBe(19);
+  it('CURRENT_SCHEMA_VERSION is 20 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill)', () => {
+    expect(getCurrentSchemaVersion()).toBe(20);
   });
 
-  it('fresh db migrates to v19', () => {
+  it('fresh db migrates to v20', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(19);
+    expect(getSchemaVersion(db)).toBe(20);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 20 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill)', () => {
-    expect(getCurrentSchemaVersion()).toBe(20);
+    expect(getCurrentSchemaVersion()).toBe(21);
   });
 
   it('fresh db migrates to v20', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(20);
+    expect(getSchemaVersion(db)).toBe(21);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -7,11 +7,11 @@ import { createMemory, Layer } from '../src/memory.js';
 import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
-  it('CURRENT_SCHEMA_VERSION is 20 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill)', () => {
+  it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
     expect(getCurrentSchemaVersion()).toBe(21);
   });
 
-  it('fresh db migrates to v20', () => {
+  it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
     expect(getSchemaVersion(db)).toBe(21);

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -7,14 +7,14 @@ import { createMemory, Layer } from '../src/memory.js';
 import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
-  it('CURRENT_SCHEMA_VERSION is 18 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth)', () => {
-    expect(getCurrentSchemaVersion()).toBe(18);
+  it('CURRENT_SCHEMA_VERSION is 19 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns)', () => {
+    expect(getCurrentSchemaVersion()).toBe(19);
   });
 
-  it('fresh db migrates to v18', () => {
+  it('fresh db migrates to v19', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(18);
+    expect(getSchemaVersion(db)).toBe(19);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('A5 schema migration v16: tenant_id columns', () => {
-  it('migrates to latest schema version (currently 20)', () => {
+  it('migrates to latest schema version (currently 21)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(20);
-      expect(getCurrentSchemaVersion()).toBe(20);
+      expect(getSchemaVersion(db)).toBe(21);
+      expect(getCurrentSchemaVersion()).toBe(21);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('A5 schema migration v16: tenant_id columns', () => {
-  it('migrates to latest schema version (currently 19)', () => {
+  it('migrates to latest schema version (currently 20)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(19);
-      expect(getCurrentSchemaVersion()).toBe(19);
+      expect(getSchemaVersion(db)).toBe(20);
+      expect(getCurrentSchemaVersion()).toBe(20);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('A5 schema migration v16: tenant_id columns', () => {
-  it('migrates to latest schema version (currently 18)', () => {
+  it('migrates to latest schema version (currently 19)', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(18);
-      expect(getCurrentSchemaVersion()).toBe(18);
+      expect(getSchemaVersion(db)).toBe(19);
+      expect(getCurrentSchemaVersion()).toBe(19);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(20);
-      expect(getCurrentSchemaVersion()).toBe(20);
+      expect(getSchemaVersion(db)).toBe(21);
+      expect(getCurrentSchemaVersion()).toBe(21);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('B3 schema migration v18', () => {
-  it('migrates to schema version 18', () => {
+  it('migrates to schema version 19', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(18);
-      expect(getCurrentSchemaVersion()).toBe(18);
+      expect(getSchemaVersion(db)).toBe(19);
+      expect(getCurrentSchemaVersion()).toBe(19);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion } from '../src/db.js';
 
 describe('B3 schema migration v18', () => {
-  it('migrates to schema version 19', () => {
+  it('migrates to schema version 20', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(19);
-      expect(getCurrentSchemaVersion()).toBe(19);
+      expect(getSchemaVersion(db)).toBe(20);
+      expect(getCurrentSchemaVersion()).toBe(20);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(20);
-      expect(getCurrentSchemaVersion()).toBe(20);
+      expect(getSchemaVersion(db)).toBe(21);
+      expect(getCurrentSchemaVersion()).toBe(21);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(18);
-      expect(getCurrentSchemaVersion()).toBe(18);
+      expect(getSchemaVersion(db)).toBe(19);
+      expect(getCurrentSchemaVersion()).toBe(19);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(19);
-      expect(getCurrentSchemaVersion()).toBe(19);
+      expect(getSchemaVersion(db)).toBe(20);
+      expect(getCurrentSchemaVersion()).toBe(20);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/raw-archive.test.ts
+++ b/tests/raw-archive.test.ts
@@ -21,9 +21,17 @@ describe('archiveRawMemory', () => {
     expect(archived.memory_id).toBe('r1');
     expect(archived.reason).toBe('GDPR right-to-be-forgotten');
     expect(archived.archived_by).toBe('user:42');
+    // v0.39 Path A: payload_json is metadata-only — original content is NOT
+    // stored. The audit_log row carries the compliance trail; raw_archive
+    // tracks only that an archive happened, for what tenant/kind, and why.
     const payload = JSON.parse(archived.payload_json) as Record<string, unknown>;
-    expect(payload.id).toBe('r1');
-    expect(payload.content).toBe('sensitive content');
+    expect(payload.redacted).toBe(true);
+    expect(payload.tenant_id).toBe('default');
+    expect(payload.kind).toBe('raw');
+    expect(payload.reason).toBe('GDPR right-to-be-forgotten');
+    expect(typeof payload.archived_at).toBe('string');
+    expect(payload.id).toBeUndefined();
+    expect(payload.content).toBeUndefined();
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/server-bearer-lockdown.test.ts
+++ b/tests/server-bearer-lockdown.test.ts
@@ -30,22 +30,51 @@ describe('server Bearer lockdown', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  const v1Routes: ReadonlyArray<{ method: string; path: string; body?: string }> = [
+  // v0.39 commit 5: route-parity expansion — every authed route in
+  // src/server.ts is parameterized here. /v1/connectors/slack/events is
+  // public-by-design (HMAC-verified) and covered by Slack tests; /health
+  // is public and needs no test. 12 authed routes total.
+  const authedRoutes: ReadonlyArray<{ method: string; path: string; body?: string }> = [
     { method: 'POST', path: '/v1/memories', body: '{"content":"x"}' },
-    { method: 'GET', path: '/v1/memories?q=x' },
-    { method: 'POST', path: '/v1/auth/keys', body: '{}' },
+    { method: 'GET', path: '/v1/memories?q=test' },
+    { method: 'POST', path: '/v1/memories/abc/archive', body: '{"reason":"x"}' },
+    { method: 'POST', path: '/v1/memories/abc/supersede', body: '{"content":"y"}' },
+    { method: 'POST', path: '/v1/memories/abc/promote' },
+    { method: 'DELETE', path: '/v1/memories/abc' },
+    { method: 'POST', path: '/v1/auth/keys', body: '{"label":"x"}' },
     { method: 'GET', path: '/v1/auth/keys' },
+    { method: 'DELETE', path: '/v1/auth/keys/hk_xyz' },
     { method: 'GET', path: '/v1/audit' },
+    { method: 'POST', path: '/mcp', body: '{"jsonrpc":"2.0","method":"tools/list","id":1}' },
+    { method: 'GET', path: '/mcp/stream' },
   ];
 
-  it('all /v1/* routes except slack require Bearer', async () => {
-    for (const r of v1Routes) {
-      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, {
+  it.each(authedRoutes)(
+    'requires Bearer: $method $path (missing header)',
+    async (r) => {
+      const init: RequestInit = {
         method: r.method,
         headers: { 'content-type': 'application/json' },
-        body: r.body,
-      });
+      };
+      if (r.body !== undefined) init.body = r.body;
+      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, init);
       expect(res.status, `${r.method} ${r.path}`).toBe(401);
-    }
-  });
+    },
+  );
+
+  it.each(authedRoutes)(
+    'requires Bearer: $method $path (bad token)',
+    async (r) => {
+      const init: RequestInit = {
+        method: r.method,
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer hk_invalid.deadbeef',
+        },
+      };
+      if (r.body !== undefined) init.body = r.body;
+      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, init);
+      expect(res.status, `${r.method} ${r.path}`).toBe(401);
+    },
+  );
 });

--- a/tests/slack-tenant-routing.test.ts
+++ b/tests/slack-tenant-routing.test.ts
@@ -30,24 +30,30 @@ describe('resolveTenantForTeam', () => {
     }
   });
 
-  it('returns null when slack_workspaces is empty', () => {
+  it('falls back to env tenant when slack_workspaces is empty (single-workspace install)', () => {
     const db = openHippoDb(root);
+    const prev = process.env.HIPPO_TENANT;
+    process.env.HIPPO_TENANT = 'env-tenant';
     try {
-      expect(resolveTenantForTeam(db, 'TANY')).toBeNull();
+      // v0.39 fail-closed contract: empty slack_workspaces means single-
+      // workspace install, env fallback is safe.
+      expect(resolveTenantForTeam(db, 'TANY')).toBe('env-tenant');
     } finally {
+      if (prev === undefined) delete process.env.HIPPO_TENANT;
+      else process.env.HIPPO_TENANT = prev;
       closeHippoDb(db);
     }
   });
 
-  it('matches team_id exactly (no prefix bleed)', () => {
+  it('matches team_id exactly (no prefix bleed) — fails closed on unknown when workspaces non-empty', () => {
     const db = openHippoDb(root);
     try {
       db.prepare(
         `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
       ).run('TTEAM', 'tenant-short', new Date().toISOString());
-      // Prefix-extended id must NOT match.
+      // Prefix-extended id must NOT match — fail closed (workspaces non-empty).
       expect(resolveTenantForTeam(db, 'TTEAMX')).toBeNull();
-      // Substring must NOT match.
+      // Substring must NOT match — fail closed.
       expect(resolveTenantForTeam(db, 'TTEA')).toBeNull();
       // Exact still works.
       expect(resolveTenantForTeam(db, 'TTEAM')).toBe('tenant-short');

--- a/tests/v039-api-tenant-isolation.test.ts
+++ b/tests/v039-api-tenant-isolation.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, readEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey } from '../src/auth.js';
+import { queryAuditEvents } from '../src/audit.js';
+import {
+  remember,
+  promote,
+  forget,
+  supersede,
+  archiveRaw,
+} from '../src/api.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+// v0.39 commit 1 regressions:
+//  - promote: tenant pre-check matches archiveRaw (CRITICAL #1)
+//  - forget: lock the existing tenant pre-check invariant
+//  - archiveRaw: lock the existing tenant pre-check invariant (already covered
+//    in api-tenant-deny.test.ts; duplicated here for one-stop hardening surface)
+//  - authCreate: HTTP body.tenantId ignored, key bound to caller (CRITICAL #2)
+//  - supersede: BEGIN IMMEDIATE CAS — direct SQL race + clean path + tenant scope
+//    (CRITICAL #4)
+
+function makeRoot(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), `hippo-${prefix}-`));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('v039 api tenant isolation', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+
+  beforeEach(() => {
+    home = makeRoot('v039');
+    globalHome = makeRoot('v039-global');
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+  });
+
+  afterEach(() => {
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+    try { rmSync(globalHome, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  // ---- Test 1: promote cross-tenant denied ----------------------------------
+  it('promote refuses to promote a row that belongs to another tenant', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-row promote-cross-tenant canary' },
+    );
+
+    expect(() =>
+      promote(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+      ),
+    ).toThrow(/memory not found/i);
+
+    // The original row must still exist on the local root, untouched.
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // The global root must NOT have a copy. promoteToGlobal must never have
+    // run because the tenant pre-check throws before it does.
+    const gdb = openHippoDb(globalHome);
+    try {
+      const grows = gdb.prepare(`SELECT COUNT(*) AS c FROM memories`).get() as { c: number };
+      expect(Number(grows.c)).toBe(0);
+    } finally {
+      closeHippoDb(gdb);
+    }
+  });
+
+  // ---- Test 2: forget cross-tenant denied -----------------------------------
+  it('forget refuses to delete a row that belongs to another tenant (lock invariant)', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-row forget-cross-tenant canary' },
+    );
+
+    expect(() =>
+      forget(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+      ),
+    ).toThrow(/memory not found/i);
+
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 3: archiveRaw cross-tenant denied -------------------------------
+  it('archiveRaw refuses to archive a row that belongs to another tenant (lock invariant)', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-raw archiveraw-cross-tenant canary', kind: 'raw' },
+    );
+
+    expect(() =>
+      archiveRaw(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+        'cross-tenant probe',
+      ),
+    ).toThrow(/memory not found/i);
+
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id, kind FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string; kind: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+      expect(row!.kind).toBe('raw');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 5: supersede CAS — direct SQL race -------------------------------
+  // The CAS UPDATE in supersede() is:
+  //   UPDATE memories SET superseded_by = ?
+  //    WHERE id = ? AND tenant_id = ? AND superseded_by IS NULL
+  // The WHERE-clause `superseded_by IS NULL` is the race guard. Two assertions:
+  //   (a) The user-visible contract: pre-setting superseded_by causes
+  //       supersede() to throw with the "already superseded" wording. The
+  //       readEntry early guard wins in the single-process case, which is
+  //       fine — it surfaces the same observable contract (a concurrent
+  //       writer prevents this supersede from succeeding) and uses the
+  //       same canonical error wording.
+  //   (b) The CAS WHERE-clause itself: run the exact UPDATE statement that
+  //       supersede() runs against a row whose `superseded_by` is already
+  //       non-NULL, and assert `changes=0`. This locks the SQL contract
+  //       independently of supersede()'s control flow, so a future refactor
+  //       that drops the `IS NULL` guard would fail this test even if the
+  //       early-readEntry guard still fires.
+  it('supersede CAS: pre-superseded row throws + WHERE clause returns changes=0', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-row supersede CAS race canary' },
+    );
+
+    // Pre-set superseded_by to simulate a concurrent writer that won.
+    const db = openHippoDb(home);
+    try {
+      db.prepare(`UPDATE memories SET superseded_by = ? WHERE id = ?`).run(
+        'mem_preexisting_racer',
+        created.id,
+      );
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // (a) supersede() throws with the canonical wording.
+    expect(() =>
+      supersede(
+        { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+        created.id,
+        'replacement content',
+      ),
+    ).toThrow(/already superseded/i);
+
+    // (b) Direct SQL: the CAS WHERE clause returns changes=0 against a row
+    //     whose `superseded_by` is already non-NULL.
+    const db2 = openHippoDb(home);
+    try {
+      const result = db2.prepare(`
+        UPDATE memories
+        SET superseded_by = ?
+        WHERE id = ? AND tenant_id = ? AND superseded_by IS NULL
+      `).run('mem_would_be_new', created.id, 'alpha');
+      expect(Number(result.changes ?? 0)).toBe(0);
+
+      // And the pre-existing supersede pointer is untouched.
+      const row = db2
+        .prepare(`SELECT superseded_by FROM memories WHERE id = ?`)
+        .get(created.id) as { superseded_by: string | null } | undefined;
+      expect(row?.superseded_by).toBe('mem_preexisting_racer');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  // ---- Test 6: supersede CAS — clean path -----------------------------------
+  it('supersede CAS clean path: both rows present, audit row written, chain pointer set', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-row supersede clean-path canary' },
+    );
+
+    const result = supersede(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      created.id,
+      'fresh replacement content',
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.oldId).toBe(created.id);
+    expect(result.newId).toMatch(/^mem_/);
+
+    // Old row carries the chain pointer.
+    const oldEntry = readEntry(home, created.id, 'alpha');
+    expect(oldEntry).not.toBeNull();
+    expect(oldEntry!.superseded_by).toBe(result.newId);
+
+    // New row landed.
+    const newEntry = readEntry(home, result.newId, 'alpha');
+    expect(newEntry).not.toBeNull();
+    expect(newEntry!.content).toBe('fresh replacement content');
+    expect(newEntry!.tenantId).toBe('alpha');
+
+    // Audit log: 'supersede' op with newId metadata + 'remember' for the new row.
+    const db = openHippoDb(home);
+    try {
+      const supersedeEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'supersede' });
+      const supersedeRow = supersedeEvents.find((e) => e.targetId === created.id);
+      expect(supersedeRow).toBeDefined();
+      expect((supersedeRow!.metadata as { newId?: string }).newId).toBe(result.newId);
+
+      const rememberEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'remember' });
+      const rememberRow = rememberEvents.find((e) => e.targetId === result.newId);
+      expect(rememberRow).toBeDefined();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 7: supersede CAS — tenant-scoped --------------------------------
+  it('supersede across tenants throws "Memory not found" via readEntry tenant scope', () => {
+    const created = remember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-row supersede tenant-scope canary' },
+    );
+
+    expect(() =>
+      supersede(
+        { hippoRoot: home, tenantId: 'bravo', actor: 'api_key:bravo-key' },
+        created.id,
+        'cross-tenant supersede attempt',
+      ),
+    ).toThrow(/memory not found/i);
+
+    // The original row is untouched: no superseded_by, no new memory created.
+    const db = openHippoDb(home);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id, superseded_by FROM memories WHERE id = ?`)
+        .get(created.id) as { tenant_id: string; superseded_by: string | null } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+      expect(row!.superseded_by).toBeNull();
+
+      const totalRows = db.prepare(`SELECT COUNT(*) AS c FROM memories`).get() as { c: number };
+      expect(Number(totalRows.c)).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: authCreate body tenantId ignored (HTTP layer regression)
+// ---------------------------------------------------------------------------
+//
+// HTTP POST /v1/auth/keys with a Bearer for tenant alpha and a body
+// containing tenantId='bravo' must mint the key for ALPHA, not bravo.
+// The body field is ignored at the HTTP layer; opts.tenantId no longer
+// exists on AuthCreateOpts.
+
+describe('v039 authCreate HTTP body.tenantId ignored', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot('v039-authcreate');
+    globalHome = makeRoot('v039-authcreate-global');
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+    try { rmSync(globalHome, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  it('POST /v1/auth/keys ignores body.tenantId, binds key to bearer tenant', async () => {
+    // Mint an alpha key directly so we have a Bearer for tenant alpha.
+    const db = openHippoDb(home);
+    let alphaPlaintext: string;
+    try {
+      const created = createApiKey(db, { tenantId: 'alpha', label: 'alpha-bootstrap' });
+      alphaPlaintext = created.plaintext;
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // Call POST /v1/auth/keys as alpha but try to smuggle tenantId='bravo'
+    // in the body. The route handler must drop body.tenantId and bind the
+    // new key to ctx.tenantId='alpha'.
+    const res = await fetch(`${handle.url}/v1/auth/keys`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': `Bearer ${alphaPlaintext}`,
+      },
+      body: JSON.stringify({ tenantId: 'bravo', label: 'should-be-alpha' }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { keyId: string; plaintext: string; tenantId: string };
+    expect(body.tenantId).toBe('alpha');
+    expect(body.keyId).toMatch(/^hk_/);
+
+    // Confirm in the DB: the api_keys row carries tenant_id='alpha'.
+    const db2 = openHippoDb(home);
+    try {
+      const row = db2
+        .prepare(`SELECT tenant_id FROM api_keys WHERE key_id = ?`)
+        .get(body.keyId) as { tenant_id: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.tenant_id).toBe('alpha');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+});

--- a/tests/v039-gdpr-completeness.test.ts
+++ b/tests/v039-gdpr-completeness.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import {
   openHippoDb,
   closeHippoDb,
-  getMeta,
 } from '../src/db.js';
 import { remember, archiveRaw, recall } from '../src/api.js';
 import { queryAuditEvents } from '../src/audit.js';
@@ -18,6 +17,11 @@ import { queryAuditEvents } from '../src/audit.js';
  *   1. Markdown mirror reaper after migration v20 (RTBF on historical archives)
  *   2. Recall audit stores sha256(query) hash instead of original query text
  *   3. archiveRaw mirror cleanup wrapped in try/catch; reaper handles retry
+ *
+ * Codex round 3 update: the reaper now tracks completion per-row via
+ * raw_archive.mirror_cleaned_at (v21), not via a global meta flag. Tests
+ * assert the per-row contract: cleaned rows get a timestamp; failed unlinks
+ * leave the column NULL so the next openHippoDb retries.
  *
  * The full-DB canary scan (test 4) is the load-bearing assertion: after the
  * archive + redact + hash flow, the original content must not exist in any
@@ -40,7 +44,8 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
 
   it('1. mirror reaper deletes markdown files for raw_archive rows on first open', () => {
     // Bootstrap a fresh DB so we can hand-craft a "v18-style" raw_archive row
-    // and matching markdown mirror that would have existed pre-70180b5.
+    // (mirror_cleaned_at NULL) and matching markdown mirror that would have
+    // existed pre-70180b5.
     const db1 = openHippoDb(root);
     try {
       db1
@@ -54,12 +59,6 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
           'cli',
           JSON.stringify({ redacted: true, tenant_id: 'default', kind: 'raw' }),
         );
-      // Rewind cleanup flag so a re-open triggers the reaper.
-      db1
-        .prepare(
-          `INSERT INTO meta(key, value) VALUES('gdpr_v20_mirror_cleanup', '') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
-        )
-        .run();
     } finally {
       closeHippoDb(db1);
     }
@@ -75,29 +74,45 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
     );
     expect(existsSync(orphanPath)).toBe(true);
 
-    // Re-open: reaper runs, file disappears.
+    // Re-open: reaper runs, file disappears, per-row timestamp set.
     const db2 = openHippoDb(root);
     try {
       expect(existsSync(orphanPath)).toBe(false);
-      expect(getMeta(db2, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+      const cleanedAt = (
+        db2
+          .prepare(`SELECT mirror_cleaned_at FROM raw_archive WHERE memory_id = ?`)
+          .get('mem_legacy_canary_1') as { mirror_cleaned_at?: string | null }
+      )?.mirror_cleaned_at;
+      expect(cleanedAt).toBeTruthy();
     } finally {
       closeHippoDb(db2);
     }
 
-    // Re-open again: idempotent — reaper short-circuits, no errors.
+    // Re-open again: idempotent — reaper SELECT returns empty, no errors.
     const db3 = openHippoDb(root);
     try {
-      expect(getMeta(db3, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+      const stillCleaned = (
+        db3
+          .prepare(`SELECT mirror_cleaned_at FROM raw_archive WHERE memory_id = ?`)
+          .get('mem_legacy_canary_1') as { mirror_cleaned_at?: string | null }
+      )?.mirror_cleaned_at;
+      expect(stillCleaned).toBeTruthy();
+      // Confirm zero pending rows.
+      const pending = (
+        db3
+          .prepare(`SELECT COUNT(*) AS c FROM raw_archive WHERE mirror_cleaned_at IS NULL`)
+          .get() as { c?: number }
+      )?.c;
+      expect(pending).toBe(0);
     } finally {
       closeHippoDb(db3);
     }
   });
 
   it('2. mirror reaper is idempotent on a DB with zero raw_archive rows', () => {
-    // Fresh open — no raw_archive rows. Reaper should set the meta flag and exit cleanly.
+    // Fresh open — no raw_archive rows. Reaper should exit cleanly.
     const db = openHippoDb(root);
     try {
-      expect(getMeta(db, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
       const count = (
         db.prepare(`SELECT COUNT(*) AS c FROM raw_archive`).get() as { c?: number }
       )?.c;
@@ -113,8 +128,6 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
     const ctx = { hippoRoot: root, tenantId: 'default', actor: 'cli' };
     const live = remember(ctx, { content: 'i-am-still-alive-content' });
 
-    // Force re-run of reaper on next open by inserting a raw_archive row +
-    // resetting the meta flag.
     const db1 = openHippoDb(root);
     try {
       db1
@@ -128,19 +141,19 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
           'cli',
           JSON.stringify({ redacted: true, tenant_id: 'default', kind: 'raw' }),
         );
-      db1
-        .prepare(
-          `INSERT INTO meta(key, value) VALUES('gdpr_v20_mirror_cleanup', '') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
-        )
-        .run();
     } finally {
       closeHippoDb(db1);
     }
 
-    // Re-open: reaper runs. live memory's mirror must survive.
+    // Re-open: reaper runs. Live memory's mirror must survive.
     const db2 = openHippoDb(root);
     try {
-      expect(getMeta(db2, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+      const cleanedAt = (
+        db2
+          .prepare(`SELECT mirror_cleaned_at FROM raw_archive WHERE memory_id = ?`)
+          .get('mem_other_archived_id') as { mirror_cleaned_at?: string | null }
+      )?.mirror_cleaned_at;
+      expect(cleanedAt).toBeTruthy();
     } finally {
       closeHippoDb(db2);
     }
@@ -152,6 +165,91 @@ describe('v0.39 GDPR Path A completeness fixes', () => {
       existsSync(join(root, layer, `${live.id}.md`)),
     );
     expect(liveStillPresent).toBe(true);
+  });
+
+  it('2c. reaper retries: mirror_cleaned_at stays NULL when no work done, set on next open', () => {
+    // Per-row contract: a row with mirror_cleaned_at IS NULL is processed every
+    // open until it succeeds. We verify the success path here by:
+    //   1. Inserting a raw_archive row + planting a mirror file.
+    //   2. Asserting first open clears the mirror and stamps the row.
+    //   3. Asserting a second open's reaper SELECT returns 0 pending rows
+    //      (proving the row is no longer revisited — the steady state).
+    //
+    // Reproducing a real unlink failure on Windows requires either ACL
+    // manipulation (flaky in CI) or a held file handle (race-sensitive). We
+    // use the more direct contract test: assert the SELECT WHERE NULL bound
+    // shrinks to 0 once cleanup succeeds, which is the load-bearing property
+    // for "retry on next open" — failures keep the row in the SELECT, success
+    // removes it.
+    const memId = 'mem_retry_canary_1';
+
+    const db1 = openHippoDb(root);
+    try {
+      db1
+        .prepare(
+          `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          memId,
+          '2026-04-15T00:00:00.000Z',
+          'GDPR purge',
+          'cli',
+          JSON.stringify({ redacted: true, tenant_id: 'default', kind: 'raw' }),
+        );
+      // Pre-condition: row is in the reaper's SELECT set.
+      const pendingBefore = (
+        db1
+          .prepare(`SELECT COUNT(*) AS c FROM raw_archive WHERE mirror_cleaned_at IS NULL`)
+          .get() as { c?: number }
+      )?.c;
+      expect(pendingBefore).toBe(1);
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    // Plant the mirror in episodic (one of the LAYERS the reaper sweeps).
+    const episodicDir = join(root, 'episodic');
+    mkdirSync(episodicDir, { recursive: true });
+    const mirrorPath = join(episodicDir, `${memId}.md`);
+    writeFileSync(mirrorPath, 'legacy mirror content', 'utf8');
+
+    // Open #1: reaper runs, unlinks mirror, stamps row.
+    const db2 = openHippoDb(root);
+    try {
+      expect(existsSync(mirrorPath)).toBe(false);
+      const pendingAfter = (
+        db2
+          .prepare(`SELECT COUNT(*) AS c FROM raw_archive WHERE mirror_cleaned_at IS NULL`)
+          .get() as { c?: number }
+      )?.c;
+      expect(pendingAfter).toBe(0);
+    } finally {
+      closeHippoDb(db2);
+    }
+
+    // Open #2: reaper SELECTs WHERE NULL and gets 0 rows — no re-processing
+    // of a row that's already been cleaned. This is the regression guard
+    // against the previous one-shot meta gate that, once flipped to 'done',
+    // never revisited stale work.
+    const db3 = openHippoDb(root);
+    try {
+      const stillNoPending = (
+        db3
+          .prepare(`SELECT COUNT(*) AS c FROM raw_archive WHERE mirror_cleaned_at IS NULL`)
+          .get() as { c?: number }
+      )?.c;
+      expect(stillNoPending).toBe(0);
+      // Idempotency belt-and-braces: timestamp is unchanged across opens
+      // (we don't re-stamp already-cleaned rows).
+      const cleanedAt = (
+        db3
+          .prepare(`SELECT mirror_cleaned_at FROM raw_archive WHERE memory_id = ?`)
+          .get(memId) as { mirror_cleaned_at?: string }
+      )?.mirror_cleaned_at;
+      expect(cleanedAt).toBeTruthy();
+    } finally {
+      closeHippoDb(db3);
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/v039-gdpr-completeness.test.ts
+++ b/tests/v039-gdpr-completeness.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import {
+  openHippoDb,
+  closeHippoDb,
+  getMeta,
+} from '../src/db.js';
+import { remember, archiveRaw, recall } from '../src/api.js';
+import { queryAuditEvents } from '../src/audit.js';
+
+/**
+ * v0.39 GDPR Path A completeness regression suite.
+ *
+ * Closes the three holes flagged by the pre-landing /review:
+ *   1. Markdown mirror reaper after migration v20 (RTBF on historical archives)
+ *   2. Recall audit stores sha256(query) hash instead of original query text
+ *   3. archiveRaw mirror cleanup wrapped in try/catch; reaper handles retry
+ *
+ * The full-DB canary scan (test 4) is the load-bearing assertion: after the
+ * archive + redact + hash flow, the original content must not exist in any
+ * persistent table.
+ */
+describe('v0.39 GDPR Path A completeness fixes', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-v039-completeness-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 1: post-migration mirror reaper for legacy archives
+  // ---------------------------------------------------------------------------
+
+  it('1. mirror reaper deletes markdown files for raw_archive rows on first open', () => {
+    // Bootstrap a fresh DB so we can hand-craft a "v18-style" raw_archive row
+    // and matching markdown mirror that would have existed pre-70180b5.
+    const db1 = openHippoDb(root);
+    try {
+      db1
+        .prepare(
+          `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'mem_legacy_canary_1',
+          '2026-04-01T00:00:00.000Z',
+          'GDPR purge',
+          'cli',
+          JSON.stringify({ redacted: true, tenant_id: 'default', kind: 'raw' }),
+        );
+      // Rewind cleanup flag so a re-open triggers the reaper.
+      db1
+        .prepare(
+          `INSERT INTO meta(key, value) VALUES('gdpr_v20_mirror_cleanup', '') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+        )
+        .run();
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    // Plant the orphan markdown file containing the original content.
+    const episodicDir = join(root, 'episodic');
+    mkdirSync(episodicDir, { recursive: true });
+    const orphanPath = join(episodicDir, 'mem_legacy_canary_1.md');
+    writeFileSync(
+      orphanPath,
+      '# legacy memory\n\noriginal-content-canary-FORGET-ME-quaxle',
+      'utf8',
+    );
+    expect(existsSync(orphanPath)).toBe(true);
+
+    // Re-open: reaper runs, file disappears.
+    const db2 = openHippoDb(root);
+    try {
+      expect(existsSync(orphanPath)).toBe(false);
+      expect(getMeta(db2, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+    } finally {
+      closeHippoDb(db2);
+    }
+
+    // Re-open again: idempotent — reaper short-circuits, no errors.
+    const db3 = openHippoDb(root);
+    try {
+      expect(getMeta(db3, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+    } finally {
+      closeHippoDb(db3);
+    }
+  });
+
+  it('2. mirror reaper is idempotent on a DB with zero raw_archive rows', () => {
+    // Fresh open — no raw_archive rows. Reaper should set the meta flag and exit cleanly.
+    const db = openHippoDb(root);
+    try {
+      expect(getMeta(db, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+      const count = (
+        db.prepare(`SELECT COUNT(*) AS c FROM raw_archive`).get() as { c?: number }
+      )?.c;
+      expect(count).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('2b. mirror reaper does NOT delete mirrors of non-archived (live) memories', () => {
+    // Plant a raw_archive row + a UNRELATED live memory with a mirror; reaper
+    // must only touch files whose id appears in raw_archive.
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'cli' };
+    const live = remember(ctx, { content: 'i-am-still-alive-content' });
+
+    // Force re-run of reaper on next open by inserting a raw_archive row +
+    // resetting the meta flag.
+    const db1 = openHippoDb(root);
+    try {
+      db1
+        .prepare(
+          `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'mem_other_archived_id',
+          '2026-04-01T00:00:00.000Z',
+          'GDPR purge',
+          'cli',
+          JSON.stringify({ redacted: true, tenant_id: 'default', kind: 'raw' }),
+        );
+      db1
+        .prepare(
+          `INSERT INTO meta(key, value) VALUES('gdpr_v20_mirror_cleanup', '') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+        )
+        .run();
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    // Re-open: reaper runs. live memory's mirror must survive.
+    const db2 = openHippoDb(root);
+    try {
+      expect(getMeta(db2, 'gdpr_v20_mirror_cleanup', '')).toBe('done');
+    } finally {
+      closeHippoDb(db2);
+    }
+
+    // The live memory's markdown file should still exist somewhere under the
+    // layer dirs (writeEntry mirrors it on remember).
+    const layers = ['episodic', 'buffer', 'semantic'];
+    const liveStillPresent = layers.some((layer) =>
+      existsSync(join(root, layer, `${live.id}.md`)),
+    );
+    expect(liveStillPresent).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 2: recall audit stores query_hash, not query text
+  // ---------------------------------------------------------------------------
+
+  it('3. recall audit_log row stores query_hash + query_length, no query field', () => {
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'cli' };
+    remember(ctx, { content: 'something to find with the canary query' });
+
+    const distinctive = 'gdpr-canary-quaxle-2026';
+    recall(ctx, { query: distinctive });
+
+    const db = openHippoDb(root);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'recall' });
+      expect(events.length).toBeGreaterThan(0);
+      const meta = events[0].metadata as Record<string, unknown>;
+      const expectedHash = createHash('sha256').update(distinctive).digest('hex').slice(0, 16);
+      expect(meta.query_hash).toBe(expectedHash);
+      expect(meta.query_length).toBe(distinctive.length);
+      expect(meta.query).toBeUndefined();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fix 3 verification (also full RTBF): canary scan across all tables
+  // ---------------------------------------------------------------------------
+
+  it('4. full RTBF: original content + query text appear in zero persistent tables after archive', () => {
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'cli' };
+    const canary = 'gdpr-canary-99-special-token-xyz';
+
+    // Seed: kind='raw' so it can be archived. Content embeds the canary.
+    const { id } = remember(ctx, {
+      content: `payload contains ${canary} as a secret`,
+      kind: 'raw',
+    });
+
+    // Archive (RTBF). Mirror cleanup must NOT throw.
+    archiveRaw(ctx, id, 'GDPR right-to-be-forgotten');
+
+    // Recall using the canary as the query — must not bring back the archived row.
+    recall(ctx, { query: canary });
+
+    // Markdown mirrors gone.
+    const layers = ['episodic', 'buffer', 'semantic'];
+    for (const layer of layers) {
+      const file = join(root, layer, `${id}.md`);
+      expect(existsSync(file)).toBe(false);
+    }
+
+    // Full-DB scan: enumerate every user table, dump every TEXT/BLOB column,
+    // assert the canary appears nowhere.
+    const db = openHippoDb(root);
+    try {
+      const tables = (
+        db
+          .prepare(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '%_fts%' AND name NOT LIKE '%_config' AND name NOT LIKE '%_data' AND name NOT LIKE '%_idx' AND name NOT LIKE '%_docsize' AND name NOT LIKE '%_content'`,
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name);
+
+      const hits: Array<{ table: string; row: unknown }> = [];
+      for (const table of tables) {
+        const rows = db.prepare(`SELECT * FROM "${table}"`).all() as Array<Record<string, unknown>>;
+        for (const row of rows) {
+          const blob = JSON.stringify(row);
+          if (blob.includes(canary)) {
+            hits.push({ table, row });
+          }
+        }
+      }
+      // FTS5 is intentionally excluded above (its shadow tables can hold pre-
+      // delete tokens for a moment). The persistent record tables must be clean.
+      expect(hits).toEqual([]);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('5. cross-recall non-leakage: two recalls before/after archive both leave hash-only audit rows', () => {
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'cli' };
+    const queryText = 'special-private-cross-recall-string';
+    const { id } = remember(ctx, {
+      content: `contains ${queryText} as content`,
+      kind: 'raw',
+    });
+
+    // Recall #1: matches.
+    const r1 = recall(ctx, { query: queryText });
+    expect(r1.results.length).toBeGreaterThanOrEqual(1);
+
+    // Archive.
+    archiveRaw(ctx, id, 'GDPR purge');
+
+    // Recall #2: same query text, no match.
+    const r2 = recall(ctx, { query: queryText });
+    expect(r2.results.length).toBe(0);
+
+    const db = openHippoDb(root);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'recall' });
+      expect(events.length).toBe(2);
+      const expectedHash = createHash('sha256').update(queryText).digest('hex').slice(0, 16);
+      for (const ev of events) {
+        const meta = ev.metadata as Record<string, unknown>;
+        expect(meta.query).toBeUndefined();
+        expect(meta.query_hash).toBe(expectedHash);
+        expect(meta.query_length).toBe(queryText.length);
+      }
+
+      // Belt-and-braces: query text appears nowhere in audit_log raw json.
+      const rawAudit = db
+        .prepare(`SELECT metadata_json FROM audit_log`)
+        .all() as Array<{ metadata_json: string }>;
+      for (const r of rawAudit) {
+        expect(r.metadata_json).not.toContain(queryText);
+      }
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(20);
+    expect(getCurrentSchemaVersion()).toBe(21);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(20);
+      expect(getSchemaVersion(db)).toBe(21);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(20);
+      expect(getSchemaVersion(db2)).toBe(21);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(20);
+      expect(getSchemaVersion(db2)).toBe(21);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  openHippoDb,
+  closeHippoDb,
+  getCurrentSchemaVersion,
+  getSchemaVersion,
+} from '../src/db.js';
+import { remember, archiveRaw, recall } from '../src/api.js';
+
+/**
+ * v0.39 GDPR Path A regression suite.
+ *
+ * Path A semantics: archiveRawMemory writes a redacted metadata-only payload
+ * to raw_archive instead of snapshotting the full row. The compliance audit
+ * trail lives in audit_log (op='archive_raw'). True right-to-be-forgotten —
+ * after archive, the original content is unrecoverable from the database.
+ *
+ * Migration v20 backfills existing raw_archive rows to the new shape,
+ * preserving tenant_id and kind from the legacy payload when parseable and
+ * falling back to 'unknown' when the legacy JSON is malformed.
+ */
+describe('v0.39 GDPR Path A redaction + migration v20', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-v039-gdpr-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
+    expect(getCurrentSchemaVersion()).toBe(20);
+    const db = openHippoDb(root);
+    try {
+      expect(getSchemaVersion(db)).toBe(20);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('2. fresh archive Path A: payload_json is metadata-only (no original content)', () => {
+    const ctx = { hippoRoot: root, tenantId: 'tenant-A', actor: 'cli' };
+    const { id } = remember(ctx, {
+      content: 'a-very-distinctive-secret-string-zylph123',
+      kind: 'raw',
+    });
+    archiveRaw(ctx, id, 'GDPR right-to-be-forgotten');
+
+    const db = openHippoDb(root);
+    try {
+      const archived = db
+        .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
+        .get(id) as { payload_json: string } | undefined;
+      expect(archived).toBeDefined();
+      const payload = JSON.parse(archived!.payload_json) as Record<string, unknown>;
+      expect(payload.redacted).toBe(true);
+      expect(payload.tenant_id).toBe('tenant-A');
+      expect(payload.kind).toBe('raw');
+      expect(payload.reason).toBe('GDPR right-to-be-forgotten');
+      expect(typeof payload.archived_at).toBe('string');
+      // Critical: original content fields are NOT present.
+      expect(payload.id).toBeUndefined();
+      expect(payload.content).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain('zylph123');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('3. migration v20 backfill: legacy payload with full content is redacted, tenant_id + kind preserved', () => {
+    // Open at current version, then rewind schema_version meta to 19 so
+    // reopening triggers the v20 migration. Hand-insert a legacy raw_archive
+    // row whose payload_json carries the original content shape.
+    const db1 = openHippoDb(root);
+    try {
+      db1
+        .prepare(
+          `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'm-legacy-1',
+          '2026-04-01T00:00:00.000Z',
+          'GDPR purge',
+          'user:42',
+          JSON.stringify({
+            id: 'm-legacy-1',
+            content: 'legacy-secret-canary-xyzzy',
+            tenant_id: 't1',
+            kind: 'raw',
+          }),
+        );
+      // Rewind schema_version so the next openHippoDb() re-runs migration v20
+      // against the row we just seeded.
+      db1
+        .prepare(
+          `INSERT INTO meta(key, value) VALUES('schema_version', '19') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+        )
+        .run();
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    const db2 = openHippoDb(root);
+    try {
+      expect(getSchemaVersion(db2)).toBe(20);
+      const row = db2
+        .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
+        .get('m-legacy-1') as { payload_json: string };
+      const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+      expect(payload.redacted).toBe(true);
+      expect(payload.tenant_id).toBe('t1');
+      expect(payload.kind).toBe('raw');
+      expect(payload.reason).toBe('GDPR purge');
+      expect(payload.archived_at).toBe('2026-04-01T00:00:00.000Z');
+      expect(payload.migration).toBe('v20_redact');
+      // Original content gone.
+      expect(JSON.stringify(payload)).not.toContain('xyzzy');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('4. migration v20 with malformed legacy payload: falls back to unknowns', () => {
+    const db1 = openHippoDb(root);
+    try {
+      db1
+        .prepare(
+          `INSERT INTO raw_archive (memory_id, archived_at, reason, archived_by, payload_json) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          'm-malformed-1',
+          '2026-04-02T00:00:00.000Z',
+          'corrupted legacy',
+          'user:99',
+          'not-json',
+        );
+      db1
+        .prepare(
+          `INSERT INTO meta(key, value) VALUES('schema_version', '19') ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
+        )
+        .run();
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    const db2 = openHippoDb(root);
+    try {
+      expect(getSchemaVersion(db2)).toBe(20);
+      const row = db2
+        .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
+        .get('m-malformed-1') as { payload_json: string };
+      const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+      expect(payload.redacted).toBe(true);
+      expect(payload.tenant_id).toBe('unknown');
+      expect(payload.kind).toBe('unknown');
+      expect(payload.reason).toBe('corrupted legacy');
+      expect(payload.archived_at).toBe('2026-04-02T00:00:00.000Z');
+      expect(payload.migration).toBe('v20_redact');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('5. audit row preserved: archiveRaw writes audit_log op=archive_raw even though raw_archive is gone', () => {
+    const ctx = { hippoRoot: root, tenantId: 'tenant-B', actor: 'user:42' };
+    const { id } = remember(ctx, { content: 'audit-trail-content', kind: 'raw' });
+    archiveRaw(ctx, id, 'compliance test');
+
+    const db = openHippoDb(root);
+    try {
+      const auditRows = db
+        .prepare(
+          `SELECT tenant_id, actor, op, target_id, metadata_json FROM audit_log WHERE op = 'archive_raw' AND target_id = ?`,
+        )
+        .all(id) as Array<{
+        tenant_id: string;
+        actor: string;
+        op: string;
+        target_id: string;
+        metadata_json: string;
+      }>;
+      expect(auditRows.length).toBe(1);
+      const audit = auditRows[0];
+      expect(audit.op).toBe('archive_raw');
+      expect(audit.tenant_id).toBe('tenant-B');
+      expect(audit.actor).toBe('user:42');
+      expect(audit.target_id).toBe(id);
+      const meta = JSON.parse(audit.metadata_json) as Record<string, unknown>;
+      expect(meta.reason).toBe('compliance test');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('6. no re-recall after archive: original content text returns 0 results', () => {
+    const ctx = { hippoRoot: root, tenantId: 'tenant-C', actor: 'cli' };
+    const distinctive = 'gdpr-canary-token-quaxle';
+    const { id } = remember(ctx, { content: distinctive, kind: 'raw' });
+
+    // Pre-condition: recall finds it.
+    const before = recall(ctx, { query: distinctive });
+    expect(before.results.some((r) => r.id === id)).toBe(true);
+
+    archiveRaw(ctx, id, 'right-to-be-forgotten');
+
+    // Post-condition: gone from recall.
+    const after = recall(ctx, { query: distinctive });
+    expect(after.results.length).toBe(0);
+  });
+});

--- a/tests/v039-mcp-tenant-isolation.test.ts
+++ b/tests/v039-mcp-tenant-isolation.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
+import { remember as apiRemember } from '../src/api.js';
+import { handleMcpRequest } from '../src/mcp/server.js';
+
+// v0.39 commit 2 regressions:
+//  - lastRecalledIds keyed per-client so two HTTP-MCP clients on the same
+//    tenant cannot poison each other's outcome feedback (Fix 2.1)
+//  - clientKey built from hash(bearer + remoteAddr) by src/server.ts (Fix 2.2)
+//  - hippo_recall / hippo_remember route through src/api.ts so audit_log
+//    captures actor='mcp' uniformly with CLI/REST (Fix 2.3)
+//  - hippo_share passes ctx.tenantId so a Bearer for tenant A cannot share
+//    tenant B's memory to the global store (Fix 2.4)
+//  - hippo_outcome reads with ctx.tenantId (Fix 2.5)
+
+function makeRoot(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), `hippo-${prefix}-`));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+function callTool(
+  reqId: number,
+  name: string,
+  args: Record<string, unknown>,
+  ctx: { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
+) {
+  return handleMcpRequest(
+    {
+      jsonrpc: '2.0',
+      id: reqId,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    },
+    ctx,
+  );
+}
+
+function extractText(res: unknown): string {
+  const r = res as { result?: { content?: Array<{ text?: string }> } } | null;
+  return r?.result?.content?.[0]?.text ?? '';
+}
+
+describe('v039 mcp tenant + client-key isolation', () => {
+  let home: string;
+  let globalHome: string;
+  let originalHippoHome: string | undefined;
+
+  beforeEach(() => {
+    home = makeRoot('v039-mcp');
+    globalHome = makeRoot('v039-mcp-global');
+    originalHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+  });
+
+  afterEach(() => {
+    if (originalHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = originalHippoHome;
+    }
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* windows file locks */ }
+    try { rmSync(globalHome, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  // ---- Test 1: lastRecalledIds keyed by clientKey --------------------------
+  it('lastRecalledIds is keyed by clientKey — outcome from client B cannot touch client A', async () => {
+    // Seed a memory in tenant alpha for both clients to recall.
+    const seeded = apiRemember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'shared-canary lastRecalled keyed-by-clientKey alpha-tenant' },
+    );
+
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenA:1.2.3.4' };
+    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenB:5.6.7.8' };
+
+    // Both clients recall the same memory.
+    await callTool(1, 'hippo_recall', { query: 'lastRecalled', budget: 1500 }, ctxA);
+    await callTool(2, 'hippo_recall', { query: 'lastRecalled', budget: 1500 }, ctxB);
+
+    // Snapshot retrieval_count for the seeded memory before any outcome.
+    const before = (() => {
+      const db = openHippoDb(home);
+      try {
+        return db
+          .prepare(`SELECT retrieval_count, strength FROM memories WHERE id = ?`)
+          .get(seeded.id) as { retrieval_count: number; strength: number };
+      } finally {
+        closeHippoDb(db);
+      }
+    })();
+    expect(before).toBeDefined();
+
+    // Client B applies a positive outcome. With per-client keying, this
+    // touches B's lastRecalledIds set only — both happen to point at the
+    // same memory id since they both queried alpha, so this DOES update
+    // the memory. The discriminating test: client B has no recalls and
+    // client A has recalls → B's outcome must not touch A's set.
+    //
+    // Probe that branch directly: clear B's set by giving a different
+    // clientKey that has never recalled.
+    const ctxC = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenC:never-recalled' };
+    const cOutcome = await callTool(3, 'hippo_outcome', { good: true }, ctxC);
+    expect(extractText(cOutcome)).toMatch(/No recent recalls/i);
+
+    // And client A's set is still active (its recall happened, no outcome
+    // applied yet on its key).
+    const aOutcome = await callTool(4, 'hippo_outcome', { good: true }, ctxA);
+    expect(extractText(aOutcome)).toMatch(/Applied positive outcome to 1 memories/);
+  });
+
+  // ---- Test 2: MCP recall produces audit_log with actor='mcp' ---------------
+  it('hippo_recall via MCP routes through api.ts and writes audit_log with actor=mcp', async () => {
+    apiRemember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'audit-canary recall actor-mcp shape lock' },
+    );
+
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr' };
+    await callTool(1, 'hippo_recall', { query: 'audit-canary', budget: 1500 }, ctx);
+
+    const db = openHippoDb(home);
+    try {
+      const recallEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'recall' });
+      const mcpRecall = recallEvents.find((e) => e.actor === 'mcp');
+      expect(mcpRecall).toBeDefined();
+      expect((mcpRecall!.metadata as { query?: string }).query).toContain('audit-canary');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 3: MCP remember produces audit_log with actor='mcp' -------------
+  it('hippo_remember via MCP routes through api.ts and writes audit_log with actor=mcp', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr' };
+    const res = await callTool(
+      1,
+      'hippo_remember',
+      { text: 'audit-canary remember actor-mcp shape lock' },
+      ctx,
+    );
+    expect(extractText(res)).toMatch(/Remembered \[mem_/);
+
+    const db = openHippoDb(home);
+    try {
+      const rememberEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'remember' });
+      const mcpRemember = rememberEvents.find((e) => e.actor === 'mcp');
+      expect(mcpRemember).toBeDefined();
+      expect(mcpRemember!.targetId).toMatch(/^mem_/);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 4: stdio backward-compat — no clientKey → stdio-${pid} ---------
+  it('McpContext with no clientKey falls back to stdio-${pid} and recall/outcome work end-to-end', async () => {
+    apiRemember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'stdio-fallback canary backward-compat clientKey-undefined' },
+    );
+
+    const ctxNoKey = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp' };
+
+    // Recall sets the keyed Map under the stdio-${pid}:alpha fallback.
+    const recallRes = await callTool(1, 'hippo_recall', { query: 'stdio-fallback', budget: 1500 }, ctxNoKey);
+    expect(extractText(recallRes)).toContain('stdio-fallback');
+
+    // Outcome under the same no-clientKey context resolves the same fallback
+    // key and finds the recalled set.
+    const outcomeRes = await callTool(2, 'hippo_outcome', { good: true }, ctxNoKey);
+    expect(extractText(outcomeRes)).toMatch(/Applied positive outcome to 1 memories/);
+  });
+
+  // ---- Test 5: Cross-tenant outcome blocked under HTTP-MCP -----------------
+  // Two HTTP-MCP simulated clients, same tenant but different bearers (so
+  // their hash(bearer) prefixes differ → different clientKeys). Client B's
+  // outcome on a key client B never recalled returns "No recent recalls".
+  it('two HTTP-MCP clients on the same tenant have isolated lastRecalledIds (buildMcpClientKey shape)', async () => {
+    apiRemember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'cross-client http-mcp simulated bearer-isolation' },
+    );
+
+    // Simulate exactly what server.ts:buildMcpClientKey produces:
+    //   `http:${sha256(bearer).slice(0,16)}:${remoteAddr}`
+    const bearerA = 'hk_test_alpha_A';
+    const bearerB = 'hk_test_alpha_B';
+    const remoteAddr = '127.0.0.1';
+    const keyA = `http:${createHash('sha256').update(bearerA).digest('hex').slice(0, 16)}:${remoteAddr}`;
+    const keyB = `http:${createHash('sha256').update(bearerB).digest('hex').slice(0, 16)}:${remoteAddr}`;
+    expect(keyA).not.toBe(keyB);
+
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: keyA };
+    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: keyB };
+
+    // Only A recalls.
+    await callTool(1, 'hippo_recall', { query: 'cross-client', budget: 1500 }, ctxA);
+
+    // B has never recalled — outcome on B's key returns "No recent recalls".
+    const bOutcome = await callTool(2, 'hippo_outcome', { good: true }, ctxB);
+    expect(extractText(bOutcome)).toMatch(/No recent recalls/i);
+
+    // A's recalled set is intact.
+    const aOutcome = await callTool(3, 'hippo_outcome', { good: true }, ctxA);
+    expect(extractText(aOutcome)).toMatch(/Applied positive outcome to 1 memories/);
+  });
+
+  // ---- Test 6: hippo_share cross-tenant denied -----------------------------
+  it('hippo_share cross-tenant: tenant B cannot share tenant A\'s memory to the global store', async () => {
+    // Tenant A pushes a memory.
+    const a = apiRemember(
+      { hippoRoot: home, tenantId: 'alpha', actor: 'cli' },
+      { content: 'alpha-private hippo_share cross-tenant exfil canary' },
+    );
+
+    // Tenant B's MCP context tries to call hippo_share with A's id. The
+    // tool surface returns the JSON-RPC error envelope rather than throwing
+    // through to the test — handleMcpRequest catches the executeTool throw
+    // only in the HTTP handler, but here we're calling handleMcpRequest
+    // directly, so the throw propagates. Wrap accordingly.
+    const ctxB = { hippoRoot: home, tenantId: 'bravo', actor: 'mcp', clientKey: 'http:bravo-token:1.2.3.4' };
+
+    let threwNotFound = false;
+    try {
+      await callTool(1, 'hippo_share', { id: a.id, force: true }, ctxB);
+    } catch (err) {
+      threwNotFound = /memory not found/i.test(err instanceof Error ? err.message : String(err));
+    }
+    expect(threwNotFound).toBe(true);
+
+    // The global store must NOT have received a copy of alpha's memory.
+    const gdb = openHippoDb(globalHome);
+    try {
+      const rows = gdb
+        .prepare(`SELECT COUNT(*) AS c FROM memories WHERE content LIKE '%alpha-private%'`)
+        .get() as { c: number };
+      expect(Number(rows.c)).toBe(0);
+    } finally {
+      closeHippoDb(gdb);
+    }
+
+    // Sanity: tenant A can still share its own memory.
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:alpha-token:1.2.3.4' };
+    const okRes = await callTool(2, 'hippo_share', { id: a.id, force: true }, ctxA);
+    expect(extractText(okRes)).toMatch(/Shared \[mem_|Shared \[g_/);
+  });
+});
+

--- a/tests/v039-mcp-tenant-isolation.test.ts
+++ b/tests/v039-mcp-tenant-isolation.test.ts
@@ -131,7 +131,16 @@ describe('v039 mcp tenant + client-key isolation', () => {
       const recallEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'recall' });
       const mcpRecall = recallEvents.find((e) => e.actor === 'mcp');
       expect(mcpRecall).toBeDefined();
-      expect((mcpRecall!.metadata as { query?: string }).query).toContain('audit-canary');
+      // GDPR Path A: recall audit stores query_hash (sha256/16) instead of
+      // truncated query text. Assert hash shape + length, not the original text.
+      const meta = mcpRecall!.metadata as {
+        query?: string;
+        query_hash?: string;
+        query_length?: number;
+      };
+      expect(meta.query).toBeUndefined();
+      expect(meta.query_hash).toMatch(/^[0-9a-f]{16}$/);
+      expect(typeof meta.query_length).toBe('number');
     } finally {
       closeHippoDb(db);
     }

--- a/tests/v039-mcp-tenant-isolation.test.ts
+++ b/tests/v039-mcp-tenant-isolation.test.ts
@@ -159,6 +159,27 @@ describe('v039 mcp tenant + client-key isolation', () => {
     }
   });
 
+  // ---- Test 3.5: hippo_outcome routes through api.ts (audit_log actor=mcp) -
+  it('hippo_outcome via MCP routes through api.ts and writes audit_log with op=outcome actor=mcp', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr-outcome' };
+    // Seed a memory + recall it so lastRecalledIds is populated for clientKey.
+    apiRemember({ hippoRoot: home, tenantId: 'alpha', actor: 'cli' }, { content: 'outcome-canary memory for audit shape lock' });
+    await callTool(1, 'hippo_recall', { query: 'outcome-canary' }, ctx);
+    // Apply positive outcome.
+    const res = await callTool(2, 'hippo_outcome', { good: true }, ctx);
+    expect(extractText(res)).toMatch(/Applied positive outcome to \d+ memories/);
+
+    const db = openHippoDb(home);
+    try {
+      const outcomeEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'outcome' });
+      const mcpOutcome = outcomeEvents.find((e) => e.actor === 'mcp');
+      expect(mcpOutcome).toBeDefined();
+      expect(mcpOutcome!.targetId).toMatch(/^mem_/);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
   // ---- Test 4: stdio backward-compat — no clientKey → stdio-${pid} ---------
   it('McpContext with no clientKey falls back to stdio-${pid} and recall/outcome work end-to-end', async () => {
     apiRemember(

--- a/tests/v039-server-hardening.test.ts
+++ b/tests/v039-server-hardening.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHmac, scryptSync, randomBytes } from 'node:crypto';
+import { initStore } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey, revokeApiKey, validateApiKey } from '../src/auth.js';
+import { remember as apiRemember } from '../src/api.js';
+import { handleMcpRequest } from '../src/mcp/server.js';
+
+// v0.39 commit 5 — Server hardening regressions:
+//   - Fix 5.2: DUMMY_HASH precomputed at module load; miss path runs verifyKey
+//     so the timing signal between hit and miss is reduced.
+//   - Fix 5.3: /mcp/stream heartbeat re-validates bearer; MCP_SSE_MAX_AGE_SEC
+//     caps stream age. MCP_SSE_HEARTBEAT_MS makes the interval testable.
+//   - Fix 5.4: graceful shutdown awaits server.stop() before process.exit.
+//     Tested by directly exercising stop() while a request is in flight; we
+//     do NOT raise SIGTERM because vitest skips signal handlers (VITEST=1)
+//     and a real signal would also kill the test runner.
+//   - Fix 5.5: PUBLIC_ROUTES bypass attempts (trailing slash, encoded slash,
+//     wrong method, query string).
+//   - Fix 5.6: default-deny lower-level loader — MCP recall with no scope
+//     hides slack:private:* memories.
+
+const SLACK_SECRET = 'shhh-v039-hardening';
+
+function signSlack(ts: string, body: string): string {
+  return `v0=${createHmac('sha256', SLACK_SECRET).update(`v0:${ts}:${body}`).digest('hex')}`;
+}
+
+describe('v039 server hardening', () => {
+  let root: string;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-v039-server-'));
+    initStore(root);
+  });
+
+  afterEach(async () => {
+    if (handle) {
+      try { await handle.stop(); } catch { /* already stopped */ }
+    }
+    delete process.env.HIPPO_REQUIRE_AUTH;
+    delete process.env.SLACK_SIGNING_SECRET;
+    delete process.env.MCP_SSE_MAX_AGE_SEC;
+    delete process.env.MCP_SSE_HEARTBEAT_MS;
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* windows file locks */ }
+  });
+
+  // ---- Fix 5.2: auth timing reduced -------------------------------------
+  //
+  // We measure wall-clock elapsed time of validateApiKey on:
+  //   - hit: a real key in the DB
+  //   - miss-known-format: an unknown key with the dotted shape
+  // Both should run scrypt exactly once now. We assert the miss path is
+  // within 50% of the hit path (loose bound — CI is noisy and scrypt is
+  // sensitive to background load). The key behavioral assertion is "miss
+  // path ran scrypt at all" — pre-fix it returned ~instantly.
+  it('auth timing: miss path pays scrypt cost (within 50% of hit)', () => {
+    const db = openHippoDb(root);
+    let plaintext: string;
+    try {
+      const created = createApiKey(db, { tenantId: 'default', label: 'timing-hit' });
+      plaintext = created.plaintext;
+
+      // Warmup — JIT, scrypt cost cache, etc.
+      for (let i = 0; i < 3; i++) {
+        validateApiKey(db, plaintext);
+        validateApiKey(db, 'hk_unknown_key.unknown_secret_blob');
+      }
+
+      // Sample multiple iterations; take the median to dampen GC noise.
+      const N = 7;
+      const hitTimes: number[] = [];
+      const missTimes: number[] = [];
+      for (let i = 0; i < N; i++) {
+        const t0 = process.hrtime.bigint();
+        validateApiKey(db, plaintext);
+        const t1 = process.hrtime.bigint();
+        hitTimes.push(Number(t1 - t0));
+
+        const t2 = process.hrtime.bigint();
+        validateApiKey(db, 'hk_unknown_key.unknown_secret_blob');
+        const t3 = process.hrtime.bigint();
+        missTimes.push(Number(t3 - t2));
+      }
+      hitTimes.sort((a, b) => a - b);
+      missTimes.sort((a, b) => a - b);
+      const hit = hitTimes[Math.floor(N / 2)]!;
+      const miss = missTimes[Math.floor(N / 2)]!;
+      // Both branches now run scrypt once. Hard floor: miss must be at
+      // least 30% of hit (proves scrypt ran). Hard ceiling: miss within
+      // +50% of hit (loose for CI; tight enough to catch a regression
+      // where the miss path skipped verifyKey entirely).
+      expect(miss).toBeGreaterThan(hit * 0.3);
+      expect(miss).toBeLessThan(hit * 1.5);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Fix 5.2: malformed key (no dot) still pays scrypt cost ----------
+  it('auth timing: malformed input (no dot) pays scrypt cost', () => {
+    const db = openHippoDb(root);
+    try {
+      // Warmup
+      for (let i = 0; i < 3; i++) validateApiKey(db, 'no-dot-here');
+
+      const t0 = process.hrtime.bigint();
+      const result = validateApiKey(db, 'no-dot-here');
+      const t1 = process.hrtime.bigint();
+      const elapsed = Number(t1 - t0);
+      expect(result.valid).toBe(false);
+      // scrypt of 32-byte keylen costs ~30ms on dev hardware. We assert at
+      // least 5ms to stay safe under heavily-loaded CI; the pre-fix path
+      // returned in <0.1ms.
+      expect(elapsed).toBeGreaterThan(5_000_000);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Fix 5.3: SSE max-age closes stream ------------------------------
+  it('SSE max-age closes stream with reason=max_age_exceeded', async () => {
+    process.env.MCP_SSE_MAX_AGE_SEC = '1';
+    process.env.MCP_SSE_HEARTBEAT_MS = '200'; // poll fast
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+
+    const ac = new AbortController();
+    try {
+      const res = await fetch(`${handle.url}/mcp/stream`, {
+        headers: { accept: 'text/event-stream' },
+        signal: ac.signal,
+      });
+      expect(res.status).toBe(200);
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+
+      // Drain frames for up to 3s, looking for "event: closed" with
+      // reason=max_age_exceeded.
+      let buf = '';
+      let closedReason: string | null = null;
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline && closedReason === null) {
+        const r = await Promise.race([
+          reader.read(),
+          new Promise<{ value: undefined; done: true }>((resolve) =>
+            setTimeout(() => resolve({ value: undefined, done: true }), 500),
+          ),
+        ]);
+        if (r.value) buf += decoder.decode(r.value);
+        const m = buf.match(/event:\s*closed\s*\ndata:\s*(\{[^\n]*\})/);
+        if (m) {
+          const parsed = JSON.parse(m[1]!) as { reason?: string };
+          closedReason = parsed.reason ?? null;
+          break;
+        }
+        if (r.done) break;
+      }
+      try { reader.cancel().catch(() => {}); } catch { /* no-op */ }
+      expect(closedReason).toBe('max_age_exceeded');
+    } finally {
+      ac.abort();
+    }
+  }, 10_000);
+
+  // ---- Fix 5.3: SSE auth-revoked closes stream -------------------------
+  it('SSE heartbeat closes stream with reason=auth_revoked when key revoked', async () => {
+    process.env.HIPPO_REQUIRE_AUTH = '1';
+    process.env.MCP_SSE_HEARTBEAT_MS = '200';
+    process.env.MCP_SSE_MAX_AGE_SEC = '60'; // far enough out of the way
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+
+    // Mint a key, open stream with it, then revoke and wait for the
+    // heartbeat to detect.
+    const db = openHippoDb(root);
+    let keyId: string;
+    let plaintext: string;
+    try {
+      const created = createApiKey(db, { tenantId: 'default', label: 'sse-revoke' });
+      keyId = created.keyId;
+      plaintext = created.plaintext;
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const ac = new AbortController();
+    try {
+      const res = await fetch(`${handle.url}/mcp/stream`, {
+        headers: { accept: 'text/event-stream', authorization: `Bearer ${plaintext}` },
+        signal: ac.signal,
+      });
+      expect(res.status).toBe(200);
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+
+      // Read initial ping to confirm stream live.
+      const first = await Promise.race([
+        reader.read(),
+        new Promise<{ value: undefined; done: true }>((resolve) =>
+          setTimeout(() => resolve({ value: undefined, done: true }), 1000),
+        ),
+      ]);
+      expect(first.done).toBe(false);
+
+      // Now revoke the key. Next heartbeat should close the stream.
+      const db2 = openHippoDb(root);
+      try { revokeApiKey(db2, keyId); } finally { closeHippoDb(db2); }
+
+      let buf = decoder.decode(first.value);
+      let closedReason: string | null = null;
+      const deadline = Date.now() + 3000;
+      while (Date.now() < deadline && closedReason === null) {
+        const r = await Promise.race([
+          reader.read(),
+          new Promise<{ value: undefined; done: true }>((resolve) =>
+            setTimeout(() => resolve({ value: undefined, done: true }), 500),
+          ),
+        ]);
+        if (r.value) buf += decoder.decode(r.value);
+        const m = buf.match(/event:\s*closed\s*\ndata:\s*(\{[^\n]*\})/);
+        if (m) {
+          const parsed = JSON.parse(m[1]!) as { reason?: string };
+          closedReason = parsed.reason ?? null;
+          break;
+        }
+        if (r.done) break;
+      }
+      try { reader.cancel().catch(() => {}); } catch { /* no-op */ }
+      expect(closedReason).toBe('auth_revoked');
+    } finally {
+      ac.abort();
+    }
+  }, 10_000);
+
+  // ---- Fix 5.4: graceful shutdown awaits stop() ------------------------
+  //
+  // We exercise the async stop() path directly (vitest skips signal
+  // handlers, so a real SIGTERM here would kill the runner). The contract
+  // we care about: stop() resolves only after server.close() resolves,
+  // which can only happen after in-flight requests finish.
+  //
+  // Strategy: open a long-lived SSE stream, then call stop(). Pre-fix,
+  // stop() either hung (SSE keepalive blocks server.close) or returned
+  // before the connection was force-closed. Post-fix, stop() calls
+  // closeAllConnections() and resolves cleanly.
+  it('graceful shutdown: stop() resolves while SSE stream is open', async () => {
+    process.env.MCP_SSE_HEARTBEAT_MS = '60000'; // keep stream sleepy
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+
+    const ac = new AbortController();
+    const streamPromise = fetch(`${handle.url}/mcp/stream`, {
+      headers: { accept: 'text/event-stream' },
+      signal: ac.signal,
+    }).catch(() => null);
+
+    const res = await streamPromise;
+    expect(res?.status).toBe(200);
+
+    const stopStarted = Date.now();
+    await handle.stop();
+    const stopElapsed = Date.now() - stopStarted;
+    // stop() must resolve within a few seconds — pre-fix this hung
+    // until the SSE keepalive timer fired (30s).
+    expect(stopElapsed).toBeLessThan(5000);
+    // Re-running stop is safe (idempotent).
+    await handle.stop();
+    ac.abort();
+    // Mark handle stopped so afterEach doesn't double-stop.
+    (handle as { stop: () => Promise<void> }).stop = async () => {};
+  }, 10_000);
+
+  // ---- Fix 5.5: PUBLIC_ROUTES bypass attempts --------------------------
+  describe('PUBLIC_ROUTES bypass attempts', () => {
+    beforeEach(async () => {
+      process.env.SLACK_SIGNING_SECRET = SLACK_SECRET;
+      process.env.HIPPO_REQUIRE_AUTH = '1';
+      handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+    });
+
+    it('trailing slash on slack events does NOT bypass auth (still HMAC-required)', async () => {
+      const body = JSON.stringify({ type: 'url_verification', challenge: 'x' });
+      // Trailing slash → path !== exact match in PUBLIC_ROUTES, so route
+      // falls through. With HIPPO_REQUIRE_AUTH=1, the bearer check fires
+      // and returns 401. Critically: NOT 200.
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events/`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      });
+      expect(res.status).not.toBe(200);
+      // 401 (auth required) or 404 (no such route) both prove no bypass.
+      expect([401, 404]).toContain(res.status);
+    });
+
+    it('encoded slash variant does not bypass', async () => {
+      // %2F encoded slash creates a different path that does not match
+      // the public route. Must NOT 200 without bearer.
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack%2Fevents`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      expect(res.status).not.toBe(200);
+      expect([401, 404]).toContain(res.status);
+    });
+
+    it('wrong method (GET) on slack events route requires auth', async () => {
+      // Only POST is in PUBLIC_ROUTES. GET should 401 without bearer.
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+        method: 'GET',
+      });
+      expect(res.status).not.toBe(200);
+      expect([401, 404, 405]).toContain(res.status);
+    });
+
+    it('query string on public route does not change routing (still HMAC-verified)', async () => {
+      // Adding ?bypass=1 must not affect routing — pathname is matched,
+      // search is ignored. A request without a valid signature still 401s.
+      const res = await fetch(
+        `http://127.0.0.1:${handle.port}/v1/connectors/slack/events?bypass=1`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+        },
+      );
+      // No x-slack-signature header → HMAC verify fails → 401.
+      expect(res.status).toBe(401);
+    });
+
+    it('valid POST with HMAC still works (positive control)', async () => {
+      const body = JSON.stringify({ type: 'url_verification', challenge: 'positive' });
+      const ts = String(Math.floor(Date.now() / 1000));
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-slack-request-timestamp': ts,
+          'x-slack-signature': signSlack(ts, body),
+        },
+        body,
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ---- Fix 5.6: default-deny lower-level loader test -------------------
+  it('MCP recall with no scope hides slack:private:* memories (default-deny)', async () => {
+    // Seed a private slack memory + a regular memory under the same tenant.
+    apiRemember(
+      { hippoRoot: root, tenantId: 'default', actor: 'cli' },
+      {
+        content: 'private-slack-canary should not surface in default recall',
+        scope: 'slack:private:CSECRET',
+      },
+    );
+    apiRemember(
+      { hippoRoot: root, tenantId: 'default', actor: 'cli' },
+      { content: 'public-canary should surface in default recall' },
+    );
+
+    // Call MCP recall with no scope.
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'mcp', clientKey: 'http:t:test' };
+    const res = await handleMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'hippo_recall', arguments: { query: 'canary', budget: 1500 } },
+      },
+      ctx,
+    );
+    const text = ((res as { result?: { content?: Array<{ text?: string }> } } | null)
+      ?.result?.content?.[0]?.text) ?? '';
+    expect(text).toContain('public-canary');
+    expect(text).not.toContain('private-slack-canary');
+  });
+});

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(19);
+    expect(getCurrentSchemaVersion()).toBe(20);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(19);
+      expect(getSchemaVersion(db)).toBe(20);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(20);
+    expect(getCurrentSchemaVersion()).toBe(21);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(20);
+      expect(getSchemaVersion(db)).toBe(21);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -1,0 +1,506 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHmac } from 'node:crypto';
+import { initStore, loadAllEntries, writeEntry } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { openHippoDb, closeHippoDb, getCurrentSchemaVersion, getSchemaVersion } from '../src/db.js';
+import { resolveTenantForTeam } from '../src/connectors/slack/tenant-routing.js';
+import { ingestMessage } from '../src/connectors/slack/ingest.js';
+import { writeToDlq, listDlq, replayDlqEntry } from '../src/connectors/slack/dlq.js';
+import { archiveRawMemory } from '../src/raw-archive.js';
+import { verifySlackSignature } from '../src/connectors/slack/signature.js';
+import { slackHistoryFetcher } from '../src/connectors/slack/web-client.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+const SECRET = 'shhh-current';
+const PREVIOUS_SECRET = 'shhh-old';
+
+function sign(secret: string, ts: string, body: string): string {
+  return `v0=${createHmac('sha256', secret).update(`v0:${ts}:${body}`).digest('hex')}`;
+}
+
+function withEnv(name: string, value: string | undefined): () => void {
+  const prev = process.env[name];
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+  return () => {
+    if (prev === undefined) delete process.env[name];
+    else process.env[name] = prev;
+  };
+}
+
+describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-v039-slack-'));
+    initStore(root);
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // 1. Migration v19 schema additions present.
+  it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
+    expect(getCurrentSchemaVersion()).toBe(19);
+    const db = openHippoDb(root);
+    try {
+      expect(getSchemaVersion(db)).toBe(19);
+      const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
+      const names = cols.map((c) => c.name);
+      expect(names).toContain('team_id');
+      expect(names).toContain('bucket');
+      expect(names).toContain('retry_count');
+      expect(names).toContain('signature');
+      expect(names).toContain('slack_timestamp');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // 2. Unknown team + empty workspaces → fallback.
+  it('resolveTenantForTeam: empty slack_workspaces → env fallback', () => {
+    const restore = withEnv('HIPPO_TENANT', 'env-tenant-A');
+    const db = openHippoDb(root);
+    try {
+      expect(resolveTenantForTeam(db, 'TUNKNOWN')).toBe('env-tenant-A');
+    } finally {
+      closeHippoDb(db);
+      restore();
+    }
+  });
+
+  // 3. Unknown team + non-empty workspaces → fail closed (null).
+  it('resolveTenantForTeam: non-empty workspaces + unknown team → null (fail closed)', () => {
+    const restore = withEnv('SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK', undefined);
+    const db = openHippoDb(root);
+    try {
+      db.prepare(
+        `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+      ).run('TKNOWN', 'tenant-known', new Date().toISOString());
+      expect(resolveTenantForTeam(db, 'TUNKNOWN')).toBeNull();
+    } finally {
+      closeHippoDb(db);
+      restore();
+    }
+  });
+
+  // 4. Escape hatch SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK=1.
+  it('resolveTenantForTeam: escape hatch returns env tenant when both flag and workspaces non-empty', () => {
+    const r1 = withEnv('SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK', '1');
+    const r2 = withEnv('HIPPO_TENANT', 'env-fallback');
+    const db = openHippoDb(root);
+    try {
+      db.prepare(
+        `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+      ).run('TKNOWN', 'tenant-known', new Date().toISOString());
+      expect(resolveTenantForTeam(db, 'TUNKNOWN')).toBe('env-fallback');
+    } finally {
+      closeHippoDb(db);
+      r2();
+      r1();
+    }
+  });
+
+  // 5. Server slack-events: unroutable goes to DLQ with bucket='unroutable' + team_id.
+  it('server slack-events: unknown team writes to slack_dlq with bucket=unroutable + team_id captured', async () => {
+    const r1 = withEnv('SLACK_SIGNING_SECRET', SECRET);
+    const r2 = withEnv('SLACK_ALLOW_UNKNOWN_TEAM_FALLBACK', undefined);
+    // Seed slack_workspaces so unknown teams fail closed.
+    {
+      const db = openHippoDb(root);
+      try {
+        db.prepare(
+          `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+        ).run('TREGISTERED', 'tenant-known', new Date().toISOString());
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+    let handle: ServerHandle | null = null;
+    try {
+      handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+      const body = JSON.stringify({
+        type: 'event_callback',
+        team_id: 'TFOREIGN',
+        event_id: 'EvUnroutable',
+        event_time: Math.floor(Date.now() / 1000),
+        event: {
+          type: 'message',
+          channel: 'C1',
+          channel_type: 'channel',
+          user: 'U1',
+          text: 'leak attempt',
+          ts: '1700000000.000100',
+        },
+      });
+      const ts = String(Math.floor(Date.now() / 1000));
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-slack-request-timestamp': ts,
+          'x-slack-signature': sign(SECRET, ts, body),
+        },
+        body,
+      });
+      // Mandatory ACK.
+      expect(res.status).toBe(200);
+      // No memory created.
+      expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(0);
+      const db = openHippoDb(root);
+      try {
+        const rows = db
+          .prepare(
+            `SELECT tenant_id, team_id, bucket, signature, slack_timestamp FROM slack_dlq ORDER BY id`,
+          )
+          .all() as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].bucket).toBe('unroutable');
+        expect(rows[0].team_id).toBe('TFOREIGN');
+        expect(rows[0].tenant_id).toBe('__unroutable__');
+        expect(rows[0].signature).toBeTruthy();
+        expect(rows[0].slack_timestamp).toBe(ts);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      if (handle) await handle.stop();
+      r2();
+      r1();
+    }
+  });
+
+  // 6. Ingest race: simultaneous ingest with same eventId. Since single-
+  //    process serialization makes a true race hard to reproduce, we exercise
+  //    the afterWrite race-detection branch directly: we use the documented
+  //    `remember()` afterWrite hook to insert a slack_event_log row for an
+  //    event_id mid-SAVEPOINT, then have the same hook run the production
+  //    INSERT-OR-IGNORE-with-changes-check logic. This is a real DB test (no
+  //    mocks) that validates the exact contract: pre-existing event_log row
+  //    causes INSERT OR IGNORE to return changes=0 → throw → SAVEPOINT
+  //    rollback → no orphan memory row.
+  //
+  //    For the public ingestMessage path under the same-eventId fast-path
+  //    pre-check, we also assert the second call returns 'duplicate' (the
+  //    short-circuit branch) and a single memory row exists.
+  it('ingest race: duplicate event_id yields exactly one memory + skipped_duplicate via afterWrite throw', async () => {
+    const { remember } = await import('../src/api.js');
+    const { DuplicateEventError } = await import('../src/connectors/slack/idempotency.js');
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'connector:slack' };
+
+    // First call: ordinary ingest succeeds and writes to slack_event_log.
+    const r1 = ingestMessage(ctx, {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'race-msg', ts: '1700.000099' },
+      eventId: 'EvRace',
+    });
+    expect(r1.status).toBe('ingested');
+    expect(r1.memoryId).toBeTruthy();
+
+    // Second call with same eventId: fast-path pre-check returns duplicate
+    // immediately. The plan stop-condition documents this: "the existing
+    // pre-check hasSeenEvent stays as fast-path optimization."
+    const r2 = ingestMessage(ctx, {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      message: { type: 'message', channel: 'C1', user: 'U1', text: 'race-msg', ts: '1700.000099' },
+      eventId: 'EvRace',
+    });
+    expect(r2.status).toBe('duplicate');
+    expect(r2.memoryId).toBe(r1.memoryId);
+
+    // Now exercise the afterWrite throw directly. A different event_id whose
+    // slack_event_log row has been pre-seeded simulates the two-worker race
+    // where worker B's pre-check missed worker A's commit.
+    const racedEventId = 'EvRaceB';
+    {
+      const db = openHippoDb(root);
+      try {
+        db.prepare(
+          `INSERT INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`,
+        ).run(racedEventId, new Date().toISOString(), r1.memoryId);
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+
+    // Build a fresh memory entry that would otherwise be valid, and let the
+    // afterWrite hook run the real production logic. The race-loser commit
+    // must throw DuplicateEventError → SAVEPOINT rollback → no new row.
+    const memBefore = loadAllEntries(root).length;
+    const seedMem = createMemory('would-be-second-write', {
+      layer: Layer.Buffer,
+      tenantId: 'default',
+      kind: 'raw',
+    });
+
+    // Re-implement the production afterWrite logic exactly so this is a
+    // real-DB integration test of the pattern without going through ingest.ts
+    // (which would short-circuit at hasSeenEvent).
+    expect(() =>
+      remember(ctx, {
+        content: seedMem.content,
+        layer: seedMem.layer,
+        tags: seedMem.tags,
+        kind: 'raw',
+        afterWrite: (innerDb, memoryId) => {
+          const ins = innerDb
+            .prepare(
+              `INSERT OR IGNORE INTO slack_event_log (event_id, ingested_at, memory_id) VALUES (?, ?, ?)`,
+            )
+            .run(racedEventId, new Date().toISOString(), memoryId);
+          if (Number(ins.changes ?? 0) === 0) {
+            throw new DuplicateEventError(racedEventId);
+          }
+        },
+      }),
+    ).toThrow(DuplicateEventError);
+
+    // No new memory row: the SAVEPOINT rolled back the would-be-second-write.
+    const memAfter = loadAllEntries(root).length;
+    expect(memAfter).toBe(memBefore);
+
+    // slack_event_log still has exactly one row for the raced event_id.
+    {
+      const db = openHippoDb(root);
+      try {
+        const rows = db
+          .prepare(`SELECT memory_id FROM slack_event_log WHERE event_id = ?`)
+          .all(racedEventId) as Array<{ memory_id: string }>;
+        expect(rows).toHaveLength(1);
+        // The pre-seeded memory_id (r1.memoryId), not the rolled-back one.
+        expect(rows[0].memory_id).toBe(r1.memoryId);
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+  });
+
+  // 7. Deletion afterArchive atomic: throw inside callback rolls back the archive.
+  it('archiveRawMemory: throw inside afterArchive callback rolls back the archive', () => {
+    // Seed a kind=raw memory directly.
+    const mem = createMemory('archive-rollback-test', {
+      layer: Layer.Buffer,
+      tenantId: 'default',
+      kind: 'raw',
+    });
+    writeEntry(root, mem);
+
+    const db = openHippoDb(root);
+    try {
+      expect(() =>
+        archiveRawMemory(db, mem.id, {
+          reason: 'test',
+          who: 'cli',
+          afterArchive: () => {
+            throw new Error('hook says no');
+          },
+        }),
+      ).toThrow(/hook says no/);
+
+      // Memory is still present — SAVEPOINT rolled back.
+      const stillThere = db
+        .prepare(`SELECT id, kind FROM memories WHERE id = ?`)
+        .get(mem.id) as { id?: string; kind?: string } | undefined;
+      expect(stillThere?.id).toBe(mem.id);
+      expect(stillThere?.kind).toBe('raw');
+
+      // raw_archive has no row for this id.
+      const archCount = db
+        .prepare(`SELECT COUNT(*) AS c FROM raw_archive WHERE memory_id = ?`)
+        .get(mem.id) as { c: number | bigint };
+      expect(Number(archCount.c)).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // 8. DLQ replay clean path: retry_count=1, ingest succeeds, memory created.
+  it('DLQ replay: clean path increments retry_count and ingests the memory', () => {
+    // Seed a parse_error row whose payload IS a valid event_callback envelope —
+    // simulating "the route handler dropped this for an old reason; routing is
+    // now fixed and we can replay it".
+    const body = JSON.stringify({
+      type: 'event_callback',
+      team_id: 'TREPLAY',
+      event_id: 'EvReplay1',
+      event_time: Math.floor(Date.now() / 1000),
+      event: {
+        type: 'message',
+        channel: 'CR1',
+        channel_type: 'channel',
+        user: 'U1',
+        text: 'replay-me',
+        ts: '1700000000.000777',
+      },
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const sigVal = sign(SECRET, ts, body);
+
+    // Pre-register the workspace so resolveTenantForTeam succeeds on replay.
+    {
+      const db = openHippoDb(root);
+      try {
+        db.prepare(
+          `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+        ).run('TREPLAY', 'default', new Date().toISOString());
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+
+    // Seed the DLQ row.
+    let dlqId: number;
+    {
+      const db = openHippoDb(root);
+      try {
+        dlqId = writeToDlq(db, {
+          tenantId: 'default',
+          teamId: 'TREPLAY',
+          rawPayload: body,
+          error: 'historical parse_error',
+          bucket: 'parse_error',
+          signature: sigVal,
+          slackTimestamp: ts,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+    }
+
+    // Replay using the current secret. Use a wide skew override so the test is
+    // not flaky against the now/skew check inside verifySlackSignature.
+    const result = replayDlqEntry(
+      { hippoRoot: root },
+      dlqId,
+      { signingSecret: SECRET, now: Number(ts), skewSeconds: 60 },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('ingested');
+    expect(result.retryCount).toBe(1);
+    expect(result.memoryId).toBeTruthy();
+
+    // Memory exists.
+    const created = loadAllEntries(root).find((e) => e.id === result.memoryId);
+    expect(created).toBeDefined();
+    expect(created?.kind).toBe('raw');
+
+    // DLQ row has retried_at + retry_count = 1.
+    const db = openHippoDb(root);
+    try {
+      const after = db
+        .prepare(`SELECT retried_at, retry_count FROM slack_dlq WHERE id = ?`)
+        .get(dlqId) as { retried_at?: string; retry_count?: number | bigint };
+      expect(after.retried_at).toBeTruthy();
+      expect(Number(after.retry_count)).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // 9. Web-client emits oldest only on first-page resume.
+  it('slackHistoryFetcher: oldest is emitted only when caller passes one', async () => {
+    const calls: string[] = [];
+    const fakeFetch = vi.fn(async (url: string) => {
+      calls.push(url);
+      return {
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ok: true, messages: [], response_metadata: {} }),
+      } as unknown as Response;
+    });
+    const fetcher = slackHistoryFetcher('xoxb-fake', fakeFetch as unknown as typeof fetch);
+
+    // First page (resume): caller passes oldest.
+    await fetcher({ channelId: 'C1', cursor: null, oldest: '1700000000.000001' });
+    // Second page: caller passes cursor only, no oldest.
+    await fetcher({ channelId: 'C1', cursor: 'NEXT_TOKEN' });
+
+    expect(calls[0]).toContain('oldest=1700000000.000001');
+    expect(calls[1]).not.toContain('oldest=');
+    expect(calls[1]).toContain('cursor=NEXT_TOKEN');
+  });
+
+  // 10. Signing-secret rotation: signature with previous secret valid when both env set.
+  it('verifySlackSignature: previousSecret is accepted when current fails (rotation window)', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const ts = String(now);
+    const body = '{"hello":"world"}';
+    const oldSig = sign(PREVIOUS_SECRET, ts, body);
+
+    // Without previousSecret: fails.
+    expect(
+      verifySlackSignature({
+        rawBody: body,
+        timestamp: ts,
+        signature: oldSig,
+        signingSecret: SECRET,
+        now,
+      }),
+    ).toBe(false);
+
+    // With previousSecret: passes.
+    expect(
+      verifySlackSignature({
+        rawBody: body,
+        timestamp: ts,
+        signature: oldSig,
+        signingSecret: SECRET,
+        previousSecret: PREVIOUS_SECRET,
+        now,
+      }),
+    ).toBe(true);
+
+    // Garbage signature: still fails even with previousSecret set.
+    expect(
+      verifySlackSignature({
+        rawBody: body,
+        timestamp: ts,
+        signature: 'v0=deadbeef',
+        signingSecret: SECRET,
+        previousSecret: PREVIOUS_SECRET,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  // 11. DLQ team_id captured from malformed body via regex.
+  it('server slack-events: malformed JSON body → DLQ row has team_id captured via regex', async () => {
+    const r1 = withEnv('SLACK_SIGNING_SECRET', SECRET);
+    let handle: ServerHandle | null = null;
+    try {
+      handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+      // Body is INVALID JSON (trailing comma, unclosed brace) but still
+      // contains "team_id":"TPARTIAL" in plain text.
+      const malformed = '{"type":"event_callback","team_id":"TPARTIAL","event":{,';
+      const ts = String(Math.floor(Date.now() / 1000));
+      const res = await fetch(`http://127.0.0.1:${handle.port}/v1/connectors/slack/events`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-slack-request-timestamp': ts,
+          'x-slack-signature': sign(SECRET, ts, malformed),
+        },
+        body: malformed,
+      });
+      expect(res.status).toBe(200);
+      const db = openHippoDb(root);
+      try {
+        const rows = db
+          .prepare(`SELECT team_id, bucket FROM slack_dlq ORDER BY id DESC LIMIT 1`)
+          .all() as Array<{ team_id?: string; bucket?: string }>;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].team_id).toBe('TPARTIAL');
+        expect(rows[0].bucket).toBe('parse_error');
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      if (handle) await handle.stop();
+      r1();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v0.39.0 security hardening release. Closes 21 retrospective findings from /codex review of the v0.38 ship, in 6 atomic commits.

### Commits
- `af178ec` cross-tenant authorization (promote / authCreate) + supersede CAS race + `writeEntryDbOnly`
- `846023b` MCP client-key isolation + recall/remember/outcome routed via `src/api.ts` + `hippo_share` guard
- `7cda4f4` `outcome()` function in api.ts + `hippo_outcome` MCP tool routed through it
- `623ecca` Slack hardening: unknown-team DLQ fallback, signing-secret rotation, DLQ schema (v19), idempotent deletion via `afterArchive`
- `70180b5` GDPR Path A on `raw_archive` (BREAKING data shape) — migration v20 redacts `payload_json` in place
- `0e1a318` Bearer route parity, auth timing reduction (precomputed `DUMMY_HASH`), SSE rebind on 60s heartbeat, graceful shutdown
- `bec3e7f` Version bump to 0.39.0, CHANGELOG, README, TODOS, p99/soak benchmark honesty

### Security (CRITICAL)
- 5 cross-tenant fixes (CVE candidates): promote auth, authCreate body.tenantId trust, supersede CAS race, MCP outcome poisoning, Slack unknown-team fallback
- GDPR Path A on archive: true RTBF — content removed from `raw_archive.payload_json` (BREAKING data shape, migration v20)
- Auth timing leak reduced: scrypt always runs on miss path
- `/mcp/stream` re-validates bearer on 60s heartbeat; `MCP_SSE_MAX_AGE_SEC` caps stream age

### Schema
- Migration v19: `slack_dlq` columns (team_id, bucket, retry_count, signature, slack_timestamp)
- Migration v20: `raw_archive.payload_json` redacted in place (Path A backfill, no down-migration)

### Retracted / deferred
- v0.36 <50ms p99 target retracted (current 58.4ms sequential single-thread, scaffold not gate)
- 24h soak harness documented as scaffold-only, not a release gate
- Tenant-guard audit on remaining 6 MCP tools (context, status, learn, conflicts, resolve, peers) deferred to v0.40
- Request-level rate limit on /v1/* deferred to v0.40

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` shows 996 pass, 2 skipped, 0 fail
- [x] Zero `0.38.0` stragglers in JSON manifests / src constants
- [x] All 6 atomic commits keep the suite green at each step
- [ ] Manual: `npm pack` + global install dry-run before merge
- [ ] Manual: `hippo serve` + MCP smoke test on stdio + HTTP

## Notes

BREAKING data shape on `raw_archive.payload_json`. Operators wanting v0.38 retention semantics must roll back or copy archive content before upgrading.