### PR TITLE
fix(hooks): opencode integration via plugin instead of JSON hooks (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ benchmarks/longmemeval/data/bm25_corpus_*.json
 benchmarks/longmemeval/data/turn_index_bge_oracle.json*
 results/f9_phase1/
 results/f9_phase2/
+
+# Local agent + benchmark workspace artifacts (not part of the package)
+.claude/settings.local.json
+benchmarks/stateful-frontier/
+nlnet-application/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.11.2 (2026-05-23): opencode plugin installer
+
+A patch release fixing [#24](https://github.com/kitfunso/hippo-memory/issues/24) at root.
+
+### Shipped
+
+- **OpenCode integration switched from JSON hooks to a TS plugin.** v1.10.x-v1.11.1 wrote a Claude Code-style `hooks` block into `~/.config/opencode/opencode.json`, which opencode's strict schema (`additionalProperties: false`) rejects with `ConfigInvalidError: Unrecognized key: hooks` — preventing opencode from launching. Root cause: `src/hooks.ts:4` assumed "Claude Code and OpenCode share the same SessionStart/SessionEnd schema." They don't. OpenCode's actual integration surface is its plugin system (`~/.config/opencode/plugins/`, TS/JS modules with `event` hooks per https://opencode.ai/docs/plugins/). The fix: narrow `JsonHookTarget` to `'claude-code'` (compile-time guard), add `installOpencodePlugin()` that writes a type-free TS plugin at `~/.config/opencode/plugins/hippo.ts` subscribing to `session.idle` (→ `hippo session-end`) and `session.created` (→ `hippo last-sleep`).
+- **Surgical migration of broken installs.** On the next `hippo hook install opencode`, the installer detects and removes any hippo-owned hook entries from `opencode.json` so opencode can launch again. The migration is structural — per-entry filter on commands starting with `hippo ` — not substring-matched, so user content that coincidentally mentions `hippo sleep` survives unchanged. When opencode.json is unparseable (the literal failure-mode that motivated the fix), the installer surfaces a `jsonRepairFailed=true` signal that the CLI logs as a clear "manual fix needed" warning.
+- **`hippo setup` `pluginTools` branch wired.** Pre-fix this branch only printed `tool.notes` without calling any installer; the fix adds an opencode special-case so `hippo setup` actually installs the plugin for opencode users (was a silent regression hidden behind the original bug).
+- **`detectInstalledTools`** marks opencode as `kind: 'plugin'` (was `'json-hook'`), aligning with the actual integration model.
+- **Uninstall also runs the legacy migration.** A user running `hippo hook uninstall opencode` to remove hippo entirely now also strips any leftover broken hooks block from `opencode.json` — the downgrade/remove path leaves opencode launchable.
+- **Deferred to a future release:** pinned-context auto-injection on opencode. `message.updated` fires per token, not per prompt submit, so there's no clean opencode plugin event equivalent to Claude Code's `UserPromptSubmit`. Users can still call `hippo context --pinned-only` via the MCP server (`hippo mcp`).
+
+### Tests
+
+`tests/opencode-plugin-install.test.ts` is new and covers (real FS, no mocks): plugin source content (marker + event types + no type imports + Bun-$ guard); fresh install writes the plugin file with marker; idempotence when content matches; overwrite when marker matches but content differs (future-proof); surgical migration preserving non-hippo entries; empty-hooks-key cleanup; `jsonRepairFailed=true` on unparseable JSON; no creation of opencode.json when none existed; false-positive defense on coincidental `hippo sleep` substrings; non-object hooks values (string + array) handled gracefully; uninstall removes only marker-bearing files; uninstall refuses user-written files; uninstall runs migration on downgrade path; detectInstalledTools marks opencode as plugin. `tests/_helpers/with-fake-home.ts` is a new shared HOME-isolation helper extracted from `tests/hooks.test.ts`. Full suite green: 220 files, 1605 tests.
+
+### Migration
+
+Users on v1.10.x-v1.11.1 with the broken opencode hooks block recover automatically by running `hippo hook install opencode` on v1.11.2 (the install path auto-migrates). Manual alternative: delete the `hooks` key from `~/.config/opencode/opencode.json`.
+
 ## 1.11.1 (2026-05-23): v1.11.0 tenant-isolation residue
 
 A patch release closing the two named residues from the v1.11.0 conflict-subsystem pass, flagged by its independent-review critic and tracked in `TODOS.md`. Plan: `docs/plans/2026-05-22-tenant-isolation-residue.md`.

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ hippo watch "npm run build"
 | Codex | `AGENTS.md` or `.codex` | `AGENTS.md` + automatic in-place Codex launcher wrapper |
 | Cursor | `.cursorrules` or `.cursor/rules` | `.cursorrules` |
 | OpenClaw | `.openclaw` or `AGENTS.md` | native OpenClaw plugin or `AGENTS.md` |
-| OpenCode | `.opencode/` or `opencode.json` | `AGENTS.md` |
+| OpenCode | `.opencode/` or `opencode.json` | `AGENTS.md` + TS plugin at `~/.config/opencode/plugins/hippo.ts` (subscribes to `session.idle` + `session.created`) |
 
 No extra commands needed. Just `hippo init` and your agent knows about Hippo.
 
@@ -639,7 +639,7 @@ hippo hook install claude-code   # patches CLAUDE.md + adds SessionStart/Session
 hippo hook install codex         # optional repair/manual run: patches AGENTS.md + wraps the detected Codex launcher
 hippo hook install cursor        # patches .cursorrules
 hippo hook install openclaw      # patches AGENTS.md
-hippo hook install opencode      # patches AGENTS.md
+hippo hook install opencode      # patches AGENTS.md + installs the opencode TS plugin
 ```
 
 This adds a `<!-- hippo:start -->` ... `<!-- hippo:end -->` block that tells the agent to:

--- a/docs/plans/2026-05-23-opencode-plugin-fix.md
+++ b/docs/plans/2026-05-23-opencode-plugin-fix.md
@@ -1,0 +1,660 @@
+# OpenCode Plugin Fix Implementation Plan — Revision 1
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Revision history:**
+- **Rev 0** (2026-05-23 13:02 UTC): initial draft. plan-eng-critic returned `fail` (score 62) with 2 crit + 5 high + 3 med findings: (1) migration silently no-ops on invalid JSON — the literal failure mode being fixed; (2) `hippo setup` pluginTools branch only prints notes — would silently skip opencode install after kind flip; (3) existing tests directly use opencode in installJsonHooks — must explicitly update, not "if found"; (4) `@opencode-ai/plugin` import unverified (WebFetch on npm returned 403); (5) substring-match isHippoOwned has false-positive blast-radius risk; (6) marker not future-proof; (7) missing Bun-$ guard; (8) test convention not aligned with existing withFakeHome helper; (9) commit sequence breaks bisect; (10) uninstall doesn't run legacy migration.
+- **Rev 1** (2026-05-23 13:07 UTC): every must_fix item addressed. Verified cli.ts:4444-4450 pluginTools branch — confirmed critic was right (only `console.log(tool.notes)`, no installer). Verified tests/hooks.test.ts:19 `withFakeHome` helper — extracted to shared module in Task 0 below. Verified tests/hooks.test.ts:231-257 + :355 — explicit deletions/updates added. Verified `@opencode-ai/plugin` unconfirmable from this sandbox (npm 403) — switched plugin source to type-free signature, eliminating the dependency question. Migration on invalid JSON returns structured error. `isHippoOwned` switched from substring match to structural per-entry filter. Idempotence checks marker AND content match. Bun `$` guard added. Commit sequence reordered: add-new-first, atomic refactor-narrow-last. uninstall now also runs migration.
+
+**Goal:** Fix [hippo-memory issue #24](https://github.com/kitfunso/hippo-memory/issues/24) at root by replacing the wrong assumption (`opencode` uses Claude Code's JSON-hook format) with opencode's actual integration model (a TypeScript plugin loaded from `~/.config/opencode/plugins/`). Migrate users on v1.10.x-v1.11.1 who have the broken `hooks` block in their `opencode.json` so opencode launches again.
+
+**Architecture:** Same overall direction as Rev 0 but tightened: extract a shared `tests/_helpers/with-fake-home.ts` from the existing inline helper to align new test file with project conventions; ship the plugin source as a constant in `src/hooks.ts` with a type-free signature (no `import type` dependency on `@opencode-ai/plugin`) and a defensive `if (typeof $ !== 'function') return;` guard; structural per-entry `hooks` filter (not a substring-match wipe) when migrating opencode.json; idempotence keyed on marker AND content match so future plugin source revisions overwrite; uninstall also runs the legacy migration; `cmdSetup` pluginTools branch explicitly patched to install opencode; structured error return on unparseable opencode.json so the CLI can surface "manual fix needed".
+
+**Tech Stack:** TypeScript, Node fs, vitest (real FS, no mocks per project rule). Plugin file has NO type imports (eliminates `@opencode-ai/plugin` publication-status question). Bun `$` shell invocation at runtime, with a defensive `typeof $ !== 'function'` guard so a non-Bun deployment fails closed instead of crashing the opencode session.
+
+---
+
+## Research notes (completed before this plan)
+
+Per `/writing-plans` § "Research Before Writing", and updated for Rev 1:
+
+- **Source-read all of `src/hooks.ts` (753 lines)**. Confirmed every line-number claim in Rev 0.
+- **Verified `cli.ts:4444-4450` pluginTools branch** prints `tool.notes` only — confirms Rev 0 critic CRIT #2. The plan now patches this branch explicitly (Task 6).
+- **Verified `tests/hooks.test.ts`**: `withFakeHome` helper at line 19 sets BOTH `HOME` and `USERPROFILE`; existing `describe('installJsonHooks(opencode)')` block runs lines 231-257 (2 tests); `detectInstalledTools` assertion at line 355 expects `opencode kind === 'json-hook'`. All 3 explicitly addressed in Task 3b and Task 5.
+- **Verified opencode plugin API** at https://opencode.ai/docs/plugins/ in discover.
+- **`@opencode-ai/plugin` npm publication status: UNVERIFIABLE from this sandbox** (npmjs.com returned 403 to WebFetch). Rev 1 sidesteps by using a type-free plugin signature; the `Plugin` type was only convenience, not required for opencode to load the plugin.
+
+---
+
+## Task 0: Branch + extract shared test helper
+
+**Files:**
+- Working tree.
+- Create: `tests/_helpers/with-fake-home.ts`.
+- Modify: `tests/hooks.test.ts` (import the helper instead of declaring inline).
+
+**Step 1:** `git checkout -b fix/opencode-plugin-installer` from master (tip `098b095`).
+
+**Step 2:** Create `tests/_helpers/with-fake-home.ts`:
+
+```typescript
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Each test gets its own fake $HOME so we never touch the real
+ * ~/.claude/settings.json, ~/.config/opencode/opencode.json, or
+ * ~/.config/opencode/plugins/ on the machine running the tests.
+ *
+ * Sets HOME on POSIX and USERPROFILE on Windows; restores both on cleanup.
+ * Extracted from tests/hooks.test.ts 2026-05-23 so the opencode plugin
+ * install tests use the same isolation pattern.
+ */
+export function withFakeHome(prefix = 'hippo-test-'): { cleanup: () => void; home: string } {
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const fake = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  process.env.HOME = fake;
+  process.env.USERPROFILE = fake;
+  return {
+    home: fake,
+    cleanup: () => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      fs.rmSync(fake, { recursive: true, force: true });
+    },
+  };
+}
+```
+
+**Step 3:** Modify `tests/hooks.test.ts` — replace the inline `withFakeHome` at lines 19-33 with `import { withFakeHome } from './_helpers/with-fake-home.js';`. This is a pure refactor; no behavior change.
+
+**Step 4:** Run `npm test -- tests/hooks.test.ts`. Expected: all existing tests still pass (this is a refactor, no test logic changed).
+
+**Step 5: Commit** `refactor(tests): extract withFakeHome helper to tests/_helpers/`.
+
+---
+
+## Task 1: Add `OPENCODE_PLUGIN_SOURCE` constant (type-free)
+
+**Files:**
+- Modify: `src/hooks.ts` (add new exports — no signature changes yet).
+- Create: `tests/opencode-plugin-install.test.ts` (initial — content-of-plugin-source tests).
+
+**Step 1: Write failing tests:**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { OPENCODE_PLUGIN_SOURCE, HIPPO_OPENCODE_PLUGIN_MARKER } from '../src/hooks.js';
+
+describe('OPENCODE_PLUGIN_SOURCE', () => {
+  it('contains the versioned hippo marker', () => {
+    expect(OPENCODE_PLUGIN_SOURCE).toContain(HIPPO_OPENCODE_PLUGIN_MARKER);
+    expect(HIPPO_OPENCODE_PLUGIN_MARKER).toMatch(/^HIPPO_OPENCODE_PLUGIN_V\d+$/);
+  });
+  it('handles session.idle and session.created events', () => {
+    expect(OPENCODE_PLUGIN_SOURCE).toContain('session.idle');
+    expect(OPENCODE_PLUGIN_SOURCE).toContain('session.created');
+  });
+  it('guards against non-Bun runtimes (typeof $ check)', () => {
+    expect(OPENCODE_PLUGIN_SOURCE).toMatch(/typeof\s+\$\s*!==\s*['"]function['"]/);
+  });
+  it('uses no type imports (type-free signature)', () => {
+    // Avoids the unresolved @opencode-ai/plugin dependency at install time.
+    expect(OPENCODE_PLUGIN_SOURCE).not.toContain('import type');
+    expect(OPENCODE_PLUGIN_SOURCE).not.toContain('@opencode-ai/plugin');
+  });
+});
+```
+
+**Step 2:** Run — expected FAIL on imports.
+
+**Step 3: Add to `src/hooks.ts`** after line 110 (after `HIPPO_CODEX_WRAPPER_MARKER`):
+
+```typescript
+const HIPPO_OPENCODE_PLUGIN_MARKER = 'HIPPO_OPENCODE_PLUGIN_V1';
+
+/**
+ * The opencode plugin file we install at ~/.config/opencode/plugins/hippo.ts.
+ *
+ * Per https://opencode.ai/docs/plugins/, plugins are TS/JS modules exporting an
+ * async function returning hooks. We subscribe to `event` and route:
+ *   session.idle    → `hippo session-end` (Claude Code's SessionEnd equiv)
+ *   session.created → `hippo last-sleep` (Claude Code's SessionStart equiv)
+ *
+ * Design choices the critic forced into Rev 1:
+ *
+ * 1. No `import type { Plugin } from "@opencode-ai/plugin"`. The package's
+ *    npm publication status was unverifiable from the build sandbox; an
+ *    unresolved import would crash plugin load. opencode infers plugin shape
+ *    from the returned object, so the type annotation is convenience-only.
+ *
+ * 2. Defensive `typeof $ !== 'function'` guard. opencode runs in Bun (where
+ *    `$` is the shell-template helper), but a future Node-mode deployment
+ *    would have `$` undefined and the plugin would ReferenceError on every
+ *    session.idle, killing opencode sessions in a hard-to-recover way (the
+ *    idempotence marker prevents re-install). Fail closed, log a warning,
+ *    let opencode continue.
+ *
+ * 3. `.quiet().nothrow()` on each `$\`...\`` so a missing hippo binary (e.g.
+ *    PATH-misconfigured user) does NOT throw out of the event handler and
+ *    crash the opencode session.
+ *
+ * 4. UserPromptSubmit equivalent NOT wired. opencode's `message.updated`
+ *    fires per-token; per-prompt-submit is not a clean opencode event. Users
+ *    who want pinned-context auto-injection can call `hippo context` via the
+ *    MCP server.
+ *
+ * 5. Versioned marker `HIPPO_OPENCODE_PLUGIN_V1` allows future versions to
+ *    overwrite cleanly; install checks marker AND content equality so a
+ *    plugin-source revision under the same V1 marker re-writes the file.
+ */
+export const OPENCODE_PLUGIN_SOURCE = `// ${HIPPO_OPENCODE_PLUGIN_MARKER}
+// hippo-memory opencode plugin. Re-install with \`hippo hook install opencode\`.
+// Source of truth: src/hooks.ts OPENCODE_PLUGIN_SOURCE in https://github.com/kitfunso/hippo-memory
+
+export const HippoPlugin = async ({ $ }) => {
+  return {
+    event: async ({ event }) => {
+      // Defense in depth: opencode currently runs in Bun where $ is the shell
+      // template helper. A non-Bun runtime would crash the plugin on first
+      // event fire; fail closed instead so opencode keeps working.
+      if (typeof $ !== "function") return;
+      try {
+        if (event.type === "session.idle") {
+          await $\`hippo session-end\`.quiet().nothrow();
+        } else if (event.type === "session.created") {
+          await $\`hippo last-sleep\`.quiet().nothrow();
+        }
+      } catch {
+        // hippo CLI not on PATH or other failure — never crash the host session.
+      }
+    },
+  };
+};
+`;
+
+export { HIPPO_OPENCODE_PLUGIN_MARKER };
+```
+
+**Step 4:** Run tests — expected 4 pass.
+
+**Step 5: Commit** `feat(hooks): add OPENCODE_PLUGIN_SOURCE plugin file constant`.
+
+---
+
+## Task 2: Add `installOpencodePlugin` / `uninstallOpencodePlugin` + structural migration
+
+**Files:**
+- Modify: `src/hooks.ts` (add new exported functions, ~120 lines, after `uninstallJsonHooks` around line 735).
+- Modify: `tests/opencode-plugin-install.test.ts` (add install/uninstall/migration tests).
+
+**Step 1: Write failing tests** (using the extracted `withFakeHome` helper):
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { withFakeHome } from './_helpers/with-fake-home.js';
+import {
+  installOpencodePlugin,
+  uninstallOpencodePlugin,
+  resolveOpencodePluginPath,
+  HIPPO_OPENCODE_PLUGIN_MARKER,
+  OPENCODE_PLUGIN_SOURCE,
+} from '../src/hooks.js';
+
+describe('installOpencodePlugin (real-FS)', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => { env = withFakeHome('hippo-opencode-'); });
+  afterEach(() => { env.cleanup(); });
+
+  it('writes a TS plugin file with the hippo marker on a fresh host', () => {
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(result.migratedLegacyHooks).toBe(false);
+    expect(result.jsonRepairFailed).toBe(false);
+    expect(fs.readFileSync(resolveOpencodePluginPath(), 'utf8')).toContain(HIPPO_OPENCODE_PLUGIN_MARKER);
+  });
+
+  it('is idempotent when content matches', () => {
+    installOpencodePlugin();
+    const result2 = installOpencodePlugin();
+    expect(result2.installed).toBe(false);
+  });
+
+  it('overwrites when marker matches but content differs (future-proof for V1-revision)', () => {
+    const pluginPath = resolveOpencodePluginPath();
+    fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+    // Stale V1 plugin with old content (e.g. shipped in a prior 1.11.x).
+    fs.writeFileSync(pluginPath, `// ${HIPPO_OPENCODE_PLUGIN_MARKER}\n// stale\n`);
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(fs.readFileSync(pluginPath, 'utf8')).toBe(OPENCODE_PLUGIN_SOURCE);
+  });
+
+  it('migrates: removes only hippo-owned hook entries from opencode.json', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      theme: 'dark',
+      hooks: {
+        SessionEnd: [
+          { hooks: [{ type: 'command', command: 'hippo session-end --log-file ...', timeout: 5 }] },
+          { hooks: [{ type: 'command', command: 'echo my own hook', timeout: 5 }] },
+        ],
+        SessionStart: [{ hooks: [{ type: 'command', command: 'hippo last-sleep --path ...', timeout: 5 }] }],
+      },
+    }, null, 2));
+
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.theme).toBe('dark');
+    // SessionStart was 100% hippo → key removed; SessionEnd had a non-hippo
+    // entry → key preserved with only the non-hippo entry left.
+    expect(after.hooks.SessionStart).toBeUndefined();
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+    expect(JSON.stringify(after.hooks.SessionEnd)).toContain('my own hook');
+  });
+
+  it('drops the empty hooks key entirely when nothing survives', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'hippo session-end --log-file ...' }] }],
+      },
+    }, null, 2));
+    installOpencodePlugin();
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks).toBeUndefined();
+  });
+
+  it('returns jsonRepairFailed=true when opencode.json is unparseable', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, '{ "hooks": ["unterminated string ');
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);          // plugin file still written
+    expect(result.migratedLegacyHooks).toBe(false); // nothing migrated
+    expect(result.jsonRepairFailed).toBe(true);     // structured error surfaced
+  });
+
+  it('does NOT create opencode.json on a fresh install with no legacy block', () => {
+    installOpencodePlugin();
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    expect(fs.existsSync(opencodeJsonPath)).toBe(false);
+  });
+
+  it('leaves a non-hippo hooks key alone (false-positive defense)', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    // A user command that coincidentally mentions "hippo sleep" inside its
+    // payload but is NOT a hippo-owned hook entry — should survive.
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'echo "remember to hippo sleep your laptop"' }] }],
+      },
+    }, null, 2));
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(false);
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+  });
+});
+
+describe('uninstallOpencodePlugin (real-FS)', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => { env = withFakeHome('hippo-opencode-'); });
+  afterEach(() => { env.cleanup(); });
+
+  it('removes only files with the hippo marker', () => {
+    installOpencodePlugin();
+    expect(uninstallOpencodePlugin()).toBe(true);
+    expect(fs.existsSync(resolveOpencodePluginPath())).toBe(false);
+  });
+
+  it('returns false when plugin not installed', () => {
+    expect(uninstallOpencodePlugin()).toBe(false);
+  });
+
+  it('refuses to delete a user-written hippo.ts without the marker', () => {
+    const pluginPath = resolveOpencodePluginPath();
+    fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+    fs.writeFileSync(pluginPath, '// user-written content, no marker\n');
+    expect(uninstallOpencodePlugin()).toBe(false);
+    expect(fs.existsSync(pluginPath)).toBe(true);
+  });
+
+  it('ALSO runs the legacy-hooks migration (downgrade path)', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'hippo session-end --log-file x' }] }] },
+    }, null, 2));
+    // No plugin installed; uninstall should still clean the legacy block so a
+    // user running `hippo hook uninstall opencode` to remove hippo entirely
+    // leaves opencode launchable.
+    expect(uninstallOpencodePlugin()).toBe(true);
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks).toBeUndefined();
+  });
+});
+```
+
+**Step 2:** Run — FAIL on imports.
+
+**Step 3: Implement** in `src/hooks.ts` after `uninstallJsonHooks`:
+
+```typescript
+export interface OpencodePluginInstallResult {
+  installed: boolean;
+  pluginPath: string;
+  migratedLegacyHooks: boolean;
+  jsonRepairFailed: boolean;
+}
+
+export function resolveOpencodePluginPath(): string {
+  return path.join(homeDir(), '.config', 'opencode', 'plugins', 'hippo.ts');
+}
+
+function resolveOpencodeConfigPath(): string {
+  return path.join(homeDir(), '.config', 'opencode', 'opencode.json');
+}
+
+/**
+ * Return true iff a single hook entry's serialized form has a `command` string
+ * that starts with `hippo ` (the verb-prefix). This is the same structural test
+ * used by uninstallJsonHooks; substring matching against arbitrary user content
+ * is unsafe (a user's `echo "remember to hippo sleep your laptop"` is not a
+ * hippo-owned hook).
+ */
+function entryIsHippoOwned(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => {
+    if (!h || typeof h !== 'object') return false;
+    const cmd = (h as { command?: unknown }).command;
+    return typeof cmd === 'string' && /^\s*hippo\s/.test(cmd);
+  });
+}
+
+/**
+ * Structurally strip every hippo-owned entry from opencode.json's hooks key.
+ * Returns one of:
+ *   { migrated: true,  jsonRepairFailed: false } — at least one entry removed.
+ *   { migrated: false, jsonRepairFailed: false } — file fine, nothing to do.
+ *   { migrated: false, jsonRepairFailed: true  } — file present but unparseable.
+ *
+ * When all hippo-owned entries are removed and a hook key becomes empty, that
+ * key is deleted. When the top-level hooks object becomes empty it is deleted
+ * too. Other keys (theme, etc.) are preserved.
+ */
+function migrateLegacyOpencodeHooksBlock(): { migrated: boolean; jsonRepairFailed: boolean } {
+  const configPath = resolveOpencodeConfigPath();
+  if (!fs.existsSync(configPath)) return { migrated: false, jsonRepairFailed: false };
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch {
+    return { migrated: false, jsonRepairFailed: true };
+  }
+
+  const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+  if (!hooks || typeof hooks !== 'object') return { migrated: false, jsonRepairFailed: false };
+
+  let changed = false;
+  // Walk every event key (SessionEnd / SessionStart / UserPromptSubmit / Stop / etc.)
+  // and remove hippo-owned entries surgically.
+  for (const key of Object.keys(hooks)) {
+    if (!Array.isArray(hooks[key])) continue;
+    const before = hooks[key].length;
+    hooks[key] = hooks[key].filter((entry) => !entryIsHippoOwned(entry));
+    if (hooks[key].length !== before) {
+      changed = true;
+      if (hooks[key].length === 0) delete hooks[key];
+    }
+  }
+
+  if (!changed) return { migrated: false, jsonRepairFailed: false };
+
+  if (Object.keys(hooks).length === 0) delete settings.hooks;
+  fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  return { migrated: true, jsonRepairFailed: false };
+}
+
+export function installOpencodePlugin(): OpencodePluginInstallResult {
+  const pluginPath = resolveOpencodePluginPath();
+  const { migrated, jsonRepairFailed } = migrateLegacyOpencodeHooksBlock();
+
+  // Idempotence: skip the write only if BOTH the marker is present AND the
+  // content matches the current source. Marker-only matches (with stale
+  // content) overwrite cleanly so future patches reach existing installs.
+  if (fs.existsSync(pluginPath)) {
+    const existing = fs.readFileSync(pluginPath, 'utf8');
+    if (existing.includes(HIPPO_OPENCODE_PLUGIN_MARKER) && existing === OPENCODE_PLUGIN_SOURCE) {
+      return { installed: false, pluginPath, migratedLegacyHooks: migrated, jsonRepairFailed };
+    }
+  }
+  fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+  fs.writeFileSync(pluginPath, OPENCODE_PLUGIN_SOURCE, 'utf8');
+  return { installed: true, pluginPath, migratedLegacyHooks: migrated, jsonRepairFailed };
+}
+
+export function uninstallOpencodePlugin(): boolean {
+  const pluginPath = resolveOpencodePluginPath();
+  let removedFile = false;
+  if (fs.existsSync(pluginPath)) {
+    const existing = fs.readFileSync(pluginPath, 'utf8');
+    if (existing.includes(HIPPO_OPENCODE_PLUGIN_MARKER)) {
+      fs.unlinkSync(pluginPath);
+      removedFile = true;
+    }
+  }
+  // Always run the legacy migration on uninstall — the downgrade path (user
+  // removing hippo entirely) must leave opencode launchable.
+  const { migrated } = migrateLegacyOpencodeHooksBlock();
+  return removedFile || migrated;
+}
+```
+
+**Step 4:** Run tests — expected 12 green.
+
+**Step 5: Commit** `feat(hooks): add installOpencodePlugin + uninstallOpencodePlugin + structural opencode.json migration`.
+
+---
+
+## Task 3: Atomic refactor — narrow `JsonHookTarget`, flip detect, re-route CLI
+
+**Files:**
+- Modify: `src/hooks.ts` (lines 4-21 comment, line 28 type, lines 500-517 `resolveJsonHookPaths`, line 747 `detectInstalledTools`).
+- Modify: `src/cli.ts` (lines 527, 4301, 4356, 4400-4421 jsonTools loop, 4444-4450 pluginTools loop, imports at 34-47).
+- Modify: `tests/hooks.test.ts` (delete `describe('installJsonHooks(opencode)')` block at lines 231-257; change line ~355 `opencode kind === 'json-hook'` to `'plugin'`).
+- Modify: `tests/opencode-plugin-install.test.ts` (add a `detectInstalledTools` assertion test for kind='plugin').
+
+**This task is intentionally one commit** — the critic flagged Rev 0's 3-cut chain as un-bisectable. Doing the narrow + detect-flip + dispatch all in one atomic commit means every commit on the branch is green.
+
+**Step 1: Edit `src/hooks.ts`**
+
+- Lines 4-21: replace the file-header comment. New text describes claude-code uses JSON hooks; opencode uses a separate `installOpencodePlugin` code path. Keep migration-history bullets that still apply (Stop→SessionEnd, split SessionEnd) for the claude-code path.
+- Line 28: `export type JsonHookTarget = 'claude-code';`
+- Lines 500-517 `resolveJsonHookPaths`: drop the `'opencode'` case.
+- Line 747: `{ name: 'opencode', configDir: '~/.config/opencode', detected: exists('.config', 'opencode'), kind: 'plugin', notes: 'installs a TS plugin at ~/.config/opencode/plugins/hippo.ts' },`
+
+**Step 2: Edit `src/cli.ts`**
+
+- Lines 34-47 import block: add `installOpencodePlugin`, `uninstallOpencodePlugin`, `resolveOpencodePluginPath` to the named imports.
+- Line 527 (`hippo init` auto-install): the existing `if (hook === 'claude-code' || hook === 'opencode')` branch becomes `if (hook === 'claude-code')` for the JSON path, and a sibling `else if (hook === 'opencode')` block calls `installOpencodePlugin()` and logs accordingly.
+- Lines 4301-4326 (`hippo hook install <target>`): same split. New log line for opencode includes the migration outcome ("Removed legacy Claude Code-style hooks block from opencode.json — opencode can now launch") when `migratedLegacyHooks` is true; warning when `jsonRepairFailed` is true ("opencode.json is unparseable; opencode plugin installed but the legacy hooks block could not be removed — fix the file manually").
+- Lines 4356-4380 (`hippo hook uninstall <target>`): same split — claude-code → `uninstallJsonHooks('claude-code')`; opencode → `uninstallOpencodePlugin()`.
+- Lines 4400-4421 (`hippo setup` jsonTools loop): leave the loop iterating claude-code-only json-hook tools (with the kind flip in Step 1, opencode no longer enters `jsonTools`). Update the no-tools message from "checked: claude-code, opencode" to "checked: claude-code" so it doesn't lie.
+- Lines 4444-4450 (`hippo setup` pluginTools loop): patch the `for (const tool of pluginTools)` body — when `tool.name === 'opencode'` AND not dryRun, call `installOpencodePlugin()` and log the result the same way as the jsonTools loop. For other plugin tools (openclaw), keep the existing notes-only behavior. Dry-run prints "would install hippo plugin at ~/.config/opencode/plugins/hippo.ts".
+
+**Step 3: Edit `tests/hooks.test.ts`**
+
+- Delete lines 231-257 (the entire `describe('installJsonHooks(opencode)')` block — both tests are about JSON-hook semantics for opencode that no longer applies).
+- Change line ~355 from `expect(tools.find((t) => t.name === 'opencode')?.kind).toBe('json-hook');` to `'plugin'`.
+
+**Step 4: Add a detectInstalledTools test for opencode in `tests/opencode-plugin-install.test.ts`:**
+
+```typescript
+import { detectInstalledTools } from '../src/hooks.js';
+
+describe('detectInstalledTools opencode entry', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => { env = withFakeHome('hippo-detect-'); });
+  afterEach(() => { env.cleanup(); });
+
+  it('marks opencode as kind:"plugin" with the plugin path in notes', () => {
+    fs.mkdirSync(path.join(env.home, '.config', 'opencode'), { recursive: true });
+    const tool = detectInstalledTools().find((t) => t.name === 'opencode');
+    expect(tool?.kind).toBe('plugin');
+    expect(tool?.notes).toContain('plugins/hippo.ts');
+  });
+});
+```
+
+**Step 5:** Run `npx tsc --noEmit && npm test`. Expected: clean tsc, full suite green.
+
+**Step 6: Commit (one atomic commit covering Steps 1-4):**
+
+```
+fix(hooks): route opencode to plugin installer instead of JSON hooks (#24)
+
+Narrows JsonHookTarget to 'claude-code' (compile-time guard so opencode
+can't be re-introduced into the JSON installer). Updates the 5 CLI
+dispatch sites in src/cli.ts including the previously-overlooked
+pluginTools branch in cmdSetup. Flips detectInstalledTools to mark
+opencode as kind:'plugin'. Deletes the now-stale
+installJsonHooks(opencode) test block; updates the detectInstalledTools
+assertion to expect 'plugin'. Adds a detectInstalledTools test in the
+new opencode-plugin-install suite.
+
+The single-commit shape is deliberate: a multi-commit split would leave
+an intermediate commit with type errors (build broken) on the bisect
+trail. Per the plan-eng-critic Rev 0 review.
+```
+
+---
+
+## Task 4: README + CHANGELOG
+
+**Files:** `README.md` (Framework Integrations table + any opencode mention), `CHANGELOG.md` (new 1.11.2 entry at top).
+
+**Step 1:** `grep -n 'opencode\|OpenCode' README.md`. Update Framework Integrations table to say "installs a TS plugin at `~/.config/opencode/plugins/hippo.ts`".
+
+**Step 2:** Prepend `## 1.11.2` entry to CHANGELOG. Content mirrors Rev 0 plan's CHANGELOG draft, with these additions:
+- Note the structured error surface (`jsonRepairFailed`) on unparseable opencode.json.
+- Note the `pluginTools` branch was overlooked in v1.10.x-v1.11.1 (the bug was wider than the original issue).
+- Note `uninstall` now also runs the migration (downgrade-path safe).
+
+**Commit** `docs: update README + CHANGELOG for v1.11.2 opencode plugin fix`.
+
+---
+
+## Task 5: Version bump
+
+**Files:** `package.json`, `package-lock.json`, `src/version.ts`, `openclaw.plugin.json`, `extensions/openclaw-plugin/*.json`.
+
+`grep -rEl '"version":\s*"1\.11\.1"' --include='*.json' --include='*.ts' . | grep -v node_modules` → bump each via targeted Edit. Run `npm run build:all && npm test; echo "exit=$?"`. Expected exit=0.
+
+**Commit** `chore: bump version 1.11.1 → 1.11.2`.
+
+---
+
+## Verify stage (post-execute)
+
+- `npm test; echo "exit=$?"` — both pass-summary AND exit=0 required.
+- Manual smoke against tmp HOME:
+  ```bash
+  HIPPO_TEST_HOME=$(mktemp -d)
+  HOME=$HIPPO_TEST_HOME node ./bin/hippo.js hook install opencode
+  test -f $HIPPO_TEST_HOME/.config/opencode/plugins/hippo.ts
+  test ! -f $HIPPO_TEST_HOME/.config/opencode/opencode.json
+  ```
+- Migration smoke (broken hooks block + unrelated user hook):
+  ```bash
+  mkdir -p $HIPPO_TEST_HOME/.config/opencode
+  cat > $HIPPO_TEST_HOME/.config/opencode/opencode.json <<EOF
+  {"theme":"dark","hooks":{"SessionEnd":[
+    {"hooks":[{"type":"command","command":"hippo session-end --log-file foo"}]},
+    {"hooks":[{"type":"command","command":"echo my-own-hook"}]}
+  ]}}
+  EOF
+  HOME=$HIPPO_TEST_HOME node ./bin/hippo.js hook install opencode
+  jq '.theme' $HIPPO_TEST_HOME/.config/opencode/opencode.json   # → "dark"
+  jq '.hooks.SessionEnd | length' $HIPPO_TEST_HOME/.config/opencode/opencode.json   # → 1 (only my-own-hook survived)
+  ```
+- Unparseable-JSON smoke:
+  ```bash
+  echo '{ "hooks": [bad json' > $HIPPO_TEST_HOME/.config/opencode/opencode.json
+  HOME=$HIPPO_TEST_HOME node ./bin/hippo.js hook install opencode 2>&1 | grep -i 'unparseable\|manual fix\|json'
+  test -f $HIPPO_TEST_HOME/.config/opencode/plugins/hippo.ts   # plugin still installed
+  ```
+
+---
+
+## Review stage
+
+- `/self-review` on diff.
+- `independent-review-critic`: brief on diff + plan + opencode docs URL; check the structural migration handles edge cases not covered by the 12 unit tests (e.g. a hooks key whose value is a string instead of an object, an array instead of object, etc.).
+- `/review` per `feedback_hippo_release_workflow`.
+
+---
+
+## Ship stage
+
+- `/ship-check`.
+- `ship-readiness-critic`.
+- `gh pr create` title `fix(hooks): opencode integration via plugin instead of JSON hooks (#24)`.
+- Human-final-gate before `/publish-repo`.
+
+---
+
+## Deploy stage
+
+- Merge + `/publish-repo` (npm publish + tag + GitHub Release).
+- Close issue #24 with comment linking the merge commit + npm version.
+- Smoke the npm tarball: `npm install -g hippo-memory@1.11.2 && hippo hook install opencode` in a fresh tmp dir.
+
+---
+
+## Success criteria (binary, verifiable) — REVISED for Rev 1
+
+- [ ] `JsonHookTarget` narrowed to `'claude-code'`; `tsc --noEmit` clean.
+- [ ] `installOpencodePlugin()` exported; writes plugin file with `HIPPO_OPENCODE_PLUGIN_V1` marker; returns `{ installed, pluginPath, migratedLegacyHooks, jsonRepairFailed }`.
+- [ ] Plugin source has `typeof $ !== 'function'` guard; no `import type`; uses `.quiet().nothrow()` on every `$\`...\``.
+- [ ] Idempotence keyed on marker AND content equality; stale-marker overwrites cleanly.
+- [ ] Structural migration: only hippo-owned entries removed; non-hippo entries (including coincidental substring matches like `echo "remember to hippo sleep"`) preserved.
+- [ ] `jsonRepairFailed=true` returned when opencode.json is unparseable; plugin install still succeeds.
+- [ ] Empty hook-key arrays AND empty top-level hooks object are deleted (no `{ "hooks": {} }` litter).
+- [ ] `detectInstalledTools` returns `kind: 'plugin'` for opencode with `notes` containing the plugin path.
+- [ ] All 5 cli.ts dispatch sites route opencode to the plugin code path — including the previously-overlooked `pluginTools` branch in `cmdSetup` (cli.ts:4444).
+- [ ] `hippo setup` against a host with opencode installs the plugin (not just prints notes).
+- [ ] `uninstallOpencodePlugin()` also runs the legacy migration so downgrade leaves opencode launchable.
+- [ ] `tests/_helpers/with-fake-home.ts` is the shared HOME-isolation helper; both `tests/hooks.test.ts` and `tests/opencode-plugin-install.test.ts` import it.
+- [ ] tests/hooks.test.ts:231-257 `installJsonHooks(opencode)` block deleted; line ~355 assertion updated to `'plugin'`.
+- [ ] Every commit on the branch is independently green (`npm test` and `tsc --noEmit` clean at each ref).
+- [ ] Full test suite green (1599+ tests, exit code 0) at branch tip.
+- [ ] Manual smoke + migration smoke + unparseable-JSON smoke pass.
+- [ ] CHANGELOG 1.11.2 entry includes the root-cause analysis + the jsonRepairFailed surface + the pluginTools branch oversight + the uninstall-also-migrates note.
+- [ ] Version 1.11.2 in package.json + lockfile + src/version.ts + openclaw manifests.
+- [ ] PR opened, all critics pass, human gate clears, merged to master.
+- [ ] npm @latest tag points to 1.11.2.
+- [ ] Issue #24 closed.
+
+---
+
+## Out of scope (deliberate)
+
+- **Pinned-context auto-injection on opencode.** No clean per-prompt-submit event. Future release.
+- **Adding more opencode events** (file.edited, tool.execute.after, etc.) — outside #24's scope.
+- **Per-project `.opencode/plugins/hippo.ts`** — hippo is cross-project by design.
+- **Refactoring the codex wrapper / openclaw plugin code paths** — correct for their respective tools.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.1",
+  "version": "1.11.2",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,9 @@ import {
   uninstallCodexWrapper,
   resolveCodexSessionTranscript,
   resolveCodexWrapperPaths,
+  installOpencodePlugin,
+  uninstallOpencodePlugin,
+  resolveOpencodePluginPath,
   type CodexWrapperMetadata,
   type JsonHookTarget,
 } from './hooks.js';
@@ -521,10 +524,10 @@ function autoInstallHooks(quiet: boolean): void {
       console.log(`   Auto-installed ${hook} hook in ${hookDef.file}`);
     }
 
-    // For JSON-hook tools, also install SessionEnd+SessionStart entries.
-    // Keeps `hippo init` in lockstep with `hippo hook install <target>` and
-    // `hippo setup`, which both cover claude-code + opencode now.
-    if (hook === 'claude-code' || hook === 'opencode') {
+    // For Claude Code, also install SessionEnd+SessionStart entries in its
+    // settings.json. Keeps `hippo init` in lockstep with `hippo hook install
+    // claude-code` and `hippo setup`.
+    if (hook === 'claude-code') {
       const result = installJsonHooks(hook);
       if (result.installedSessionEnd) {
         console.log(`   Auto-installed hippo session-end SessionEnd hook in ${hook} settings`);
@@ -542,6 +545,20 @@ function autoInstallHooks(quiet: boolean): void {
         console.log(`   Migrated split sleep+capture SessionEnd entries → single detached hippo session-end`);
       } else if (result.migratedLegacySessionEnd) {
         console.log(`   Migrated legacy SessionEnd entry to the new detached form`);
+      }
+    } else if (hook === 'opencode') {
+      // opencode uses a TS plugin, not Claude Code's JSON-hook schema.
+      // See OPENCODE_PLUGIN_SOURCE in src/hooks.ts for the plugin file
+      // content + design rationale.
+      const result = installOpencodePlugin();
+      if (result.installed) {
+        console.log(`   Auto-installed hippo opencode plugin -> ${result.pluginPath}`);
+      }
+      if (result.migratedLegacyHooks) {
+        console.log(`   Removed legacy Claude Code-style hooks block from opencode.json — opencode can now launch`);
+      }
+      if (result.jsonRepairFailed) {
+        console.log(`   WARNING: opencode.json is unparseable; legacy hooks block could not be auto-removed. Fix the file manually.`);
       }
     }
   }
@@ -4296,9 +4313,9 @@ function cmdHook(
       console.log(`   Create ${hook.file} and re-run \`hippo hook install ${target}\` if you want the agent prompt.`);
     }
 
-    // For tools with JSON hook systems, also install SessionEnd+SessionStart
-    // entries in their settings file. Currently: claude-code + opencode.
-    if (target === 'claude-code' || target === 'opencode') {
+    // For Claude Code, also install SessionEnd+SessionStart entries in its
+    // settings file.
+    if (target === 'claude-code') {
       const result = installJsonHooks(target);
       if (result.installedSessionEnd) {
         console.log(`Installed hippo session-end SessionEnd hook in ${result.target} settings`);
@@ -4316,6 +4333,20 @@ function cmdHook(
         console.log(`Migrated split sleep+capture SessionEnd entries → single detached hippo session-end`);
       } else if (result.migratedLegacySessionEnd) {
         console.log(`Migrated legacy SessionEnd entry to the new detached form`);
+      }
+    } else if (target === 'opencode') {
+      // opencode uses a TS plugin, not JSON hooks. See src/hooks.ts.
+      const result = installOpencodePlugin();
+      if (result.installed) {
+        console.log(`Installed hippo opencode plugin at ${result.pluginPath}`);
+      } else {
+        console.log(`opencode plugin already up to date at ${result.pluginPath}`);
+      }
+      if (result.migratedLegacyHooks) {
+        console.log(`Removed legacy Claude Code-style hooks block from opencode.json — opencode can now launch`);
+      }
+      if (result.jsonRepairFailed) {
+        console.log(`WARNING: opencode.json is unparseable; legacy hooks block could not be auto-removed. Fix the file manually.`);
       }
     } else if (target === 'codex') {
       const result = installCodexWrapper();
@@ -4352,10 +4383,17 @@ function cmdHook(
       console.log(`${hook.file} not found, skipping agent-instructions uninstall.`);
     }
 
-    // For JSON-hook tools, also strip their SessionEnd/SessionStart entries.
-    if (target === 'claude-code' || target === 'opencode') {
+    // For Claude Code, also strip its SessionEnd/SessionStart entries.
+    if (target === 'claude-code') {
       if (uninstallJsonHooks(target)) {
         console.log(`Removed hippo hooks from ${target} settings`);
+      }
+    } else if (target === 'opencode') {
+      // opencode uses a TS plugin; uninstall removes the plugin file AND
+      // also runs the legacy-hooks migration so the downgrade/remove path
+      // leaves opencode launchable.
+      if (uninstallOpencodePlugin()) {
+        console.log(`Removed hippo opencode plugin (and any legacy hooks block from opencode.json)`);
       }
     } else if (target === 'codex') {
       if (uninstallCodexWrapper()) {
@@ -4393,7 +4431,7 @@ function cmdSetup(flags: Record<string, string | boolean | string[]>): void {
   const pluginTools = tools.filter((t) => t.kind === 'plugin' && t.detected);
 
   if (jsonTools.length === 0 && !forceAll) {
-    console.log('No JSON-hook-capable tools detected (checked: claude-code, opencode).');
+    console.log('No JSON-hook-capable tools detected (checked: claude-code).');
     console.log('Run with --all to install hooks anyway.');
   }
 
@@ -4445,7 +4483,26 @@ function cmdSetup(flags: Record<string, string | boolean | string[]>): void {
     console.log('');
     console.log('Plugin-based tools (hook API via plugin, not JSON):');
     for (const tool of pluginTools) {
-      console.log(`  ${tool.name.padEnd(14)} ${tool.notes}`);
+      if (tool.name === 'opencode') {
+        if (dryRun) {
+          console.log(`  ${tool.name.padEnd(14)} [dry-run] would install hippo plugin at ${resolveOpencodePluginPath()}`);
+          continue;
+        }
+        const result = installOpencodePlugin();
+        const bits: string[] = [];
+        if (result.installed) bits.push('installed plugin');
+        if (result.migratedLegacyHooks) bits.push('migrated legacy hooks block');
+        if (result.jsonRepairFailed) bits.push('WARNING: opencode.json unparseable — manual fix needed');
+        if (bits.length === 0) {
+          console.log(`  ${tool.name.padEnd(14)} already configured (${result.pluginPath})`);
+        } else {
+          console.log(`  ${tool.name.padEnd(14)} ${bits.join(', ')} -> ${result.pluginPath}`);
+        }
+      } else {
+        // Other plugin tools (openclaw) have their own installer; the notes
+        // line points the user at it.
+        console.log(`  ${tool.name.padEnd(14)} ${tool.notes}`);
+      }
     }
   }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,23 +1,32 @@
 /**
- * JSON-hook install/uninstall for AI coding tools.
+ * Hook install/uninstall for AI coding tools.
  *
- * Currently supports Claude Code and OpenCode, which share the same
- * SessionStart/SessionEnd schema. Hippo installs two entries:
- *   - SessionEnd: `hippo session-end --log-file <path>` - spawns a detached
- *     child that runs `hippo sleep` then `hippo capture --last-session`
- *     in sequence, writing both outputs to the log file. The parent returns
- *     in <100ms so the TUI teardown can't kill the child before it finishes.
- *   - SessionStart: `hippo last-sleep --path <path>` - prints the log written
- *     by the previous session's detached worker and then clears it, so the
- *     user actually sees what was consolidated.
+ * Two integration models live in this file:
  *
- * Earlier forms are detected and migrated automatically:
- *   - < 0.20.2: `Stop` hook firing `hippo sleep` on every assistant turn.
- *   - < 0.21.0: bare `hippo sleep` in SessionEnd, no `--log-file`.
- *   - 0.22.x: separate sleep + capture SessionEnd entries. Ran in parallel
- *     and were both SIGTERM'd by TUI teardown, so completion lines rarely
- *     made it to the log. 0.23.0+ collapses them into the single
- *     `hippo session-end` entry above.
+ * 1. JSON-hook install (Claude Code only). Writes a `hooks` block into the
+ *    tool's settings.json with two entries:
+ *      - SessionEnd: `hippo session-end --log-file <path>` - spawns a detached
+ *        child that runs `hippo sleep` then `hippo capture --last-session` in
+ *        sequence, writing both outputs to the log file. The parent returns in
+ *        <100ms so the TUI teardown can't kill the child before it finishes.
+ *      - SessionStart: `hippo last-sleep --path <path>` - prints the log
+ *        written by the previous session's detached worker and then clears it,
+ *        so the user actually sees what was consolidated.
+ *    Earlier Claude Code forms are detected and migrated automatically:
+ *      - < 0.20.2: `Stop` hook firing `hippo sleep` on every assistant turn.
+ *      - < 0.21.0: bare `hippo sleep` in SessionEnd, no `--log-file`.
+ *      - 0.22.x: separate sleep + capture SessionEnd entries.
+ *
+ * 2. Plugin install (OpenCode only). OpenCode does NOT share Claude Code's
+ *    JSON-hook schema — its config has `additionalProperties: false` and no
+ *    `hooks` key, so v1.10.x-v1.11.1's JSON-hook installer broke opencode
+ *    launch (issue #24). Hippo now installs a TypeScript plugin at
+ *    `~/.config/opencode/plugins/hippo.ts` subscribing to opencode's
+ *    `session.idle` (→ `hippo session-end`) and `session.created` (→
+ *    `hippo last-sleep`) events. See OPENCODE_PLUGIN_SOURCE below for the
+ *    plugin file content + design rationale; see installOpencodePlugin for
+ *    the installer + the migration that removes any pre-existing broken
+ *    `hooks` block from opencode.json.
  */
 
 import * as fs from 'fs';
@@ -25,7 +34,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-export type JsonHookTarget = 'claude-code' | 'opencode';
+export type JsonHookTarget = 'claude-code';
 
 export interface CodexWrapperPaths {
   wrapperDir: string;
@@ -573,12 +582,6 @@ export function resolveJsonHookPaths(target: JsonHookTarget): JsonHookPaths {
         logFile: path.join(logsDir, 'claude-code-sleep.log'),
         display: 'Claude Code',
       };
-    case 'opencode':
-      return {
-        settings: path.join(home, '.config', 'opencode', 'opencode.json'),
-        logFile: path.join(logsDir, 'opencode-sleep.log'),
-        display: 'OpenCode',
-      };
   }
 }
 
@@ -939,7 +942,7 @@ export function detectInstalledTools(): ToolDetection[] {
   const exists = (...parts: string[]) => fs.existsSync(path.join(home, ...parts));
   return [
     { name: 'claude-code', configDir: '~/.claude', detected: exists('.claude'), kind: 'json-hook' },
-    { name: 'opencode', configDir: '~/.config/opencode', detected: exists('.config', 'opencode'), kind: 'json-hook' },
+    { name: 'opencode', configDir: '~/.config/opencode', detected: exists('.config', 'opencode'), kind: 'plugin', notes: 'installs a TS plugin at ~/.config/opencode/plugins/hippo.ts' },
     { name: 'openclaw', configDir: '~/.openclaw', detected: exists('.openclaw'), kind: 'plugin', notes: 'install via `openclaw plugins install hippo-memory`' },
     { name: 'codex', configDir: '~/.codex', detected: exists('.codex'), kind: 'wrapper', notes: 'wraps the detected codex launcher for session-end consolidation' },
     { name: 'cursor', configDir: '~/.cursor', detected: exists('.cursor'), kind: 'markdown-instruction', notes: 'no hook API - patches .cursorrules in the project' },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -801,6 +801,135 @@ export function uninstallJsonHooks(target: JsonHookTarget): boolean {
   return true;
 }
 
+// ---------------------------------------------------------------------------
+// OpenCode plugin installer (fix for issue #24).
+//
+// OpenCode does NOT share Claude Code's JSON-hook schema. Its config has
+// `additionalProperties: false` and no `hooks` key, so the v1.10.x-v1.11.1
+// installer broke opencode launch. The fix writes a TS plugin at the canonical
+// plugin path and surgically migrates any pre-existing broken hooks block out
+// of opencode.json.
+// ---------------------------------------------------------------------------
+
+export interface OpencodePluginInstallResult {
+  installed: boolean;
+  pluginPath: string;
+  migratedLegacyHooks: boolean;
+  jsonRepairFailed: boolean;
+}
+
+export function resolveOpencodePluginPath(): string {
+  return path.join(homeDir(), '.config', 'opencode', 'plugins', 'hippo.ts');
+}
+
+function resolveOpencodeConfigPath(): string {
+  return path.join(homeDir(), '.config', 'opencode', 'opencode.json');
+}
+
+/**
+ * Return true iff a single hook-array entry's command string starts with
+ * `hippo ` (the verb-prefix). Used to surgically remove only hippo-owned
+ * entries when migrating an opencode.json. We own the install side, so only
+ * the canonical `hippo <verb>` form needs to match.
+ *
+ * Critic-mandated structural check (Rev 0): substring matching against
+ * arbitrary user content is unsafe — a user's
+ * `echo "remember to hippo sleep your laptop"` is not a hippo-owned hook.
+ */
+function entryIsHippoOwned(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => {
+    if (!h || typeof h !== 'object') return false;
+    const cmd = (h as { command?: unknown }).command;
+    return typeof cmd === 'string' && /^\s*hippo\s/.test(cmd);
+  });
+}
+
+/**
+ * Structurally strip every hippo-owned entry from opencode.json's hooks key.
+ * Returns one of:
+ *   { migrated: true,  jsonRepairFailed: false } — at least one entry removed.
+ *   { migrated: false, jsonRepairFailed: false } — file fine, nothing to do.
+ *   { migrated: false, jsonRepairFailed: true  } — file present but unparseable.
+ *
+ * When all hippo-owned entries are removed and a hook key becomes empty, that
+ * key is deleted. When the top-level hooks object becomes empty it is deleted
+ * too. Other keys (theme, etc.) are preserved.
+ */
+function migrateLegacyOpencodeHooksBlock(): { migrated: boolean; jsonRepairFailed: boolean } {
+  const configPath = resolveOpencodeConfigPath();
+  if (!fs.existsSync(configPath)) return { migrated: false, jsonRepairFailed: false };
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  } catch {
+    return { migrated: false, jsonRepairFailed: true };
+  }
+
+  const hooks = settings.hooks;
+  // Non-object hooks values (string, array, null) are user content we don't
+  // recognise — leave them alone, return migrated=false.
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) {
+    return { migrated: false, jsonRepairFailed: false };
+  }
+
+  const hooksObj = hooks as Record<string, unknown[]>;
+  let changed = false;
+  for (const key of Object.keys(hooksObj)) {
+    if (!Array.isArray(hooksObj[key])) continue;
+    const before = hooksObj[key].length;
+    hooksObj[key] = hooksObj[key].filter((entry) => !entryIsHippoOwned(entry));
+    if (hooksObj[key].length !== before) {
+      changed = true;
+      if (hooksObj[key].length === 0) delete hooksObj[key];
+    }
+  }
+
+  if (!changed) return { migrated: false, jsonRepairFailed: false };
+
+  if (Object.keys(hooksObj).length === 0) delete settings.hooks;
+  fs.writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
+  return { migrated: true, jsonRepairFailed: false };
+}
+
+export function installOpencodePlugin(): OpencodePluginInstallResult {
+  const pluginPath = resolveOpencodePluginPath();
+  const { migrated, jsonRepairFailed } = migrateLegacyOpencodeHooksBlock();
+
+  // Idempotence: skip the write only if BOTH the marker is present AND the
+  // content matches the current source. Marker-only matches (with stale
+  // content) overwrite cleanly so future plugin-source patches reach
+  // existing installs.
+  if (fs.existsSync(pluginPath)) {
+    const existing = fs.readFileSync(pluginPath, 'utf8');
+    if (existing.includes(HIPPO_OPENCODE_PLUGIN_MARKER) && existing === OPENCODE_PLUGIN_SOURCE) {
+      return { installed: false, pluginPath, migratedLegacyHooks: migrated, jsonRepairFailed };
+    }
+  }
+  fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+  fs.writeFileSync(pluginPath, OPENCODE_PLUGIN_SOURCE, 'utf8');
+  return { installed: true, pluginPath, migratedLegacyHooks: migrated, jsonRepairFailed };
+}
+
+export function uninstallOpencodePlugin(): boolean {
+  const pluginPath = resolveOpencodePluginPath();
+  let removedFile = false;
+  if (fs.existsSync(pluginPath)) {
+    const existing = fs.readFileSync(pluginPath, 'utf8');
+    if (existing.includes(HIPPO_OPENCODE_PLUGIN_MARKER)) {
+      fs.unlinkSync(pluginPath);
+      removedFile = true;
+    }
+  }
+  // Always run the legacy migration on uninstall — the downgrade path (user
+  // removing hippo entirely) must leave opencode launchable.
+  const { migrated } = migrateLegacyOpencodeHooksBlock();
+  return removedFile || migrated;
+}
+
 /**
  * Detect which AI coding tools are installed based on config directory presence.
  * Used by `hippo setup` to decide which JSON-hook installs to run.

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -109,6 +109,72 @@ const HIPPO_PINNED_INJECT_MARKER = 'hippo context --pinned-only';
 const HIPPO_PINNED_INJECT_COMMAND = 'hippo context --pinned-only --include-recent 5 --format additional-context';
 const HIPPO_CODEX_WRAPPER_MARKER = 'hippo codex wrapper';
 
+const HIPPO_OPENCODE_PLUGIN_MARKER = 'HIPPO_OPENCODE_PLUGIN_V1';
+
+/**
+ * The opencode plugin file we install at ~/.config/opencode/plugins/hippo.ts.
+ *
+ * Per https://opencode.ai/docs/plugins/, plugins are TS/JS modules exporting an
+ * async function returning hooks. We subscribe to `event` and route:
+ *   session.idle    → `hippo session-end` (Claude Code's SessionEnd equiv)
+ *   session.created → `hippo last-sleep` (Claude Code's SessionStart equiv)
+ *
+ * Design choices forced by plan-eng-critic Rev 0 review (2026-05-23):
+ *
+ * 1. No `import type { Plugin } from "@opencode-ai/plugin"`. The package's npm
+ *    publication status was unverifiable from the build sandbox (npmjs.com
+ *    returned 403); an unresolved type-only import would still crash the TS
+ *    runtime opencode uses to load the plugin. opencode infers plugin shape
+ *    from the returned object, so the type was convenience-only.
+ *
+ * 2. Defensive `typeof $ !== 'function'` guard. opencode runs in Bun (where
+ *    `$` is the shell-template helper), but a future Node-mode deployment
+ *    would have `$` undefined in the destructured context and the plugin
+ *    would throw on every session.idle, killing opencode sessions in a
+ *    hard-to-recover way (the idempotence marker prevents auto-reinstall).
+ *    Fail closed, let opencode continue.
+ *
+ * 3. `.quiet().nothrow()` on each `$\`...\`` so a missing hippo binary
+ *    (e.g. PATH-misconfigured user) does NOT throw out of the event handler.
+ *    The surrounding try/catch is belt-and-braces.
+ *
+ * 4. UserPromptSubmit equivalent NOT wired. opencode's `message.updated`
+ *    fires per-token, not per-prompt-submit; no clean per-prompt event.
+ *    Users wanting pinned-context auto-injection can call `hippo context`
+ *    via the MCP server (`hippo mcp`).
+ *
+ * 5. Versioned marker `HIPPO_OPENCODE_PLUGIN_V1` allows future versions to
+ *    overwrite cleanly. The installer's idempotence check requires BOTH
+ *    marker match AND content equality, so a plugin-source revision under
+ *    the same V1 marker re-writes the file on next install.
+ */
+export const OPENCODE_PLUGIN_SOURCE = `// ${HIPPO_OPENCODE_PLUGIN_MARKER}
+// hippo-memory opencode plugin. Re-install with \`hippo hook install opencode\`.
+// Source of truth: src/hooks.ts OPENCODE_PLUGIN_SOURCE in https://github.com/kitfunso/hippo-memory
+
+export const HippoPlugin = async ({ $ }) => {
+  return {
+    event: async ({ event }) => {
+      // Defense in depth: opencode currently runs in Bun where $ is the shell
+      // template helper. A non-Bun runtime would have $ as undefined; fail
+      // closed instead of crashing the host session.
+      if (typeof $ !== "function") return;
+      try {
+        if (event.type === "session.idle") {
+          await $\`hippo session-end\`.quiet().nothrow();
+        } else if (event.type === "session.created") {
+          await $\`hippo last-sleep\`.quiet().nothrow();
+        }
+      } catch {
+        // hippo CLI not on PATH or other failure — never crash the host session.
+      }
+    },
+  };
+};
+`;
+
+export { HIPPO_OPENCODE_PLUGIN_MARKER };
+
 function homeDir(): string {
   return process.env.HOME || process.env.USERPROFILE || os.homedir();
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -158,8 +158,9 @@ const HIPPO_OPENCODE_PLUGIN_MARKER = 'HIPPO_OPENCODE_PLUGIN_V1';
  *    the same V1 marker re-writes the file on next install.
  */
 export const OPENCODE_PLUGIN_SOURCE = `// ${HIPPO_OPENCODE_PLUGIN_MARKER}
-// hippo-memory opencode plugin. Re-install with \`hippo hook install opencode\`.
-// Source of truth: src/hooks.ts OPENCODE_PLUGIN_SOURCE in https://github.com/kitfunso/hippo-memory
+// hippo-memory opencode plugin. DO NOT EDIT — regenerated on every
+// \`hippo hook install opencode\` from src/hooks.ts OPENCODE_PLUGIN_SOURCE
+// in https://github.com/kitfunso/hippo-memory. Local changes will be lost.
 
 export const HippoPlugin = async ({ $ }) => {
   return {
@@ -832,34 +833,44 @@ function resolveOpencodeConfigPath(): string {
 /**
  * Return true iff a single hook-array entry's command string starts with
  * `hippo ` (the verb-prefix). Used to surgically remove only hippo-owned
- * entries when migrating an opencode.json. We own the install side, so only
- * the canonical `hippo <verb>` form needs to match.
+ * commands when migrating an opencode.json. We own the install side, so only
+ * the canonical `hippo <verb>` form needs to match — and only canonical verbs
+ * hippo itself installs (session-end, last-sleep, sleep, capture, context),
+ * not any third-party tool that happens to be named `hippo`.
  *
  * Critic-mandated structural check (Rev 0): substring matching against
  * arbitrary user content is unsafe — a user's
  * `echo "remember to hippo sleep your laptop"` is not a hippo-owned hook.
+ *
+ * Per-hook (not per-entry) granularity (Rev 1 review): an entry whose inner
+ * hooks array mixes hippo-installed commands with user-authored commands
+ * must NOT lose the user-authored commands. The migration filters the inner
+ * array per-hook, then drops the entry only when its inner array is empty.
  */
-function entryIsHippoOwned(entry: unknown): boolean {
-  if (!entry || typeof entry !== 'object') return false;
-  const hooks = (entry as { hooks?: unknown }).hooks;
-  if (!Array.isArray(hooks)) return false;
-  return hooks.some((h) => {
-    if (!h || typeof h !== 'object') return false;
-    const cmd = (h as { command?: unknown }).command;
-    return typeof cmd === 'string' && /^\s*hippo\s/.test(cmd);
-  });
+const HIPPO_OWNED_COMMAND_RE = /^\s*hippo\s+(session-end|last-sleep|sleep|capture|context)\b/;
+
+function hookIsHippoOwned(hook: unknown): boolean {
+  if (!hook || typeof hook !== 'object') return false;
+  const cmd = (hook as { command?: unknown }).command;
+  return typeof cmd === 'string' && HIPPO_OWNED_COMMAND_RE.test(cmd);
 }
 
 /**
- * Structurally strip every hippo-owned entry from opencode.json's hooks key.
+ * Structurally strip every hippo-owned hook from opencode.json's hooks key.
  * Returns one of:
- *   { migrated: true,  jsonRepairFailed: false } — at least one entry removed.
+ *   { migrated: true,  jsonRepairFailed: false } — at least one hook removed.
  *   { migrated: false, jsonRepairFailed: false } — file fine, nothing to do.
  *   { migrated: false, jsonRepairFailed: true  } — file present but unparseable.
  *
- * When all hippo-owned entries are removed and a hook key becomes empty, that
- * key is deleted. When the top-level hooks object becomes empty it is deleted
- * too. Other keys (theme, etc.) are preserved.
+ * Per-hook surgery:
+ *   - For each entry in each event-key array, filter the inner `hooks` array
+ *     to remove hippo-owned hooks only. User-authored hooks in the same
+ *     inner array are preserved.
+ *   - When an entry's inner `hooks` array becomes empty, that entry is
+ *     removed from the outer array.
+ *   - When an event-key array becomes empty, the key is deleted.
+ *   - When the top-level `hooks` object becomes empty, it is deleted.
+ *   - Other keys (theme, etc.) are always preserved.
  */
 function migrateLegacyOpencodeHooksBlock(): { migrated: boolean; jsonRepairFailed: boolean } {
   const configPath = resolveOpencodeConfigPath();
@@ -883,12 +894,27 @@ function migrateLegacyOpencodeHooksBlock(): { migrated: boolean; jsonRepairFaile
   let changed = false;
   for (const key of Object.keys(hooksObj)) {
     if (!Array.isArray(hooksObj[key])) continue;
-    const before = hooksObj[key].length;
-    hooksObj[key] = hooksObj[key].filter((entry) => !entryIsHippoOwned(entry));
-    if (hooksObj[key].length !== before) {
-      changed = true;
-      if (hooksObj[key].length === 0) delete hooksObj[key];
+    const survivingEntries: unknown[] = [];
+    for (const entry of hooksObj[key]) {
+      if (!entry || typeof entry !== 'object') {
+        survivingEntries.push(entry);
+        continue;
+      }
+      const innerHooks = (entry as { hooks?: unknown }).hooks;
+      if (!Array.isArray(innerHooks)) {
+        survivingEntries.push(entry);
+        continue;
+      }
+      const beforeInner = innerHooks.length;
+      const survivingInner = innerHooks.filter((h) => !hookIsHippoOwned(h));
+      if (survivingInner.length !== beforeInner) changed = true;
+      if (survivingInner.length === 0) continue; // drop entry, nothing left
+      (entry as { hooks: unknown[] }).hooks = survivingInner;
+      survivingEntries.push(entry);
     }
+    if (survivingEntries.length !== hooksObj[key].length) changed = true;
+    hooksObj[key] = survivingEntries;
+    if (hooksObj[key].length === 0) delete hooksObj[key];
   }
 
   if (!changed) return { migrated: false, jsonRepairFailed: false };

--- a/src/version.ts
+++ b/src/version.ts
@@ -16,7 +16,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.11.1';
+export const PACKAGE_VERSION = '1.11.2';
 // Bump on every release alongside the 4 manifests + lockfile.
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,9 +1,11 @@
 /**
  * Single source of truth for the hippo-memory binary's package version.
  *
- * Bumped manually on every release alongside the four package manifests
- * (package.json, openclaw.plugin.json, extensions/openclaw-plugin/package.json,
- * extensions/openclaw-plugin/openclaw.plugin.json) and the lockfile.
+ * Bumped manually on every release alongside this file + four other package
+ * manifests (package.json, openclaw.plugin.json,
+ * extensions/openclaw-plugin/package.json,
+ * extensions/openclaw-plugin/openclaw.plugin.json) and the lockfile —
+ * five manifests in total carrying the version field.
  *
  * Used by:
  *   - src/db.ts rollback-safety guard (refuses to open a DB stamped with
@@ -17,7 +19,7 @@
  * any packager that drops .json files.
  */
 export const PACKAGE_VERSION = '1.11.2';
-// Bump on every release alongside the 4 manifests + lockfile.
+// Bump on every release alongside the 4 other manifests + lockfile.
 
 /**
  * Compare two semver strings. Returns positive if a > b, 0 if equal, negative

--- a/tests/_helpers/with-fake-home.ts
+++ b/tests/_helpers/with-fake-home.ts
@@ -1,0 +1,30 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Each test gets its own fake $HOME so we never touch the real
+ * ~/.claude/settings.json, ~/.config/opencode/opencode.json, or
+ * ~/.config/opencode/plugins/ on the machine running the tests.
+ *
+ * Sets HOME on POSIX and USERPROFILE on Windows; restores both on cleanup.
+ * Extracted from tests/hooks.test.ts 2026-05-23 so the new opencode plugin
+ * install tests use the same isolation pattern.
+ */
+export function withFakeHome(prefix = 'hippo-test-'): { cleanup: () => void; home: string } {
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const fake = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  process.env.HOME = fake;
+  process.env.USERPROFILE = fake;
+  return {
+    home: fake,
+    cleanup: () => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      fs.rmSync(fake, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -216,33 +216,10 @@ describe('JSON hook installer', () => {
     });
   });
 
-  describe('installJsonHooks(opencode)', () => {
-    it('writes to ~/.config/opencode/opencode.json with the same schema', () => {
-      const result = installJsonHooks('opencode');
-
-      expect(result.installedSessionEnd).toBe(true);
-      expect(result.installedSessionStart).toBe(true);
-      expect(result.settingsPath).toMatch(/opencode[/\\]opencode\.json$/);
-
-      const settings = JSON.parse(fs.readFileSync(result.settingsPath, 'utf8'));
-      expect(settings.hooks.SessionEnd[0].hooks[0].command).toContain('hippo session-end --log-file');
-      expect(settings.hooks.SessionStart[0].hooks[0].command).toContain('hippo last-sleep');
-    });
-
-    it('uses a per-tool log path so claude-code and opencode do not collide', () => {
-      const claudeResult = installJsonHooks('claude-code');
-      const opencodeResult = installJsonHooks('opencode');
-
-      const claudeCmd = JSON.parse(fs.readFileSync(claudeResult.settingsPath, 'utf8'))
-        .hooks.SessionEnd[0].hooks[0].command as string;
-      const opencodeCmd = JSON.parse(fs.readFileSync(opencodeResult.settingsPath, 'utf8'))
-        .hooks.SessionEnd[0].hooks[0].command as string;
-
-      expect(claudeCmd).toContain('claude-code-sleep.log');
-      expect(opencodeCmd).toContain('opencode-sleep.log');
-      expect(claudeCmd).not.toEqual(opencodeCmd);
-    });
-  });
+  // The former 'installJsonHooks(opencode)' describe block was removed
+  // 2026-05-23 when opencode flipped from JSON-hook integration to a TS plugin.
+  // Coverage for the new plugin installer lives in
+  // tests/opencode-plugin-install.test.ts.
 
   describe('uninstallJsonHooks', () => {
     it('removes SessionEnd, SessionStart, and legacy Stop entries', () => {
@@ -340,7 +317,7 @@ describe('JSON hook installer', () => {
     it('classifies tool kinds correctly', () => {
       const tools = detectInstalledTools();
       expect(tools.find((t) => t.name === 'claude-code')?.kind).toBe('json-hook');
-      expect(tools.find((t) => t.name === 'opencode')?.kind).toBe('json-hook');
+      expect(tools.find((t) => t.name === 'opencode')?.kind).toBe('plugin');
       expect(tools.find((t) => t.name === 'openclaw')?.kind).toBe('plugin');
       expect(tools.find((t) => t.name === 'codex')?.kind).toBe('wrapper');
       expect(tools.find((t) => t.name === 'cursor')?.kind).toBe('markdown-instruction');

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -10,26 +9,15 @@ import {
   detectInstalledTools,
   defaultSleepLogPath,
 } from '../src/hooks.js';
+import { withFakeHome as withFakeHomeShared } from './_helpers/with-fake-home.js';
 
 /**
  * Each test gets its own fake $HOME so we never touch the real
  * ~/.claude/settings.json or ~/.config/opencode/opencode.json on the machine
- * running the tests.
+ * running the tests. Delegates to the shared helper extracted 2026-05-23.
  */
 function withFakeHome(): { cleanup: () => void; home: string } {
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
-  const fake = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-hooks-test-'));
-  process.env.HOME = fake;
-  process.env.USERPROFILE = fake;
-  return {
-    home: fake,
-    cleanup: () => {
-      process.env.HOME = prevHome;
-      process.env.USERPROFILE = prevUserProfile;
-      fs.rmSync(fake, { recursive: true, force: true });
-    },
-  };
+  return withFakeHomeShared('hippo-hooks-test-');
 }
 
 describe('JSON hook installer', () => {

--- a/tests/opencode-plugin-install.test.ts
+++ b/tests/opencode-plugin-install.test.ts
@@ -177,6 +177,51 @@ describe('installOpencodePlugin (real-FS)', () => {
     expect(result.installed).toBe(true);
     expect(result.migratedLegacyHooks).toBe(false);
   });
+
+  it('preserves user-authored hooks in the same inner array as a hippo hook (per-hook surgery)', () => {
+    // Independent-review-critic flagged this as the missed surgical case:
+    // if an entry's inner `hooks` array mixes a hippo command and a user
+    // command, the user command must survive.
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{
+          hooks: [
+            { type: 'command', command: 'hippo session-end --log-file foo', timeout: 5 },
+            { type: 'command', command: 'echo "my custom cleanup"', timeout: 10 },
+          ],
+        }],
+      },
+    }, null, 2));
+
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+    expect(after.hooks.SessionEnd[0].hooks).toHaveLength(1);
+    expect(after.hooks.SessionEnd[0].hooks[0].command).toBe('echo "my custom cleanup"');
+    // timeout preserved on the surviving entry
+    expect(after.hooks.SessionEnd[0].hooks[0].timeout).toBe(10);
+  });
+
+  it('does NOT match a third-party `hippo` binary that lacks a canonical hippo verb', () => {
+    // entryIsHippoOwned regex now requires a known hippo verb. A user with a
+    // wrapper script literally named 'hippo' that takes non-hippo args should
+    // not have their entry deleted.
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'hippo deploy', timeout: 5 }] }],
+      },
+    }, null, 2));
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(false);
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+  });
 });
 
 describe('uninstallOpencodePlugin (real-FS)', () => {

--- a/tests/opencode-plugin-install.test.ts
+++ b/tests/opencode-plugin-install.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the opencode plugin installer (fix for issue #24).
+ *
+ * The opencode plugin installer replaces the v1.10.x-v1.11.1 JSON-hook installer
+ * which wrote a Claude Code-style `hooks` block into ~/.config/opencode/opencode.json,
+ * breaking opencode's launch (opencode's schema is additionalProperties:false and
+ * has no `hooks` key). The fix writes a TS plugin at ~/.config/opencode/plugins/hippo.ts
+ * subscribing to opencode's `session.idle` and `session.created` events, and migrates
+ * any pre-existing broken hooks block out of opencode.json.
+ *
+ * Convention: real FS, no mocks. HOME isolated via tests/_helpers/with-fake-home.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  OPENCODE_PLUGIN_SOURCE,
+  HIPPO_OPENCODE_PLUGIN_MARKER,
+} from '../src/hooks.js';
+
+describe('OPENCODE_PLUGIN_SOURCE', () => {
+  it('contains the versioned hippo marker', () => {
+    expect(OPENCODE_PLUGIN_SOURCE).toContain(HIPPO_OPENCODE_PLUGIN_MARKER);
+    expect(HIPPO_OPENCODE_PLUGIN_MARKER).toMatch(/^HIPPO_OPENCODE_PLUGIN_V\d+$/);
+  });
+
+  it('handles session.idle and session.created events', () => {
+    expect(OPENCODE_PLUGIN_SOURCE).toContain('session.idle');
+    expect(OPENCODE_PLUGIN_SOURCE).toContain('session.created');
+  });
+
+  it('guards against non-Bun runtimes (typeof $ check)', () => {
+    // Critic-mandated defense: opencode runs in Bun in practice but a future
+    // Node-mode deployment would have $ undefined; fail closed instead of
+    // crashing the host session with the idempotence marker locking the
+    // broken file in place.
+    expect(OPENCODE_PLUGIN_SOURCE).toMatch(/typeof\s+\$\s*!==\s*['"]function['"]/);
+  });
+
+  it('uses no type imports (avoids unverified @opencode-ai/plugin dependency)', () => {
+    // @opencode-ai/plugin's npm publication status was unverifiable from the
+    // build sandbox (npmjs.com returned 403 to WebFetch). opencode infers
+    // plugin shape from the returned object so the type annotation was
+    // convenience-only — drop it to eliminate the runtime resolution risk.
+    expect(OPENCODE_PLUGIN_SOURCE).not.toContain('import type');
+    expect(OPENCODE_PLUGIN_SOURCE).not.toContain('@opencode-ai/plugin');
+  });
+});

--- a/tests/opencode-plugin-install.test.ts
+++ b/tests/opencode-plugin-install.test.ts
@@ -10,10 +10,16 @@
  *
  * Convention: real FS, no mocks. HOME isolated via tests/_helpers/with-fake-home.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { withFakeHome } from './_helpers/with-fake-home.js';
 import {
   OPENCODE_PLUGIN_SOURCE,
   HIPPO_OPENCODE_PLUGIN_MARKER,
+  installOpencodePlugin,
+  uninstallOpencodePlugin,
+  resolveOpencodePluginPath,
 } from '../src/hooks.js';
 
 describe('OPENCODE_PLUGIN_SOURCE', () => {
@@ -42,5 +48,174 @@ describe('OPENCODE_PLUGIN_SOURCE', () => {
     // convenience-only — drop it to eliminate the runtime resolution risk.
     expect(OPENCODE_PLUGIN_SOURCE).not.toContain('import type');
     expect(OPENCODE_PLUGIN_SOURCE).not.toContain('@opencode-ai/plugin');
+  });
+});
+
+describe('installOpencodePlugin (real-FS)', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => {
+    env = withFakeHome('hippo-opencode-');
+  });
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it('writes a TS plugin file with the hippo marker on a fresh host', () => {
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(result.migratedLegacyHooks).toBe(false);
+    expect(result.jsonRepairFailed).toBe(false);
+    expect(fs.existsSync(resolveOpencodePluginPath())).toBe(true);
+    expect(fs.readFileSync(resolveOpencodePluginPath(), 'utf8')).toContain(HIPPO_OPENCODE_PLUGIN_MARKER);
+  });
+
+  it('is idempotent when content matches', () => {
+    installOpencodePlugin();
+    const result2 = installOpencodePlugin();
+    expect(result2.installed).toBe(false);
+  });
+
+  it('overwrites when marker matches but content differs (future-proof for V1-revision)', () => {
+    const pluginPath = resolveOpencodePluginPath();
+    fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+    fs.writeFileSync(pluginPath, `// ${HIPPO_OPENCODE_PLUGIN_MARKER}\n// stale content from an earlier 1.11.x\n`);
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(fs.readFileSync(pluginPath, 'utf8')).toBe(OPENCODE_PLUGIN_SOURCE);
+  });
+
+  it('migrates: removes only hippo-owned hook entries from opencode.json', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      theme: 'dark',
+      hooks: {
+        SessionEnd: [
+          { hooks: [{ type: 'command', command: 'hippo session-end --log-file foo', timeout: 5 }] },
+          { hooks: [{ type: 'command', command: 'echo my own hook', timeout: 5 }] },
+        ],
+        SessionStart: [{ hooks: [{ type: 'command', command: 'hippo last-sleep --path bar', timeout: 5 }] }],
+      },
+    }, null, 2));
+
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.theme).toBe('dark');
+    // SessionStart was 100% hippo → key removed entirely.
+    expect(after.hooks.SessionStart).toBeUndefined();
+    // SessionEnd had a non-hippo entry → key preserved with only that entry left.
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+    expect(JSON.stringify(after.hooks.SessionEnd)).toContain('my own hook');
+  });
+
+  it('drops the empty hooks key entirely when nothing survives', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'hippo session-end --log-file x' }] }],
+      },
+    }, null, 2));
+    installOpencodePlugin();
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks).toBeUndefined();
+  });
+
+  it('returns jsonRepairFailed=true when opencode.json is unparseable', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, '{ "hooks": ["unterminated string ');
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);            // plugin file still written
+    expect(result.migratedLegacyHooks).toBe(false); // nothing migrated
+    expect(result.jsonRepairFailed).toBe(true);     // structured error surfaced
+  });
+
+  it('does NOT create opencode.json on a fresh install with no legacy block', () => {
+    installOpencodePlugin();
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    expect(fs.existsSync(opencodeJsonPath)).toBe(false);
+  });
+
+  it('leaves a non-hippo hooks key alone (false-positive defense)', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    // User's coincidental substring "hippo sleep" inside an echo payload —
+    // must NOT trigger hippo-owned detection.
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'echo "remember to hippo sleep your laptop"' }] }],
+      },
+    }, null, 2));
+    const result = installOpencodePlugin();
+    expect(result.migratedLegacyHooks).toBe(false);
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks.SessionEnd).toHaveLength(1);
+  });
+
+  it('handles non-object hooks values gracefully (string)', () => {
+    // Belt-and-braces: critic Rev 1 low-sev #3.
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({ hooks: 'oops, a string' }));
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(result.migratedLegacyHooks).toBe(false);
+    expect(result.jsonRepairFailed).toBe(false);
+    // File untouched.
+    expect(JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8')).hooks).toBe('oops, a string');
+  });
+
+  it('handles non-object hooks values gracefully (array)', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({ hooks: ['oops'] }));
+    const result = installOpencodePlugin();
+    expect(result.installed).toBe(true);
+    expect(result.migratedLegacyHooks).toBe(false);
+  });
+});
+
+describe('uninstallOpencodePlugin (real-FS)', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => {
+    env = withFakeHome('hippo-opencode-');
+  });
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it('removes only files with the hippo marker', () => {
+    installOpencodePlugin();
+    expect(uninstallOpencodePlugin()).toBe(true);
+    expect(fs.existsSync(resolveOpencodePluginPath())).toBe(false);
+  });
+
+  it('returns false when plugin not installed and no legacy block', () => {
+    expect(uninstallOpencodePlugin()).toBe(false);
+  });
+
+  it('refuses to delete a user-written hippo.ts without the marker', () => {
+    const pluginPath = resolveOpencodePluginPath();
+    fs.mkdirSync(path.dirname(pluginPath), { recursive: true });
+    fs.writeFileSync(pluginPath, '// user-written content, no marker\n');
+    expect(uninstallOpencodePlugin()).toBe(false);
+    expect(fs.existsSync(pluginPath)).toBe(true);
+  });
+
+  it('ALSO runs the legacy-hooks migration (downgrade path)', () => {
+    const opencodeJsonPath = path.join(env.home, '.config', 'opencode', 'opencode.json');
+    fs.mkdirSync(path.dirname(opencodeJsonPath), { recursive: true });
+    fs.writeFileSync(opencodeJsonPath, JSON.stringify({
+      hooks: { SessionEnd: [{ hooks: [{ type: 'command', command: 'hippo session-end --log-file x' }] }] },
+    }, null, 2));
+    // No plugin installed; uninstall should still clean the legacy block so a
+    // user running `hippo hook uninstall opencode` to remove hippo entirely
+    // leaves opencode launchable.
+    expect(uninstallOpencodePlugin()).toBe(true);
+    const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
+    expect(after.hooks).toBeUndefined();
   });
 });

--- a/tests/opencode-plugin-install.test.ts
+++ b/tests/opencode-plugin-install.test.ts
@@ -20,6 +20,7 @@ import {
   installOpencodePlugin,
   uninstallOpencodePlugin,
   resolveOpencodePluginPath,
+  detectInstalledTools,
 } from '../src/hooks.js';
 
 describe('OPENCODE_PLUGIN_SOURCE', () => {
@@ -217,5 +218,23 @@ describe('uninstallOpencodePlugin (real-FS)', () => {
     expect(uninstallOpencodePlugin()).toBe(true);
     const after = JSON.parse(fs.readFileSync(opencodeJsonPath, 'utf8'));
     expect(after.hooks).toBeUndefined();
+  });
+});
+
+describe('detectInstalledTools opencode entry', () => {
+  let env: { cleanup: () => void; home: string };
+  beforeEach(() => {
+    env = withFakeHome('hippo-detect-');
+  });
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it('marks opencode as kind:"plugin" with the plugin path in notes', () => {
+    fs.mkdirSync(path.join(env.home, '.config', 'opencode'), { recursive: true });
+    const tool = detectInstalledTools().find((t) => t.name === 'opencode');
+    expect(tool?.kind).toBe('plugin');
+    expect(tool?.notes).toContain('plugins/hippo.ts');
+    expect(tool?.detected).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#24](https://github.com/kitfunso/hippo-memory/issues/24). v1.10.x-v1.11.1's `hippo hook install opencode` wrote a Claude Code-style `hooks` block into `~/.config/opencode/opencode.json`, which opencode's strict schema (`additionalProperties: false`) rejects with `ConfigInvalidError: Unrecognized key: hooks` — **preventing opencode from launching at all**.

## Root cause

`src/hooks.ts:4` assumed *"Claude Code and OpenCode share the same SessionStart/SessionEnd schema."* They don't. OpenCode's actual integration surface is its [plugin system](https://opencode.ai/docs/plugins/) — TS/JS modules at `~/.config/opencode/plugins/` with `event` hooks.

## Fix

- **Narrow `JsonHookTarget` to `'claude-code'`** (compile-time guard so opencode can't be re-introduced into the JSON installer).
- **Add `installOpencodePlugin()`** — writes a type-free TS plugin at `~/.config/opencode/plugins/hippo.ts` subscribing to:
  - `session.idle` → `hippo session-end` (Claude Code's SessionEnd equivalent)
  - `session.created` → `hippo last-sleep` (Claude Code's SessionStart equivalent)
- **Surgical migration** of broken installs — on next install, detects and removes hippo-owned hook entries from `opencode.json` so opencode launches again. Per-hook structural filter (not substring match): user-authored hooks in the same inner array as a hippo hook are preserved.
- **Structured error path** — `jsonRepairFailed: true` returned (and surfaced as a CLI warning) when opencode.json is unparseable. Plugin install still succeeds; user gets a clear "manual fix needed" message.
- **Fix the `hippo setup` `pluginTools` branch** (was the second hidden bug — pre-fix only printed `tool.notes` without calling any installer; would have silently regressed for opencode after the kind flip).
- **`uninstallOpencodePlugin()` also runs the legacy migration** — downgrade/remove path leaves opencode launchable.
- **`detectInstalledTools`** marks opencode as `kind: 'plugin'` (was `'json-hook'`).

## Defense in depth

- **No `import type { Plugin } from "@opencode-ai/plugin"`** — package's npm publication status was unverifiable; type-free signature eliminates the dependency entirely.
- **`typeof $ !== 'function'` guard** in the plugin — fails closed on non-Bun runtimes.
- **`.quiet().nothrow()` + try/catch** on every `hippo` invocation — plugin never crashes the host opencode session.
- **DO-NOT-EDIT marker** in plugin source preamble — users who customize hippo.ts get an in-source warning before silent overwrite.
- **Canonical-verb regex** for the migration — `/^\s*hippo\s+(session-end|last-sleep|sleep|capture|context)\b/` — won't match a third-party tool literally named `hippo` (e.g. a user's `hippo deploy` wrapper).
- **Per-hook surgical migration** (not per-entry) — mixed entries preserve user-authored hooks.

## Critic gates

| Stage | Critic | Verdict | Score | Notes |
|---|---|---|---|---|
| plan | plan-eng-critic | pass | 88 | Rev 1 after Rev 0 fail-62 with 2 crit + 5 high (all addressed) |
| execute | code-review-critic | pass | 88 | 0 must_fix, 4 cosmetic |
| review | independent-review-critic | pass | 84 | 0 must_fix, 4 med/low — folded med-sev data-loss vector (mixed-entry surgical case) into commit 41eee0f |
| ship | ship-readiness-critic | pass | 94 | 0 must_fix, 2 cosmetic |

## Test plan

- [x] `npm test` — 220 files / 1607 tests passed, 3 files + 4 tests skipped. **exit code 0.**
- [x] `tsc --noEmit` clean.
- [x] Manual smoke 1 (fresh install): plugin file written at `~/.config/opencode/plugins/hippo.ts` with marker, opencode.json NOT created.
- [x] Manual smoke 2 (migration): seeded pre-broken opencode.json with theme + hippo entry + non-hippo entry; install preserved theme + non-hippo entry, removed hippo entry, CLI logged the migration.
- [x] Manual smoke 3 (unparseable JSON): seeded malformed opencode.json; install still wrote plugin, CLI surfaced "WARNING: opencode.json is unparseable — fix manually", opencode.json left untouched.
- [x] Every commit on the branch is independently green (bisect-safe).
- [x] Version 1.11.2 across all 6 manifests.

## Migration path for affected users

On v1.10.x-v1.11.1: opencode won't launch. On v1.11.2: `hippo hook install opencode` auto-cleans the broken hooks block. Manual alternative: delete the `hooks` key from `~/.config/opencode/opencode.json`.

## Out of scope

- Pinned-context auto-injection on opencode — `message.updated` fires per-token, not per-prompt-submit; no clean opencode plugin event equivalent to Claude Code's `UserPromptSubmit`. Users can still call `hippo context --pinned-only` via the MCP server. Deferred.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)