### PR TITLE
feat: server and lifecycle hardening (H1, L3, H3, M3, H2, A3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.10.0 (2026-05-21): server and lifecycle hardening
+
+A pivot from the F-track research arc to product hardening. This release closes the "server / lifecycle hardening" cluster from `TODOS.md`: deferred follow-ups from the v0.37 server-mode work, the v0.40 security pass, and the A3 envelope review. Plan: `docs/plans/2026-05-21-server-lifecycle-hardening.md`.
+
+### Shipped
+
+- **H1: stale-pidfile and PID-reuse detection.** `detectServer` (`src/server-detect.ts`) is now async. After the `process.kill(pid, 0)` liveness check it issues a `GET /health` and confirms the answering process is this hippo server by matching `started_at`, so a reused pid that passes the signal check but belongs to a different or non-hippo process is caught. `serve()` threads one `startedAt` into both the pidfile and `/health` so the values are comparable. The probe runs only when a pidfile exists and the pid is live, so the common no-server path is unchanged. The probe target is validated as a loopback `http` url, the response body is read under a 64 KB cap, and a probe timeout (ambiguous, since the server may be alive but busy) returns null without unlinking the pidfile.
+- **L3: pidfile schema version.** The pidfile now carries `schema: 1`; readers treat a missing `schema` as legacy and still accept it.
+- **H3: concurrent `hippo serve` detection.** `serve()` probes for a live peer before `listen()` and refuses to start with a clear "already running on port N" error instead of racing for the pidfile.
+- **M3: oversized-body socket leak.** The `BodyTooLargeError` (413) path now calls `req.destroy()` so the remainder of an over-cap request body is not drained into an already-answered exchange.
+- **H2: `HIPPO_REQUIRE_SERVER` env knob.** When set, the CLI errors instead of silently falling back to direct mode (which discards a configured `HIPPO_API_KEY`). Default behaviour is unchanged.
+- **A3: `hippo forget --archive --reason`.** `hippo forget <id>` on a raw, append-only memory previously failed with a misleading "Memory not found". It now reports the append-only nature and points at `--archive`, which routes to the sanctioned `api.archiveRaw` path. `--archive` always takes the direct path; the HTTP `forget` route does not carry it.
+
+### Tests
+
+New `tests/cli-forget.test.ts` (4 cases). `tests/server-detect.test.ts` rewritten (9 cases: the H1 probe matrix, the L3 schema cases, and a forged-pidfile rejection). `tests/server-lifecycle.test.ts` gains H3 and M3 cases; `tests/cli-thin-client.test.ts` gains H2 and a `forget --archive` bypass case. Full suite: 216 files, 1557 tests, green.
+
+### Not in this release
+
+- Phase 3 tenant-guard threading (deferred to its own plan).
+- `hippo forget --archive` over the server-routed HTTP path, and a `stop()` pidfile-ownership check (both tracked in `TODOS.md`).
+
 ## 1.9.3 (2026-05-20) — reranker review-tail patch
 
 This release does not re-assert the retracted −10pp magnitude.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ hippo recall "data pipeline issues" --budget 2000
 
 ---
 
+### What's new in v1.10.0
+
+- **Server and lifecycle hardening.** Closes the `TODOS.md` "server / lifecycle hardening" cluster (deferred follow-ups from the v0.37 server-mode work, the v0.40 security pass, and the A3 envelope review), six items in all. `detectServer` is now async and confirms a recorded server is genuinely this hippo process by matching a `/health` `started_at` before the CLI routes to it (H1). The pidfile carries a `schema` version (L3). `hippo serve` refuses to start when a live peer already serves the hippoRoot (H3). The 413 over-cap-body path closes the socket instead of draining the rest (M3). A `HIPPO_REQUIRE_SERVER` env knob turns a missing server into a loud error instead of a silent direct-mode fallback that discards `HIPPO_API_KEY` (H2). And `hippo forget --archive --reason` gives raw, append-only memories a real removal path via `archiveRaw` instead of a misleading "not found" (A3).
+- **Reviewed via the dev-framework chain.** self-review, an independent code review, a cross-model codex (gpt-5.5) pass, and a security pass. Four findings were fixed before ship: the `forget --archive` server-routing bypass, an unbounded `/health` response parse, a timeout that wrongly unlinked a busy server's pidfile, and pidfile-url validation against off-box redirection. Full suite green: 216 files, 1557 tests.
+
 ### What's new in v1.9.3
 
 - **Reranker review-tail patch.** Closes the three follow-ups raised on PR #25: `src/rerankers/llm.ts` now wires `AbortController` + `setTimeout` around the fetch (default 30 s, overridable via `HIPPO_LLM_RERANKER_TIMEOUT_MS`) so recall never hangs on a wedged endpoint; `src/rerankers/cross-encoder.ts` emits a single `console.warn` on first identity-fallback per process so silent fallback no longer masquerades as a working reranker; the orphan `RerankSignals` type (sole consumer retracted in v1.9.1) is removed at both the re-export and the definition.

--- a/TODOS.md
+++ b/TODOS.md
@@ -75,7 +75,9 @@ From `/review` on commits 41b1f4d..6456e7d (now hardened to 00764ce). Each item 
 
 - [ ] **--scope CLI semantics.** `hippo remember --scope <v>` writes both the envelope `scope` column AND a `scope:<v>` tag. Recall's `--scope` filter currently matches the tag form. Decide: rename envelope flag to `--envelope-scope`, OR teach recall to filter the envelope column. Belongs in **A5** (auth/multi-tenancy) where scope semantics tighten. Until then, dual-write is documented in MEMORY_ENVELOPE.md.
 
-- [ ] **Wire `hippo forget` for raw rows.** Today `hippo forget <raw-id>` aborts via the append-only trigger with no user-facing recovery. Add a `--archive --reason --owner` mode to `hippo forget` that routes through `archiveRawMemory`. Belongs in **A4** (lifecycle compliance). Until then, `--kind raw` is gated at the CLI so users can't create unforgettable rows.
+- [x] **Wire `hippo forget` for raw rows.** Shipped 2026-05-21 (`docs/plans/2026-05-21-server-lifecycle-hardening.md`, item A3): `hippo forget <id> --archive --reason "<why>"` routes through `api.archiveRaw`, and the non-archive path now distinguishes the append-only abort from a true not-found. Per eng-review decision D1, no `--owner` flag; the envelope owner is a separate A3 concern.
+
+- [ ] **`hippo forget --archive` HTTP route.** `--archive` always takes the direct path (`cmdForget` → `api.archiveRaw`): the `forget` dispatch skips server routing for archive requests, since the HTTP `forget` route does not carry `--archive`. Correct and WAL-safe, but archive is the one `forget` path that does not route through a running server. If strict single-writer routing matters, extend the HTTP `forget` route + `client.forget` to carry the archive intent. Low priority. Noted 2026-05-21.
 
 - [ ] **--owner format validation.** Currently any string is accepted. The documented contract is `user:<id>` or `agent:<id>`. Add regex validation `^(user|agent):[A-Za-z0-9_-]+$` either as warn-only (log, accept) or strict-reject. Decide alongside A5.
 
@@ -356,3 +358,11 @@ v0.39 could ship the CRITICAL cross-tenant fixes without scope creep.
   `req.destroy()` on the BodyTooLargeError path so the socket closes
   cleanly instead of accepting another MB of bytes the server will
   immediately discard.
+
+- [ ] **`stop()` can unlink a newer server's pidfile.** `serve()`'s `stop()`
+  calls `removePidfile` unconditionally. If server A is shutting down while
+  server B has already started and rewritten the pidfile, A's stop deletes
+  B's pidfile and orphans the live B. Flagged by codex review 2026-05-21;
+  out of scope for the 2026-05-21 lifecycle-hardening release (`stop()` /
+  `removePidfile` were not in that diff). Fix: in `stop()`, unlink only when
+  the pidfile's `pid` + `started_at` match this server handle.

--- a/docs/plans/2026-05-21-server-lifecycle-hardening.md
+++ b/docs/plans/2026-05-21-server-lifecycle-hardening.md
@@ -1,0 +1,162 @@
+# Server / Lifecycle Hardening
+
+Date: 2026-05-21
+Status: APPROVED — eng-reviewed 2026-05-21, ready to implement (Phase 1 + Phase 2)
+
+## Context
+
+After the F-track LongMemEval research arc (F6-F16, mostly Gate-B FAIL), the
+decision on 2026-05-21 is to pivot from research to product hardening. This
+plan scopes the "server / lifecycle hardening" cluster from `TODOS.md` —
+deferred follow-ups from the v0.37 server-mode work, the v0.40 security pass,
+and the A3 envelope review.
+
+All current-state `file:line` references were verified against the working
+tree at commit `2eda721` on 2026-05-21.
+
+## Eng review (2026-05-21)
+
+Reviewed via `/plan-eng-review`. Step 0 scope check passed — Phase 1+2 touch
+~3-4 files, well under the complexity smell, and the plan reuses existing code
+(H1 reuses the wired `started_at`; A3 reuses `archiveRaw`). Decisions:
+
+- **D1** — `hippo forget --archive` takes no `--owner` flag (see Phase 2).
+- **D2** — Phase 3 (tenant-guard) is deferred to its own plan (see Phase 3).
+
+Minor revisions folded in below: H1 caller scope made concrete, H1 probe
+timeout specified, three test cases + a regression test added.
+
+## Scope — this release is Phase 1 + Phase 2
+
+### Phase 1 — server-mode robustness
+
+All touch `hippo serve` / the HTTP server / the pidfile. These are live bugs.
+
+**H1 — stale pidfile / PID-reuse.** `detectServer` (`src/server-detect.ts:21-44`)
+proves liveness with `process.kill(pid, 0)` only. A pid reused by an unrelated
+process passes, so the CLI thin-client can route to a non-hippo process.
+
+Corrected 2026-05-21 (post-eng-review, during execution): the pidfile and
+`/health` *each* record a `started_at`, but they were independent `new Date()`
+calls — `server-detect.ts:57` inside `writePidfile` vs `server.ts:1416` for
+`/health` — so they never matched. The fix therefore also threads `serve()`'s
+single `startedAt` into `writePidfile` (a new `opts.startedAt`); the pidfile
+and `/health` then carry one identical value, and `detectServer` compares for
+exact equality. Still wiring, ~2 lines beyond the original plan.
+
+Fix: make `detectServer` async; after the pid check, GET `${info.url}/health`
+with a short timeout (~300ms) and compare `body.started_at` to
+`info.started_at`. A mismatch, non-200, or malformed body → stale (unlink,
+return null). Corrected during execution (codex review, 2026-05-21): a probe
+*timeout* returns null WITHOUT unlinking, since a live but busy server can miss
+the window and destroying its pidfile would orphan it. The recorded url is also
+validated as loopback `http` on the recorded port before the probe (so a forged
+pidfile cannot point a HIPPO_API_KEY-bearing request off-box), and the /health
+body is read under a 64 KB cap.
+The probe runs only when a pidfile exists and the pid is live, so the common
+no-server path stays a fast file-read and the CLI hot path is not slowed.
+`detectServer` has exactly one caller — `runViaServerIfAvailable`
+(`cli.ts:240`), already in an async path; H3 adds a second. Size: M.
+
+**H3 — concurrent `hippo serve`, no winner detection.** `serve()`
+(`src/server.ts:~1404-1461`) calls `server.listen` directly; two invocations on
+one hippoRoot race, the loser exits EADDRINUSE, the winner overwrites the
+pidfile. Fix: at the top of `serve()`, call the now-async `detectServer`; if a
+live peer answers `/health`, throw a clear "already running on port N" error
+before `listen()`. Depends on H1. Size: S-M.
+
+**L3 — pidfile schema version.** `ServerInfo` (`server-detect.ts:4-9`) has no
+version field. Fix: add `schema: 1` to the interface and the `writePidfile`
+`info` object; `detectServer` treats a missing `schema` as legacy and tolerates
+it. Bundle with H1/H3 (same file). Size: S.
+
+**H2 — `HIPPO_API_KEY` silently dropped on fallback.** `runViaServerIfAvailable`
+(`cli.ts:~236-254`): on connection-refused it unlinks the pidfile and returns
+false, so the caller runs direct mode and the configured `apiKey` is silently
+discarded — masking a production misconfiguration. Fix: add a
+`HIPPO_REQUIRE_SERVER` env knob; when set, the connection-refused branch
+re-throws a clear error instead of falling back. Default behaviour unchanged.
+Size: S.
+
+**M3 — `BodyTooLargeError` leaves the socket open.** `readBody`
+(`src/server.ts:~138-150`) throws on the 1 MB cap; the handler catch (`~1424`)
+sends 413 but never `req.destroy()`, so the rest of the body drains into a
+closed exchange. Fix: `req.destroy()` in the `BodyTooLargeError` branch after
+`sendError`, on the generic route and the Slack / GitHub webhook routes (all
+share `readBody`). Size: S.
+
+### Phase 2 — lifecycle: `hippo forget` for raw rows
+
+**A3 — `hippo forget <raw-id>` is a dead end.** `cmdForget` (`cli.ts:2678-2694`)
+→ `api.forget` → `deleteEntry` → the BEFORE-DELETE SQLite trigger
+`RAISE(ABORT, 'raw is append-only')`. `cmdForget`'s bare `catch` reports a
+misleading "Memory not found". `--kind raw` is CLI-gated, but connector
+ingestion (Slack / GitHub) creates raw rows that are legitimate forget targets.
+Fix: add `--archive` and `--reason` flags to `cmdForget`; with `--archive`,
+route to `api.archiveRaw(ctx, id, reason)` — which exists (`api.ts:1288`), is
+tenant-checked, and is the sanctioned raw-removal path. Without `--archive`, the
+catch must distinguish the append-only abort from a true not-found and tell the
+user to use `--archive`. Size: M.
+
+Decided (eng-review, 2026-05-21): **no `--owner` flag.** `archiveRawMemory`
+records the archiver (`ctx.actor`) as `who` — correct provenance for an archive.
+A user-supplied owner is a different concept (the envelope owner set by
+`hippo remember --owner`, a separate A3 TODO); conflating it here is scope
+creep. Final scope: `hippo forget <id> --archive --reason "..."`.
+
+### Phase 3 — tenant-guard threading — DEFERRED (separate plan)
+
+Not in this release. Recorded here for traceability.
+
+`listMemoryConflicts` (`store.ts:2008`) and `resolveConflict` (`store.ts:2116`)
+take no `tenantId`, so the `hippo_status` / `hippo_conflicts` / `hippo_resolve`
+MCP tools leak and can mutate conflict rows across tenants. The fix would thread
+a `tenantId` parameter through both functions, their SQL, and the MCP handlers
+(`server.ts:741,776,788`). Size: L (~12 call sites).
+
+Decided (eng-review, 2026-05-21): out of scope for this release. The leak is
+latent — per `TODOS.md` L9, hippo's deployment model today is "single tenant per
+deployment", so it is not currently reachable. Threading `tenantId` through SQL
+is a security-shaped change that wants its own focused review and test pass.
+Tenant-guard gets its own plan, sequenced with the A5 v2 multi-tenant track.
+
+## Test plan
+
+- **H1:** (a) live server, matching `started_at` → `detectServer` returns the
+  info; (b) stale `started_at` (pid alive, `/health` returns a different value)
+  → null + unlink; (c) `/health` unreachable / times out → null + unlink;
+  (d) dead pid → null (existing behaviour, keep covered).
+- **H3:** two `serve()` on one hippoRoot → the second throws a clear error, the
+  pidfile is not corrupted.
+- **L3:** a new pidfile carries `schema: 1`; a legacy pidfile (no `schema`) is
+  still accepted by `detectServer`.
+- **H2:** `HIPPO_REQUIRE_SERVER=1` with no server → CLI errors clearly; unset →
+  falls back as today.
+- **M3:** POST a >1 MB body → 413 + socket destroyed (no further bytes accepted)
+  — on the generic `/v1` route AND a webhook route (Slack or GitHub), since they
+  share `readBody`.
+- **A3:** `hippo forget <raw-id>` → clear "use --archive" error;
+  `... --archive --reason "..."` → row archived, `archive_raw` audit emitted.
+- **Regression:** `detectServer` becomes async — the existing `server-detect`
+  tests gain `await`, and the `writePidfile + removePidfile roundtrip` test is
+  rewritten: under H1 a pidfile with no live server behind it is correctly
+  stale, so case (a) "returns the info" now drives a real in-process `serve()`.
+- All tests stay store-isolated — the leak guard from `2470fff` stays green.
+
+## Risks / open questions
+
+- H1: `detectServer` going async has a one-caller blast radius
+  (`runViaServerIfAvailable`, `cli.ts:240`, already async); H3 adds a second.
+  No sync caller — verified.
+- M3: `req.destroy()` on the webhook routes must run after `sendError`, not race it.
+- Versioning: `package.json` is `1.9.3`, `ROADMAP.md` is stale at `v0.33.0`.
+  Pick the release version at ship time.
+
+## NOT in scope
+
+- Phase 3 tenant-guard threading — deferred to its own plan (D2).
+- p99 latency hardening (`TODOS.md`: explicitly no current target).
+- 24h soak harness as a CI gate (separate infra work).
+- B3 dlPFC / vlPFC research items (this pivot is away from research).
+- UI redesign port and Slack-connector-v2 follow-ups (other backlog clusters).
+- `ROADMAP.md` refresh (overdue, but not part of this release).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@
  *   hippo session <log|show|latest|resume|complete>
  *   hippo handoff <create|latest|show>
  *   hippo current <show>
- *   hippo forget <id>
+ *   hippo forget <id> [--archive --reason "<why>"]
  *   hippo inspect <id>
  *   hippo embed [--status]
  *   hippo watch "<command>"
@@ -223,6 +223,22 @@ function requireInit(hippoRoot: string): void {
 }
 
 /**
+ * H2: when HIPPO_REQUIRE_SERVER is set, the CLI must not silently fall back to
+ * direct DB mode — a missing server then masks a real misconfiguration (the
+ * configured HIPPO_API_KEY is also silently discarded on fallback). Throws a
+ * clear, actionable error in that case; a no-op when the knob is unset, so
+ * default behaviour is unchanged.
+ */
+function failIfServerRequired(reason: string): void {
+  if (process.env['HIPPO_REQUIRE_SERVER']) {
+    throw new Error(
+      `hippo: HIPPO_REQUIRE_SERVER is set but ${reason}. ` +
+      `Start \`hippo serve\`, or unset HIPPO_REQUIRE_SERVER to allow direct-mode fallback.`,
+    );
+  }
+}
+
+/**
  * Run an HTTP-routed command if a `hippo serve` instance is detected for
  * `hippoRoot`. Returns:
  *   - true  if the HTTP path ran (success OR a structured server error that
@@ -232,19 +248,26 @@ function requireInit(hippoRoot: string): void {
  *           and the caller should fall back to the direct path.
  *
  * Per the A1 plan footgun #1: stale pidfiles must self-heal, not crash.
+ * H2: when HIPPO_REQUIRE_SERVER is set, both fallback paths throw instead of
+ * returning false, so a missing server fails loudly rather than silently
+ * degrading to direct mode.
  */
 async function runViaServerIfAvailable(
   hippoRoot: string,
   httpFn: (info: ServerInfo, apiKey: string | undefined) => Promise<void>,
 ): Promise<boolean> {
-  const info = detectServer(hippoRoot);
-  if (!info) return false;
+  const info = await detectServer(hippoRoot);
+  if (!info) {
+    failIfServerRequired('no running server was detected for this hippoRoot');
+    return false;
+  }
   const apiKey = process.env['HIPPO_API_KEY'];
   try {
     await httpFn(info, apiKey);
     return true;
   } catch (err) {
     if (client.isConnectionRefused(err)) {
+      failIfServerRequired('the server pidfile was stale (connection refused)');
       console.error('hippo: stale server pidfile detected, falling back to direct mode');
       removePidfile(hippoRoot);
       return false;
@@ -2675,7 +2698,11 @@ function cmdOutcome(
   console.log(`Applied ${good ? 'positive' : 'negative'} outcome to ${updated} memor${updated === 1 ? 'y' : 'ies'}`);
 }
 
-function cmdForget(hippoRoot: string, id: string): void {
+function cmdForget(
+  hippoRoot: string,
+  id: string,
+  flags: Record<string, string | boolean | string[]>,
+): void {
   requireInit(hippoRoot);
 
   const ctx: api.Context = {
@@ -2683,12 +2710,43 @@ function cmdForget(hippoRoot: string, id: string): void {
     tenantId: resolveTenantId({}),
     actor: 'cli',
   };
+
+  // A3: raw memories (Slack / GitHub connector ingestion) are append-only — a
+  // BEFORE-DELETE trigger aborts any delete. archiveRaw is the sanctioned
+  // removal path; it records ctx.actor as the archiver for provenance.
+  if (flags['archive'] === true) {
+    const reason = typeof flags['reason'] === 'string' ? flags['reason'] : null;
+    if (!reason) {
+      console.error('hippo forget --archive requires --reason "<why>" (recorded on the archive).');
+      process.exit(1);
+    }
+    try {
+      api.archiveRaw(ctx, id, reason);
+      updateStats(hippoRoot, { forgotten: 1 });
+      console.log(`Archived ${id}`);
+    } catch (err) {
+      console.error(`Could not archive ${id}: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    return;
+  }
+
   try {
     api.forget(ctx, id);
     updateStats(hippoRoot, { forgotten: 1 });
     console.log(`Forgot ${id}`);
-  } catch {
-    console.error(`Memory not found: ${id}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/append-only/i.test(msg)) {
+      // The delete was refused by the append-only trigger — this is a raw
+      // memory, not a missing one. Point the user at the archive path.
+      console.error(
+        `Cannot forget ${id}: it is a raw, append-only memory. ` +
+        `Archive it instead: hippo forget ${id} --archive --reason "<why>"`,
+      );
+    } else {
+      console.error(`Memory not found: ${id}`);
+    }
     process.exit(1);
   }
 }
@@ -5458,6 +5516,8 @@ Commands:
     current show           Active task + recent session events (default)
       --json               Output as JSON
   forget <id>              Force remove a memory
+    --archive              Archive a raw (append-only) memory instead of deleting
+    --reason "<why>"       Reason recorded on the archive (required with --archive)
   inspect <id>             Show full memory detail
   embed                    Embed all memories for semantic search
     --status               Show embedding coverage
@@ -5924,17 +5984,22 @@ async function main(): Promise<void> {
         console.error('Please provide a memory ID.');
         process.exit(1);
       }
-      const routed = await runViaServerIfAvailable(hippoRoot, async (info, apiKey) => {
-        try {
-          await client.forget(info.url, apiKey, id);
-          console.log(`Forgot ${id}`);
-        } catch (err) {
-          console.error((err as Error).message);
-          process.exit(1);
-        }
-      });
-      if (routed) break;
-      cmdForget(hippoRoot, id);
+      // A3: --archive is a direct-DB operation (raw archival via archiveRaw);
+      // the HTTP forget route does not carry it, so archive requests always
+      // take the direct path rather than silently no-op'ing over a server.
+      if (flags['archive'] !== true) {
+        const routed = await runViaServerIfAvailable(hippoRoot, async (info, apiKey) => {
+          try {
+            await client.forget(info.url, apiKey, id);
+            console.log(`Forgot ${id}`);
+          } catch (err) {
+            console.error((err as Error).message);
+            process.exit(1);
+          }
+        });
+        if (routed) break;
+      }
+      cmdForget(hippoRoot, id, flags);
       break;
     }
 

--- a/src/server-detect.ts
+++ b/src/server-detect.ts
@@ -2,6 +2,12 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync, renameSync } from 
 import { join } from 'node:path';
 
 export interface ServerInfo {
+  /**
+   * Pidfile schema version (L3). Absent on pidfiles written before this
+   * field existed — detectServer treats a missing `schema` as legacy and
+   * still accepts the pidfile.
+   */
+  schema?: number;
   pid: number;
   port: number;
   url: string;
@@ -14,11 +20,43 @@ export interface ServerInfo {
 const PIDFILE = 'server.pid';
 
 /**
- * Read .hippo/server.pid and return the embedded ServerInfo if the recorded
- * pid is still alive. Returns null on missing, malformed, or stale pidfiles,
- * and best-effort unlinks the file in the latter two cases.
+ * How long detectServer waits for the `/health` liveness probe before
+ * treating the pidfile as stale. Short by design: the probe only fires on
+ * the rare path where a pidfile exists and its pid is live, and the target
+ * is always loopback, so a healthy server answers well within this bound.
  */
-export function detectServer(hippoRoot: string): ServerInfo | null {
+const HEALTH_PROBE_TIMEOUT_MS = 300;
+
+/**
+ * Hard cap on the /health response body detectServer will buffer. A real
+ * hippo /health payload is well under 1 KB; a larger body means the process
+ * answering on the recorded port is not hippo, so the pidfile is stale.
+ */
+const HEALTH_BODY_MAX_BYTES = 64 * 1024;
+
+/**
+ * Loopback hosts the recorded pidfile url is allowed to point at. serve()
+ * only binds these (it mirrors LOOPBACK_HOSTS in server.ts); a pidfile url
+ * with any other host is malformed or forged and must not be probed.
+ */
+const PIDFILE_LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
+/**
+ * Read .hippo/server.pid and return the embedded ServerInfo if a live hippo
+ * server is genuinely answering on the recorded url. Returns null on missing,
+ * malformed, or stale pidfiles, and best-effort unlinks the file in the
+ * stale/malformed cases.
+ *
+ * Liveness is proven in two steps. `process.kill(pid, 0)` rules out dead
+ * pids. But a pid can be reused by an unrelated process, so a GET /health
+ * then confirms the process that answers is *this* hippo server: its
+ * `started_at` must equal the pidfile's. A mismatch, non-200, malformed
+ * body, or timeout all mean the pidfile is stale.
+ *
+ * The /health probe runs only when a pidfile exists and the pid is live, so
+ * the common no-server path stays a single fast file existence check.
+ */
+export async function detectServer(hippoRoot: string): Promise<ServerInfo | null> {
   const path = join(hippoRoot, PIDFILE);
   if (!existsSync(path)) return null;
 
@@ -40,21 +78,99 @@ export function detectServer(hippoRoot: string): ServerInfo | null {
     try { unlinkSync(path); } catch {}
     return null;
   }
+
+  // The pid is live, but it may have been reused by an unrelated process, and
+  // the recorded url is read from a file anyone could forge. serve() only ever
+  // binds a loopback host, so a url that is not http on a loopback host and the
+  // recorded port is malformed or forged. Reject it before probing: the probe,
+  // and the routed request that may follow, can carry HIPPO_API_KEY.
+  let probeUrl: URL;
+  try {
+    probeUrl = new URL(info.url);
+  } catch {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+  if (
+    probeUrl.protocol !== 'http:' ||
+    !PIDFILE_LOOPBACK_HOSTS.has(probeUrl.hostname) ||
+    probeUrl.port !== String(info.port)
+  ) {
+    try { unlinkSync(path); } catch {}
+    return null;
+  }
+
+  // Confirm the process answering on info.url is this hippo server by matching
+  // the /health `started_at` against the pidfile. A connection refusal, a
+  // non-200, or a malformed body unlink the pidfile as stale. A probe timeout
+  // is deliberately left ambiguous: a live but momentarily-busy server (e.g.
+  // blocked on a synchronous query) can miss the 300ms window, so a timeout
+  // returns null WITHOUT unlinking. The pidfile survives for the next probe.
+  try {
+    const res = await fetch(`${info.url}/health`, {
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok || !res.body) {
+      try { unlinkSync(path); } catch {}
+      return null;
+    }
+    // Read the body under a hard byte cap. The process answering on info.url
+    // may not be hippo (pid reuse is the case this probe guards against), so
+    // its response is untrusted: never hand an unbounded stream to a parser.
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let raw = '';
+    let received = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > HEALTH_BODY_MAX_BYTES) {
+        await reader.cancel();
+        try { unlinkSync(path); } catch {}
+        return null;
+      }
+      raw += decoder.decode(value, { stream: true });
+    }
+    raw += decoder.decode();
+    const body = JSON.parse(raw) as { started_at?: unknown };
+    if (body.started_at !== info.started_at) {
+      try { unlinkSync(path); } catch {}
+      return null;
+    }
+  } catch (err) {
+    // A timeout is ambiguous (the server may be alive but busy), so keep the
+    // pidfile. Any other failure (connection refused, malformed body) is
+    // definitive: unlink it as stale.
+    if ((err as { name?: unknown })?.name !== 'TimeoutError') {
+      try { unlinkSync(path); } catch {}
+    }
+    return null;
+  }
+
   return info;
 }
 
 /**
  * Atomically write the pidfile. Writes to a process-scoped temp file then
  * renames into place, which is atomic on POSIX and on NTFS via MoveFileEx.
+ *
+ * `startedAt` is supplied by the caller (`serve()`) rather than generated
+ * here, so the pidfile and the server's GET /health response carry the same
+ * timestamp — detectServer's liveness probe compares the two for equality.
  */
-export function writePidfile(hippoRoot: string, opts: { port: number; url: string }): void {
+export function writePidfile(
+  hippoRoot: string,
+  opts: { port: number; url: string; startedAt: string },
+): void {
   const path = join(hippoRoot, PIDFILE);
   const tmp = `${path}.tmp.${process.pid}`;
   const info: ServerInfo = {
+    schema: 1,
     pid: process.pid,
     port: opts.port,
     url: opts.url,
-    started_at: new Date().toISOString(),
+    started_at: opts.startedAt,
   };
   writeFileSync(tmp, JSON.stringify(info));
   renameSync(tmp, path);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { createHash } from 'node:crypto';
-import { writePidfile, removePidfile } from './server-detect.js';
+import { detectServer, writePidfile, removePidfile } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { openHippoDb, closeHippoDb } from './db.js';
 import { PACKAGE_VERSION } from './version.js';
@@ -1413,6 +1413,21 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
     );
   }
 
+  // H3: refuse to start if a live hippo server already serves this hippoRoot.
+  // detectServer probes the recorded /health — a stale pidfile is unlinked and
+  // ignored, but a live peer means a concurrent `hippo serve` would race for
+  // the port and clobber the pidfile.
+  const existing = await detectServer(opts.hippoRoot);
+  if (existing) {
+    throw new Error(
+      `hippo serve: already running on port ${existing.port} (pid ${existing.pid}). ` +
+      `Stop that server before starting another on the same hippoRoot.`,
+    );
+  }
+
+  // The server's start time. Single source of truth: it is returned by every
+  // GET /health response and (below) written into the pidfile, so detectServer
+  // can match the two and prove a pid-reusing impostor is not the real server.
   const startedAt = new Date().toISOString();
 
   const server: Server = createServer((req, res) => {
@@ -1423,6 +1438,11 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
       }
       if (err instanceof BodyTooLargeError) {
         sendError(res, 413, err.message);
+        // M3: readBody hit the 1 MB cap mid-stream, so the request body is
+        // only partially consumed. Destroy the socket rather than let the
+        // client's remaining (unbounded) bytes drain into an exchange we have
+        // already answered.
+        req.destroy();
         return;
       }
       if (err instanceof HttpError) {
@@ -1467,7 +1487,7 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
   const actualPort = address.port;
   const url = `http://${host}:${actualPort}`;
 
-  writePidfile(opts.hippoRoot, { port: actualPort, url });
+  writePidfile(opts.hippoRoot, { port: actualPort, url, startedAt });
 
   let stopping = false;
   const stop = async (): Promise<void> => {

--- a/tests/cli-forget.test.ts
+++ b/tests/cli-forget.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
+
+// A3: `hippo forget` on a raw (append-only) memory must not dead-end with a
+// misleading "Memory not found" — it reports the append-only nature and points
+// at `--archive`, which routes to the sanctioned archiveRaw path.
+
+const REPO_ROOT = join(__dirname, '..');
+const CLI_PATH = join(REPO_ROOT, 'dist', 'cli.js');
+
+// Column list copied from raw-archive.test.ts — a minimal raw row. tenant_id is
+// omitted; the column defaults to 'default', matching the CLI's default tenant.
+const RAW_COLS =
+  'id, created, last_retrieved, retrieval_count, strength, half_life_days, ' +
+  'layer, tags_json, emotional_valence, schema_fit, source, conflicts_with_json, ' +
+  'pinned, confidence, content, kind';
+
+function runCli(cwd: string, ...args: string[]): { out: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI_PATH, ...args], {
+      cwd, env: { ...process.env }, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { out: stdout, status: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string | Buffer; stderr?: string | Buffer; status?: number };
+    const stdout = typeof err.stdout === 'string' ? err.stdout : (err.stdout?.toString('utf8') ?? '');
+    const stderr = typeof err.stderr === 'string' ? err.stderr : (err.stderr?.toString('utf8') ?? '');
+    return { out: stdout + stderr, status: err.status ?? 1 };
+  }
+}
+
+function makeWorkspaceWithRaw(rawId: string): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-forget-'));
+  const hippoRoot = join(home, '.hippo');
+  mkdirSync(hippoRoot, { recursive: true });
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    db.prepare(
+      `INSERT INTO memories (${RAW_COLS}) VALUES ` +
+      `(?, '2026-01-01', '2026-01-01', 0, 1.0, 7, 'episodic', '[]', 'neutral', ` +
+      `0.5, 'connector', '[]', 0, 'observed', 'connector raw content', ?)`,
+    ).run(rawId, 'raw');
+  } finally {
+    closeHippoDb(db);
+  }
+  return home;
+}
+
+describe('cli forget — raw memory archive (A3)', () => {
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH) || !statSync(CLI_PATH).isFile()) {
+      throw new Error(`dist/cli.js not found at ${CLI_PATH}. Run \`npm run build\` first.`);
+    }
+  });
+
+  it('reports append-only and points at --archive when forgetting a raw memory', () => {
+    const home = makeWorkspaceWithRaw('mem_rawa3a');
+    try {
+      const run = runCli(home, 'forget', 'mem_rawa3a');
+      expect(run.status).not.toBe(0);
+      expect(run.out).toMatch(/append-only/i);
+      expect(run.out).toMatch(/--archive/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('--archive --reason archives the raw memory and emits an archive_raw audit', () => {
+    const home = makeWorkspaceWithRaw('mem_rawa3b');
+    try {
+      const run = runCli(home, 'forget', 'mem_rawa3b', '--archive', '--reason', 'A3 test cleanup');
+      expect(run.status, run.out).toBe(0);
+      expect(run.out).toMatch(/Archived mem_rawa3b/);
+      const db = openHippoDb(join(home, '.hippo'));
+      try {
+        expect(db.prepare(`SELECT id FROM memories WHERE id = 'mem_rawa3b'`).get()).toBeUndefined();
+        const events = queryAuditEvents(db, { tenantId: 'default', op: 'archive_raw', limit: 10 });
+        expect(events.length).toBeGreaterThan(0);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('--archive without --reason errors clearly', () => {
+    const home = makeWorkspaceWithRaw('mem_rawa3c');
+    try {
+      const run = runCli(home, 'forget', 'mem_rawa3c', '--archive');
+      expect(run.status).not.toBe(0);
+      expect(run.out).toMatch(/--reason/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('still reports "not found" for a genuinely missing id', () => {
+    const home = makeWorkspaceWithRaw('mem_rawa3d');
+    try {
+      const run = runCli(home, 'forget', 'mem_definitely_missing');
+      expect(run.status).not.toBe(0);
+      expect(run.out).toMatch(/not found/i);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/tests/cli-thin-client.test.ts
+++ b/tests/cli-thin-client.test.ts
@@ -232,4 +232,63 @@ describe('cli thin-client mode', () => {
       rmSync(workspace, { recursive: true, force: true });
     }
   }, 15_000);
+
+  it('errors instead of silently falling back when HIPPO_REQUIRE_SERVER is set (H2)', () => {
+    const workspace = makeWorkspace();
+    try {
+      // No server running. With HIPPO_REQUIRE_SERVER set the CLI must NOT
+      // quietly drop to direct mode — that masks a misconfiguration (and
+      // silently discards a configured HIPPO_API_KEY). It must fail loudly.
+      process.env.HIPPO_REQUIRE_SERVER = '1';
+      const run = runCli(workspace, 'remember', 'require-server-canary-66');
+      expect(run.stdout + run.stderr).toMatch(/HIPPO_REQUIRE_SERVER/);
+      // The memory must not have been written via the direct path.
+      expect(getActorForContent(workspace, 'require-server-canary-66')).toBeNull();
+    } finally {
+      delete process.env.HIPPO_REQUIRE_SERVER;
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('hippo forget --archive bypasses the server and archives directly (A3)', async () => {
+    const workspace = makeWorkspace();
+    let server: SpawnedServer | null = null;
+    try {
+      // Insert a raw memory directly; connectors create these, the CLI gates --kind raw.
+      const hippoRoot = join(workspace, '.hippo');
+      const db = openHippoDb(hippoRoot);
+      try {
+        db.prepare(
+          `INSERT INTO memories (id, created, last_retrieved, retrieval_count, strength, ` +
+          `half_life_days, layer, tags_json, emotional_valence, schema_fit, source, ` +
+          `conflicts_with_json, pinned, confidence, content, kind) VALUES ` +
+          `('mem_rawthin', '2026-01-01', '2026-01-01', 0, 1.0, 7, 'episodic', '[]', ` +
+          `'neutral', 0.5, 'connector', '[]', 0, 'observed', 'connector raw content', 'raw')`,
+        ).run();
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const port = await pickFreePort();
+      server = await startServer(workspace, port);
+
+      // With the server up, a plain forget routes over HTTP. forget --archive must
+      // not route there (the HTTP path cannot archive); it takes the direct path.
+      const run = runCli(workspace, 'forget', 'mem_rawthin', '--archive', '--reason', 'thin-client archive test');
+      expect(run.stdout, `stderr: ${run.stderr}`).toMatch(/Archived mem_rawthin/);
+
+      // Row archived: gone from memories, archive_raw audit emitted.
+      const db2 = openHippoDb(hippoRoot);
+      try {
+        expect(db2.prepare(`SELECT id FROM memories WHERE id = 'mem_rawthin'`).get()).toBeUndefined();
+        const events = queryAuditEvents(db2, { tenantId: 'default', op: 'archive_raw', limit: 10 });
+        expect(events.length).toBeGreaterThan(0);
+      } finally {
+        closeHippoDb(db2);
+      }
+    } finally {
+      if (server) await server.stop();
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/tests/server-detect.test.ts
+++ b/tests/server-detect.test.ts
@@ -1,37 +1,175 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createServer, type Server } from 'node:http';
 import { detectServer, writePidfile, removePidfile } from '../src/server-detect.js';
+import { serve } from '../src/server.js';
+
+// hippoRoot is the directory the pidfile sits directly inside, matching the
+// api.ts / store.ts convention. serve() and detectServer take it as-is.
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
+}
 
 describe('server-detect', () => {
-  it('returns null when no pidfile exists', () => {
-    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
-    expect(detectServer(home)).toBeNull();
-    rmSync(home, { recursive: true, force: true });
+  it('returns null when no pidfile exists', async () => {
+    const home = makeRoot();
+    try {
+      expect(await detectServer(home)).toBeNull();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
-  it('returns null when pidfile exists but process is dead', () => {
-    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
-    // hippoRoot is the .hippo directory itself, matching the api.ts/store.ts
-    // convention; pidfile sits directly inside it.
+  it('returns null and unlinks a pidfile whose process is dead (H1 case d)', async () => {
+    const home = makeRoot();
     const pidfile = join(home, 'server.pid');
-    writeFileSync(pidfile,
-      JSON.stringify({ pid: 99999999, port: 6789, url: 'http://127.0.0.1:6789', started_at: new Date().toISOString() }));
-    expect(detectServer(home)).toBeNull();
-    // Stale pidfile should have been deleted
-    expect(existsSync(pidfile)).toBe(false);
-    rmSync(home, { recursive: true, force: true });
+    try {
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: 99_999_999, port: 6789,
+        url: 'http://127.0.0.1:6789', started_at: new Date().toISOString(),
+      }));
+      expect(await detectServer(home)).toBeNull();
+      // Stale pidfile should have been deleted.
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
-  it('writePidfile + removePidfile roundtrip', () => {
-    const home = mkdtempSync(join(tmpdir(), 'hippo-pidf-'));
-    writePidfile(home, { port: 6789, url: 'http://127.0.0.1:6789' });
-    const detected = detectServer(home);
-    expect(detected?.url).toBe('http://127.0.0.1:6789');
-    expect(detected?.pid).toBe(process.pid);
-    removePidfile(home);
-    expect(detectServer(home)).toBeNull();
-    rmSync(home, { recursive: true, force: true });
+  it('returns the info when a live server /health started_at matches (H1 case a)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    try {
+      const detected = await detectServer(home);
+      expect(detected).not.toBeNull();
+      expect(detected?.url).toBe(handle.url);
+      expect(detected?.pid).toBe(process.pid);
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null and unlinks when /health started_at does not match (H1 case b)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    const pidfile = join(home, 'server.pid');
+    try {
+      // The server is genuinely live, but rewrite the pidfile's started_at to
+      // a value /health will never report — simulates the pid + port being
+      // held by a different process than the one named in the pidfile.
+      const info = JSON.parse(readFileSync(pidfile, 'utf8'));
+      info.started_at = '1999-01-01T00:00:00.000Z';
+      writeFileSync(pidfile, JSON.stringify(info));
+
+      expect(await detectServer(home)).toBeNull();
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null and unlinks when /health is unreachable (H1 case c)', async () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      // pid is alive (this very test process) but nothing listens on the url,
+      // so the probe gets connection-refused — the pidfile is stale.
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid, port: 59_999,
+        url: 'http://127.0.0.1:59999', started_at: new Date().toISOString(),
+      }));
+      expect(await detectServer(home)).toBeNull();
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null but keeps the pidfile when /health times out (H1 case c)', async () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    // A stub server that accepts the connection but never answers, so the
+    // AbortSignal.timeout inside detectServer fires.
+    const stub: Server = createServer(() => { /* deliberately never responds */ });
+    try {
+      const port = await new Promise<number>((resolve) => {
+        stub.listen(0, '127.0.0.1', () => {
+          const addr = stub.address();
+          resolve(typeof addr === 'object' && addr ? addr.port : 0);
+        });
+      });
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid, port,
+        url: `http://127.0.0.1:${port}`, started_at: new Date().toISOString(),
+      }));
+      expect(await detectServer(home)).toBeNull();
+      // A timeout is ambiguous (the server may be alive but busy), so the
+      // pidfile is left in place for the next probe to re-confirm.
+      expect(existsSync(pidfile)).toBe(true);
+    } finally {
+      stub.closeAllConnections?.();
+      await new Promise<void>((resolve) => stub.close(() => resolve()));
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('writePidfile stamps schema 1 and the caller-supplied started_at (L3)', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      const startedAt = '2026-05-21T12:00:00.000Z';
+      writePidfile(home, { port: 6789, url: 'http://127.0.0.1:6789', startedAt });
+      const info = JSON.parse(readFileSync(pidfile, 'utf8'));
+      expect(info.schema).toBe(1);
+      expect(info.started_at).toBe(startedAt);
+      expect(info.pid).toBe(process.pid);
+      removePidfile(home);
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('detectServer still accepts a legacy pidfile with no schema field (L3)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    const pidfile = join(home, 'server.pid');
+    try {
+      // Strip `schema` to mimic a pidfile written before L3. A missing schema
+      // is legacy, not invalid — detectServer must still accept it.
+      const info = JSON.parse(readFileSync(pidfile, 'utf8'));
+      delete info.schema;
+      writeFileSync(pidfile, JSON.stringify(info));
+
+      const detected = await detectServer(home);
+      expect(detected).not.toBeNull();
+      expect(detected?.schema).toBeUndefined();
+    } finally {
+      await handle.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects and unlinks a pidfile whose url is not loopback (forged pidfile)', async () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      // pid is alive (this test process), but the url points off-box. A real
+      // hippo server only binds loopback, so detectServer must treat this as a
+      // forged or malformed pidfile and never probe the off-box host.
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid, port: 6789,
+        url: 'http://malicious.example.com:6789',
+        started_at: new Date().toISOString(),
+      }));
+      expect(await detectServer(home)).toBeNull();
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { serve } from '../src/server.js';
@@ -104,6 +104,57 @@ describe('server lifecycle', () => {
       expect(body.ok).toBe(true);
     } finally {
       await second.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to start a second server on a hippoRoot already served (H3)', async () => {
+    const home = makeRoot();
+    const first = await serve({ hippoRoot: home, port: 0 });
+    try {
+      // A concurrent `hippo serve` on the same root must be rejected before it
+      // can listen or clobber the pidfile.
+      await expect(serve({ hippoRoot: home, port: 0 }))
+        .rejects.toThrow(/already running/i);
+
+      // The pidfile must still describe the first (real) server, uncorrupted.
+      const info = JSON.parse(readFileSync(join(home, 'server.pid'), 'utf8'));
+      expect(info.port).toBe(first.port);
+      expect(info.pid).toBe(process.pid);
+    } finally {
+      await first.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an over-1MB request body with 413 and destroys the socket (M3)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    // Exactly one byte over readBody's 1 MB cap. The +1 matters: the server
+    // reads the whole body before `total > cap` trips, so the request is fully
+    // consumed and req.destroy() is a clean close (no RST) — the 413 reaches
+    // the client deterministically. A larger body leaves the client mid-upload
+    // when the socket dies, which fetch cannot resolve into a response.
+    const oversize = 'x'.repeat(1024 * 1024 + 1);
+    const postOversize = async (path: string): Promise<number> => {
+      const res = await fetch(`${handle.url}${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: oversize,
+      });
+      await res.text().catch(() => { /* body stream may be cut by req.destroy */ });
+      return res.status;
+    };
+    try {
+      // The cap lives in readBody, shared by every route — exercise the generic
+      // /v1 route and a webhook route, which both call it before any auth.
+      expect(await postOversize('/v1/memories')).toBe(413);
+      expect(await postOversize('/v1/connectors/slack/events')).toBe(413);
+      // The server shed the oversized requests without wedging — still serving.
+      const health = await fetch(`${handle.url}/health`);
+      expect(health.status).toBe(200);
+    } finally {
+      await handle.stop();
       rmSync(home, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

Closes the TODOS.md server / lifecycle hardening cluster: six items from the v0.37 server-mode work, the v0.40 security pass, and the A3 envelope review. Plan: docs/plans/2026-05-21-server-lifecycle-hardening.md.

- H1: async detectServer with a /health liveness probe (started_at match, loopback-validated target, 64KB-bounded body; a probe timeout keeps the pidfile rather than orphaning a busy server).
- L3: pidfile schema:1 field; a missing schema is tolerated as legacy.
- H3: serve() refuses to start when a live peer answers /health.
- M3: req.destroy() on the BodyTooLargeError (413) path.
- H2: HIPPO_REQUIRE_SERVER env knob makes a missing server a loud error, not a silent direct-mode fallback that discards HIPPO_API_KEY.
- A3: hippo forget --archive --reason routes raw, append-only rows to api.archiveRaw.

## Review

Reviewed via dev-framework: self-review, senior-code-reviewer, codex (gpt-5.5), and a CSO security pass. Four findings fixed: forget --archive server-bypass, unbounded /health parse, timeout-unlink, forged-pidfile url validation.

## Test plan

- [x] Full suite green: 216 files, 1557 tests
- [x] npm run build clean
- [x] CLI exercised: hippo forget --archive, HIPPO_REQUIRE_SERVER, help text
- [x] New / updated tests: cli-forget.test.ts (4), server-detect.test.ts (9), server-lifecycle.test.ts (H3/M3), cli-thin-client.test.ts (H2/bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
