### PR TITLE
v1.9.3: reranker review-tail + version alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.9.3 (2026-05-20) — reranker review-tail patch
+
+This release does not re-assert the retracted −10pp magnitude.
+
+Post-merge cleanup of the three review-tail items called out on PR #25, plus the version-bump that aligns `package.json` with the v1.9.x docs shipped on master. No new research; no canonical-doc changes beyond this entry, the README "What's new" block, and the package version.
+
+### Shipped
+
+- **`src/rerankers/llm.ts`** — wires `AbortController` + `setTimeout` around the `fetch` call. Default timeout 30 s; overridable via the new `HIPPO_LLM_RERANKER_TIMEOUT_MS` env var. On timeout (or any other fetch failure) the reranker silently falls back to identity ordering — recall must not hang on a wedged endpoint.
+- **`src/rerankers/cross-encoder.ts`** — emits a single `console.warn` on first identity-fallback per process. Prevents the silent-fallback failure mode where a user believes the cross-encoder is doing work it isn't. Subsequent fallbacks within the same process are silent.
+- **`src/rerankers/index.ts` + `src/rerankers/types.ts`** — drop the orphaned `RerankSignals` type. Its sole consumer (`src/rerankers/features.ts`) was retracted in v1.9.1 (F10 HARD RETRACTION); the type is now dead code and is removed at both the re-export and the definition.
+- **`package.json` / `package-lock.json`** — version 1.8.1 → 1.9.3, aligning the npm-published version with the v1.9.0 / v1.9.1 / v1.9.2 entries already documented on master. No v1.9.0/1/2 line items were ever published to npm; this is the first published `1.9.x` release and it carries the cumulative scope from F6 (rerankers) through F13 (chunk-per-turn) plus the F10 retraction.
+
+### Mechanism cumulative-null status
+
+Per `docs/RETRACTION.md:94-113`. No `src/` change in this patch touches the dlPFC goal-stack mechanism. The cumulative-null status is unaffected.
+
+### Tests
+
+- **`tests/rerankers/llm.test.ts`** — new case asserting the AbortController wires through: a 5 ms timeout + a fetch that respects `init.signal` proves the reranker aborts and falls back to identity ordering without throwing.
+- **`tests/rerankers/cross-encoder.test.ts`** — new case asserting `console.warn` is called at most once across three repeated calls (the "don't spam" contract).
+
+### Not in this patch
+
+The Track 2 cross-encoder's real-evaluation gate, the LLM reranker's full characterisation, the cross-encoder model-fetch path under HF egress restrictions — all remain queued per v1.9.0's deferred-characterisation note. F9 hybrid-retrieval parity (BM25 + dense-vector RRF on `_s`, the `[critical, next]` track in `ROADMAP-RESEARCH.md`) is the recommended next research arc.
+
 ## 1.9.2 (2026-05-12) — F13 chunk-per-turn LongMemEval R@5 = 86.8 on oracle (Gate-B PASS)
 
 This release does not re-assert the retracted −10pp magnitude.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v1.9.3
+
+- **Reranker review-tail patch.** Closes the three follow-ups raised on PR #25: `src/rerankers/llm.ts` now wires `AbortController` + `setTimeout` around the fetch (default 30 s, overridable via `HIPPO_LLM_RERANKER_TIMEOUT_MS`) so recall never hangs on a wedged endpoint; `src/rerankers/cross-encoder.ts` emits a single `console.warn` on first identity-fallback per process so silent fallback no longer masquerades as a working reranker; the orphan `RerankSignals` type (sole consumer retracted in v1.9.1) is removed at both the re-export and the definition.
+- **Version alignment.** `package.json` bumped 1.8.1 → 1.9.3. v1.9.0 / v1.9.1 / v1.9.2 were on-master research milestones never published to npm; v1.9.3 is the first published `1.9.x` release and carries the cumulative scope from F6 (rerankers) through F13 (chunk-per-turn) plus the F10 HARD RETRACTION.
+- **Mechanism cumulative-null status unaffected.** Per `docs/RETRACTION.md:94-113`. No `src/` change in this patch touches the dlPFC goal-stack mechanism. **This release does not re-assert the retracted −10pp magnitude.**
+
 ### What's new in v1.9.2
 
 - **F13 chunk-per-turn LongMemEval R@5 = 86.8 on oracle (Gate-B PASS).** Plan F13 (`docs/evals/2026-05-12-r5-track6-chunk-per-turn-prereg.md`) addresses the structural pathology that limited every prior LongMemEval track (F8–F12): sessions in `data/longmemeval_oracle.json` are ~14k chars median (~3,500 tokens), but the embedders we can reach (MiniLM, BGE-base, multilingual-e5-large) cap at 512–514 tokens. Every prior track embedded only the first ~2 turns of each 12-turn session and truncated the rest. F13 replaces session-level embedding with turn-level embedding (10,866 turns over the 940 oracle sessions, max-pool by `session_id` at retrieval). Gate-A PASS (10,866 turns, all 940 sessions covered, 768-dim normalized). **Gate-B PASS:** F13 + F9 sub-agent rerank stack R@5 = 86.8 on `data/longmemeval_oracle.json` (threshold ≥ 83.2 = F11+F9 deployable best 78.2 + 5pp; margin 3.6). R@1 = 70.8, R@10 = 90.2, R@20 = 93.4.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.8.1",
+  "version": "1.9.3",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.8.1",
+      "version": "1.9.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/rerankers/cross-encoder.ts
+++ b/src/rerankers/cross-encoder.ts
@@ -11,6 +11,7 @@ const _dynImport = new Function('s', 'return import(s)') as (
 
 type CrossEncoderFn = (query: string, candidate: string) => Promise<{ score: number }[]>;
 let cachedPipeline: CrossEncoderFn | null = null;
+let warnedOnFallback = false;
 
 /**
  * True if @xenova/transformers is importable. Note: this does NOT confirm
@@ -66,7 +67,16 @@ export const crossEncoderReranker: RerankerFn = async (
 
   const pipe = await loadPipeline();
   if (!pipe) {
-    // Fallback: identity ordering with rerankScore = original score
+    // Fallback: identity ordering with rerankScore = original score. Warn
+    // once per process so a silent identity-fallback doesn't mislead users
+    // into thinking the cross-encoder is doing work it isn't.
+    if (!warnedOnFallback) {
+      warnedOnFallback = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[hippo] cross-encoder reranker unavailable (no @xenova/transformers, or model fetch blocked); falling back to identity ordering. Subsequent calls will not repeat this warning.',
+      );
+    }
     return head.map((r, i) => ({
       ...r,
       rerankScore: r.score,

--- a/src/rerankers/index.ts
+++ b/src/rerankers/index.ts
@@ -18,4 +18,4 @@ export function getReranker(name: string | null | undefined): RerankerFn | null 
   return fn;
 }
 
-export type { RerankerFn, RerankResult, RerankerOptions, RerankSignals } from './types.js';
+export type { RerankerFn, RerankResult, RerankerOptions } from './types.js';

--- a/src/rerankers/llm.ts
+++ b/src/rerankers/llm.ts
@@ -1,5 +1,7 @@
 import type { RerankerFn, RerankResult, RerankerOptions } from './types.js';
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 /**
  * Track 3 reranker: listwise LLM rerank. Uses a customer-supplied
  * OpenAI-compatible endpoint. Gated on HIPPO_LLM_RERANKER_URL to prevent
@@ -7,6 +9,10 @@ import type { RerankerFn, RerankResult, RerankerOptions } from './types.js';
  *
  * Skeleton only — see docs/plans/2026-05-10-f6-reranker-hardening.md Task 8.
  * Full characterisation deferred to a follow-on plan.
+ *
+ * Timeout: defaults to 30s; overridable via HIPPO_LLM_RERANKER_TIMEOUT_MS.
+ * On timeout or any fetch failure, the reranker silently falls back to
+ * identity ordering — recall must not hang on a wedged endpoint.
  */
 export const llmReranker: RerankerFn = async (
   query,
@@ -29,6 +35,13 @@ export const llmReranker: RerankerFn = async (
     `Output format: [<int>, <int>, ...] with all ${head.length} indices.`,
   ].join('\n');
 
+  const timeoutMs = Number.parseInt(
+    process.env.HIPPO_LLM_RERANKER_TIMEOUT_MS ?? '',
+    10,
+  ) || DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
   let permutation: number[] | null = null;
   try {
     const resp = await fetch(`${url.replace(/\/$/, '')}/chat/completions`, {
@@ -42,6 +55,7 @@ export const llmReranker: RerankerFn = async (
         messages: [{ role: 'user', content: prompt }],
         temperature: 0,
       }),
+      signal: controller.signal,
     });
     if (resp.ok) {
       const j = (await resp.json()) as { choices?: Array<{ message?: { content?: string } }> };
@@ -59,7 +73,10 @@ export const llmReranker: RerankerFn = async (
       }
     }
   } catch {
-    // Fall through to identity
+    // Fall through to identity. Includes AbortError on timeout — see
+    // DEFAULT_TIMEOUT_MS / HIPPO_LLM_RERANKER_TIMEOUT_MS above.
+  } finally {
+    clearTimeout(timer);
   }
 
   const ordered = permutation

--- a/src/rerankers/types.ts
+++ b/src/rerankers/types.ts
@@ -34,18 +34,3 @@ export interface RerankResult extends SearchResult {
   /** 1-indexed rank in the reranker output. */
   postRerankRank: number;
 }
-
-/**
- * Signals available to feature-based rerankers, extracted once per
- * candidate to avoid re-tokenizing or re-fetching.
- */
-export interface RerankSignals {
-  confidence: 'verified' | 'observed' | 'inferred' | 'stale' | null;
-  schemaFit: number;
-  kind: 'raw' | 'distilled' | 'superseded' | 'archived' | null;
-  strength: number;
-  retrievalCount: number;
-  outcomePositive: number;
-  outcomeNegative: number;
-  emotionalValence: 'neutral' | 'error' | 'success' | 'critical' | null;
-}

--- a/tests/rerankers/cross-encoder.test.ts
+++ b/tests/rerankers/cross-encoder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import {
   crossEncoderReranker,
   isCrossEncoderAvailable,
@@ -64,5 +64,18 @@ describe('crossEncoderReranker', () => {
       expect(out[0].entry.content).toBe('alpha');
       expect(out[1].entry.content).toBe('beta');
     }
+  });
+
+  it('does not spam console.warn on repeated fallback calls', async () => {
+    // The warn fires at most once per process on first identity-fallback.
+    // beforeAll's probe call may have already consumed the warn on
+    // fallback-mode machines, so the upper bound holds in both modes.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const inputs = [asResult('alpha', 1.0), asResult('beta', 0.5)];
+    await crossEncoderReranker('q', inputs);
+    await crossEncoderReranker('q', inputs);
+    await crossEncoderReranker('q', inputs);
+    expect(warnSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    warnSpy.mockRestore();
   });
 });

--- a/tests/rerankers/llm.test.ts
+++ b/tests/rerankers/llm.test.ts
@@ -54,4 +54,32 @@ describe('llmReranker', () => {
     delete process.env.HIPPO_LLM_RERANKER_KEY;
     await expect(llmReranker('q', [asResult('xyz', 1.0)])).rejects.toThrow(/HIPPO_LLM_RERANKER_URL/);
   });
+
+  it('aborts the fetch and falls back to input ordering on timeout', async () => {
+    // Tiny timeout + a fetch that respects AbortSignal proves the
+    // AbortController is wired through. Falls back to identity ordering,
+    // does NOT throw.
+    process.env.HIPPO_LLM_RERANKER_TIMEOUT_MS = '5';
+    let abortedFromSignal = false;
+    vi.spyOn(globalThis, 'fetch' as never).mockImplementation((async (
+      _url: unknown,
+      init?: { signal?: AbortSignal },
+    ) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          abortedFromSignal = true;
+          reject(new DOMException('aborted', 'AbortError'));
+        });
+        // never resolves on its own; only the abort can complete it
+      });
+    }) as never);
+
+    const inputs = [asResult('alpha', 1.0), asResult('beta', 0.5)];
+    const out = await llmReranker('q', inputs);
+
+    expect(abortedFromSignal).toBe(true);
+    expect(out.map((r) => r.entry.content)).toEqual(['alpha', 'beta']);
+
+    delete process.env.HIPPO_LLM_RERANKER_TIMEOUT_MS;
+  });
 });


### PR DESCRIPTION
## Summary

Post-merge patch closing the three review-tail items from PR #25, plus the version-bump that aligns `package.json` with the v1.9.x research milestones documented on master.

### Shipped

- **`src/rerankers/llm.ts`** — `AbortController` + `setTimeout` around the fetch. Default 30 s; overridable via `HIPPO_LLM_RERANKER_TIMEOUT_MS`. Timeouts and other fetch failures silently fall back to identity ordering. Recall no longer hangs on a wedged endpoint.
- **`src/rerankers/cross-encoder.ts`** — one `console.warn` on first identity-fallback per process. Subsequent fallbacks within the same process are silent. Closes the "user thinks the cross-encoder is doing work it isn't" failure mode.
- **`src/rerankers/index.ts` + `types.ts`** — drop the orphan `RerankSignals` type. Sole consumer (`src/rerankers/features.ts`) was retracted in v1.9.1.
- **Version bump 1.8.1 → 1.9.3** across `package.json`, `package-lock.json`, root `openclaw.plugin.json`, and the OpenClaw extension's own `package.json` + `openclaw.plugin.json` (tests/openclaw-package.test.ts asserts manifest alignment).
- **CHANGELOG + README "What's new in v1.9.3"** documenting the patch + the version-alignment story (v1.9.0/1/2 were on-master research milestones never published to npm).

### Mechanism cumulative-null status

Per `docs/RETRACTION.md:94-113`. No `src/` change in this patch touches the dlPFC goal-stack mechanism. **This release does not re-assert the retracted −10pp magnitude.**

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly (no dead `RerankSignals` references).
- [x] `npm test` — 1531 tests pass, 4 skipped (model-availability-gated cross-encoder tests + harness-mmr-lambda when no store). New tests: AbortController-wires-through (llm), warn-at-most-once (cross-encoder).
- [ ] CI green on push.

After merge: `npm publish` to ship as the first published `1.9.x` release.