### PR TITLE
fix: stop() pidfile-ownership guard, release 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.10.1 (2026-05-21): stop() pidfile-ownership guard
+
+A single-fix patch release closing the last open item in the v0.37 server-hardening cluster, deferred from v1.10.0. Plan: `docs/plans/2026-05-21-stop-pidfile-ownership.md`.
+
+### Shipped
+
+- **`stop()` no longer unlinks a newer server's pidfile.** `serve()`'s `stop()` and the `cli.ts` `runViaServerIfAvailable` stale-pidfile self-heal both removed `server.pid` unconditionally. If a second server had started on the same hippoRoot and rewritten the pidfile, the first server's shutdown deleted the second one's pidfile and orphaned it (no longer discoverable by `detectServer` or the thin client). The new `removePidfileIfOwned` (`src/server-detect.ts`) unlinks the pidfile only when its recorded `(pid, started_at)` identity matches the caller's own; `stop()` and the cli self-heal are rewired to it. `removePidfile` (unconditional removal) is retained as a primitive. A residual microsecond read-to-unlink window is documented and accepted, consistent with `detectServer`.
+- **`openclaw.plugin.json` version parity.** The root OpenClaw manifest was left at `1.9.3` by v1.10.0; it now tracks `package.json` at `1.10.1`, which `tests/openclaw-package.test.ts` enforces.
+
+### Tests
+
+`tests/server-detect.test.ts` adds 7 `removePidfileIfOwned` unit cases (identity match, `started_at` mismatch, `pid` mismatch, missing pidfile, malformed JSON, valid JSON without identity fields, literal `null`). `tests/server-lifecycle.test.ts` adds an integration test proving a foreign pidfile survives `stop()`. `tests/cli-thin-client.test.ts` adds a spawned-CLI test driving the connection-refused self-heal branch. Full suite: 216 files, 1566 tests, green.
+
+### Not in this release
+
+- `src/version.ts` `PACKAGE_VERSION` is still `1.8.1`, and `extensions/openclaw-plugin/package.json` and `extensions/openclaw-plugin/openclaw.plugin.json` are still `1.9.3`: version-field drift left by the v1.9.x and v1.10.0 releases. None is version-parity-tested, so none blocked this release, but `/health` and the MCP `serverInfo` consequently under-report the version. Tracked in `TODOS.md` together with the root cause: the release process does not sync every version field.
+- `hippo forget --archive` over the server-routed HTTP path (tracked in `TODOS.md`).
+
 ## 1.10.0 (2026-05-21): server and lifecycle hardening
 
 A pivot from the F-track research arc to product hardening. This release closes the "server / lifecycle hardening" cluster from `TODOS.md`: deferred follow-ups from the v0.37 server-mode work, the v0.40 security pass, and the A3 envelope review. Plan: `docs/plans/2026-05-21-server-lifecycle-hardening.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 1.10.1 (2026-05-21): stop() pidfile-ownership guard
 
-A single-fix patch release closing the last open item in the v0.37 server-hardening cluster, deferred from v1.10.0. Plan: `docs/plans/2026-05-21-stop-pidfile-ownership.md`.
+A patch release closing the last open item in the v0.37 server-hardening cluster (deferred from v1.10.0), plus a sync of every version field to `1.10.1`. Plan: `docs/plans/2026-05-21-stop-pidfile-ownership.md`.
 
 ### Shipped
 
 - **`stop()` no longer unlinks a newer server's pidfile.** `serve()`'s `stop()` and the `cli.ts` `runViaServerIfAvailable` stale-pidfile self-heal both removed `server.pid` unconditionally. If a second server had started on the same hippoRoot and rewritten the pidfile, the first server's shutdown deleted the second one's pidfile and orphaned it (no longer discoverable by `detectServer` or the thin client). The new `removePidfileIfOwned` (`src/server-detect.ts`) unlinks the pidfile only when its recorded `(pid, started_at)` identity matches the caller's own; `stop()` and the cli self-heal are rewired to it. `removePidfile` (unconditional removal) is retained as a primitive. A residual microsecond read-to-unlink window is documented and accepted, consistent with `detectServer`.
-- **`openclaw.plugin.json` version parity.** The root OpenClaw manifest was left at `1.9.3` by v1.10.0; it now tracks `package.json` at `1.10.1`, which `tests/openclaw-package.test.ts` enforces.
+- **Every version field synced to `1.10.1`.** `package.json`, the lockfile, `openclaw.plugin.json`, `src/version.ts` (`PACKAGE_VERSION`), and both `extensions/openclaw-plugin` manifests are now consistent. v1.9.x and v1.10.0 had bumped only some: `openclaw.plugin.json` was stranded at `1.9.3` (caught by `tests/openclaw-package.test.ts`), and `src/version.ts` at `1.8.1` left `/health` and the MCP `serverInfo` under-reporting the version. A version-parity guard covering every manifest is tracked in `TODOS.md` so the drift cannot recur.
 
 ### Tests
 
@@ -15,7 +15,6 @@ A single-fix patch release closing the last open item in the v0.37 server-harden
 
 ### Not in this release
 
-- `src/version.ts` `PACKAGE_VERSION` is still `1.8.1`, and `extensions/openclaw-plugin/package.json` and `extensions/openclaw-plugin/openclaw.plugin.json` are still `1.9.3`: version-field drift left by the v1.9.x and v1.10.0 releases. None is version-parity-tested, so none blocked this release, but `/health` and the MCP `serverInfo` consequently under-report the version. Tracked in `TODOS.md` together with the root cause: the release process does not sync every version field.
 - `hippo forget --archive` over the server-routed HTTP path (tracked in `TODOS.md`).
 
 ## 1.10.0 (2026-05-21): server and lifecycle hardening

--- a/docs/plans/2026-05-21-stop-pidfile-ownership.md
+++ b/docs/plans/2026-05-21-stop-pidfile-ownership.md
@@ -1,0 +1,168 @@
+# Plan: stop() pidfile-ownership guard
+
+**Episode:** 01KS69V6C4P07YWE5FXM6FSN4M (`/dev-framework-rl`)
+**Date:** 2026-05-21
+**Type:** bug fix (library-internal server lifecycle)
+**Branch:** `fix/stop-pidfile-ownership` off `master`
+
+## Context
+
+v1.10.0 (2026-05-21) shipped server/lifecycle hardening (H1, L3, H3, M3, H2, A3).
+The v0.37.0 server-hardening section of `TODOS.md` now has every item closed
+except one, codex-flagged 2026-05-21 and deliberately deferred from v1.10.0:
+
+> `stop()` can unlink a newer server's pidfile. `serve()`'s `stop()` calls
+> `removePidfile` unconditionally. If server A is shutting down while server B
+> has already started and rewritten the pidfile, A's stop deletes B's pidfile
+> and orphans the live B.
+
+## Problem
+
+`serve()`'s `stop()` (`src/server.ts:1496`) calls `removePidfile(opts.hippoRoot)`,
+which unconditionally `unlinkSync`s `${hippoRoot}/server.pid`. It never checks
+whether the pidfile on disk still describes *this* server.
+
+## Root cause
+
+`removePidfile` (`src/server-detect.ts:183`) is identity-blind: it deletes
+whatever pidfile is present. The pidfile is shared mutable state keyed by
+`hippoRoot`; any server on that root can be its writer. `stop()` assumes the
+pidfile it deletes is its own, which holds only if no other server rewrote it
+in between.
+
+## The race
+
+1. Server A starts on `hippoRoot`, writes the pidfile `(pid_A, started_at_A)`.
+2. Server B starts on the same `hippoRoot` (different port). B's H3
+   `detectServer` guard probes A's `/health`; if A is momentarily busy and
+   misses the 300 ms probe window, `detectServer` treats the timeout as
+   ambiguous, keeps A's pidfile, and returns `null`, so B proceeds.
+3. B's `listen()` on its own port succeeds; B's `writePidfile` overwrites the
+   pidfile, which now describes B.
+4. A later shuts down. A's `stop()` calls `removePidfile`, which **deletes B's
+   pidfile**. B is live but orphaned: `detectServer` returns `null` for it, the
+   CLI thin-client can no longer route to it, and the H3 guard will not see it.
+
+The step 2-3 window is not exotic: any same-root multi-port server pair plus one
+transient `/health` miss reaches it. A pidfile written before the H3 guard
+existed (pre-v1.10.0) reaches it with no race at all.
+
+## Fix
+
+Add an identity-checked removal to `src/server-detect.ts`:
+
+```ts
+/**
+ * Remove the pidfile only if it still describes the caller's own server.
+ * Reads + parses the pidfile and unlinks it ONLY when both `pid` and
+ * `started_at` match `owner`. A pidfile rewritten by a newer server is left
+ * intact, so a shutting-down older server cannot orphan the newer one.
+ *
+ * Best-effort and never throws: a missing, unreadable, or malformed pidfile
+ * is "not provably mine" and left alone (detectServer unlinks a malformed
+ * pidfile on its next probe). Returns true iff a matching pidfile was removed.
+ *
+ * Residual TOCTOU: the pidfile could be rewritten between the read and the
+ * unlink. The window is microseconds and the shape is the same read-check-
+ * unlink detectServer already uses; it narrows the bug from an unbounded
+ * window to a negligible one.
+ */
+export function removePidfileIfOwned(
+  hippoRoot: string,
+  owner: { pid: number; startedAt: string },
+): boolean
+```
+
+`removePidfile` is kept: unconditional removal is still a legitimate primitive
+and `tests/server-detect.test.ts` exercises it directly.
+
+## Scope
+
+- **Primary:** `serve()`'s `stop()` (`src/server.ts:1496`) — the `TODOS.md` item.
+- **Sibling, same bug, included:** `src/cli.ts:272`, inside
+  `runViaServerIfAvailable`'s stale-pidfile self-heal, also calls
+  `removePidfile` unconditionally. The CLI already holds `info` (the
+  `ServerInfo` from `detectServer` at line 259) — the exact identity to check
+  against. Same bug class, same one-line fix with the same helper, so per the
+  "fix all instances in one pass" rule it is in scope. This is one coherent
+  fix, not the unrelated "hardening sweep" the episode scope ruled out.
+
+## Files changed
+
+1. `src/server-detect.ts` — add `removePidfileIfOwned`; keep `removePidfile`.
+2. `src/server.ts` — `stop()` calls `removePidfileIfOwned(opts.hippoRoot, { pid: process.pid, startedAt })`; import: drop `removePidfile`, add `removePidfileIfOwned`.
+3. `src/cli.ts` — line 272 calls `removePidfileIfOwned(hippoRoot, { pid: info.pid, startedAt: info.started_at })`; import: drop `removePidfile`, add `removePidfileIfOwned`.
+4. `tests/server-detect.test.ts` — unit tests for `removePidfileIfOwned`.
+5. `tests/server-lifecycle.test.ts` — integration test: `stop()` leaves a foreign pidfile intact.
+6. `CHANGELOG.md`, `package.json`, `package-lock.json` — version bump at ship.
+7. `TODOS.md` — mark the v0.37.0 `stop()` item `[x]`.
+
+## Steps
+
+### Step 1 — `removePidfileIfOwned` helper
+Add the function to `src/server-detect.ts` as specified.
+**Success:** `npm run build` clean; `removePidfileIfOwned` exported.
+
+### Step 2 — wire `stop()`
+`src/server.ts` `stop()`: replace `removePidfile(opts.hippoRoot)` with
+`removePidfileIfOwned(opts.hippoRoot, { pid: process.pid, startedAt })`. Update
+the `server-detect.js` import (drop `removePidfile`, add `removePidfileIfOwned`).
+**Success:** `npm run build` clean (no unused-import error).
+
+### Step 3 — wire `cli.ts:272`
+`src/cli.ts` line 272: replace `removePidfile(hippoRoot)` with
+`removePidfileIfOwned(hippoRoot, { pid: info.pid, startedAt: info.started_at })`.
+Update the `server-detect.js` import (drop `removePidfile`, add `removePidfileIfOwned`).
+**Success:** `npm run build` clean.
+
+### Step 4 — unit tests (`tests/server-detect.test.ts`)
+Cases: (a) pid (the test process's own `process.pid`) + started_at match ->
+returns true, file gone; (b) pid matches, started_at differs -> false, file
+present; (c) started_at matches, pid differs -> false, file present; (d) no
+pidfile -> false, no throw; (e) malformed pidfile -> false, file left, no throw.
+**Success:** the 5 new tests pass.
+
+### Step 5 — integration test (`tests/server-lifecycle.test.ts`)
+Start server A (`port: 0`); overwrite `server.pid` with a forged foreign
+identity (different pid + started_at); call `A.stop()`; assert the forged
+pidfile still exists with its forged content. Confirm the existing "stop()
+removes the pidfile" test still passes (own pidfile IS removed). The forged pid
+value is arbitrary: `removePidfileIfOwned` is a pure read-compare-unlink and
+never probes process liveness.
+**Success:** new test passes; pre-existing `stop()` lifecycle tests still green.
+
+### Step 6 — full suite
+**Success:** `npm run build && npm test` — full suite green, 0 failures.
+
+## Edge cases
+
+- **Malformed / unreadable pidfile:** not provably ours -> left alone.
+  `detectServer` already unlinks malformed pidfiles on its next probe, so it
+  does not leak.
+- **Missing pidfile:** `stop()` is idempotent and may run after the pidfile is
+  already gone -> `removePidfileIfOwned` returns false, no throw.
+- **Same-process two-server case (tests):** same `pid`, different `started_at`
+  -> `started_at` discriminates. `(pid, started_at)` is the same identity tuple
+  `detectServer`'s H1 liveness probe already relies on.
+- **Residual TOCTOU:** accepted, commented, consistent with `detectServer`.
+
+## Version / semver
+
+**PATCH -> 1.10.1**: an internal lifecycle bug fix, behavior-preserving for
+every existing caller (`stop()` on a still-own pidfile is unchanged; only the
+foreign-pidfile case changes, and that case was the bug). `removePidfileIfOwned`
+is a new symbol in `server-detect.ts`. Confirmed not a public-API change:
+`package.json` declares `main`/`exports` as `./dist/index.js`, but the repo has
+no `src/index.ts` and therefore no public barrel; consumers enter via
+`bin/hippo.js` -> `dist/cli.js`. `server-detect.ts` is an internal-only module,
+so the new symbol cannot reach the public `exports` surface, which makes PATCH
+correct, not MINOR. Final version set at ship.
+
+## Out of scope
+
+- The other A3 follow-up (`hippo forget --archive` HTTP route) — separate `TODOS.md` item.
+- A general flock / lockfile rewrite of pidfile ownership — over-engineered for
+  this bug (rejected in brainstorm).
+- Refactoring `detectServer`'s inline read+parse into a shared `readPidfile`
+  helper — `detectServer` is not broken; the ~4-line duplication does not
+  justify touching working code.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.9.3",
+  "version": "1.10.1",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.9.3",
+  "version": "1.10.1",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.9.3",
+  "version": "1.10.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -155,7 +155,7 @@ import { buildProvenanceCoverage } from './provenance-coverage.js';
 import { buildCorrectionLatency } from './correction-latency.js';
 import * as api from './api.js';
 import * as client from './client.js';
-import { detectServer, removePidfile, type ServerInfo } from './server-detect.js';
+import { detectServer, removePidfileIfOwned, type ServerInfo } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { runEval, bootstrapCorpus, compareSummaries, type EvalCase, type EvalSummary } from './eval.js';
 import { runFeatureEval, formatResult, resultToBaseline, detectRegressions, type EvalBaseline } from './eval-suite.js';
@@ -245,7 +245,8 @@ function failIfServerRequired(reason: string): void {
  *           was already surfaced to stdout/stderr by `httpFn`),
  *   - false if no server was detected, or if the detected pidfile turned out
  *           to be stale (connection refused). On stale, the pidfile is removed
- *           and the caller should fall back to the direct path.
+ *           if it still names that dead server (a newer one may have replaced
+ *           it) and the caller should fall back to the direct path.
  *
  * Per the A1 plan footgun #1: stale pidfiles must self-heal, not crash.
  * H2: when HIPPO_REQUIRE_SERVER is set, both fallback paths throw instead of
@@ -269,7 +270,9 @@ async function runViaServerIfAvailable(
     if (client.isConnectionRefused(err)) {
       failIfServerRequired('the server pidfile was stale (connection refused)');
       console.error('hippo: stale server pidfile detected, falling back to direct mode');
-      removePidfile(hippoRoot);
+      // Clear the pidfile only if it still names the dead server we just
+      // probed — a newer server may have rewritten it (removePidfileIfOwned).
+      removePidfileIfOwned(hippoRoot, { pid: info.pid, startedAt: info.started_at });
       return false;
     }
     throw err;

--- a/src/server-detect.ts
+++ b/src/server-detect.ts
@@ -179,8 +179,50 @@ export function writePidfile(
 /**
  * Best-effort pidfile removal. Silent on ENOENT or any other error so the
  * caller can use this in shutdown paths without fear of throwing.
+ *
+ * Identity-blind: deletes whatever pidfile is on disk. A shutdown path that
+ * must not clobber a newer server's pidfile should use removePidfileIfOwned.
  */
 export function removePidfile(hippoRoot: string): void {
   const path = join(hippoRoot, PIDFILE);
   try { unlinkSync(path); } catch {}
+}
+
+/**
+ * Remove the pidfile only if it still describes the caller's own server.
+ * Reads and parses the pidfile and unlinks it ONLY when both `pid` and
+ * `started_at` match `owner`. A pidfile rewritten by a newer server is left
+ * intact, so a shutting-down older server cannot orphan the newer one by
+ * deleting its pidfile out from under it.
+ *
+ * Best-effort and never throws: a missing, unreadable, malformed, or
+ * non-object pidfile (including a literal JSON `null`) is "not provably mine"
+ * and left alone — detectServer unlinks a malformed pidfile on its next
+ * probe, so it does not leak. Returns true iff a matching pidfile was removed.
+ *
+ * Residual TOCTOU: the pidfile could be rewritten between the read and the
+ * unlink. The window is microseconds and the shape is the same read-check-
+ * unlink detectServer already uses; this narrows the clobber from an
+ * unbounded window (any time between writePidfile and stop) to a negligible
+ * one.
+ */
+export function removePidfileIfOwned(
+  hippoRoot: string,
+  owner: { pid: number; startedAt: string },
+): boolean {
+  const path = join(hippoRoot, PIDFILE);
+  try {
+    const info: ServerInfo = JSON.parse(readFileSync(path, 'utf8'));
+    // A literal JSON `null` parses cleanly but throws on property access;
+    // that lands in the catch below, which is the intended "not mine" path.
+    if (info.pid !== owner.pid || info.started_at !== owner.startedAt) {
+      return false; // a different server owns the pidfile now
+    }
+    unlinkSync(path);
+    return true;
+  } catch {
+    // Missing, unreadable, malformed, or non-object pidfile, or an unlink
+    // failure: none is a provable own-removal, so report not-removed.
+    return false;
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { createHash } from 'node:crypto';
-import { detectServer, writePidfile, removePidfile } from './server-detect.js';
+import { detectServer, writePidfile, removePidfileIfOwned } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { openHippoDb, closeHippoDb } from './db.js';
 import { PACKAGE_VERSION } from './version.js';
@@ -1493,7 +1493,10 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
   const stop = async (): Promise<void> => {
     if (stopping) return;
     stopping = true;
-    removePidfile(opts.hippoRoot);
+    // Remove the pidfile only if it still names this server. A newer server
+    // may have started on this hippoRoot and rewritten the pidfile; an
+    // unconditional unlink here would orphan it. (v0.37.0 server-hardening.)
+    removePidfileIfOwned(opts.hippoRoot, { pid: process.pid, startedAt });
     // Force-close any long-lived idle connections (e.g. SSE keepalive streams
     // on /mcp/stream) so server.close() can resolve. Without this, SIGTERM
     // would hang the process until the SSE client cancels. Available on

--- a/src/version.ts
+++ b/src/version.ts
@@ -16,7 +16,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.8.1';
+export const PACKAGE_VERSION = '1.10.1';
 // Bump on every release alongside the 4 manifests + lockfile.
 
 /**

--- a/tests/cli-thin-client.test.ts
+++ b/tests/cli-thin-client.test.ts
@@ -134,6 +134,28 @@ function runCli(workspace: string, ...cliArgs: string[]): { stdout: string; stde
   }
 }
 
+/**
+ * Async variant of runCli: spawns the CLI without blocking the test event
+ * loop, so an in-process stub HTTP server can serve the spawned CLI's
+ * requests. execFileSync (used by runCli) freezes this process's event loop
+ * for the whole child run, which starves any in-process server.
+ */
+function runCliAsync(workspace: string, ...cliArgs: string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...cliArgs], {
+      cwd: workspace,
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c.toString('utf8'); });
+    child.stderr.on('data', (c: Buffer) => { stderr += c.toString('utf8'); });
+    child.on('close', () => resolve({ stdout, stderr }));
+  });
+}
+
 function getActorForContent(workspace: string, contentNeedle: string): string | null {
   const db = openHippoDb(join(workspace, '.hippo'));
   try {
@@ -288,6 +310,55 @@ describe('cli thin-client mode', () => {
       }
     } finally {
       if (server) await server.stop();
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it('connection-refused fallback clears the pidfile only when it still owns it (cli.ts removePidfileIfOwned)', async () => {
+    const workspace = makeWorkspace();
+    const { createServer } = await import('node:http');
+    const startedAt = new Date().toISOString();
+    const port = await pickFreePort();
+    const pidfilePath = join(workspace, '.hippo', 'server.pid');
+
+    // A stub that answers ONE /health probe (so detectServer returns a live
+    // ServerInfo) then shuts its listener down. detectServer succeeds; the
+    // subsequent HTTP command request hits a closed port and fails
+    // connection-refused — the exact branch that calls removePidfileIfOwned.
+    const stub = createServer((req, res) => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          ok: true, version: '0.0.0', started_at: startedAt, pid: process.pid,
+        }));
+        res.on('finish', () => stub.close());
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => stub.listen(port, '127.0.0.1', () => resolve()));
+
+    try {
+      // Pidfile names this stub: pid is the (alive) test process so
+      // detectServer's liveness check passes, started_at matches /health.
+      writeFileSync(pidfilePath, JSON.stringify({
+        schema: 1, pid: process.pid, port,
+        url: `http://127.0.0.1:${port}`, started_at: startedAt,
+      }));
+
+      const run = await runCliAsync(workspace, 'remember', 'conn-refused-canary-55');
+      expect(run.stdout + run.stderr).toMatch(/Remembered|fallback/i);
+
+      // The pidfile named the (now dead) server detectServer probed, so
+      // removePidfileIfOwned cleared it and the command completed direct.
+      expect(existsSync(pidfilePath)).toBe(false);
+      expect(getActorForContent(workspace, 'conn-refused-canary-55')).toBe('cli');
+    } finally {
+      if (stub.listening) {
+        stub.closeAllConnections?.();
+        await new Promise<void>((resolve) => stub.close(() => resolve()));
+      }
       rmSync(workspace, { recursive: true, force: true });
     }
   }, 30_000);

--- a/tests/server-detect.test.ts
+++ b/tests/server-detect.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'no
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer, type Server } from 'node:http';
-import { detectServer, writePidfile, removePidfile } from '../src/server-detect.js';
+import { detectServer, writePidfile, removePidfile, removePidfileIfOwned } from '../src/server-detect.js';
 import { serve } from '../src/server.js';
 
 // hippoRoot is the directory the pidfile sits directly inside, matching the
@@ -168,6 +168,118 @@ describe('server-detect', () => {
       }));
       expect(await detectServer(home)).toBeNull();
       expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned removes the pidfile when pid and started_at both match', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      const startedAt = new Date().toISOString();
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid, port: 6789,
+        url: 'http://127.0.0.1:6789', started_at: startedAt,
+      }));
+      expect(removePidfileIfOwned(home, { pid: process.pid, startedAt })).toBe(true);
+      expect(existsSync(pidfile)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned keeps the pidfile when started_at differs (a newer server rewrote it)', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      // Same pid (a second server could share this process), different
+      // started_at. The (pid, started_at) tuple must treat this as not-ours.
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid, port: 6790,
+        url: 'http://127.0.0.1:6790', started_at: '2099-01-01T00:00:00.000Z',
+      }));
+      expect(removePidfileIfOwned(home, {
+        pid: process.pid, startedAt: '2026-01-01T00:00:00.000Z',
+      })).toBe(false);
+      expect(existsSync(pidfile)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned keeps the pidfile when pid differs', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      const startedAt = new Date().toISOString();
+      // started_at matches but the pid is a different process. The pid value
+      // is arbitrary — removePidfileIfOwned compares it, never probes it.
+      writeFileSync(pidfile, JSON.stringify({
+        schema: 1, pid: process.pid + 1, port: 6789,
+        url: 'http://127.0.0.1:6789', started_at: startedAt,
+      }));
+      expect(removePidfileIfOwned(home, { pid: process.pid, startedAt })).toBe(false);
+      expect(existsSync(pidfile)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned returns false without throwing when no pidfile exists', () => {
+    const home = makeRoot();
+    try {
+      expect(removePidfileIfOwned(home, {
+        pid: process.pid, startedAt: new Date().toISOString(),
+      })).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned leaves a malformed pidfile in place without throwing', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      writeFileSync(pidfile, 'not json at all');
+      expect(removePidfileIfOwned(home, {
+        pid: process.pid, startedAt: new Date().toISOString(),
+      })).toBe(false);
+      // Not provably ours, so left alone; detectServer unlinks malformed
+      // pidfiles on its next probe.
+      expect(existsSync(pidfile)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned keeps a valid-JSON pidfile that lacks pid and started_at', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      // Parses as JSON but carries no pid/started_at — info.pid is undefined,
+      // so the identity check fails closed and the file is left in place.
+      writeFileSync(pidfile, JSON.stringify({ schema: 1, port: 6789 }));
+      expect(removePidfileIfOwned(home, {
+        pid: process.pid, startedAt: new Date().toISOString(),
+      })).toBe(false);
+      expect(existsSync(pidfile)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('removePidfileIfOwned leaves a pidfile that is literally JSON null without throwing', () => {
+    const home = makeRoot();
+    const pidfile = join(home, 'server.pid');
+    try {
+      // `null` parses cleanly but is not an object — property access on it
+      // throws. removePidfileIfOwned must absorb that, not propagate it.
+      writeFileSync(pidfile, 'null');
+      expect(removePidfileIfOwned(home, {
+        pid: process.pid, startedAt: new Date().toISOString(),
+      })).toBe(false);
+      expect(existsSync(pidfile)).toBe(true);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/server-lifecycle.test.ts
+++ b/tests/server-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { serve } from '../src/server.js';
@@ -166,6 +166,36 @@ describe('server lifecycle', () => {
         .rejects.toThrow(/auth/i);
       await expect(serve({ hippoRoot: home, port: 0, host: '192.168.1.1' }))
         .rejects.toThrow(/loopback/i);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('stop() does not remove a pidfile that a newer server rewrote (ownership guard)', async () => {
+    const home = makeRoot();
+    const handle = await serve({ hippoRoot: home, port: 0 });
+    const pidfile = join(home, 'server.pid');
+    try {
+      // A is live and owns the pidfile. Simulate a newer server B taking over
+      // this hippoRoot: overwrite the pidfile with a foreign identity (a
+      // different pid AND a different started_at). The forged pid value is
+      // arbitrary — removePidfileIfOwned compares it, never probes liveness.
+      const forged = {
+        schema: 1,
+        pid: process.pid + 12345,
+        port: handle.port + 1,
+        url: `http://127.0.0.1:${handle.port + 1}`,
+        started_at: '2099-12-31T23:59:59.000Z',
+      };
+      writeFileSync(pidfile, JSON.stringify(forged));
+
+      // A shuts down. Its stop() must NOT delete B's pidfile.
+      await handle.stop();
+
+      expect(existsSync(pidfile)).toBe(true);
+      const after = JSON.parse(readFileSync(pidfile, 'utf8'));
+      expect(after.pid).toBe(forged.pid);
+      expect(after.started_at).toBe(forged.started_at);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Closes the last open item in the v0.37 server-hardening cluster (`TODOS.md`), deferred from v1.10.0 and codex-flagged 2026-05-21.

`serve()`'s `stop()` and the `cli.ts` stale-pidfile self-heal both removed `server.pid` unconditionally. If a second server had started on the same hippoRoot and rewritten the pidfile, the first server's shutdown deleted the second one's pidfile and orphaned it. New `removePidfileIfOwned` (`src/server-detect.ts`) unlinks the pidfile only on a `(pid, started_at)` identity match; both call sites are rewired to it.

Shipped as patch release **1.10.1**. The release also syncs every version field (`src/version.ts`, `openclaw.plugin.json`, the `extensions/openclaw-plugin` manifests) to 1.10.1, correcting drift left by v1.9.x/v1.10.0.

Built via `/dev-framework-rl` (episode 01KS69V6C4P07YWE5FXM6FSN4M): plan-eng 91, code-review 88, independent-review 88, ship-readiness 92.

## Test plan

- [x] `removePidfileIfOwned`: 7 unit cases (identity match, pid/started_at mismatch, missing, malformed, valid-JSON-without-fields, literal null)
- [x] `stop()` integration: a foreign pidfile survives shutdown
- [x] cli connection-refused self-heal: spawned-CLI end-to-end test
- [x] Full suite green: 216 files, 1566 tests, 0 failures
- [x] Build clean (tsc + benchmarks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
