### PR TITLE
Release v1.11.1: v1.11.0 tenant-isolation residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.11.1 (2026-05-23): v1.11.0 tenant-isolation residue
+
+A patch release closing the two named residues from the v1.11.0 conflict-subsystem pass, flagged by its independent-review critic and tracked in `TODOS.md`. Plan: `docs/plans/2026-05-22-tenant-isolation-residue.md`.
+
+### Shipped
+
+- **`readEntry` call-site audit.** v0.39 made the `readEntry(hippoRoot, id, tenantId?)` primitive tenant-aware (adds `AND tenant_id = ?` when set) but preserved the unscoped legacy behaviour on omitted `tenantId`, so each downstream caller had to opt in. Twelve sites still passed nothing: nine in `src/cli.ts` (`cmdSupersede`, `cmdTrace`'s local + global + parent walk, `cmdOutcome`, `cmdInspect`, `cmdResolve`'s conflict-display reads, `cmdDecide --supersedes`), one in `src/dashboard.ts` (`POST /api/star/:id`), one in `src/api.ts` (the `promoteToGlobal` call), one in `src/shared.ts` (the `promoteToGlobal` lookup). Each now passes the in-scope `tenantId` via the existing `resolveTenantId({})` helper from `src/tenant.ts`. `cmdResolve`'s sibling `listMemoryConflicts`/`resolveConflict` calls and `cmdTrace`'s `listMemoryConflicts` enumeration (same defect class in the same functions) are folded in. `promoteToGlobal` gains a `tenantId?` opt; `api.promote` passes `ctx.tenantId`. Three legacy `process.env.HIPPO_TENANT ?? 'default'` reads in `cli.ts` (4974, 5237, 5257) are switched to the helper, which uses the strictly-safer `?.trim() || 'default'` form. In a single-tenant deployment (`HIPPO_TENANT` unset, every memory carries `'default'`) nothing changes; in a multi-tenant deployment a CLI / dashboard process running under `HIPPO_TENANT=tenant_b` no longer reads or mutates a `tenant_a` memory by id, and `cmdTrace` no longer surfaces a memory promoted to global under `tenant_a`.
+- **Cross-tenant stale conflict auto-resolve.** `replaceDetectedConflicts` already built a `tenantById` map and a `sameTenant(a, b)` helper, and used them in the insert loop and the `conflicts_with_json` rebuild to skip cross-tenant pairs. The resolve-stale loop did not: a re-detected cross-tenant pair sat in `detectedKeys`, the insert skipped it (cross-tenant), and the open row lingered `status='open'` forever (inert, hidden from scoped reads and from the refMap rebuild, but untidy). The resolve-stale condition is extended to `(stale || crossTenant)`, so a pre-fix cross-tenant row now self-heals on the next detector pass. No schema change; no new query (the `tenantById` map is already built one block up).
+- **`serveDashboard` returns the `http.Server`.** Small testability change: the return type widens from `void` to `http.Server` with `return server;` at the end. The new dashboard tenant-scoping test depends on it to `server.close()` cleanly. Existing CLI callers discard the return; no behaviour change.
+
+### Tests
+
+`tests/resolve-conflict.test.ts` adds one cross-tenant auto-resolve case (seeds memories under two tenants via `createMemory({tenantId})`, manually inserts a pre-fix open cross-tenant `memory_conflicts` row, runs `replaceDetectedConflicts` with the cross-tenant pair in the detected set, asserts the row is `status='resolved'` with the run's `detectedAt` timestamp). `tests/cli-tenant-scoping.test.ts` is new and adds two `cmdTrace` cases via real CLI spawn (local-store cross-tenant denial under `HIPPO_TENANT=tenant_b`; cross-store global denial for a `g_*` memory promoted under another tenant). `tests/dashboard-tenant-scoping.test.ts` is new and adds one `POST /api/star/:id` cross-tenant mutation denial via real `http.request` against `serveDashboard`. `tests/shared.test.ts` adds one `promoteToGlobal` `opts.tenantId` case. All against the real DB / real CLI / real HTTP. Full suite: 219 files, 1588 tests, green.
+
+### Not in this release
+
+- `refine-llm.ts:151` is intentionally deferred. Its per-parent `readEntry` cannot be safely scoped in isolation because the upstream `loadAllEntries(hippoRoot)` on line 130 is itself unscoped (the L9 "background pipelines bypass tenant filter" item in `TODOS.md`). Scoping the per-parent read alone would silently drop parent text for cross-tenant lineage rows. Refine lands together with the rest of L9 / A5 v2; `TODOS.md` now carries a cross-reference on the L9 entry.
+- `hippo_peers`' intentionally cross-project read (A5 v2 trust-boundary work).
+- Three other unscoped `listMemoryConflicts` call sites (`cli.ts:2602` `cmdStats`, `cli.ts:2848` `cmdConflicts`, `dashboard.ts:75` `buildDashboardData`) and the five remaining `HIPPO_TENANT ?? 'default'` legacy reads in `src/server.ts`. Same defect class, narrower exposure (no mutation paths); tracked in `TODOS.md` for a follow-up pass.
+
 ## 1.11.0 (2026-05-22): v0.40 security and hardening
 
 A minor release working the v0.40 security and hardening follow-ups as a batch. Plans: `docs/plans/2026-05-22-conflict-tenant-isolation.md`, `docs/plans/2026-05-22-v1-rate-limit.md`, `docs/plans/2026-05-22-test-store-isolation.md`.

--- a/TODOS.md
+++ b/TODOS.md
@@ -128,7 +128,11 @@ by post-review fixes 2db5017..38339f4). Each item belongs in **A5 v2**
   stub model, but a multi-tenant deployment running `hippo sleep` would
   decay/merge/dedupe across tenants. Cross-tenant isolation must be threaded
   through every background pass before flipping the deployment model. Track
-  with the same v2 audit as M2.
+  with the same v2 audit as M2. (Dependent site: `refine-llm.ts:151`'s
+  per-parent `readEntry` was deferred from the v1.11.0 tenant-isolation
+  residue episode (01KS8W156) because half-scoping it without first scoping
+  the upstream `loadAllEntries(hippoRoot)` on line 130 would silently drop
+  parent text; lands together with this L9 work.)
 
 ---
 

--- a/docs/plans/2026-05-22-tenant-isolation-residue.md
+++ b/docs/plans/2026-05-22-tenant-isolation-residue.md
@@ -1,0 +1,255 @@
+# v1.11.0 tenant-isolation residue (`readEntry` call-site audit + cross-tenant conflict auto-resolve)
+
+Status: SHIPPED v1.11.1 — dev-framework-rl episode 01KS8W15619CC6CCW5HPMHCSN6
+Roadmap: v0.40 follow-up — direct v1.11.0 residue, flagged by the v1.11.0 independent-review critic and tracked in `TODOS.md` "Tenant-isolation residue from the v1.11.0 conflict-subsystem pass".
+
+Revision 1 folds in the plan-eng-critic review (which failed Revision 0 at
+score 58 on 7 must-fix items): drop the proposed new `cliTenantId()` helper in
+favour of the existing canonical `resolveTenantId({})` from `src/tenant.ts`;
+correct the `promoteToGlobal` edit site from `cmdPromote` to `api.ts:1146`
+(the only direct caller); fold in the sibling unscoped
+`listMemoryConflicts`/`resolveConflict` calls in `cmdResolve` (same function
+as the in-scope reads); defer `refine-llm.ts:151` alongside its unscoped
+upstream `loadAllEntries` to L9 / A5 v2 (half-scoping would silently drop
+parent text); correct mis-labelled per-site annotations
+(`cmdOutcome` / `cmdInspect` / `cmdDecide --supersedes`); add a dashboard
+`POST /api/star/:id` cross-tenant mutation test and a `cmdTrace` cross-store
+test.
+
+## Context
+
+v1.11.0 shipped tenant-scoped `listMemoryConflicts` and `resolveConflict`
+(`docs/plans/2026-05-22-conflict-tenant-isolation.md`, episode 01KS7HH2). Two
+residues were carved out and tracked:
+
+- (a) Unscoped `readEntry` call sites in `cli.ts`, `dashboard.ts`,
+  `refine-llm.ts` (per the TODO text; `shared.ts`/`api.ts` carry the same
+  defect class via `promoteToGlobal` and are folded in here).
+- (b) `replaceDetectedConflicts` skips re-detected cross-tenant pairs in its
+  insert and refMap loops but leaves them `status='open'` in its resolve-stale
+  loop.
+
+Out of scope per the TODO: (c) `hippo_peers`' intentionally cross-project read
+(A5 v2 trust-boundary work).
+
+## Problem
+
+### (a) Unscoped `readEntry` call sites
+
+`readEntry(hippoRoot, id, tenantId?)` (`src/store.ts:1210`) gained an optional
+trailing `tenantId` in v0.39: when set, `WHERE id = ? AND tenant_id = ?`; when
+omitted, unscoped (legacy behaviour, preserved for single-tenant deployments
+and consolidation paths). `loadSearchEntries` got the same treatment, and
+every `loadSearchEntries` call site already passes `tenantId`. `readEntry` has
+11 in-scope unscoped sites that need to gain `tenantId`:
+
+- `src/cli.ts` — 9 sites: line 757 (`cmdSupersede`), 1799 + 1803 + 1829
+  (`cmdTrace` local-root, global-root, and parent walk on both roots), 2694
+  (`cmdOutcome` — apply-good/bad outcome loop), 2760 (`cmdInspect`), 2897 +
+  2898 (`cmdResolve`'s conflict-display lookups for memories A and B), 6283
+  (`cmdDecide`'s `--supersedes` lookup).
+- `src/dashboard.ts` — 1 site: line 415 (the `POST /api/star/:id` toggle, the
+  only MUTATION path in (a)).
+- `src/api.ts` — 1 site: line 1146 (`promoteToGlobal` call — the only direct
+  caller of `promoteToGlobal` in `src/`; this replaces what Revision 0
+  incorrectly addressed as a `cmdPromote` edit).
+
+`src/refine-llm.ts:151` is **deferred** — see "Deferred to L9" below.
+
+`cmdResolve` also runs unscoped sibling calls in the same function as
+2897/2898: `cli.ts:2885` (`listMemoryConflicts(hippoRoot, 'open')`) and
+`cli.ts:2913` (`resolveConflict(hippoRoot, conflictId, keepId, forgetLoser)`).
+Same defect class. Folded into this episode rather than deferred: leaving the
+same-function siblings unscoped would let a multi-tenant CLI user enumerate
+and resolve a cross-tenant conflict by id in the very function being edited.
+
+In a single-tenant deployment (`HIPPO_TENANT` unset → `'default'`) every memory
+carries `tenant_id='default'`, so unscoped reads return the right rows by
+coincidence. In a multi-tenant deployment a CLI / dashboard process running
+under `HIPPO_TENANT=tenant_b` can read (or, via `POST /api/star/:id`, mutate)
+a memory belonging to `tenant_a`.
+
+### (b) Stale cross-tenant rows lingering in `memory_conflicts`
+
+`replaceDetectedConflicts` (`src/store.ts:2042`) builds a `tenantById` map and
+a `sameTenant(a, b)` helper, and uses it to skip cross-tenant pairs in the
+insert loop (line 2089) and the `conflicts_with_json` rebuild (line 2117). But
+its resolve-stale loop (lines 2081-2086) resolves an open row only when the
+row's key is absent from `detectedKeys`. If the detector re-detects a
+cross-tenant pair (the detector calls `loadAllEntries(root)` with no tenant
+filter — the broader L9 concern), the cross-tenant key IS in `detectedKeys`.
+The insert loop skips re-inserting (cross-tenant), the refMap loop skips it
+(cross-tenant), and the resolve-stale loop sees the key in `detectedKeys` and
+does NOT resolve. The open cross-tenant row stays `status='open'`.
+
+## The fix
+
+### (a) Tenant-scope every in-scope unscoped `readEntry` site
+
+**Reuse the canonical `resolveTenantId({})` helper** from `src/tenant.ts:9`.
+The helper already exists and is used 17+ times in `cli.ts` (imported on line
+159) and in `dashboard.ts` (imported on line 16). It returns
+`process.env.HIPPO_TENANT?.trim() || 'default'` for the no-`apiKey` path
+(and validates via api key when one is supplied — irrelevant for CLI direct
+mode). Every unscoped CLI / dashboard `readEntry` site gains
+`, resolveTenantId({})` as the third argument. Three legacy inline
+`process.env.HIPPO_TENANT ?? 'default'` reads (`cli.ts:4974`, `5237`, `5257`)
+are switched to `resolveTenantId({})` in the same pass — they predate the
+helper, use the strictly-less-safe `??` form (which lets a literal empty
+`HIPPO_TENANT=""` through), and the DRY win is free.
+
+Per-site mapping (each gains `resolveTenantId({})` as the in-scope tenant):
+- `cli.ts:757` — `cmdSupersede`, `readEntry(hippoRoot, oldId)`.
+- `cli.ts:1799`, `:1803`, `:1829` — `cmdTrace` local-root, global-root, and
+  parent walk on both roots. See "cmdTrace cross-store" below.
+- `cli.ts:2694` — `cmdOutcome`, outcome loop over `index.last_retrieval_ids`.
+- `cli.ts:2760` — `cmdInspect`.
+- `cli.ts:2885` — `cmdResolve`, `listMemoryConflicts(hippoRoot, 'open',
+  resolveTenantId({}))` (sibling-defect-class, folded in).
+- `cli.ts:2897`, `:2898` — `cmdResolve`'s conflict-display readEntries for
+  memories A and B.
+- `cli.ts:2913` — `cmdResolve`, `resolveConflict(hippoRoot, conflictId,
+  keepId, forgetLoser, resolveTenantId({}))` (sibling-defect-class, folded
+  in).
+- `cli.ts:6283` — `cmdDecide`'s `--supersedes` lookup.
+- `dashboard.ts:415` — `POST /api/star/:id`.
+
+**cmdTrace cross-store.** `cmdTrace` reads from both local and global roots
+(lines 1799 / 1803, plus the parent walk at 1829 against both). The global
+store preserves `tenant_id` on promoted entries (`shared.ts:66` spreads the
+entry — the source `tenant_id` is preserved). The scoping is applied to BOTH
+local and global reads: tracing under `HIPPO_TENANT=tenant_b` no longer
+returns a memory promoted to global by `tenant_a`. This is consistent with the
+security tightening across every other site in this pass; a user who needs to
+trace cross-tenant can set `HIPPO_TENANT` explicitly. The behaviour change is
+named in Risks and covered by a `cmdTrace` cross-store test.
+
+**`promoteToGlobal` at `api.ts:1146`.** `cmdPromote` does NOT call
+`promoteToGlobal` directly — it routes through `api.promote(ctx, id)`, which
+calls `promoteToGlobal` on line 1146. Extend `shared.ts:52`'s
+`opts?: { actor?: string }` to `opts?: { actor?: string; tenantId?: string }`
+and pass it to `readEntry`. Update `api.ts:1146` to:
+
+```ts
+const globalEntry = promoteToGlobal(ctx.hippoRoot, id, {
+  actor: ctx.actor,
+  tenantId: ctx.tenantId,
+});
+```
+
+`api.promote` already verifies tenant ownership at lines 1130-1140 (an
+`ownerDb` check that throws if the local memory's `tenant_id` doesn't match
+`ctx.tenantId`). Passing `tenantId` into `promoteToGlobal` is defence in
+depth — no behaviour change for valid promotions, an extra safety net against
+any future caller that skips the ownership pre-check.
+
+### Deferred to L9 — `refine-llm.ts:151`
+
+`refineStore(hippoRoot, opts)` (`refine-llm.ts:118`) calls
+`loadAllEntries(hippoRoot)` on line 130 with no tenant filter, then for each
+consolidated entry walks `entry.parents` with a per-parent
+`readEntry(hippoRoot, pid)` on line 151. Scoping only the per-parent
+`readEntry` in isolation would silently drop parent text whose tenant differs
+from the caller's — the unscoped loader produces an entry, the scoped per-parent
+read fails to find its parents (because they sit under another tenant), and
+`sources` ends up empty for that entry. Refine itself needs Context-style
+tenant routing: thread `tenantId` through `refineStore`, scope BOTH the loader
+AND the per-parent read together. That is squarely L9 "background pipelines
+bypass tenant filter" work — already named in TODOS as A5 v2 scope.
+`refine-llm.ts:151` stays unscoped, and the L9 TODOS entry gets a one-line
+back-reference so the dependency is visible.
+
+### (b) Auto-resolve cross-tenant rows in `replaceDetectedConflicts`
+
+Extend the resolve-stale loop condition:
+
+```ts
+for (const row of openRows) {
+  const key = `${row.memory_a_id}::${row.memory_b_id}`;
+  const stale = !detectedKeys.has(key);
+  const crossTenant = !sameTenant(row.memory_a_id, row.memory_b_id);
+  if (stale || crossTenant) {
+    db.prepare(
+      `UPDATE memory_conflicts SET status = 'resolved', updated_at = ? WHERE id = ?`,
+    ).run(detectedAt, row.id);
+  }
+}
+```
+
+`sameTenant(a, b)` returns `false` when one of the ids is missing from
+`tenantById` (orphan pair) OR when the two tenants differ — both warrant
+resolution. The `tenantById` map is already built one block up (lines
+2057-2060); no extra DB query. The resolution carries the same `detectedAt`
+timestamp as a normal stale resolution; no schema change.
+
+## Tests
+
+- `tests/resolve-conflict.test.ts` (E2's existing file) gains one case: seed
+  two memories under tenants `t_a` and `t_b`, manually insert a cross-tenant
+  `memory_conflicts` row with `status='open'`, run `replaceDetectedConflicts`
+  with a `detected` set that includes the cross-tenant pair. Assert the row
+  is now `status='resolved'` with `updated_at = detectedAt`.
+- `tests/cli-tenant-scoping.test.ts` (new) — two cases:
+  - `hippo trace <id>` spawn under `HIPPO_TENANT=t_b` against a LOCAL store
+    holding the same `id` under both `t_a` and `t_b`. Asserts only `t_b`'s
+    memory is shown.
+  - `hippo trace <id>` spawn under `HIPPO_TENANT=t_b` against a GLOBAL store
+    holding a `g_*` memory with `tenant_id=t_a`. Asserts "not found" (the
+    cross-store tightening behaviour change).
+- `tests/dashboard-tenant-scoping.test.ts` (new) — a real `http.request`
+  against the `serveDashboard` handler. Seed two memories under `t_a` and
+  `t_b`, set `HIPPO_TENANT=t_b`, send `POST /api/star/:id` for the `t_a`
+  memory's id, assert the response is 404 and the `t_a` memory's `starred`
+  field is unchanged (mutation denied).
+- `tests/shared.test.ts` gains one `promoteToGlobal` case covering the new
+  `tenantId` opt: seed under two tenants, promote with `opts.tenantId = t_a`,
+  assert only `t_a`'s entry is promoted.
+- All against real DB / real CLI spawn / real `http.request` — no mocks.
+
+## Verification
+
+- `npm run build` clean.
+- `npm test` exits 0 — full suite.
+
+## Risks
+
+- **Behaviour change: `hippo trace` cross-store.** A multi-tenant CLI
+  invocation that previously traced a memory promoted to global by another
+  tenant will now return "not found". Intended (consistent across every site
+  in this pass); covered by the `cmdTrace` cross-store test.
+- **Behaviour change: dashboard `POST /api/star/:id`.** A multi-tenant
+  dashboard process running under `HIPPO_TENANT=t_b` can no longer mutate a
+  `t_a` memory by id. Intended; covered by the new dashboard test.
+- **`refine-llm.ts:151` stays unscoped pending L9.** A multi-tenant
+  deployment running `hippo refine` today already crosses tenants via the
+  unscoped `loadAllEntries`; this episode does not change that. The TODOS
+  cross-reference on the L9 line makes the dependency visible so the refine
+  scoping lands as one coherent change with the loader.
+- **Out-of-scope items, kept honest.** `hippo_peers` cross-project read
+  (A5 v2). L9 background-pipelines unscoped reads (A5 v2). The (b)
+  auto-resolve handles cross-tenant rows regardless of how they got there, so
+  the detector's unscoped read remains acceptable until L9 lands.
+
+## Files
+
+- `src/store.ts` — extend `replaceDetectedConflicts` resolve-stale loop with
+  the `crossTenant` condition.
+- `src/cli.ts` — tenant-scope 11 sites (9 `readEntry` + the two cmdResolve
+  sibling calls `listMemoryConflicts` and `resolveConflict`); switch 3 legacy
+  inline `HIPPO_TENANT ?? 'default'` reads to `resolveTenantId({})`.
+- `src/dashboard.ts` — tenant-scope the 1 `readEntry` site
+  (`POST /api/star/:id`).
+- `src/shared.ts` — extend `promoteToGlobal` opts with `tenantId?`; pass it
+  to `readEntry`.
+- `src/api.ts` — update the `promoteToGlobal` call at line 1146 to pass
+  `tenantId: ctx.tenantId`.
+- `tests/resolve-conflict.test.ts` — new cross-tenant-resolve case.
+- `tests/cli-tenant-scoping.test.ts` (new) — two `cmdTrace` cases (local and
+  cross-store).
+- `tests/dashboard-tenant-scoping.test.ts` (new) — `POST /api/star/:id`
+  cross-tenant mutation denial.
+- `tests/shared.test.ts` — new `promoteToGlobal` `tenantId` opt case.
+- `TODOS.md` — add a one-line cross-reference on the L9 entry pointing at
+  `refine-llm.ts:151` as a dependent site.
+- `docs/plans/2026-05-22-tenant-isolation-residue.md` — this plan
+  (Revision 1).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.0",
+  "version": "1.11.1",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,14 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "@huggingface/transformers": "^4.2.0"
-      },
       "bin": {
         "hippo": "bin/hippo.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1143,7 +1143,7 @@ export function promote(
   // db, which emits a 'remember' audit row. We then add the user-facing
   // 'promote' event on the global db so the audit trail keeps the intent
   // distinct from the underlying upsert.
-  const globalEntry = promoteToGlobal(ctx.hippoRoot, id, { actor: ctx.actor });
+  const globalEntry = promoteToGlobal(ctx.hippoRoot, id, { actor: ctx.actor, tenantId: ctx.tenantId });
 
   const db = openHippoDb(getGlobalRoot());
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -754,7 +754,7 @@ function cmdSupersede(
 ): void {
   requireInit(hippoRoot);
 
-  const old = readEntry(hippoRoot, oldId);
+  const old = readEntry(hippoRoot, oldId, resolveTenantId({}));
   if (!old) {
     console.error(`Error: memory ${oldId} not found.`);
     process.exit(1);
@@ -1794,13 +1794,14 @@ function cmdTrace(
 ): void {
   requireInit(hippoRoot);
   const asJson = Boolean(flags['json']);
+  const tenantId = resolveTenantId({});
 
   // Look in local store first, then global.
-  let entry = readEntry(hippoRoot, id);
+  let entry = readEntry(hippoRoot, id, tenantId);
   let sourceLabel: 'local' | 'global' = 'local';
   const globalRoot = getGlobalRoot();
   if (!entry && isInitialized(globalRoot)) {
-    entry = readEntry(globalRoot, id);
+    entry = readEntry(globalRoot, id, tenantId);
     sourceLabel = 'global';
   }
   if (!entry) {
@@ -1826,14 +1827,14 @@ function cmdTrace(
   // Parents (consolidation lineage) — schema v9 field.
   const parents = Array.isArray(entry.parents) ? entry.parents : [];
   const parentPreviews = parents.map((pid) => {
-    const p = readEntry(hippoRoot, pid) ?? (isInitialized(globalRoot) ? readEntry(globalRoot, pid) : null);
+    const p = readEntry(hippoRoot, pid, tenantId) ?? (isInitialized(globalRoot) ? readEntry(globalRoot, pid, tenantId) : null);
     return { id: pid, content: p ? p.content.replace(/\s+/g, ' ').slice(0, 70) : '(not found)' };
   });
 
   // Open conflicts involving this memory.
   const allConflicts = [
-    ...listMemoryConflicts(hippoRoot, 'open'),
-    ...(isInitialized(globalRoot) ? listMemoryConflicts(globalRoot, 'open') : []),
+    ...listMemoryConflicts(hippoRoot, 'open', tenantId),
+    ...(isInitialized(globalRoot) ? listMemoryConflicts(globalRoot, 'open', tenantId) : []),
   ];
   const myConflicts = allConflicts.filter((c) => c.memory_a_id === id || c.memory_b_id === id);
 
@@ -2691,7 +2692,7 @@ function cmdOutcome(
 
   let updated = 0;
   for (const id of ids) {
-    const entry = readEntry(hippoRoot, id);
+    const entry = readEntry(hippoRoot, id, resolveTenantId({}));
     if (!entry) continue;
     const upd = applyOutcome(entry, good);
     writeEntry(hippoRoot, upd);
@@ -2757,7 +2758,7 @@ function cmdForget(
 function cmdInspect(hippoRoot: string, id: string): void {
   requireInit(hippoRoot);
 
-  const entry = readEntry(hippoRoot, id);
+  const entry = readEntry(hippoRoot, id, resolveTenantId({}));
   if (!entry) {
     console.error(`Memory not found: ${id}`);
     process.exit(1);
@@ -2879,10 +2880,11 @@ function cmdResolve(
     process.exit(1);
   }
 
+  const tenantId = resolveTenantId({});
   const keepId = String(flags['keep'] ?? '').trim();
   if (!keepId) {
     // Show the conflict details to help the user decide
-    const conflicts = listMemoryConflicts(hippoRoot, 'open');
+    const conflicts = listMemoryConflicts(hippoRoot, 'open', tenantId);
     const conflict = conflicts.find((c) => c.id === conflictId);
     if (!conflict) {
       console.error(`Conflict ${conflictId} not found or already resolved.`);
@@ -2894,8 +2896,8 @@ function cmdResolve(
     console.log(`  Reason: ${conflict.reason}`);
     console.log('');
 
-    const entryA = readEntry(hippoRoot, conflict.memory_a_id);
-    const entryB = readEntry(hippoRoot, conflict.memory_b_id);
+    const entryA = readEntry(hippoRoot, conflict.memory_a_id, tenantId);
+    const entryB = readEntry(hippoRoot, conflict.memory_b_id, tenantId);
     if (entryA) {
       console.log(`  [A] ${conflict.memory_a_id}:`);
       console.log(`      ${entryA.content.slice(0, 120)}${entryA.content.length > 120 ? '...' : ''}`);
@@ -2910,7 +2912,7 @@ function cmdResolve(
   }
 
   const forgetLoser = Boolean(flags['forget']);
-  const result = resolveConflict(hippoRoot, conflictId, keepId, forgetLoser);
+  const result = resolveConflict(hippoRoot, conflictId, keepId, forgetLoser, tenantId);
 
   if (!result) {
     console.error(`Could not resolve conflict ${conflictId}. Check the ID and --keep value.`);
@@ -4971,7 +4973,7 @@ function resolveGoalSession(flags: Record<string, string | boolean | string[]>):
   const tenantId = (
     flags['tenant-id'] !== undefined
       ? String(flags['tenant-id'])
-      : process.env.HIPPO_TENANT ?? 'default'
+      : resolveTenantId({})
   ).trim() || 'default';
   return { sessionId, tenantId };
 }
@@ -5234,7 +5236,7 @@ function cmdSlackBackfill(hippoRoot: string, flags: Record<string, string | bool
   const fetcher = slackHistoryFetcher(token);
   const ctx = {
     hippoRoot,
-    tenantId: process.env.HIPPO_TENANT ?? 'default',
+    tenantId: resolveTenantId({}),
     actor: 'cli:slack-backfill',
   };
   backfillChannel(ctx, {
@@ -5254,7 +5256,7 @@ function cmdSlackBackfill(hippoRoot: string, flags: Record<string, string | bool
 function cmdSlackDlqList(hippoRoot: string, _flags: Record<string, string | boolean | string[]>): void {
   const db = openHippoDb(hippoRoot);
   try {
-    const tenantId = process.env.HIPPO_TENANT ?? 'default';
+    const tenantId = resolveTenantId({});
     const items = listDlq(db, { tenantId });
     for (const it of items) {
       console.log(`${it.id}\t${it.receivedAt}\t${it.error}`);
@@ -6280,7 +6282,7 @@ async function main(): Promise<void> {
 
       // Handle supersession
       if (supersedesId) {
-        const oldEntry = readEntry(hippoRoot, supersedesId);
+        const oldEntry = readEntry(hippoRoot, supersedesId, resolveTenantId({}));
         if (!oldEntry) {
           console.error(`Memory ${supersedesId} not found.`);
           process.exit(1);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -398,7 +398,7 @@ function serveStaticFile(res: http.ServerResponse, filePath: string): boolean {
   }
 }
 
-export function serveDashboard(hippoRoot: string, port: number = 3333): void {
+export function serveDashboard(hippoRoot: string, port: number = 3333): http.Server {
   const distUiDir = path.resolve(import.meta.dirname, '..', 'dist-ui');
   const hasDistUi = fs.existsSync(path.join(distUiDir, 'index.html'));
 
@@ -412,7 +412,7 @@ export function serveDashboard(hippoRoot: string, port: number = 3333): void {
       const starMatch = pathname.match(/^\/api\/star\/([A-Za-z0-9_\-]+)$/);
       if (starMatch && req.method === 'POST') {
         const id = starMatch[1];
-        const entry = readEntry(hippoRoot, id);
+        const entry = readEntry(hippoRoot, id, resolveTenantId({}));
         if (!entry) return jsonResponse(res, { error: 'Not found' }, 404);
         entry.starred = !entry.starred;
         writeEntry(hippoRoot, entry);
@@ -468,4 +468,6 @@ export function serveDashboard(hippoRoot: string, port: number = 3333): void {
     if (hasDistUi) console.log(`Serving React UI from ${distUiDir}`);
     console.log('Press Ctrl+C to stop.');
   });
+
+  return server;
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -52,9 +52,9 @@ export function initGlobal(): void {
 export function promoteToGlobal(
   localRoot: string,
   id: string,
-  opts?: { actor?: string },
+  opts?: { actor?: string; tenantId?: string },
 ): MemoryEntry {
-  const entry = readEntry(localRoot, id);
+  const entry = readEntry(localRoot, id, opts?.tenantId);
   if (!entry) throw new Error(`Memory not found: ${id}`);
 
   initGlobal();

--- a/src/store.ts
+++ b/src/store.ts
@@ -2080,7 +2080,14 @@ export function replaceDetectedConflicts(
 
     for (const row of openRows) {
       const key = `${row.memory_a_id}::${row.memory_b_id}`;
-      if (!detectedKeys.has(key)) {
+      const stale = !detectedKeys.has(key);
+      // v1.11.0 residue: auto-resolve any open cross-tenant row. The insert
+      // loop below (line 2089) and the refMap rebuild (line 2117) skip
+      // cross-tenant pairs, but the resolve-stale loop previously left
+      // re-detected cross-tenant rows lingering status='open'. The
+      // sameTenant() helper is already built one block up; no extra query.
+      const crossTenant = !sameTenant(row.memory_a_id, row.memory_b_id);
+      if (stale || crossTenant) {
         db.prepare(`UPDATE memory_conflicts SET status = 'resolved', updated_at = ? WHERE id = ?`).run(detectedAt, row.id);
       }
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -16,7 +16,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.11.0';
+export const PACKAGE_VERSION = '1.11.1';
 // Bump on every release alongside the 4 manifests + lockfile.
 
 /**

--- a/tests/cli-tenant-scoping.test.ts
+++ b/tests/cli-tenant-scoping.test.ts
@@ -1,0 +1,148 @@
+/**
+ * v1.11.0 tenant-isolation residue: CLI tenant-scoping via HIPPO_TENANT.
+ *
+ * Spawns `hippo trace <id>` under different HIPPO_TENANT values and asserts
+ * cross-tenant memories are not found. Covers both the local-store read
+ * (cmdTrace at cli.ts:1799) and the cross-store global path (cli.ts:1803 + the
+ * parent walk at cli.ts:1829). The cross-store case is the deliberate
+ * behaviour change documented in the plan's Risks section: a memory promoted
+ * to global under tenant_a returns "not found" when traced under
+ * HIPPO_TENANT=tenant_b.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { initStore, writeEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createMemory } from '../src/memory.js';
+
+const REPO_ROOT = join(__dirname, '..');
+const CLI_PATH = join(REPO_ROOT, 'dist', 'cli.js');
+
+function runCli(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  ...args: string[]
+): { out: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { out: stdout, status: 0 };
+  } catch (e) {
+    const err = e as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      status?: number;
+    };
+    const stdout =
+      typeof err.stdout === 'string'
+        ? err.stdout
+        : (err.stdout?.toString('utf8') ?? '');
+    const stderr =
+      typeof err.stderr === 'string'
+        ? err.stderr
+        : (err.stderr?.toString('utf8') ?? '');
+    return { out: stdout + stderr, status: err.status ?? 1 };
+  }
+}
+
+describe('CLI tenant-scoping (v1.11.0 residue)', () => {
+  let home: string;
+  let hippoRoot: string;
+  let globalRoot: string;
+  let envBase: NodeJS.ProcessEnv;
+
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH) || !statSync(CLI_PATH).isFile()) {
+      throw new Error(
+        `dist/cli.js not found at ${CLI_PATH}. Run \`npm run build\` first.`,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-cli-tenant-'));
+    hippoRoot = join(home, '.hippo');
+    globalRoot = join(home, '.hippo-global');
+    mkdirSync(hippoRoot, { recursive: true });
+    mkdirSync(globalRoot, { recursive: true });
+    initStore(hippoRoot);
+    initStore(globalRoot);
+    // Isolate the spawned CLI's global store from the developer's real
+    // ~/.hippo by pointing HIPPO_HOME at a per-test temp.
+    envBase = { ...process.env, HIPPO_HOME: globalRoot };
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('cmdTrace local store: HIPPO_TENANT=tenant_b hides a tenant_a memory', () => {
+    const a = createMemory('A content (local)', {
+      tenantId: 'tenant_a',
+      tags: ['x'],
+    });
+    const b = createMemory('B content (local)', {
+      tenantId: 'tenant_b',
+      tags: ['x'],
+    });
+    writeEntry(hippoRoot, a);
+    writeEntry(hippoRoot, b);
+
+    // Under HIPPO_TENANT=tenant_b, tracing tenant_a's memory returns "not found".
+    const aTrace = runCli(
+      home,
+      { ...envBase, HIPPO_TENANT: 'tenant_b' },
+      'trace',
+      a.id,
+    );
+    expect(aTrace.status).not.toBe(0);
+    expect(aTrace.out).toMatch(/not found/i);
+
+    // Tracing tenant_b's own memory under HIPPO_TENANT=tenant_b still works.
+    const bTrace = runCli(
+      home,
+      { ...envBase, HIPPO_TENANT: 'tenant_b' },
+      'trace',
+      b.id,
+    );
+    expect(bTrace.status, bTrace.out).toBe(0);
+    expect(bTrace.out).toMatch(/B content/);
+  }, 30_000);
+
+  it('cmdTrace global store: HIPPO_TENANT=tenant_b hides a tenant_a-promoted global memory', () => {
+    // Seed a g_* memory directly into the isolated global store with
+    // tenant_id=tenant_a — simulates an entry promoted by another tenant.
+    const db = openHippoDb(globalRoot);
+    try {
+      const cols =
+        'id, tenant_id, created, last_retrieved, retrieval_count, strength, ' +
+        'half_life_days, layer, tags_json, emotional_valence, schema_fit, ' +
+        'source, conflicts_with_json, pinned, confidence, content, kind';
+      db.prepare(
+        `INSERT INTO memories (${cols}) VALUES ` +
+          `(?, ?, '2026-01-01', '2026-01-01', 0, 1.0, 7, 'episodic', '[]', ` +
+          `'neutral', 0.5, 'test', '[]', 0, 'observed', ?, 'distilled')`,
+      ).run('g_taPromoted', 'tenant_a', 'A content (global)');
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // Under HIPPO_TENANT=tenant_b the cross-tenant global trace returns
+    // "not found" — the cross-store tightening behaviour change.
+    const trace = runCli(
+      home,
+      { ...envBase, HIPPO_TENANT: 'tenant_b' },
+      'trace',
+      'g_taPromoted',
+    );
+    expect(trace.status).not.toBe(0);
+    expect(trace.out).toMatch(/not found/i);
+  }, 30_000);
+});

--- a/tests/dashboard-tenant-scoping.test.ts
+++ b/tests/dashboard-tenant-scoping.test.ts
@@ -1,0 +1,106 @@
+/**
+ * v1.11.0 tenant-isolation residue: dashboard POST /api/star/:id must deny
+ * cross-tenant mutations.
+ *
+ * The dashboard process derives its tenant via resolveTenantId({}) (which
+ * reads HIPPO_TENANT). A star-toggle for another tenant's memory id must
+ * return 404 and leave the memory's starred field untouched.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { request as httpRequest } from 'node:http';
+import type { Server } from 'node:http';
+import { initStore, writeEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createMemory } from '../src/memory.js';
+import { serveDashboard } from '../src/dashboard.js';
+
+function post(
+  port: number,
+  path: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path, method: 'POST' },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (c) => {
+          body += c;
+        });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('dashboard tenant-scoping (v1.11.0 residue)', () => {
+  let home: string;
+  let hippoRoot: string;
+  let server: Server | undefined;
+  let prevTenant: string | undefined;
+  let prevHippoHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-dash-tenant-'));
+    hippoRoot = join(home, '.hippo');
+    mkdirSync(hippoRoot, { recursive: true });
+    initStore(hippoRoot);
+    prevTenant = process.env.HIPPO_TENANT;
+    prevHippoHome = process.env.HIPPO_HOME;
+    // Isolate the dashboard's resolved global store from the developer's real
+    // ~/.hippo for the duration of the test.
+    process.env.HIPPO_HOME = join(home, '.hippo-global');
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) =>
+        server!.close((err) => (err ? reject(err) : resolve())),
+      );
+      server = undefined;
+    }
+    if (prevTenant === undefined) delete process.env.HIPPO_TENANT;
+    else process.env.HIPPO_TENANT = prevTenant;
+    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = prevHippoHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('POST /api/star/:id denies a cross-tenant mutation', async () => {
+    // Seed a memory under tenant_a in the local store.
+    const a = createMemory('tenant_a memory', {
+      tenantId: 'tenant_a',
+      tags: ['x'],
+    });
+    writeEntry(hippoRoot, a);
+
+    // Run the dashboard under HIPPO_TENANT=tenant_b on an ephemeral port.
+    process.env.HIPPO_TENANT = 'tenant_b';
+    const port = 31000 + Math.floor(Math.random() * 5000);
+    server = serveDashboard(hippoRoot, port);
+    await new Promise<void>((resolve) => {
+      if (server!.listening) resolve();
+      else server!.once('listening', () => resolve());
+    });
+
+    // POST /api/star/<tenant_a memory id> under HIPPO_TENANT=tenant_b → 404.
+    const res = await post(port, `/api/star/${a.id}`);
+    expect(res.status).toBe(404);
+
+    // The tenant_a memory's starred field is unchanged in the DB.
+    const db = openHippoDb(hippoRoot);
+    try {
+      const row = db
+        .prepare(`SELECT starred FROM memories WHERE id = ?`)
+        .get(a.id) as { starred: number };
+      expect(row.starred).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  }, 15_000);
+});

--- a/tests/resolve-conflict.test.ts
+++ b/tests/resolve-conflict.test.ts
@@ -15,6 +15,7 @@ import {
   replaceDetectedConflicts,
   resolveConflict,
 } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
 
 let tmpDir: string;
 
@@ -183,6 +184,50 @@ describe('conflict tenant isolation (E2)', () => {
 
     // The conflict is untouched — still open for its real owner.
     expect(listMemoryConflicts(tmpDir, 'open', 'tenant-a').length).toBe(1);
+  });
+
+  it('auto-resolves an existing open cross-tenant row when the pair is re-detected (v1.11.0 residue)', () => {
+    // Seed two memories under different tenants.
+    const a = createMemory('tenant-a content', { tenantId: 'tenant-a', tags: ['x'] });
+    const b = createMemory('tenant-b content', { tenantId: 'tenant-b', tags: ['x'] });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, b);
+    const [memA, memB] = a.id < b.id ? [a.id, b.id] : [b.id, a.id];
+
+    // Manually insert a pre-fix open cross-tenant conflict row (the kind that
+    // could exist from before E2's tenant guard).
+    const db = openHippoDb(tmpDir);
+    try {
+      db.prepare(
+        `INSERT INTO memory_conflicts ` +
+          `(memory_a_id, memory_b_id, reason, score, status, detected_at, updated_at) ` +
+          `VALUES (?, ?, ?, ?, 'open', '2026-01-01', '2026-01-01')`,
+      ).run(memA, memB, 'pre-fix cross-tenant', 0.9);
+    } finally {
+      closeHippoDb(db);
+    }
+    expect(listMemoryConflicts(tmpDir, 'open').find((c) => c.memory_a_id === memA && c.memory_b_id === memB)).toBeDefined();
+
+    // Simulate an unscoped detector re-detecting the cross-tenant pair. Before
+    // the fix, the resolve-stale loop saw the key in detectedKeys and skipped
+    // resolution; the insert loop skipped re-inserting (cross-tenant); the
+    // refMap rebuild skipped it. The row lingered status='open' forever.
+    replaceDetectedConflicts(
+      tmpDir,
+      [{ memory_a_id: a.id, memory_b_id: b.id, reason: 're-detected cross-tenant', score: 0.9 }],
+      '2026-05-22T12:00:00.000Z',
+    );
+
+    // The cross-tenant row is now resolved.
+    const resolved = listMemoryConflicts(tmpDir, 'resolved');
+    const ours = resolved.find((c) => c.memory_a_id === memA && c.memory_b_id === memB);
+    expect(ours).toBeDefined();
+    expect(ours!.updated_at).toBe('2026-05-22T12:00:00.000Z');
+
+    // No open cross-tenant row remains.
+    expect(
+      listMemoryConflicts(tmpDir, 'open').find((c) => c.memory_a_id === memA && c.memory_b_id === memB),
+    ).toBeUndefined();
   });
 
   it('resolveConflict --forget with a foreign tenantId cannot delete the loser memory', () => {

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -111,6 +111,23 @@ describe('promoteToGlobal', () => {
   it('throws when ID does not exist in local store', () => {
     expect(() => promoteToGlobal(localRoot, 'nonexistent_id')).toThrow();
   });
+
+  it('honors opts.tenantId for cross-tenant isolation (v1.11.0 residue)', () => {
+    const a = createMemory('tenant-a content', { tenantId: 'tenant-a' });
+    const b = createMemory('tenant-b content', { tenantId: 'tenant-b' });
+    writeEntry(localRoot, a);
+    writeEntry(localRoot, b);
+
+    // Promoting tenant-a's entry with opts.tenantId='tenant-a' succeeds.
+    const promoted = promoteToGlobal(localRoot, a.id, { tenantId: 'tenant-a' });
+    expect(promoted.id).toMatch(/^g_/);
+    expect(promoted.content).toBe('tenant-a content');
+
+    // Promoting tenant-a's entry with opts.tenantId='tenant-b' throws —
+    // readEntry returns null on a cross-tenant lookup, and promoteToGlobal
+    // then surfaces 'Memory not found'.
+    expect(() => promoteToGlobal(localRoot, a.id, { tenantId: 'tenant-b' })).toThrow(/Memory not found/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## v1.11.1: v1.11.0 tenant-isolation residue

Patch release closing the two residues from the v1.11.0 conflict-subsystem pass, flagged by its independent-review critic and tracked in `TODOS.md`.

### Shipped
- **`readEntry` call-site audit.** Twelve unscoped `readEntry` call sites in `cli.ts` / `dashboard.ts` / `api.ts` / `shared.ts` now pass the in-scope `tenantId` via `resolveTenantId({})`. `cmdResolve`'s and `cmdTrace`'s sibling unscoped `listMemoryConflicts` / `resolveConflict` calls (same defect class in the same functions) are folded in. `promoteToGlobal` gains a `tenantId?` opt; `api.promote` passes `ctx.tenantId`. Three legacy `HIPPO_TENANT ?? 'default'` reads in `cli.ts` switched to the helper.
- **Cross-tenant stale conflict auto-resolve.** `replaceDetectedConflicts` resolve-stale loop extended with the existing `sameTenant()` check so re-detected cross-tenant rows self-heal on the next detector pass.
- **`serveDashboard` returns `http.Server`.** Small testability change so the new dashboard tenant-scoping test can close the server cleanly.

### Test plan
- [x] `npm run build` clean
- [x] `npm test` exits 0: 219 files, 1588 tests, no `_real-store-guard` error
- [x] real DB / real CLI spawn / real http.request throughout
- [x] version consistent at 1.11.1 across all six manifests

Full detail in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)