### PR TITLE
refactor(api): extract getContext + sleep + outcomeForLastRecall (v1.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.11.3 (2026-05-23): api.ts refactor (getContext + sleep + outcomeForLastRecall)
+
+An internal refactor enabling future HTTP API expansion (planned v1.11.4) and the Python SDK (planned v0.1.0). Three new exports added to `src/api.ts`:
+
+- `getContext(ctx, opts): Promise<ContextResult>` extracted from `cmdContext` (~315 inline lines collapsed into a pure async function plus a presentation renderer in the CLI). Named `getContext` rather than `context` to avoid collision with the `Context` interface. Covers pinnedOnly fast path, '*' fallback (strength-sorted), and hybrid search (searchBothHybrid for global, physicsSearch / hybridSearch for local-only). markRetrieved + last_retrieval_ids write-back + updateStats(recalled) + recall audit row stay inside api.getContext for parity with `api.recall`.
+- `sleep(ctx, opts): Promise<SleepResult>` extracted from `cmdSleepCore` Phase 2-6 (consolidate / dedup / audit / share / ambient). Returns structured counts instead of console-printing. The CLI log-file tee, console rendering, and the auto-learn pre-phase (Phase 1: learnFromRepo + learnFromMemoryMd, intrinsically host-bound via `process.cwd()` / `os.homedir()`) stay in the `cmdSleep` + `cmdSleepCore` wrappers. `deduplicateStore` moved to its own module (`src/dedupe.ts`).
+- `outcomeForLastRecall(ctx, good): {applied, ids}` small wrapper around the existing `outcome()` that resolves `loadIndex().last_retrieval_ids` first.
+
+CLI commands (`hippo context`, `hippo sleep`) keep byte-identical stdout. Manual smoke verified all 3 cmdContext format branches (markdown / json / additional-context) and both sleep paths (dry-run / full).
+
+**Behavior fix:** `hippo outcome` now emits one `audit_log` row per affected memory (op='outcome', actor='cli'), matching the MCP `outcome` tool path. Previously the CLI bypassed `api.outcome` and silently skipped the audit emission, an inconsistency between the CLI and MCP surfaces. Downstream consumers of `audit_log` will see new rows from CLI `outcome` invocations going forward; if you rely on counting CLI vs MCP audit rows separately, filter on the `actor` field (`'cli'` vs `'mcp'`).
+
+No public TypeScript API breakage. All `src/api.ts` exports are additive. Tenant-scoping audited: every `loadAllEntries` / `readEntry` in the new `api.getContext` uses `ctx.tenantId`, not `resolveTenantId({})`.
+
+### Shipped
+
+- **`api.outcomeForLastRecall(ctx, good)`**: small (~10 LoC) helper that loads `last_retrieval_ids` and forwards to `api.outcome`. Used by the v1.11.3 `cmdOutcome` rewire and ready for Episode B's HTTP `/v1/outcome` route. Tests (4 real-DB): empty index, multi-id, cross-tenant silent skip, audit emission per id.
+- **`api.sleep(ctx, opts)`**: pure async function over the consolidation pipeline. Auto-learn from git + MEMORY.md stays CLI-side. `deduplicateStore` extracted to `src/dedupe.ts` for cross-module access (api.sleep + cmdDedup). Tests (4 real-DB): dryRun, empty store, populated pipeline, noShare gating. Per-test `HIPPO_HOME` isolation prevents auto-share leaks.
+- **`api.getContext(ctx, opts)`**: pure async function over cmdContext's data-loading + selection. Render helpers (`printContextMarkdown` etc.) stay CLI-side because they are shared with cmdRecall / cmdSnapshot / cmdHandoffShow. Tests (6 real-DB): empty store, '*' fallback ordering, budget cap, tenant scoping, activeSnapshot return, budget=0 short-circuit.
+- **`cmdOutcome` rewired** through `api.outcomeForLastRecall` + `api.outcome`. See the behavior fix above.
+- **`cmdSleepCore` / `cmdContext` thin-wrapped** through their respective api functions, with byte-identical stdout via dedicated render helpers (`renderSleepResult` for sleep; existing `printContextMarkdown` for context).
+
+### Tests
+
+Five new test files: `api-context-sleep-contracts` (7 type-level), `api-outcome-for-last-recall` (4 real-DB), `api-sleep` (4 real-DB), `api-context` (6 real-DB). Full suite: 1628 tests passed, 4 skipped, 0 failed.
+
+### Out of scope (planned for v1.11.4 / v0.1.0)
+
+- HTTP routes for `/v1/outcome`, `/v1/context`, `/v1/sleep` (Episode B, v1.11.4).
+- Python SDK `hippo-memory` on PyPI (Episode C, v0.1.0).
+- Shared `api.renderContext`: print helpers in cli.ts still own the markdown / additional-context rendering. Episode B can extract this if the Python SDK wants server-rendered output.
+
 ## 1.11.2 (2026-05-23): opencode plugin installer
 
 A patch release fixing [#24](https://github.com/kitfunso/hippo-memory/issues/24) at root.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,18 @@
 # Hippo Brain Observatory — Roadmap
 
+## v1.11.3 (Episode A) — follow-ups for Episode B / Episode C
+
+Surfaced by independent-review-critic on PR #36 (`refactor/api-context-sleep-outcome`). All deferred deliberately — none block the v1.11.3 PATCH release but each should be addressed before the corresponding Episode B / Episode C work.
+
+- **Episode B preflight: tenant scoping for `api.sleep`.** `api.sleep` invokes `deduplicateStore(ctx.hippoRoot)` and `deleteEntry(ctx.hippoRoot, ...)` without `ctx.tenantId` / `ctx.actor`. Matches CLI pre-refactor (operator-invoked, single-tenant assumption). Episode B HTTP `/v1/sleep` MUST either (a) gate the route to a global-admin actor / API-key role, or (b) plumb `ctx.tenantId` into `deduplicateStore` + `auditMemories` + `deleteEntry` so a tenant-A Bearer can't dedupe / delete tenant-B's rows. Likely (a) for simplicity; (b) only if multi-tenant per-tenant sleep is a real product requirement.
+- **Episode B preflight: audit_log on consolidation phases.** `api.sleep`'s dedup / audit-delete phases emit no `audit_log` rows. Same CLI/MCP parity gap that T6 just fixed for `cmdOutcome`. Episode B should decide between (a) one `'consolidate'` audit row per `api.sleep` invocation with phase counters in metadata, or (b) per-phase rows (one per dedup deletion, one per audit-delete) tagged with `ctx.actor`. Either is correct; pick before exposing the route.
+- **CLI byte-identical regression coverage.** Plan T5 Step 1b mandated 10 CLI render snapshot tests in `tests/cli-context-render-snapshot.test.ts` as the byte-identical gate. Deferred to keep T5 manageable; replaced with manual smokes in the Verify section. Add real snapshot tests so future drift in `printContextMarkdown` / `renderSleepResult` is caught at CI rather than manually. Cover: pinnedOnly, markdown default, json, additional-context, framing observe / suggest / assert, query='*' fallback, hybrid local-only, hybrid with global.
+- **Ambient block redundant DB load.** `cmdContext` calls `loadAllEntries` for the ambient summary after `api.getContext` already loaded the same entries internally. Pre-refactor was a single load. Optimisation: have `api.getContext` either return the loaded sets (extends ContextResult) or expose an `api.ambientFromEntries(entries)` helper so the CLI computes ambient from the same in-memory rows.
+- **Episode C consideration: `ContextResult.entries` exposes full `MemoryEntry`.** `cmdContext`'s json format projects to `{id, score, strength, tags, confidence, content, global}`. Python SDK consumers reading the api directly will receive the full MemoryEntry surface (including `superseded_by`, `embeddings`, `goal_associations`, etc.). Either add a sibling `ContextResultEntryProjected` variant for SDK ergonomics, or document `MemoryEntry` as the stable shape.
+- **`api.getContext` pinnedOnly hot-path optimisation (low priority).** pinnedOnly path runs every UserPromptSubmit and currently does `loadAllEntries(...).filter(e => e.pinned)`. A `loadPinnedEntries(hippoRoot, tenantId)` helper with a SQLite `WHERE pinned = 1` would short-circuit the full-scan + filter on stores with thousands of memories. Not a regression vs master; flagged for future indexing work.
+
+
+
 ## v1.7.3 — review-tail from v1.7.2 (SHIPPED 2026-05-07)
 
 All four items closed in v1.7.3. See `docs/plans/2026-05-06-v1.7.3-review-tail.md` and CHANGELOG.

--- a/docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md
+++ b/docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md
@@ -149,32 +149,46 @@ Locate the actual `loadIndex` import path during execute (likely `./index-io.js`
 
 ---
 
-## Task 4: Implement `sleep()` (extract from cmdSleepCore)
+## Task 4: Implement `sleep()` (extract from cmdSleepCore — narrowed per option-B factoring)
 
-**Files:** Modify `src/api.ts` (replace stub) + `tests/api-sleep.test.ts` (new) + `src/cli.ts` cmdSleepCore (rewire to call api.sleep + render).
+**Files:** Modify `src/api.ts` (replace stub + narrow SleepOpts/SleepResult) + `tests/api-sleep.test.ts` (new) + `src/cli.ts` cmdSleepCore (rewire to call api.sleep + render) + `src/dedupe.ts` (new, extracted from cli.ts) + `tests/api-context-sleep-contracts.test.ts` (T2 contract test, minor update for the narrowed types).
 
-**Boundary discipline (required):** `cmdSleep` (the wrapper at `cli.ts:2142-2191`) STAYS UNTOUCHED. The log-file tee, `process.exit`, and any `[hippo] sleep complete` console lines stay in the CLI layer. `api.sleep` is pure: no console.log, no process.exit, no log-file IO. The prior bundled episode's CRIT finding (sleep HTTP route bypassing CLI side effects) is prevented by keeping all presentation/side-effects in cli.ts.
+**Scope correction (caught at execute, 2026-05-23):** the plan-eng-critic's "verbatim port" assumption missed that 3 helpers used by cmdSleepCore are cli-private and host-bound:
+- `learnFromRepo` (cli.ts:3830) uses `process.cwd()` — intrinsically CLI-bound
+- `learnFromMemoryMd` (cli.ts:1963) uses `os.homedir()` — intrinsically CLI-bound
+- `deduplicateStore` (cli.ts:2040) is pure (hippoRoot-only) — moveable
+
+The structurally correct factoring: **api.sleep covers only the pure-storage phases** (consolidate + dedup + audit + share + ambient). The auto-learn phases stay in `cmdSleepCore` as CLI-pre-api work. HTTP `/v1/sleep` in Episode B doesn't need auto-learn — the server has no business cwd or client home dir to scan. `deduplicateStore` moves to its own module (`src/dedupe.ts`) so both cli.ts and api.ts can import it.
+
+This narrows `SleepOpts` (drops `noLearn`) and `SleepResult` (drops `autoLearned`). T2's already-committed types are amended.
+
+**Boundary discipline (required):** `cmdSleep` wrapper (`cli.ts:2142-2191`) STAYS UNTOUCHED. The log-file tee, `process.exit`, and `[hippo] sleep complete` console lines stay in CLI. `api.sleep` is pure: no console.log, no process.exit, no log-file IO. The prior bundled episode's CRIT finding (sleep HTTP route bypassing CLI side effects) is prevented by keeping all presentation/side-effects + auto-learn in cli.ts.
 
 **Step 1: Failing tests** (real-DB):
 - `dryRun returns counts, no writes` — verify SleepResult.dryRun=true, no audit/dedup/share runs.
-- `non-dry-run runs full pipeline; returns populated SleepResult` — verify each phase's counters populate (autoLearned, deduped, audit, shared, ambient).
-- `noLearn skips git + MEMORY.md learning` — SleepResult.autoLearned is undefined.
+- `non-dry-run runs full pipeline; returns populated SleepResult` — verify each phase's counters populate (deduped, audit, shared, ambient).
 - `noShare skips auto-share` — SleepResult.shared is undefined.
 
-**Step 2:** Port cmdSleepCore logic to api.sleep verbatim, swapping console.log → result-object population:
+**Step 2:** Port cmdSleepCore's pure-storage phases (Phase 2-6 of the current implementation) to api.sleep, swapping console.log → result-object population:
 
-- Phase 1 (auto-learn, gated on !opts.noLearn): learnFromRepo + learnFromMemoryMd → result.autoLearned = `{fromGit, fromMemoryMd}`.
-- Phase 2: `await consolidate(ctx.hippoRoot, {dryRun: opts.dryRun})` → populate active/removed/mergedEpisodic/newSemantic/details.
-- Phase 3 (gated on !dryRun): deduplicateStore → result.deduped.
-- Phase 4 (gated on !dryRun): auditMemories + delete junk → result.audit.
-- Phase 5 (gated on !dryRun && !opts.noShare && config.autoShareOnSleep): autoShare → result.shared.
-- Phase 6 (gated on !dryRun && config.ambient.enabled): computeAmbientState → result.ambient.
+- Phase 1: `await consolidate(ctx.hippoRoot, {dryRun: opts.dryRun})` → populate active/removed/mergedEpisodic/newSemantic/details.
+- Phase 2 (gated on !dryRun): `deduplicateStore(ctx.hippoRoot)` (from new src/dedupe.ts) → result.deduped {removed, semDups, epiDups, crossDups}.
+- Phase 3 (gated on !dryRun): `auditMemories(loadAllEntries(...))` → for error issues, deleteEntry each; result.audit {errorsRemoved, warningCount}.
+- Phase 4 (gated on !dryRun && !opts.noShare && config.autoShareOnSleep): `autoShare(ctx.hippoRoot, {minScore: 0.6})` → result.shared.
+- Phase 5 (gated on !dryRun && config.ambient.enabled): `computeAmbientState(loadAllEntries(...).filter(!superseded_by))` → result.ambient.
 
-**Step 3:** Rewire `cmdSleepCore` to call `api.sleep(ctx, {dryRun, noLearn, noShare})` and pass the result to a new local `renderSleepResult(result)` function that produces byte-identical console output to the current implementation. The render function lives in cli.ts (or src/cli-render.ts if it grows past ~60 lines).
+NOT in api.sleep: the auto-learn phase (learnFromRepo + learnFromMemoryMd). Stays in `cmdSleepCore` as CLI-pre-api work.
 
-**Step 4:** Run full suite. Existing CLI tests pass byte-identically (compare output snapshots if any exist). New api.sleep tests pass. Manual smoke: `hippo sleep --dry-run` output identical to master.
+**Step 3:** Rewire `cmdSleepCore` to: (a) keep the existing auto-learn block before calling api, (b) build `api.Context` + `SleepOpts {dryRun, noShare}`, (c) `await api.sleep(ctx, opts)`, (d) pass the result to a new local `renderSleepResult(result)` function that produces byte-identical console output for Phase 2-6 lines. The auto-learn console lines ("Auto-learned N lessons...", "Imported N memories...") stay as-is in the CLI block. The render function lives in cli.ts (or src/cli-render.ts if it grows past ~60 lines).
 
-**Step 5: Commit** `feat(api): extract sleep() from cmdSleepCore — pure result, CLI thin-wraps for render`.
+**Step 4:** Move `deduplicateStore` + `DedupPair` interface from cli.ts to new `src/dedupe.ts`. Update `cmdDedup` (cli.ts:2090) to import from the new module. Function signature and behavior unchanged.
+
+**Step 5:** Run full suite. Existing CLI tests pass byte-identically (compare output snapshots if any exist). New api.sleep tests pass. Manual smoke: `hippo sleep --dry-run` and `hippo sleep` output identical to master.
+
+**Step 6: Commits** (3 commits for clarity):
+- `refactor(dedup): extract deduplicateStore to src/dedupe.ts (prep for api.sleep)` — pure move, no behavior change.
+- `refactor(api): narrow SleepOpts/SleepResult per option-B factoring` — drops noLearn/autoLearned (CLI-only concerns).
+- `feat(api): extract sleep() from cmdSleepCore (consolidate+dedup+audit+share+ambient)` — main extraction + renderSleepResult + cmdSleepCore rewire + tests.
 
 ---
 
@@ -270,7 +284,7 @@ CHANGELOG entry (1.11.3, prepended above 1.11.2):
 >
 > Internal refactor enabling future HTTP API expansion (planned v1.11.4) and the Python SDK (planned v0.1.0). Three new exports added to `src/api.ts`:
 > - `getContext(ctx, opts): Promise<ContextResult>` — extracted from `cmdContext` (~315 inline lines collapsed into a pure async function + a presentation renderer in the CLI). Named `getContext` rather than `context` to avoid collision with the `Context` interface.
-> - `sleep(ctx, opts): Promise<SleepResult>` — extracted from `cmdSleepCore`; returns structured counts for active/removed/merged/newSemantic/deduped/audit/shared/ambient instead of console-printing inside the core. The CLI log-file tee and console rendering stay in the `cmdSleep` wrapper.
+> - `sleep(ctx, opts): Promise<SleepResult>` — extracted from `cmdSleepCore` (Phase 2-6: consolidate / dedup / audit / share / ambient); returns structured counts for active/removed/merged/newSemantic/deduped/audit/shared/ambient instead of console-printing inside the core. The CLI log-file tee, console rendering, and the auto-learn pre-phase (Phase 1: learnFromRepo + learnFromMemoryMd, intrinsically host-bound) stay in the `cmdSleep` + `cmdSleepCore` wrappers. `deduplicateStore` moved to its own module (`src/dedupe.ts`).
 > - `outcomeForLastRecall(ctx, good): {applied, ids}` — small wrapper around the existing `outcome()` that resolves `loadIndex().last_retrieval_ids` first.
 >
 > CLI commands (`hippo context`, `hippo sleep`) keep byte-identical stdout (covered by 10 new render-snapshot tests in `tests/cli-context-render-snapshot.test.ts` and the existing sleep smokes).
@@ -332,7 +346,7 @@ Version pins (6 manifests):
 - [ ] `hippo outcome` emits one `audit_log` row per affected id (new test green); no existing test broken by the new rows.
 - [ ] Tenant scoping audit clean (zero `resolveTenantId({})` inside api.getContext or api.sleep body).
 - [ ] Full suite green, exit=0.
-- [ ] 5 new test files: api-context-sleep-contracts, api-outcome-for-last-recall, api-sleep, api-context, cli-context-render-snapshot.
+- [ ] 5 new test files: api-context-sleep-contracts, api-outcome-for-last-recall, api-sleep, api-context, cli-context-render-snapshot. (Plus existing cli-dedup tests continue to pass after deduplicateStore moves to src/dedupe.ts.)
 - [ ] CHANGELOG 1.11.3 entry present (including the audit-emission behavior-fix note).
 - [ ] Version 1.11.3 across all 6 manifests.
 - [ ] PR merged, npm published.

--- a/docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md
+++ b/docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md
@@ -1,0 +1,347 @@
+# api.ts Refactor: Extract getContext() + sleep() + outcomeForLastRecall() (Episode A of 3)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add 3 pure-function exports to `src/api.ts` — `getContext()`, `sleep()`, and `outcomeForLastRecall()` — extracted from heavyweight inline implementations in `src/cli.ts`. Refactor the CLI commands to be thin presentation wrappers over the new api. **CLI output is byte-identical**, no new HTTP routes, no Python. v1.11.3 PATCH bump for the additive `src/api.ts` exports (plus one intentional behavior fix in `cmdOutcome` — see Task 6 + Task 7 CHANGELOG).
+
+**Architecture:** `api.ts` is hippo's pure-function layer (no console.log, no process.exit, no log-file tee). Each new export takes `(ctx, opts)`, returns a structured result, and lets callers handle presentation. CLI keeps its current flag parsing → builds opts → calls the new api → renders the result via dedicated render helpers (extracted to `src/cli-render.ts` or kept inline in cli.ts).
+
+**Tech Stack:** TypeScript existing toolchain. No new dependencies. vitest for new api-level unit tests against the real SQLite store (per project rule).
+
+**Why this episode exists:** The plan-eng-critic of the bundled Python-SDK-v0.1 episode `01KSAJBMHV7F9VSJCR3YNHKBFD` flagged that `api.getContext()` and `api.sleep()` don't exist and that extracting them is itself a substantial refactor — too big to bundle with HTTP-route additions + a new Python SDK in one episode. Episode A is the foundation that lets Episode B (HTTP routes) and Episode C (Python SDK) be small.
+
+**Naming note (MED from plan-eng-critic):** The extracted function is named `getContext` (not `context`) to avoid an ergonomic collision with the existing `Context` interface (`src/api.ts:58`) and the ubiquitous `ctx: Context` parameter convention. Follows the existing `getEntry` / `getEntries` pattern.
+
+---
+
+## Research notes (completed in discover)
+
+- `cmdSleepCore` at `src/cli.ts:2193-2288` (~95 lines, plus the 50-line log-tee wrapper at 2142-2191). Phases: auto-learn-from-git → learn-from-MEMORY.md → consolidate() → dedup → audit (delete junk) → auto-share → ambient-summary. ~6 console.log groups for presentation.
+- `cmdContext` at `src/cli.ts:3344-3659` (~315 lines), plus the `printContextMarkdown` helper at `3661-3694` (~33 lines). Flag-driven: `--pinned-only` (UserPromptSubmit hot path), `--auto` (autoDetectContext from git — already lives at 3696-3728 as a separate helper, called by cmdContext), explicit args query, `--budget` (default 1500), `--limit`, `--include-recent`, `--scope`, `--framing` (observe|suggest|assert), `--format` (markdown|json|additional-context). Loads local + global entries (tenant-scoped per v1.11.1), pulls active task snapshot + handoff + recent session events, scores, budgets, renders. Pinned-only path is a separate code branch. **Do NOT read past line 3694** — lines 3696-3728 are `autoDetectContext` (already-extracted helper) and 3734+ is `cmdEmbed` (unrelated).
+- `cmdOutcome` at `src/cli.ts:2686-2720` (~35 lines). Bypasses existing `api.outcome` — does its own `loadIndex` + iteration. **Behavior bug:** current `cmdOutcome` does NOT call `appendAuditEvent`; the MCP outcome path (via `api.outcome`) does. T6 fixes this asymmetry. See Task 6 + Task 7 CHANGELOG for the parity framing.
+- `api.outcome(ctx, ids, good): {applied}` already exists (api.ts:1044) — emits one `appendAuditEvent` per affected id via `readEntry → applyOutcome → writeEntry → appendAuditEvent`. Stays unchanged.
+- Tenant scoping (v1.11.1 lesson): every new `loadAllEntries` / `readEntry` / store call MUST pass `ctx.tenantId`. Audit any extracted helpers for this. Zero `resolveTenantId({})` calls inside the new `api.getContext` or `api.sleep` bodies.
+
+---
+
+## Task 1: Branch
+
+`git checkout -b refactor/api-context-sleep-outcome` from master tip `a86490a`. Confirm clean tree.
+
+---
+
+## Task 2: Define api.ts contracts (types + stubs)
+
+**Files:** Modify `src/api.ts`, create `tests/api-context-sleep-contracts.test.ts`.
+
+**Step 1: Write failing contract test** (type-level only):
+
+```typescript
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ContextOpts, ContextResult, SleepOpts, SleepResult } from '../src/api.js';
+import { getContext, sleep, outcomeForLastRecall } from '../src/api.js';
+
+describe('api contract types', () => {
+  it('getContext signature exists', () => { expectTypeOf(getContext).toBeFunction(); });
+  it('sleep signature exists', () => { expectTypeOf(sleep).toBeFunction(); });
+  it('outcomeForLastRecall signature exists', () => { expectTypeOf(outcomeForLastRecall).toBeFunction(); });
+});
+```
+
+**Step 2: Implement type definitions + function stubs that throw:**
+
+```typescript
+export interface ContextOpts {
+  q?: string;
+  auto?: boolean;
+  budget?: number;             // default 1500
+  limit?: number;
+  pinnedOnly?: boolean;
+  framing?: 'observe' | 'suggest' | 'assert';
+  format?: 'markdown' | 'json' | 'additional-context';
+  scope?: string;
+  includeRecent?: number;
+}
+
+export interface ContextResultEntry {
+  entry: MemoryEntry;
+  score: number;
+  tokens: number;
+  isGlobal?: boolean;
+  isFreshTail?: boolean;
+}
+
+export interface ContextResult {
+  entries: ContextResultEntry[];
+  tokens: number;
+  format: 'markdown' | 'json' | 'additional-context';
+  activeSnapshot?: TaskSnapshot | null;
+  sessionHandoff?: SessionHandoff | null;
+  recentEvents?: SessionEvent[];
+  rendered?: string; // markdown/additional-context formats; absent for json
+}
+
+export interface SleepOpts {
+  dryRun?: boolean;
+  noLearn?: boolean;
+  noShare?: boolean;
+}
+
+export interface SleepResult {
+  active: number;
+  removed: number;
+  mergedEpisodic: number;
+  newSemantic: number;
+  dryRun: boolean;
+  autoLearned?: { fromGit: number; fromMemoryMd: number };
+  deduped?: { removed: number; semDups: number; epiDups: number; crossDups: number };
+  audit?: { errorsRemoved: number; warningCount: number };
+  shared?: number;
+  ambient?: AmbientState | null;
+  details?: string[];
+}
+
+// Stubs — real impl in Tasks 3, 4, 5.
+export async function getContext(_ctx: Context, _opts: ContextOpts = {}): Promise<ContextResult> {
+  throw new Error('getContext() not yet implemented');
+}
+export async function sleep(_ctx: Context, _opts: SleepOpts = {}): Promise<SleepResult> {
+  throw new Error('sleep() not yet implemented');
+}
+export function outcomeForLastRecall(_ctx: Context, _good: boolean): { applied: number; ids: string[] } {
+  throw new Error('outcomeForLastRecall() not yet implemented');
+}
+```
+
+**Step 3:** `npx tsc --noEmit` clean. Contract test passes (type-level only).
+
+**Step 4: Commit** `feat(api): add ContextOpts/Result + SleepOpts/Result types + function stubs`.
+
+---
+
+## Task 3: Implement `outcomeForLastRecall()`
+
+**Files:** Modify `src/api.ts` (replace stub) + `tests/api-outcome-for-last-recall.test.ts` (new).
+
+**Step 1:** Failing real-DB tests covering: no last-recall returns `{applied:0, ids:[]}`; 3 ids in last-recall applies to all; cross-tenant id silently skipped (matches existing api.outcome behavior — see comment in implementation).
+
+**Step 2:** Implement:
+
+```typescript
+export function outcomeForLastRecall(
+  ctx: Context, good: boolean,
+): { applied: number; ids: string[] } {
+  // loadIndex is per-hippoRoot (not tenant-scoped) — last_retrieval_ids is local-only state.
+  // Tenant filtering happens inside outcome() via readEntry(..., ctx.tenantId), which
+  // silently skips cross-tenant ids. Do NOT tighten loadIndex with tenantId here —
+  // doing so would break the (correct) cross-tenant-silent-skip behavior the test covers.
+  const idx = loadIndex(ctx.hippoRoot);
+  const ids = idx.last_retrieval_ids ?? [];
+  if (ids.length === 0) return { applied: 0, ids: [] };
+  const { applied } = outcome(ctx, ids, good);
+  return { applied, ids };
+}
+```
+
+Locate the actual `loadIndex` import path during execute (likely `./index-io.js` or `./store.js`); the source-read in execute will confirm.
+
+**Step 3: Commit** `feat(api): outcomeForLastRecall — last-recall wrapper around outcome()`.
+
+---
+
+## Task 4: Implement `sleep()` (extract from cmdSleepCore)
+
+**Files:** Modify `src/api.ts` (replace stub) + `tests/api-sleep.test.ts` (new) + `src/cli.ts` cmdSleepCore (rewire to call api.sleep + render).
+
+**Boundary discipline (required):** `cmdSleep` (the wrapper at `cli.ts:2142-2191`) STAYS UNTOUCHED. The log-file tee, `process.exit`, and any `[hippo] sleep complete` console lines stay in the CLI layer. `api.sleep` is pure: no console.log, no process.exit, no log-file IO. The prior bundled episode's CRIT finding (sleep HTTP route bypassing CLI side effects) is prevented by keeping all presentation/side-effects in cli.ts.
+
+**Step 1: Failing tests** (real-DB):
+- `dryRun returns counts, no writes` — verify SleepResult.dryRun=true, no audit/dedup/share runs.
+- `non-dry-run runs full pipeline; returns populated SleepResult` — verify each phase's counters populate (autoLearned, deduped, audit, shared, ambient).
+- `noLearn skips git + MEMORY.md learning` — SleepResult.autoLearned is undefined.
+- `noShare skips auto-share` — SleepResult.shared is undefined.
+
+**Step 2:** Port cmdSleepCore logic to api.sleep verbatim, swapping console.log → result-object population:
+
+- Phase 1 (auto-learn, gated on !opts.noLearn): learnFromRepo + learnFromMemoryMd → result.autoLearned = `{fromGit, fromMemoryMd}`.
+- Phase 2: `await consolidate(ctx.hippoRoot, {dryRun: opts.dryRun})` → populate active/removed/mergedEpisodic/newSemantic/details.
+- Phase 3 (gated on !dryRun): deduplicateStore → result.deduped.
+- Phase 4 (gated on !dryRun): auditMemories + delete junk → result.audit.
+- Phase 5 (gated on !dryRun && !opts.noShare && config.autoShareOnSleep): autoShare → result.shared.
+- Phase 6 (gated on !dryRun && config.ambient.enabled): computeAmbientState → result.ambient.
+
+**Step 3:** Rewire `cmdSleepCore` to call `api.sleep(ctx, {dryRun, noLearn, noShare})` and pass the result to a new local `renderSleepResult(result)` function that produces byte-identical console output to the current implementation. The render function lives in cli.ts (or src/cli-render.ts if it grows past ~60 lines).
+
+**Step 4:** Run full suite. Existing CLI tests pass byte-identically (compare output snapshots if any exist). New api.sleep tests pass. Manual smoke: `hippo sleep --dry-run` output identical to master.
+
+**Step 5: Commit** `feat(api): extract sleep() from cmdSleepCore — pure result, CLI thin-wraps for render`.
+
+---
+
+## Task 5: Implement `getContext()` (extract from cmdContext)
+
+**Files:** Modify `src/api.ts` (replace stub) + `tests/api-context.test.ts` (new) + `src/cli.ts` cmdContext (rewire) + `tests/cli-context-render-snapshot.test.ts` (new — see Step 1b).
+
+**Step 1: Failing api-level tests** (real-DB) — exercise the structured result:
+- Default budget returns strongest memories.
+- Explicit `q` filters results.
+- `pinnedOnly` path returns only pinned entries.
+- `auto` triggers autoDetectContext (mock git diff via the existing test fixtures if needed).
+- Framing observe/suggest/assert each produces correct prefix in rendered string.
+- Tenant scoping: tenant_a session does not see tenant_b memories. Mandatory per v1.11.1 lessons.
+- activeSnapshot/sessionHandoff/recentEvents populated when present in the store.
+- format=json returns entries with no rendered string.
+- format=markdown returns rendered string.
+- format=additional-context returns the Claude-Code-shaped envelope.
+
+**Step 1b: Failing CLI-level render snapshot tests** (new file `tests/cli-context-render-snapshot.test.ts`) — these guarantee the "CLI byte-identical" claim. Per output shape, spawn the CLI binary against a fixture store and snapshot stdout:
+- pinnedOnly path: `hippo context --pinned-only`
+- main path / markdown (default format): `hippo context --auto --budget 500`
+- main path / json: `hippo context --auto --budget 500 --format json`
+- main path / additional-context: `hippo context --auto --budget 500 --format additional-context`
+- framing=observe: `hippo context --auto --framing observe`
+- framing=suggest: `hippo context --auto --framing suggest`
+- framing=assert: `hippo context --auto --framing assert`
+- query='*' fallback (no args, no auto): `hippo context`
+- hybrid search local-only: `hippo context "foo"` after `hippo remember "foo"`
+- hybrid search with global: `hippo context "global_x"` after `hippo remember --global "global_x"`
+
+These snapshots are committed to git pre-refactor (captured against master HEAD before T2 lands) and must remain unchanged through T7. **A snapshot diff after T5 implementation = byte-identical claim failed = T5 not done.**
+
+**Step 2:** Implement `getContext(ctx, opts)` by reading cmdContext source end-to-end during execute and porting it.
+
+**Execute-stage discipline (required):** before writing any extraction code, read `cli.ts` lines `3344-3659` (cmdContext function body) + `3661-3694` (printContextMarkdown helper) — ~350 lines total in two chunks. **Stop reading at line 3694** — line 3696+ is `autoDetectContext` (already a separate helper, just called from cmdContext; do not re-extract it) and 3734+ is `cmdEmbed` (unrelated). Note every external function called (loadAllEntries, loadActiveTaskSnapshot, loadLatestHandoff, listSessionEvents, computeScore-or-whatever, formatMarkdown/formatJson/formatAdditionalContext, autoDetectContext, detectScope, loadConfig, etc.). Note every `resolveTenantId({})` call site — every one of those becomes `ctx.tenantId`. Note every `console.log` / `process.stdout.write` — every one becomes result-object population.
+
+Porting strategy: **bottom-up, test-driven**. (1) Port the pinnedOnly fast path first — smallest branch, fewest deps. Run snapshot test for `--pinned-only`. Green = commit checkpoint. (2) Port the main path's data-loading + scoring + budgeting (no rendering yet). Run api-level tests for default budget + tenant scoping + activeSnapshot. (3) Port each render path (markdown, json, additional-context, framing prefixes). Run snapshot tests per shape; green = commit checkpoint per format. (4) Rewire cmdContext to call api.getContext. Run all CLI snapshot tests. Green = T5 done.
+
+Architecture:
+- The pinned-only fast path stays a top-of-function early-return that returns a ContextResult.
+- The main path builds entries → scores → packs to budget → renders by format.
+- The render functions live in cli.ts (or a new `src/render-context.ts` if they grow past ~80 lines combined).
+
+**Step 3:** Rewire `cmdContext` to parse flags → build ContextOpts → `await api.getContext(ctx, opts)` → if `result.rendered`, `process.stdout.write(result.rendered)`; if format=json, `console.log(JSON.stringify(result, null, 2))`.
+
+**Step 4:** Full suite green. All 10 CLI snapshot tests from Step 1b green (zero stdout diff vs pre-refactor capture). Manual smokes for each format + pinnedOnly + auto.
+
+**Step 5: Commit** `feat(api): extract getContext() from cmdContext — ~315 LoC into pure result + render wrapper`.
+
+---
+
+## Task 6: Rewire cmdOutcome to use the new api (+ audit-emission fix)
+
+**Files:** Modify `src/cli.ts` cmdOutcome.
+
+```typescript
+function cmdOutcome(hippoRoot: string, flags: ...) {
+  requireInit(hippoRoot);
+  const good = Boolean(flags['good']);
+  const bad = Boolean(flags['bad']);
+  if (!good && !bad) { console.error('Specify --good or --bad'); process.exit(1); }
+  const ctx: api.Context = { hippoRoot, tenantId: resolveTenantId({}), actor: 'cli' };
+  const specificId = flags['id'] ? String(flags['id']) : null;
+  let updated: number;
+  if (specificId) {
+    updated = api.outcome(ctx, [specificId], good).applied;
+  } else {
+    const r = api.outcomeForLastRecall(ctx, good);
+    if (r.ids.length === 0) {
+      console.log('No recent recall to apply outcome to. Use --id <id> to target a specific memory.');
+      return;
+    }
+    updated = r.applied;
+  }
+  console.log(`Applied ${good ? 'positive' : 'negative'} outcome to ${updated} memor${updated === 1 ? 'y' : 'ies'}`);
+}
+```
+
+**Behavior fix flagged (H1 from plan-eng-critic):** the current `cmdOutcome` does its own `readEntry → applyOutcome → writeEntry` inline and **silently skips** the `appendAuditEvent(op='outcome')` call that `api.outcome` emits. After T6, every successful `hippo outcome` invocation writes ONE `audit_log` row per affected memory id — matching the MCP `outcome` tool path which already does this via the same `api.outcome`. This is an intentional fix to a CLI/MCP asymmetry, not an accidental side effect. Documented as such in T7 CHANGELOG.
+
+**Step 1:** Existing CLI outcome tests pass unchanged. **Add one new test** asserting that after `hippo outcome --good`, the `audit_log` table has the expected number of new rows (one per affected id, with op='outcome'). Grep `tests/**` for any existing test asserting `audit_log` row counts or absence — fix the assertion or document why no breakage.
+
+**Step 2: Commit** `fix(cli): cmdOutcome routes through api.outcomeForLastRecall + api.outcome (emits audit_log)`.
+
+---
+
+## Task 7: CHANGELOG + version bump
+
+CHANGELOG entry (1.11.3, prepended above 1.11.2):
+
+> ### 1.11.3 (2026-05-23): api.ts refactor — getContext() + sleep() + outcomeForLastRecall()
+>
+> Internal refactor enabling future HTTP API expansion (planned v1.11.4) and the Python SDK (planned v0.1.0). Three new exports added to `src/api.ts`:
+> - `getContext(ctx, opts): Promise<ContextResult>` — extracted from `cmdContext` (~315 inline lines collapsed into a pure async function + a presentation renderer in the CLI). Named `getContext` rather than `context` to avoid collision with the `Context` interface.
+> - `sleep(ctx, opts): Promise<SleepResult>` — extracted from `cmdSleepCore`; returns structured counts for active/removed/merged/newSemantic/deduped/audit/shared/ambient instead of console-printing inside the core. The CLI log-file tee and console rendering stay in the `cmdSleep` wrapper.
+> - `outcomeForLastRecall(ctx, good): {applied, ids}` — small wrapper around the existing `outcome()` that resolves `loadIndex().last_retrieval_ids` first.
+>
+> CLI commands (`hippo context`, `hippo sleep`) keep byte-identical stdout (covered by 10 new render-snapshot tests in `tests/cli-context-render-snapshot.test.ts` and the existing sleep smokes).
+>
+> **Behavior fix:** `hippo outcome` now emits one `audit_log` row per affected memory (op='outcome'), matching the MCP `outcome` tool path. Previously the CLI bypassed `api.outcome` and silently skipped the audit emission — an inconsistency between the CLI and MCP surfaces. Downstream consumers of `audit_log` will see new rows from CLI `outcome` invocations going forward; if you rely on counting CLI-vs-MCP audit rows separately, filter on the `actor` field (`'cli'` vs `'mcp'`).
+>
+> No public TypeScript API breakage — all `src/api.ts` exports are additive. Tenant-scoping audited: every `loadAllEntries`/`readEntry` in the new `api.getContext` uses `ctx.tenantId`, not `resolveTenantId({})`.
+
+Version pins (6 manifests):
+- package.json, package-lock.json (root + packages.['']), src/version.ts, openclaw.plugin.json, extensions/openclaw-plugin/{openclaw.plugin.json, package.json} — all 1.11.2 → 1.11.3.
+
+**Commit** `docs+chore: CHANGELOG + version bump 1.11.2 → 1.11.3`.
+
+---
+
+## Verify
+
+**Automated:**
+- `npm test; echo "exit=$?"` — exit=0 with all existing tests passing + new api-level tests (4 files: api-context-sleep-contracts, api-outcome-for-last-recall, api-sleep, api-context) + 10 CLI render snapshot tests + 1 cmdOutcome audit-emission test.
+- `npx tsc --noEmit` — clean.
+
+**CLI render snapshot diff (the byte-identical gate):**
+- All 10 snapshots in `tests/cli-context-render-snapshot.test.ts` (one per output shape; see T5 Step 1b) MUST match their pre-refactor capture. Any diff = re-work, not done.
+- `hippo sleep --dry-run` stdout diff vs master HEAD must be empty (existing smoke).
+
+**Manual smokes against a tmp HOME (cross-check the snapshot tests):**
+- pinnedOnly: `hippo context --pinned-only`
+- markdown default: `hippo context --auto --budget 500`
+- json: `hippo context --auto --budget 500 --format json`
+- additional-context: `hippo context --auto --budget 500 --format additional-context`
+- framing × 3: `hippo context --auto --framing {observe|suggest|assert}`
+- query fallback: `hippo context`
+- sleep dry-run, full, --no-learn, --no-share
+- outcome: `hippo remember "x" && hippo recall x && hippo outcome --good` (last-recall path) + `hippo outcome --id <id> --good` (specific-id path)
+
+---
+
+## Review
+
+- `/self-review` on diff.
+- `independent-review-critic`: brief on extraction quality, CLI byte-identical claim (render snapshots are the gate), tenant-scoping correctness in api.getContext, and the cmdOutcome audit-emission fix's CHANGELOG framing. The critic should grep for `resolveTenantId(` in the new code paths and confirm none are inside api.getContext or api.sleep.
+
+---
+
+## Ship + Deploy
+
+- `/ship-check`, `ship-readiness-critic`.
+- PR `refactor/api-context-sleep-outcome`, title `refactor(api): extract getContext() + sleep() + outcomeForLastRecall() (v1.11.3)`.
+- Human-final-gate.
+- npm publish 1.11.3, tag v1.11.3, GitHub Release.
+
+---
+
+## Success criteria
+
+- [ ] `src/api.ts` exports `getContext`, `sleep`, `outcomeForLastRecall` with the types defined in Task 2.
+- [ ] `cmdContext`, `cmdSleepCore`, `cmdOutcome` route through the new api.
+- [ ] CLI byte-identical stdout for `hippo context` (10 render snapshot tests green) and `hippo sleep` (existing smoke green).
+- [ ] `hippo outcome` emits one `audit_log` row per affected id (new test green); no existing test broken by the new rows.
+- [ ] Tenant scoping audit clean (zero `resolveTenantId({})` inside api.getContext or api.sleep body).
+- [ ] Full suite green, exit=0.
+- [ ] 5 new test files: api-context-sleep-contracts, api-outcome-for-last-recall, api-sleep, api-context, cli-context-render-snapshot.
+- [ ] CHANGELOG 1.11.3 entry present (including the audit-emission behavior-fix note).
+- [ ] Version 1.11.3 across all 6 manifests.
+- [ ] PR merged, npm published.
+
+---
+
+## Out of scope (Episodes B + C)
+
+- HTTP routes for /v1/outcome, /v1/context, /v1/sleep — Episode B (v1.11.4).
+- Python SDK — Episode C (pip hippo-memory 0.1.0).
+- `audit` HTTP route — Episode B candidate.
+- Refactoring other large cli.ts handlers (cmdRecall, cmdTrace) — separate episodes if needed.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.2",
+  "version": "1.11.3",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.11.2",
+      "version": "1.11.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,6 +28,7 @@ import {
   loadActiveTaskSnapshot,
   loadLatestHandoff,
   listSessionEvents,
+  loadIndex,
   type TaskSnapshot,
   type SessionEvent,
 } from './store.js';
@@ -1617,8 +1618,12 @@ export async function sleep(
  * Stub — real implementation lands in Task 3 of the Episode A plan.
  */
 export function outcomeForLastRecall(
-  _ctx: Context,
-  _good: boolean,
+  ctx: Context,
+  good: boolean,
 ): { applied: number; ids: string[] } {
-  throw new Error('outcomeForLastRecall() not yet implemented');
+  const idx = loadIndex(ctx.hippoRoot);
+  const ids = idx.last_retrieval_ids;
+  if (ids.length === 0) return { applied: 0, ids: [] };
+  const { applied } = outcome(ctx, ids, good);
+  return { applied, ids };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1904,9 +1904,18 @@ export interface SleepResult {
  * Run the pure-storage consolidation pipeline.
  *
  * Tenant scope note: sleep operates on the WHOLE hippoRoot (all tenants in
- * it), matching the pre-refactor cmdSleepCore behavior. This is correct for
- * a maintenance operation, but Episode B (HTTP /v1/sleep) may want to
- * reconsider per-tenant invocation policy.
+ * it), matching the pre-refactor cmdSleepCore behavior. Correct for a CLI
+ * maintenance op invoked by the operator. But once Episode B exposes this
+ * over HTTP `/v1/sleep`, the route MUST gate to a global-admin actor or
+ * scope dedup/audit/delete by ctx.tenantId — otherwise a tenant-A Bearer
+ * could dedupe and delete tenant-B's rows. See TODOS.md "Episode A
+ * follow-ups" for the Episode B preflight checklist.
+ *
+ * Audit emission gap: the consolidation phases (dedup, audit-delete) do
+ * NOT emit audit_log rows today, matching pre-refactor cmdSleepCore. Same
+ * CLI/MCP parity gap that T6 fixed for cmdOutcome, now visible at the api
+ * surface. Episode B should decide whether `/v1/sleep` writes a single
+ * 'consolidate' audit row per invocation or per-phase rows per deletion.
  */
 export async function sleep(
   ctx: Context,
@@ -2008,8 +2017,6 @@ export async function sleep(
  * Do NOT tighten `loadIndex` with `tenantId` inside this helper — doing so
  * would break the (correct) cross-tenant-silent-skip behavior covered by
  * the test in `tests/api-outcome-for-last-recall.test.ts`.
- *
- * Stub — real implementation lands in Task 3 of the Episode A plan.
  */
 export function outcomeForLastRecall(
   ctx: Context,

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,6 +29,7 @@ import {
   loadLatestHandoff,
   listSessionEvents,
   loadIndex,
+  loadAllEntries,
   type TaskSnapshot,
   type SessionEvent,
 } from './store.js';
@@ -43,10 +44,11 @@ import {
 import {
   appendAuditEvent,
   queryAuditEvents,
+  auditMemories,
   type AuditEvent,
   type AuditOp,
 } from './audit.js';
-import { promoteToGlobal, getGlobalRoot } from './shared.js';
+import { promoteToGlobal, getGlobalRoot, autoShare } from './shared.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
   createApiKey,
@@ -55,7 +57,10 @@ import {
   type ApiKeyListItem,
 } from './auth.js';
 import { applyGoalStackBoost } from './goals.js';
-import type { AmbientState } from './ambient.js';
+import { consolidate } from './consolidate.js';
+import { loadConfig } from './config.js';
+import { deduplicateStore } from './dedupe.js';
+import { computeAmbientState, type AmbientState } from './ambient.js';
 
 export interface Context {
   hippoRoot: string;
@@ -1554,18 +1559,24 @@ export async function getContext(
 }
 
 // ---------------------------------------------------------------------------
-// sleep (extracted from cmdSleepCore — Task 4 of the api.ts refactor)
+// sleep (extracted from cmdSleepCore Phase 2-6 — Task 4 of the api.ts refactor)
 // ---------------------------------------------------------------------------
 
 /**
- * Options for `sleep` — run the consolidation / audit / dedup / share
- * pipeline and return structured counts. Extracted from `cmdSleepCore` in
- * `cli.ts` in Episode A. The CLI `cmdSleep` wrapper continues to own the
- * log-file tee + console rendering + `process.exit`; `api.sleep` is pure.
+ * Options for `sleep` — run the pure-storage consolidation pipeline
+ * (consolidate + dedup + audit + share + ambient) and return structured counts.
+ *
+ * Extracted from `cmdSleepCore` Phase 2-6 in Episode A. NOT covered by api.sleep:
+ * the cli-only auto-learn phase (Phase 1: learnFromRepo + learnFromMemoryMd),
+ * which is intrinsically host-bound (uses `process.cwd()` / `os.homedir()`).
+ * Auto-learn stays in cli.ts cmdSleepCore as a pre-api block.
+ *
+ * The CLI `cmdSleep` wrapper continues to own the log-file tee + console
+ * rendering + `process.exit`; `api.sleep` is pure (no console.log, no IO
+ * beyond the store).
  */
 export interface SleepOpts {
   dryRun?: boolean;
-  noLearn?: boolean;
   noShare?: boolean;
 }
 
@@ -1575,7 +1586,6 @@ export interface SleepResult {
   mergedEpisodic: number;
   newSemantic: number;
   dryRun: boolean;
-  autoLearned?: { fromGit: number; fromMemoryMd: number };
   deduped?: {
     removed: number;
     semDups: number;
@@ -1589,13 +1599,95 @@ export interface SleepResult {
 }
 
 /**
- * Stub — real implementation lands in Task 4 of the Episode A plan.
+ * Run the pure-storage consolidation pipeline.
+ *
+ * Tenant scope note: sleep operates on the WHOLE hippoRoot (all tenants in
+ * it), matching the pre-refactor cmdSleepCore behavior. This is correct for
+ * a maintenance operation, but Episode B (HTTP /v1/sleep) may want to
+ * reconsider per-tenant invocation policy.
  */
 export async function sleep(
-  _ctx: Context,
-  _opts: SleepOpts = {},
+  ctx: Context,
+  opts: SleepOpts = {},
 ): Promise<SleepResult> {
-  throw new Error('sleep() not yet implemented');
+  const dryRun = Boolean(opts.dryRun);
+
+  // Phase 1: Consolidation.
+  const consolidateResult = await consolidate(ctx.hippoRoot, { dryRun });
+
+  const result: SleepResult = {
+    active: consolidateResult.decayed,
+    removed: consolidateResult.removed,
+    mergedEpisodic: consolidateResult.merged,
+    newSemantic: consolidateResult.semanticCreated,
+    dryRun,
+    details: consolidateResult.details,
+  };
+
+  if (dryRun) return result;
+
+  // Phase 2: Dedup (post-consolidate near-duplicate cleanup).
+  const dedupResult = deduplicateStore(ctx.hippoRoot);
+  if (dedupResult.removed > 0) {
+    const semDups = dedupResult.pairs.filter(
+      (p) => p.keptLayer === 'semantic' && p.removedLayer === 'semantic',
+    ).length;
+    const epiDups = dedupResult.pairs.filter(
+      (p) => p.keptLayer === 'episodic' && p.removedLayer === 'episodic',
+    ).length;
+    const crossDups = dedupResult.pairs.filter(
+      (p) => p.keptLayer !== p.removedLayer,
+    ).length;
+    result.deduped = {
+      removed: dedupResult.removed,
+      semDups,
+      epiDups,
+      crossDups,
+    };
+  }
+
+  // Phase 3: Quality audit (remove junk, report warnings).
+  const allEntries = loadAllEntries(ctx.hippoRoot);
+  const auditOut = auditMemories(allEntries);
+  if (auditOut.issues.length > 0) {
+    const errors = auditOut.issues.filter((i) => i.severity === 'error');
+    const warnings = auditOut.issues.filter((i) => i.severity === 'warning');
+    if (errors.length > 0) {
+      for (const issue of errors) {
+        deleteEntry(ctx.hippoRoot, issue.memoryId);
+      }
+    }
+    if (errors.length > 0 || warnings.length > 0) {
+      result.audit = {
+        errorsRemoved: errors.length,
+        warningCount: warnings.length,
+      };
+    }
+  }
+
+  // Phase 4: Auto-share high-transfer-score memories to global.
+  if (!opts.noShare) {
+    const sleepConfig = loadConfig(ctx.hippoRoot);
+    if (sleepConfig.autoShareOnSleep) {
+      const shared = autoShare(ctx.hippoRoot, { minScore: 0.6 });
+      if (shared.length > 0) {
+        result.shared = shared.length;
+      }
+    }
+  }
+
+  // Phase 5: Post-sleep ambient state summary.
+  const postSleepConfig = loadConfig(ctx.hippoRoot);
+  if (postSleepConfig.ambient.enabled) {
+    const postSleepEntries = loadAllEntries(ctx.hippoRoot).filter(
+      (e) => !e.superseded_by,
+    );
+    if (postSleepEntries.length > 0) {
+      result.ambient = computeAmbientState(postSleepEntries);
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,6 +54,7 @@ import {
   type ApiKeyListItem,
 } from './auth.js';
 import { applyGoalStackBoost } from './goals.js';
+import type { AmbientState } from './ambient.js';
 
 export interface Context {
   hippoRoot: string;
@@ -1492,4 +1493,132 @@ export function auditList(ctx: Context, opts: AuditListOpts): AuditEvent[] {
   } finally {
     closeHippoDb(db);
   }
+}
+
+// ---------------------------------------------------------------------------
+// getContext (extracted from cmdContext — Task 5 of the api.ts refactor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for `getContext` — assemble a budget-bounded context bundle
+ * (recalled memories + active task snapshot + handoff + recent events,
+ * rendered as markdown / json / additional-context). Extracted from
+ * `cmdContext` in `cli.ts` in Episode A of the api.ts refactor.
+ *
+ * Named `getContext` (not `context`) to avoid collision with the
+ * `Context` interface above and the ubiquitous `ctx: Context` convention.
+ * Follows the existing `getEntry` naming pattern in store.ts.
+ */
+export interface ContextOpts {
+  q?: string;
+  auto?: boolean;
+  /** Default 1500 tokens. */
+  budget?: number;
+  limit?: number;
+  pinnedOnly?: boolean;
+  framing?: 'observe' | 'suggest' | 'assert';
+  format?: 'markdown' | 'json' | 'additional-context';
+  scope?: string;
+  includeRecent?: number;
+}
+
+export interface ContextResultEntry {
+  entry: MemoryEntry;
+  score: number;
+  tokens: number;
+  isGlobal?: boolean;
+  isFreshTail?: boolean;
+}
+
+export interface ContextResult {
+  entries: ContextResultEntry[];
+  tokens: number;
+  format: 'markdown' | 'json' | 'additional-context';
+  activeSnapshot?: TaskSnapshot | null;
+  sessionHandoff?: SessionHandoff | null;
+  recentEvents?: SessionEvent[];
+  /** Rendered markdown / additional-context payload; absent for json. */
+  rendered?: string;
+}
+
+/**
+ * Stub — real implementation lands in Task 5 of the Episode A plan
+ * (`docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md`).
+ */
+export async function getContext(
+  _ctx: Context,
+  _opts: ContextOpts = {},
+): Promise<ContextResult> {
+  throw new Error('getContext() not yet implemented');
+}
+
+// ---------------------------------------------------------------------------
+// sleep (extracted from cmdSleepCore — Task 4 of the api.ts refactor)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for `sleep` — run the consolidation / audit / dedup / share
+ * pipeline and return structured counts. Extracted from `cmdSleepCore` in
+ * `cli.ts` in Episode A. The CLI `cmdSleep` wrapper continues to own the
+ * log-file tee + console rendering + `process.exit`; `api.sleep` is pure.
+ */
+export interface SleepOpts {
+  dryRun?: boolean;
+  noLearn?: boolean;
+  noShare?: boolean;
+}
+
+export interface SleepResult {
+  active: number;
+  removed: number;
+  mergedEpisodic: number;
+  newSemantic: number;
+  dryRun: boolean;
+  autoLearned?: { fromGit: number; fromMemoryMd: number };
+  deduped?: {
+    removed: number;
+    semDups: number;
+    epiDups: number;
+    crossDups: number;
+  };
+  audit?: { errorsRemoved: number; warningCount: number };
+  shared?: number;
+  ambient?: AmbientState | null;
+  details?: string[];
+}
+
+/**
+ * Stub — real implementation lands in Task 4 of the Episode A plan.
+ */
+export async function sleep(
+  _ctx: Context,
+  _opts: SleepOpts = {},
+): Promise<SleepResult> {
+  throw new Error('sleep() not yet implemented');
+}
+
+// ---------------------------------------------------------------------------
+// outcomeForLastRecall (last-recall wrapper around outcome — Task 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply an outcome to the ids most recently returned by `recall()`.
+ *
+ * Reads `loadIndex(ctx.hippoRoot).last_retrieval_ids` (per-hippoRoot local
+ * state; not tenant-scoped at the index layer) and forwards to `outcome()`,
+ * which DOES tenant-filter via `readEntry(..., ctx.tenantId)` — cross-tenant
+ * ids in `last_retrieval_ids` are silently skipped, matching the MCP
+ * `hippo_outcome` semantics.
+ *
+ * Do NOT tighten `loadIndex` with `tenantId` inside this helper — doing so
+ * would break the (correct) cross-tenant-silent-skip behavior covered by
+ * the test in `tests/api-outcome-for-last-recall.test.ts`.
+ *
+ * Stub — real implementation lands in Task 3 of the Episode A plan.
+ */
+export function outcomeForLastRecall(
+  _ctx: Context,
+  _good: boolean,
+): { applied: number; ids: string[] } {
+  throw new Error('outcomeForLastRecall() not yet implemented');
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,7 +29,10 @@ import {
   loadLatestHandoff,
   listSessionEvents,
   loadIndex,
+  saveIndex,
   loadAllEntries,
+  updateStats,
+  isInitialized,
   type TaskSnapshot,
   type SessionEvent,
 } from './store.js';
@@ -37,6 +40,7 @@ import type { SessionHandoff } from './handoff.js';
 import {
   createMemory,
   applyOutcome,
+  calculateStrength,
   type MemoryKind,
   type MemoryEntry,
   Layer,
@@ -48,7 +52,7 @@ import {
   type AuditEvent,
   type AuditOp,
 } from './audit.js';
-import { promoteToGlobal, getGlobalRoot, autoShare } from './shared.js';
+import { promoteToGlobal, getGlobalRoot, autoShare, searchBothHybrid } from './shared.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
   createApiKey,
@@ -57,6 +61,8 @@ import {
   type ApiKeyListItem,
 } from './auth.js';
 import { applyGoalStackBoost } from './goals.js';
+import { markRetrieved, estimateTokens, hybridSearch, physicsSearch } from './search.js';
+import { scopeMatch } from './scope.js';
 import { consolidate } from './consolidate.js';
 import { loadConfig } from './config.js';
 import { deduplicateStore } from './dedupe.js';
@@ -1507,23 +1513,27 @@ export function auditList(ctx: Context, opts: AuditListOpts): AuditEvent[] {
 
 /**
  * Options for `getContext` — assemble a budget-bounded context bundle
- * (recalled memories + active task snapshot + handoff + recent events,
- * rendered as markdown / json / additional-context). Extracted from
- * `cmdContext` in `cli.ts` in Episode A of the api.ts refactor.
+ * (recalled memories + active task snapshot + handoff + recent events).
+ * Extracted from `cmdContext` in `cli.ts` in Episode A of the api.ts refactor.
  *
- * Named `getContext` (not `context`) to avoid collision with the
- * `Context` interface above and the ubiquitous `ctx: Context` convention.
- * Follows the existing `getEntry` naming pattern in store.ts.
+ * Named `getContext` (not `context`) to avoid collision with the `Context`
+ * interface above and the ubiquitous `ctx: Context` convention. Follows the
+ * existing `getEntry` naming pattern in store.ts.
+ *
+ * Scope narrow (T5 execute decision): rendering opts (`format`, `framing`,
+ * `rendered`) and host-side opts (`auto`) are NOT included here. The print
+ * helpers (`printContextMarkdown`, `printActiveTaskSnapshot`, `printHandoff`,
+ * `printSessionEvents`) are shared with `cmdRecall` / `cmdSnapshot` /
+ * `cmdHandoffShow` — moving them into api.ts would expand T5 to also rewire
+ * those commands. CLI handles rendering + auto-resolution. Episode B can add
+ * `api.renderContext` once a shared rendering need actually materializes.
  */
 export interface ContextOpts {
   q?: string;
-  auto?: boolean;
   /** Default 1500 tokens. */
   budget?: number;
   limit?: number;
   pinnedOnly?: boolean;
-  framing?: 'observe' | 'suggest' | 'assert';
-  format?: 'markdown' | 'json' | 'additional-context';
   scope?: string;
   includeRecent?: number;
 }
@@ -1539,23 +1549,315 @@ export interface ContextResultEntry {
 export interface ContextResult {
   entries: ContextResultEntry[];
   tokens: number;
-  format: 'markdown' | 'json' | 'additional-context';
   activeSnapshot?: TaskSnapshot | null;
   sessionHandoff?: SessionHandoff | null;
   recentEvents?: SessionEvent[];
-  /** Rendered markdown / additional-context payload; absent for json. */
-  rendered?: string;
 }
 
 /**
- * Stub — real implementation lands in Task 5 of the Episode A plan
- * (`docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md`).
+ * Assemble a context bundle: recalled memories (pinned-only / strength-sorted
+ * fallback / hybrid search) + active task snapshot + session handoff + recent
+ * session events. Budget-bounded, tenant-scoped. Mutates `last_retrieval_ids`
+ * + emits a 'recall' audit row for non-pinned, non-'*' queries.
+ *
+ * Behaves like the pre-extraction `cmdContext` data-loading + selection
+ * pipeline. CLI presentation (markdown / json / additional-context rendering)
+ * stays in `cli.ts`.
+ *
+ * Tenant scope: all `loadAllEntries` / snapshot / handoff / events reads use
+ * `ctx.tenantId`. Cross-tenant rows are filtered out.
+ *
+ * Returns an empty result (`entries: []`, snapshot/handoff/events undefined)
+ * when there's nothing to surface (no memories AND no snapshot AND no handoff
+ * AND no recent events).
  */
 export async function getContext(
-  _ctx: Context,
-  _opts: ContextOpts = {},
+  ctx: Context,
+  opts: ContextOpts = {},
 ): Promise<ContextResult> {
-  throw new Error('getContext() not yet implemented');
+  const pinnedOnly = opts.pinnedOnly === true;
+  const budget = opts.budget ?? 1500;
+  const limit = opts.limit ?? Number.POSITIVE_INFINITY;
+  const includeRecent = opts.includeRecent ?? 0;
+  const activeScope = opts.scope ?? '';
+
+  if (budget <= 0) {
+    return { entries: [], tokens: 0 };
+  }
+
+  // Pinned-only path is allowed against an un-initialised local store (the
+  // UserPromptSubmit hook can run in directories without a .hippo). Non-pinned
+  // path requires an initialised local store; callers should check first.
+  const hasLocal = isInitialized(ctx.hippoRoot);
+
+  const query = (opts.q ?? '').trim() || '*';
+
+  const globalRoot = getGlobalRoot();
+  const hasGlobal = isInitialized(globalRoot);
+
+  // Tenant-scoped loads (v1.11.1 lesson: NEVER resolveTenantId({}) here).
+  let localEntries = hasLocal ? loadAllEntries(ctx.hippoRoot, ctx.tenantId) : [];
+  let globalEntries = hasGlobal ? loadAllEntries(globalRoot, ctx.tenantId) : [];
+
+  // Filter superseded — context never includes superseded rows.
+  localEntries = localEntries.filter((e) => !e.superseded_by);
+  globalEntries = globalEntries.filter((e) => !e.superseded_by);
+
+  const activeSnapshot = hasLocal
+    ? loadActiveTaskSnapshot(ctx.hippoRoot, ctx.tenantId)
+    : null;
+  const sessionHandoff = hasLocal && activeSnapshot?.session_id
+    ? loadLatestHandoff(ctx.hippoRoot, ctx.tenantId, activeSnapshot.session_id)
+    : null;
+  const recentSessionEvents = hasLocal && activeSnapshot?.session_id
+    ? listSessionEvents(ctx.hippoRoot, ctx.tenantId, {
+        session_id: activeSnapshot.session_id,
+        limit: 5,
+      })
+    : [];
+
+  if (
+    localEntries.length === 0 &&
+    globalEntries.length === 0 &&
+    !activeSnapshot &&
+    !sessionHandoff &&
+    recentSessionEvents.length === 0
+  ) {
+    return { entries: [], tokens: 0 };
+  }
+
+  let selectedItems: ContextResultEntry[] = [];
+  let totalTokens = 0;
+
+  if (pinnedOnly) {
+    // loadConfig is safe even when local isn't initialised — returns defaults.
+    const pinnedCfg = loadConfig(ctx.hippoRoot);
+    if (!pinnedCfg.pinnedInject.enabled) {
+      return { entries: [], tokens: 0 };
+    }
+    // Effective budget: explicit opts.budget wins over config.
+    const effBudget = opts.budget !== undefined ? budget : pinnedCfg.pinnedInject.budget;
+    const nowP = new Date();
+    const selectedIds = new Set<string>();
+    let usedP = 0;
+
+    if (includeRecent > 0) {
+      const recent = [
+        ...localEntries.map((entry) => ({ entry, isGlobal: false })),
+        ...globalEntries.map((entry) => ({ entry, isGlobal: true })),
+      ]
+        .sort((a, b) => {
+          const byCreated = Date.parse(b.entry.created) - Date.parse(a.entry.created);
+          return byCreated !== 0 ? byCreated : b.entry.id.localeCompare(a.entry.id);
+        })
+        .slice(0, includeRecent)
+        .map(({ entry, isGlobal }) => ({
+          entry,
+          score: calculateStrength(entry, nowP) * (isGlobal ? 1 / 1.2 : 1),
+          tokens: estimateTokens(entry.content),
+          isGlobal,
+        }));
+
+      for (const r of recent) {
+        if (selectedIds.has(r.entry.id)) continue;
+        if (usedP + r.tokens > effBudget) continue;
+        selectedItems.push(r);
+        selectedIds.add(r.entry.id);
+        usedP += r.tokens;
+      }
+    }
+
+    const pinnedLocal = localEntries.filter((e) => e.pinned);
+    const pinnedGlobal = globalEntries.filter((e) => e.pinned);
+    if (
+      pinnedLocal.length === 0 &&
+      pinnedGlobal.length === 0 &&
+      selectedItems.length === 0
+    ) {
+      return { entries: [], tokens: 0 };
+    }
+    const rankedPinned = [
+      ...pinnedLocal.map((e) => ({ entry: e, isGlobal: false })),
+      ...pinnedGlobal.map((e) => ({ entry: e, isGlobal: true })),
+    ]
+      .map(({ entry, isGlobal }) => {
+        const scopeSig = scopeMatch(entry.tags, activeScope);
+        const sBst = scopeSig === 1 ? 1.5 : scopeSig === -1 ? 0.5 : 1.0;
+        return {
+          entry,
+          score: calculateStrength(entry, nowP) * (isGlobal ? 1 / 1.2 : 1) * sBst,
+          tokens: estimateTokens(entry.content),
+          isGlobal,
+        };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    for (const r of rankedPinned) {
+      if (selectedIds.has(r.entry.id)) continue;
+      if (usedP + r.tokens > effBudget) continue;
+      selectedItems.push(r);
+      selectedIds.add(r.entry.id);
+      usedP += r.tokens;
+    }
+    totalTokens = usedP;
+  } else if (query === '*') {
+    // No query: return strongest memories by strength, up to budget.
+    const now = new Date();
+    const localRanked = localEntries
+      .map((e) => ({
+        entry: e,
+        score: calculateStrength(e, now),
+        tokens: estimateTokens(e.content),
+        isGlobal: false,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const globalRanked = globalEntries
+      .map((e) => ({
+        entry: e,
+        score: calculateStrength(e, now) * (1 / 1.2),
+        tokens: estimateTokens(e.content),
+        isGlobal: true,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const combined = [...localRanked, ...globalRanked].sort((a, b) => b.score - a.score);
+
+    let used = 0;
+    for (const r of combined) {
+      if (used + r.tokens > budget) continue;
+      selectedItems.push(r);
+      used += r.tokens;
+    }
+    totalTokens = used;
+  } else {
+    // Real query: hybrid search (global + local) or physics+hybrid (local only).
+    let results: ContextResultEntry[];
+    if (hasGlobal) {
+      const merged = await searchBothHybrid(query, ctx.hippoRoot, globalRoot, {
+        budget,
+        scope: activeScope,
+        tenantId: ctx.tenantId,
+      });
+      const localIndex = loadIndex(ctx.hippoRoot);
+      results = merged.map((r) => ({
+        entry: r.entry,
+        score: r.score,
+        tokens: r.tokens,
+        isGlobal: !localIndex.entries[r.entry.id],
+      }));
+    } else {
+      const ctxConfig = loadConfig(ctx.hippoRoot);
+      const usePhysicsCtx = ctxConfig.physics?.enabled !== false;
+      const ctxResults = usePhysicsCtx
+        ? await physicsSearch(query, localEntries, {
+            budget,
+            hippoRoot: ctx.hippoRoot,
+            physicsConfig: ctxConfig.physics,
+            scope: activeScope,
+          })
+        : await hybridSearch(query, localEntries, {
+            budget,
+            hippoRoot: ctx.hippoRoot,
+            scope: activeScope,
+          });
+      results = ctxResults.map((r) => ({
+        entry: r.entry,
+        score: r.score,
+        tokens: r.tokens,
+        isGlobal: false,
+      }));
+    }
+
+    selectedItems = results;
+    totalTokens = results.reduce((sum, r) => sum + r.tokens, 0);
+
+    // A5 H4: emit recall audit row for context-mode searches (matches the
+    // 'recall' op emitted by api.recall for parity). pinnedOnly + '*' fallback
+    // never hit the search engines, so they don't emit (matches cmdContext).
+    const ctxRecallMetadata = {
+      query: query.slice(0, 200),
+      results: selectedItems.length,
+      mode: 'context',
+    };
+    if (hasLocal) {
+      const localDb = openHippoDb(ctx.hippoRoot);
+      try {
+        appendAuditEvent(localDb, {
+          tenantId: ctx.tenantId,
+          actor: ctx.actor,
+          op: 'recall',
+          metadata: ctxRecallMetadata,
+        });
+      } finally {
+        closeHippoDb(localDb);
+      }
+    }
+    if (hasGlobal) {
+      const globalDb = openHippoDb(globalRoot);
+      try {
+        appendAuditEvent(globalDb, {
+          tenantId: ctx.tenantId,
+          actor: ctx.actor,
+          op: 'recall',
+          metadata: ctxRecallMetadata,
+        });
+      } finally {
+        closeHippoDb(globalDb);
+      }
+    }
+  }
+
+  if (limit < selectedItems.length) {
+    selectedItems = selectedItems.slice(0, limit);
+    totalTokens = selectedItems.reduce((sum, r) => sum + r.tokens, 0);
+  }
+
+  if (
+    selectedItems.length === 0 &&
+    !activeSnapshot &&
+    !sessionHandoff &&
+    recentSessionEvents.length === 0
+  ) {
+    return { entries: [], tokens: 0 };
+  }
+
+  // pinnedOnly is the UserPromptSubmit hot path — read-only so pinned
+  // memories don't inflate retrieval_count or extend half_life by 2 days per
+  // turn over a long session.
+  if (!pinnedOnly) {
+    const toUpdate = selectedItems.map((s) => s.entry);
+    const updatedEntries = markRetrieved(toUpdate);
+    const localIndex = loadIndex(ctx.hippoRoot);
+
+    for (const u of updatedEntries) {
+      const targetRoot = localIndex.entries[u.id]
+        ? ctx.hippoRoot
+        : hasGlobal
+          ? globalRoot
+          : ctx.hippoRoot;
+      writeEntry(targetRoot, u);
+    }
+
+    localIndex.last_retrieval_ids = updatedEntries.map((u) => u.id);
+    saveIndex(ctx.hippoRoot, localIndex);
+    updateStats(ctx.hippoRoot, { recalled: selectedItems.length });
+
+    // Replace selectedItems entries with markRetrieved-updated copies so
+    // the returned ContextResult reflects post-recall state.
+    selectedItems = selectedItems.map((s) => ({
+      ...s,
+      entry: updatedEntries.find((u) => u.id === s.entry.id) ?? s.entry,
+    }));
+  }
+
+  return {
+    entries: selectedItems,
+    tokens: totalTokens,
+    activeSnapshot: activeSnapshot ?? undefined,
+    sessionHandoff: sessionHandoff ?? undefined,
+    recentEvents: recentSessionEvents.length > 0 ? recentSessionEvents : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ import type { SessionHandoff } from './handoff.js';
 import { search, markRetrieved, estimateTokens, hybridSearch, physicsSearch, explainMatch, textOverlap } from './search.js';
 import { renderTraceContent, parseSteps } from './trace.js';
 import { consolidate } from './consolidate.js';
+import { deduplicateStore } from './dedupe.js';
 import {
   isEmbeddingAvailable,
   embedAll,
@@ -2020,73 +2021,6 @@ function learnFromMemoryMd(hippoRoot: string): number {
   return imported;
 }
 
-/**
- * Scan the store for near-duplicate memories and remove the weaker copy.
- * Two memories are duplicates if their content has > threshold Jaccard overlap.
- * Keeps the one with higher strength (or more retrievals if tied).
- */
-interface DedupPair {
-  kept: string;
-  keptContent: string;
-  keptLayer: string;
-  keptStrength: number;
-  removed: string;
-  removedContent: string;
-  removedLayer: string;
-  removedStrength: number;
-  similarity: number;
-}
-
-function deduplicateStore(
-  hippoRoot: string,
-  options: { threshold?: number; dryRun?: boolean } = {}
-): { removed: number; pairs: DedupPair[] } {
-  const threshold = options.threshold ?? 0.7;
-  const dryRun = options.dryRun ?? false;
-  const entries = loadAllEntries(hippoRoot);
-
-  // Sort by strength desc, then retrieval count, so we keep the most valuable copy
-  entries.sort((a, b) => {
-    const sDiff = (b.strength ?? 0) - (a.strength ?? 0);
-    if (Math.abs(sDiff) > 0.01) return sDiff;
-    return (b.retrieval_count ?? 0) - (a.retrieval_count ?? 0);
-  });
-
-  const removed = new Set<string>();
-  const pairs: DedupPair[] = [];
-
-  for (let i = 0; i < entries.length; i++) {
-    if (removed.has(entries[i].id)) continue;
-    for (let j = i + 1; j < entries.length; j++) {
-      if (removed.has(entries[j].id)) continue;
-
-      const similarity = textOverlap(entries[i].content, entries[j].content);
-      if (similarity <= threshold) continue;
-
-      removed.add(entries[j].id);
-      pairs.push({
-        kept: entries[i].id,
-        keptContent: entries[i].content,
-        keptLayer: entries[i].layer,
-        keptStrength: entries[i].strength ?? 0,
-        removed: entries[j].id,
-        removedContent: entries[j].content,
-        removedLayer: entries[j].layer,
-        removedStrength: entries[j].strength ?? 0,
-        similarity,
-      });
-    }
-  }
-
-  if (!dryRun) {
-    for (const id of removed) {
-      deleteEntry(hippoRoot, id);
-    }
-  }
-
-  return { removed: removed.size, pairs };
-}
-
 function cmdDedup(
   hippoRoot: string,
   flags: Record<string, string | boolean | string[]>
@@ -2190,13 +2124,63 @@ async function cmdSleep(
   }
 }
 
+/**
+ * Render an api.sleep result as console output, byte-identical to the
+ * pre-extraction inline implementation in cmdSleepCore.
+ */
+function renderSleepResult(result: api.SleepResult): void {
+  console.log(`Running consolidation${result.dryRun ? ' (dry run)' : ''}...`);
+
+  console.log(`\nResults:`);
+  console.log(`   Active memories:  ${result.active}`);
+  console.log(`   Removed (decayed): ${result.removed}`);
+  console.log(`   Merged episodic:   ${result.mergedEpisodic}`);
+  console.log(`   New semantic:      ${result.newSemantic}`);
+
+  if (result.details && result.details.length > 0) {
+    console.log('\nDetails:');
+    for (const d of result.details) {
+      console.log(d);
+    }
+  }
+
+  if (result.dryRun) console.log('\n(dry run  - nothing written)');
+
+  if (result.deduped && result.deduped.removed > 0) {
+    const { removed, semDups, epiDups, crossDups } = result.deduped;
+    const parts: string[] = [];
+    if (semDups > 0) parts.push(`${semDups} redundant semantic patterns`);
+    if (epiDups > 0) parts.push(`${epiDups} duplicate episodic lessons`);
+    if (crossDups > 0) parts.push(`${crossDups} cross-layer duplicates`);
+    console.log(`\nDeduped ${removed} duplicates (${parts.join(', ')}). Kept stronger copies.`);
+  }
+
+  if (result.audit) {
+    if (result.audit.errorsRemoved > 0) {
+      console.log(`\nAudit: removed ${result.audit.errorsRemoved} junk memories (too short/empty).`);
+    }
+    if (result.audit.warningCount > 0) {
+      console.log(`Audit: ${result.audit.warningCount} low-quality memories detected (run \`hippo audit\` for details).`);
+    }
+  }
+
+  if (result.shared !== undefined && result.shared > 0) {
+    console.log(`\nAuto-shared ${result.shared} high-value memories to global store.`);
+  }
+
+  if (result.ambient) {
+    console.log(`\n${renderAmbientSummary(result.ambient)}`);
+  }
+}
+
 async function cmdSleepCore(
   hippoRoot: string,
   flags: Record<string, string | boolean | string[]>
 ): Promise<void> {
   requireInit(hippoRoot);
 
-  // Auto-learn from git before consolidating (unless --no-learn)
+  // Phase 1: Auto-learn from git + MEMORY.md (CLI-only, uses process.cwd() / os.homedir()).
+  // Stays in cli.ts; api.sleep covers Phase 2-6 only.
   if (!flags['no-learn']) {
     const config = loadConfig(hippoRoot);
     if (config.autoLearnOnSleep && isGitRepo(process.cwd())) {
@@ -2209,82 +2193,17 @@ async function cmdSleepCore(
     if (memImported > 0) console.log(`Imported ${memImported} memories from Claude Code MEMORY.md files.`);
   }
 
-  const dryRun = Boolean(flags['dry-run']);
-  console.log(`Running consolidation${dryRun ? ' (dry run)' : ''}...`);
-
-  const result = await consolidate(hippoRoot, { dryRun });
-
-  console.log(`\nResults:`);
-  console.log(`   Active memories:  ${result.decayed}`);
-  console.log(`   Removed (decayed): ${result.removed}`);
-  console.log(`   Merged episodic:   ${result.merged}`);
-  console.log(`   New semantic:      ${result.semanticCreated}`);
-
-  if (result.details.length > 0) {
-    console.log('\nDetails:');
-    for (const d of result.details) {
-      console.log(d);
-    }
-  }
-
-  if (dryRun) console.log('\n(dry run  - nothing written)');
-
-  // Auto-dedup after consolidation (unless dry-run)
-  if (!dryRun) {
-    const dedupResult = deduplicateStore(hippoRoot);
-    if (dedupResult.removed > 0) {
-      const semDups = dedupResult.pairs.filter(p => p.keptLayer === 'semantic' && p.removedLayer === 'semantic').length;
-      const epiDups = dedupResult.pairs.filter(p => p.keptLayer === 'episodic' && p.removedLayer === 'episodic').length;
-      const crossDups = dedupResult.pairs.filter(p => p.keptLayer !== p.removedLayer).length;
-      const parts: string[] = [];
-      if (semDups > 0) parts.push(`${semDups} redundant semantic patterns`);
-      if (epiDups > 0) parts.push(`${epiDups} duplicate episodic lessons`);
-      if (crossDups > 0) parts.push(`${crossDups} cross-layer duplicates`);
-      console.log(`\nDeduped ${dedupResult.removed} duplicates (${parts.join(', ')}). Kept stronger copies.`);
-    }
-  }
-
-  // Quality audit — remove junk, report warnings
-  if (!dryRun) {
-    const allEntries = loadAllEntries(hippoRoot);
-    const audit = auditMemories(allEntries);
-    if (audit.issues.length > 0) {
-      const errors = audit.issues.filter(i => i.severity === 'error');
-      const warnings = audit.issues.filter(i => i.severity === 'warning');
-      if (errors.length > 0) {
-        for (const issue of errors) {
-          deleteEntry(hippoRoot, issue.memoryId);
-        }
-        console.log(`\nAudit: removed ${errors.length} junk memories (too short/empty).`);
-      }
-      if (warnings.length > 0) {
-        console.log(`Audit: ${warnings.length} low-quality memories detected (run \`hippo audit\` for details).`);
-      }
-    }
-  }
-
-  // Auto-share high-transfer-score memories to global (unless --no-share or dry-run)
-  if (!dryRun && !flags['no-share']) {
-    const sleepConfig = loadConfig(hippoRoot);
-    if (sleepConfig.autoShareOnSleep) {
-      const shared = autoShare(hippoRoot, { minScore: 0.6 });
-      if (shared.length > 0) {
-        console.log(`\nAuto-shared ${shared.length} high-value memories to global store.`);
-      }
-    }
-  }
-
-  // Post-sleep ambient state summary
-  if (!dryRun) {
-    const postSleepConfig = loadConfig(hippoRoot);
-    if (postSleepConfig.ambient.enabled) {
-      const postSleepEntries = loadAllEntries(hippoRoot).filter(e => !e.superseded_by);
-      if (postSleepEntries.length > 0) {
-        const ambientState = computeAmbientState(postSleepEntries);
-        console.log(`\n${renderAmbientSummary(ambientState)}`);
-      }
-    }
-  }
+  // Phase 2-6: Pure-storage pipeline (consolidate + dedup + audit + share + ambient).
+  const ctx: api.Context = {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
+  const result = await api.sleep(ctx, {
+    dryRun: Boolean(flags['dry-run']),
+    noShare: Boolean(flags['no-share']),
+  });
+  renderSleepResult(result);
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2616,23 +2616,28 @@ function cmdOutcome(
     process.exit(1);
   }
 
+  // Behavior fix (v1.11.3): cmdOutcome used to bypass api.outcome and do its
+  // own readEntry/writeEntry inline, which silently skipped the audit_log
+  // emission that the MCP outcome path already has via api.outcome. T6
+  // rewires through api.outcome so every successful CLI 'outcome' call now
+  // writes one audit_log row per affected id, matching MCP parity.
+  const ctx: api.Context = {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
   const specificId = flags['id'] ? String(flags['id']) : null;
-  const index = loadIndex(hippoRoot);
 
-  const ids = specificId ? [specificId] : index.last_retrieval_ids;
-
-  if (ids.length === 0) {
-    console.log('No recent recall to apply outcome to. Use --id <id> to target a specific memory.');
-    return;
-  }
-
-  let updated = 0;
-  for (const id of ids) {
-    const entry = readEntry(hippoRoot, id, resolveTenantId({}));
-    if (!entry) continue;
-    const upd = applyOutcome(entry, good);
-    writeEntry(hippoRoot, upd);
-    updated++;
+  let updated: number;
+  if (specificId) {
+    updated = api.outcome(ctx, [specificId], good).applied;
+  } else {
+    const r = api.outcomeForLastRecall(ctx, good);
+    if (r.ids.length === 0) {
+      console.log('No recent recall to apply outcome to. Use --id <id> to target a specific memory.');
+      return;
+    }
+    updated = r.applied;
   }
 
   console.log(`Applied ${good ? 'positive' : 'negative'} outcome to ${updated} memor${updated === 1 ? 'y' : 'ies'}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3267,238 +3267,67 @@ async function cmdContext(
 ): Promise<void> {
   // --pinned-only fires on every UserPromptSubmit — including in directories
   // that don't have a local .hippo. Skip requireInit for that path and fall
-  // back to global-only below. The non-pinned path still requires init.
+  // back to global-only inside api.getContext. The non-pinned path still
+  // requires init (handled by CLI for user-friendly error messaging).
   const pinnedOnly = flags['pinned-only'] === true;
-  const hasLocal = isInitialized(hippoRoot);
   if (!pinnedOnly) {
     requireInit(hippoRoot);
   }
 
   const budget = parseInt(String(flags['budget'] ?? '1500'), 10);
-  const limit = parseLimitFlag(flags['limit']);
-  const includeRecent = parseCountFlag(flags['include-recent']);
-  const ctxExplicitScope = flags['scope'] !== undefined ? String(flags['scope']).trim() : null;
-  const ctxActiveScope = ctxExplicitScope || detectScope();
-
-  // If budget is 0, skip entirely (zero token cost)
   if (budget <= 0) return;
 
-  // Determine query: explicit args, --auto (git diff), or fallback
+  // Resolve query: explicit args, --auto (git diff via CLI-side helper), or
+  // fall through to api.getContext's '*' fallback. api.getContext is host-
+  // agnostic so the auto-detect (which shells out to git) stays CLI-side.
   let query = args.join(' ').trim();
-
   if (!query && flags['auto']) {
     query = autoDetectContext();
   }
 
-  if (!query) {
-    // Fallback: return strongest memories regardless of query
-    query = '*';
-  }
+  // Scope detection (CLI-side: uses cwd). api.getContext takes the resolved
+  // scope via opts.scope to stay host-agnostic.
+  const ctxExplicitScope = flags['scope'] !== undefined ? String(flags['scope']).trim() : null;
+  const ctxActiveScope = ctxExplicitScope || detectScope();
 
-  const globalRoot = getGlobalRoot();
-  const hasGlobal = isInitialized(globalRoot);
-  // A5: scope context-mode loads to the active tenant. Without this, every
-  // tenant's memories surface through the smart-context injection path.
-  const tenantId = resolveTenantId({});
-  // When the local store isn't initialized (pinned-only path in a fresh dir),
-  // skip the local load — loadAllEntries would auto-create .hippo here and
-  // we don't want to pollute arbitrary cwds.
-  let localEntries = hasLocal ? loadAllEntries(hippoRoot, tenantId) : [];
-  let globalEntries = hasGlobal ? loadAllEntries(globalRoot, tenantId) : [];
+  const ctx: api.Context = {
+    hippoRoot,
+    tenantId: resolveTenantId({}),
+    actor: 'cli',
+  };
+  const opts: api.ContextOpts = {
+    q: query,
+    budget,
+    limit: parseLimitFlag(flags['limit']),
+    pinnedOnly,
+    scope: ctxActiveScope ?? undefined,
+    includeRecent: parseCountFlag(flags['include-recent']),
+  };
 
-  // Default context always filters superseded (no --include-superseded / --as-of for context)
-  localEntries = localEntries.filter(e => !e.superseded_by);
-  globalEntries = globalEntries.filter(e => !e.superseded_by);
+  const result = await api.getContext(ctx, opts);
 
-  let selectedItems: Array<{ entry: MemoryEntry; score: number; tokens: number; isGlobal?: boolean }> = [];
-  let totalTokens = 0;
-  // Task snapshots / session events live in the local store. Skip when
-  // local isn't initialized — loading would auto-create .hippo in the cwd.
-  const activeSnapshot = hasLocal ? loadActiveTaskSnapshot(hippoRoot, resolveTenantId({})) : null;
-  const sessionHandoff = hasLocal && activeSnapshot?.session_id
-    ? loadLatestHandoff(hippoRoot, resolveTenantId({}), activeSnapshot.session_id)
-    : null;
-  const recentSessionEvents = hasLocal && activeSnapshot?.session_id
-    ? listSessionEvents(hippoRoot, resolveTenantId({}), { session_id: activeSnapshot.session_id, limit: 5 })
-    : [];
+  // Early exit when there's nothing to render (matches pre-extraction behavior).
+  const hasContextData =
+    result.entries.length > 0 ||
+    result.activeSnapshot ||
+    result.sessionHandoff ||
+    (result.recentEvents && result.recentEvents.length > 0);
+  if (!hasContextData) return;
 
-  if (localEntries.length === 0 && globalEntries.length === 0 && !activeSnapshot && !sessionHandoff && recentSessionEvents.length === 0) {
-    return;
-  }
-
-  // --pinned-only: restrict to pinned entries only. Used by the Claude Code
-  // UserPromptSubmit hook so invariants stay in context every turn.
-  // (pinnedOnly and hasLocal are declared at the top of this function.)
-  if (pinnedOnly) {
-    // loadConfig is safe even when local isn't initialized — it returns defaults.
-    const pinnedCfg = loadConfig(hippoRoot);
-    if (!pinnedCfg.pinnedInject.enabled) return; // user disabled via config
-    // Effective budget: explicit --budget wins over config.
-    const effBudget = flags['budget'] !== undefined ? budget : pinnedCfg.pinnedInject.budget;
-    const nowP = new Date();
-    const selectedIds = new Set<string>();
-    let usedP = 0;
-
-    if (includeRecent > 0) {
-      const recent = [
-        ...localEntries.map((entry) => ({ entry, isGlobal: false })),
-        ...globalEntries.map((entry) => ({ entry, isGlobal: true })),
-      ]
-        .sort((a, b) => {
-          const byCreated = Date.parse(b.entry.created) - Date.parse(a.entry.created);
-          return byCreated !== 0 ? byCreated : b.entry.id.localeCompare(a.entry.id);
-        })
-        .slice(0, includeRecent)
-        .map(({ entry, isGlobal }) => ({
-          entry,
-          score: calculateStrength(entry, nowP) * (isGlobal ? 1 / 1.2 : 1),
-          tokens: estimateTokens(entry.content),
-          isGlobal,
-        }));
-
-      for (const r of recent) {
-        if (selectedIds.has(r.entry.id)) continue;
-        if (usedP + r.tokens > effBudget) continue;
-        selectedItems.push(r);
-        selectedIds.add(r.entry.id);
-        usedP += r.tokens;
-      }
-    }
-
-    const pinnedLocal = localEntries.filter((e) => e.pinned);
-    const pinnedGlobal = globalEntries.filter((e) => e.pinned);
-    if (pinnedLocal.length === 0 && pinnedGlobal.length === 0 && selectedItems.length === 0) return; // zero output
-    const rankedPinned = [
-      ...pinnedLocal.map((e) => ({ entry: e, isGlobal: false })),
-      ...pinnedGlobal.map((e) => ({ entry: e, isGlobal: true })),
-    ]
-      .map(({ entry, isGlobal }) => {
-        const scopeSig = scopeMatch(entry.tags, ctxActiveScope);
-        const sBst = scopeSig === 1 ? 1.5 : scopeSig === -1 ? 0.5 : 1.0;
-        return {
-          entry,
-          score: calculateStrength(entry, nowP) * (isGlobal ? 1 / 1.2 : 1) * sBst,
-          tokens: estimateTokens(entry.content),
-          isGlobal,
-        };
-      })
-      .sort((a, b) => b.score - a.score);
-
-    for (const r of rankedPinned) {
-      if (selectedIds.has(r.entry.id)) continue;
-      if (usedP + r.tokens > effBudget) continue;
-      selectedItems.push(r);
-      selectedIds.add(r.entry.id);
-      usedP += r.tokens;
-    }
-    totalTokens = usedP;
-  } else if (query === '*') {
-    // No query: return strongest memories by strength, up to budget
-    const now = new Date();
-    const localRanked = localEntries
-      .map((e) => ({
-        entry: e,
-        score: calculateStrength(e, now),
-        tokens: estimateTokens(e.content),
-        isGlobal: false,
-      }))
-      .sort((a, b) => b.score - a.score);
-
-    const globalRanked = globalEntries
-      .map((e) => ({
-        entry: e,
-        score: calculateStrength(e, now) * (1 / 1.2), // global slightly lower
-        tokens: estimateTokens(e.content),
-        isGlobal: true,
-      }))
-      .sort((a, b) => b.score - a.score);
-
-    const combined = [...localRanked, ...globalRanked].sort((a, b) => b.score - a.score);
-
-    let used = 0;
-    for (const r of combined) {
-      if (used + r.tokens > budget) continue;
-      selectedItems.push(r);
-      used += r.tokens;
-    }
-    totalTokens = used;
-  } else {
-    let results;
-    if (hasGlobal) {
-      const merged = await searchBothHybrid(query, hippoRoot, globalRoot, { budget, scope: ctxActiveScope, tenantId });
-      const localIndex = loadIndex(hippoRoot);
-      results = merged.map((r) => ({
-        entry: r.entry,
-        score: r.score,
-        tokens: r.tokens,
-        isGlobal: !localIndex.entries[r.entry.id],
-      }));
-    } else {
-      const ctxConfig = loadConfig(hippoRoot);
-      const usePhysicsCtx = ctxConfig.physics?.enabled !== false;
-      const ctxResults = usePhysicsCtx
-        ? await physicsSearch(query, localEntries, { budget, hippoRoot, physicsConfig: ctxConfig.physics, scope: ctxActiveScope })
-        : await hybridSearch(query, localEntries, { budget, hippoRoot, scope: ctxActiveScope });
-      results = ctxResults.map((r) => ({
-        entry: r.entry,
-        score: r.score,
-        tokens: r.tokens,
-        isGlobal: false,
-      }));
-    }
-
-    selectedItems = results;
-    totalTokens = results.reduce((sum, r) => sum + r.tokens, 0);
-
-    // A5 H4: emit recall audit event for context-mode searches. The recall
-    // handler emits one of these per `hippo recall` invocation; context mode
-    // is the same surface (search → user) and must leave the same audit trail.
-    // Skip pinned-only and '*' fallback (handled in branches above which never
-    // hit the search engines).
-    const ctxRecallMetadata: Record<string, unknown> = {
-      query: query.slice(0, 200),
-      results: selectedItems.length,
-      mode: 'context',
-    };
-    if (hasLocal) emitCliAudit(hippoRoot, 'recall', undefined, ctxRecallMetadata);
-    if (hasGlobal) emitCliAudit(globalRoot, 'recall', undefined, ctxRecallMetadata);
-  }
-
-  if (limit < selectedItems.length) {
-    selectedItems = selectedItems.slice(0, limit);
-    totalTokens = selectedItems.reduce((sum, r) => sum + r.tokens, 0);
-  }
-
-  if (selectedItems.length === 0 && !activeSnapshot && !sessionHandoff && recentSessionEvents.length === 0) return;
-
-  // --pinned-only is called by the UserPromptSubmit hook every turn. Treat it
-  // as read-only so pinned memories don't inflate retrieval_count or extend
-  // their half_life by 2 days * turn-count over a long session.
-  let updatedEntries: MemoryEntry[];
-  if (pinnedOnly) {
-    updatedEntries = selectedItems.map((s) => s.entry);
-  } else {
-    // Mark retrieved and persist
-    const toUpdate = selectedItems.map((s) => s.entry);
-    updatedEntries = markRetrieved(toUpdate);
-    const localIndex = loadIndex(hippoRoot);
-
-    for (const u of updatedEntries) {
-      const targetRoot = localIndex.entries[u.id] ? hippoRoot : (hasGlobal ? globalRoot : hippoRoot);
-      writeEntry(targetRoot, u);
-    }
-
-    localIndex.last_retrieval_ids = updatedEntries.map((u) => u.id);
-    saveIndex(hippoRoot, localIndex);
-    updateStats(hippoRoot, { recalled: selectedItems.length });
-  }
-
+  // Format + framing are CLI rendering concerns; api.getContext doesn't see them.
   const format = String(flags['format'] ?? 'markdown');
-
   const framing = String(flags['framing'] ?? 'observe');
 
+  // Adapter: ContextResultEntry -> the print-helper input shape.
+  const renderItems = result.entries.map((r) => ({
+    entry: r.entry,
+    score: r.score,
+    tokens: r.tokens,
+    isGlobal: r.isGlobal ?? false,
+  }));
+
   if (format === 'json') {
-    const output = selectedItems.map((r) => ({
+    const output = result.entries.map((r) => ({
       id: r.entry.id,
       score: r.score,
       strength: r.entry.strength,
@@ -3507,28 +3336,28 @@ async function cmdContext(
       content: r.entry.content,
       global: r.isGlobal ?? false,
     }));
-    console.log(JSON.stringify({ query, activeSnapshot, sessionHandoff, recentSessionEvents, memories: output, tokens: totalTokens }));
+    console.log(JSON.stringify({
+      query: query || '*',
+      activeSnapshot: result.activeSnapshot ?? null,
+      sessionHandoff: result.sessionHandoff ?? null,
+      recentSessionEvents: result.recentEvents ?? [],
+      memories: output,
+      tokens: result.tokens,
+    }));
   } else if (format === 'additional-context') {
-    // Claude Code UserPromptSubmit hook JSON shape. Capture the markdown that
-    // printContextMarkdown would write and wrap it as `additionalContext`.
+    // Claude Code UserPromptSubmit hook JSON shape. Capture print* helpers'
+    // output into a string buffer and wrap as `additionalContext`.
     const lines: string[] = [];
     const realLog = console.log;
     console.log = (...parts: unknown[]) => { lines.push(parts.map(String).join(' ')); };
     try {
-      if (activeSnapshot) printActiveTaskSnapshot(activeSnapshot);
-      if (sessionHandoff) printHandoff(sessionHandoff);
-      if (recentSessionEvents.length > 0) printSessionEvents(recentSessionEvents);
-      if (selectedItems.length > 0) {
-        printContextMarkdown(
-          selectedItems.map((r) => ({
-            entry: updatedEntries.find((u) => u.id === r.entry.id) ?? r.entry,
-            score: r.score,
-            tokens: r.tokens,
-            isGlobal: r.isGlobal ?? false,
-          })),
-          totalTokens,
-          framing
-        );
+      if (result.activeSnapshot) printActiveTaskSnapshot(result.activeSnapshot);
+      if (result.sessionHandoff) printHandoff(result.sessionHandoff);
+      if (result.recentEvents && result.recentEvents.length > 0) {
+        printSessionEvents(result.recentEvents);
+      }
+      if (renderItems.length > 0) {
+        printContextMarkdown(renderItems, result.tokens, framing);
       }
     } finally {
       console.log = realLog;
@@ -3543,32 +3372,34 @@ async function cmdContext(
     };
     process.stdout.write(JSON.stringify(payload));
   } else {
-    if (activeSnapshot) {
-      printActiveTaskSnapshot(activeSnapshot);
+    // markdown (default)
+    if (result.activeSnapshot) {
+      printActiveTaskSnapshot(result.activeSnapshot);
     }
-    if (sessionHandoff) {
-      printHandoff(sessionHandoff);
+    if (result.sessionHandoff) {
+      printHandoff(result.sessionHandoff);
     }
-    if (recentSessionEvents.length > 0) {
-      printSessionEvents(recentSessionEvents);
+    if (result.recentEvents && result.recentEvents.length > 0) {
+      printSessionEvents(result.recentEvents);
     }
-    if (selectedItems.length > 0) {
-      printContextMarkdown(
-        selectedItems.map((r) => ({
-          entry: updatedEntries.find((u) => u.id === r.entry.id) ?? r.entry,
-          score: r.score,
-          tokens: r.tokens,
-          isGlobal: r.isGlobal ?? false,
-        })),
-        totalTokens,
-        framing
-      );
+    if (renderItems.length > 0) {
+      printContextMarkdown(renderItems, result.tokens, framing);
     }
 
-    // Ambient state summary (one-line landscape overview)
+    // Ambient state summary (CLI-side: api.getContext doesn't load all entries
+    // post-selection, so we re-load here for the landscape summary).
     const ambientConfig = loadConfig(hippoRoot);
     if (ambientConfig.ambient.enabled && !pinnedOnly) {
-      const allForAmbient = [...localEntries, ...globalEntries];
+      const tenantId = ctx.tenantId;
+      const globalRoot = getGlobalRoot();
+      const hasGlobalForAmbient = isInitialized(globalRoot);
+      const localForAmbient = isInitialized(hippoRoot)
+        ? loadAllEntries(hippoRoot, tenantId).filter(e => !e.superseded_by)
+        : [];
+      const globalForAmbient = hasGlobalForAmbient
+        ? loadAllEntries(globalRoot, tenantId).filter(e => !e.superseded_by)
+        : [];
+      const allForAmbient = [...localForAmbient, ...globalForAmbient];
       if (allForAmbient.length > 0) {
         const ambientState = computeAmbientState(allForAmbient);
         console.log(`\n${renderAmbientSummary(ambientState)}`);

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -1,0 +1,80 @@
+/**
+ * Store-level deduplication. Scans for near-duplicate memories by content
+ * Jaccard overlap, keeps the stronger copy (by strength + retrieval count),
+ * removes the rest.
+ *
+ * Extracted from cli.ts in Episode A (v1.11.3) so `api.sleep` can dedupe
+ * during the consolidation pipeline without violating the cli -> api
+ * dependency direction. `cmdDedup` in cli.ts continues to import and use
+ * this function unchanged.
+ */
+
+import { textOverlap } from './search.js';
+import { loadAllEntries, deleteEntry } from './store.js';
+
+export interface DedupPair {
+  kept: string;
+  keptContent: string;
+  keptLayer: string;
+  keptStrength: number;
+  removed: string;
+  removedContent: string;
+  removedLayer: string;
+  removedStrength: number;
+  similarity: number;
+}
+
+/**
+ * Scan the store for near-duplicate memories and remove the weaker copy.
+ * Two memories are duplicates if their content has > threshold Jaccard overlap.
+ * Keeps the one with higher strength (or more retrievals if tied).
+ */
+export function deduplicateStore(
+  hippoRoot: string,
+  options: { threshold?: number; dryRun?: boolean } = {}
+): { removed: number; pairs: DedupPair[] } {
+  const threshold = options.threshold ?? 0.7;
+  const dryRun = options.dryRun ?? false;
+  const entries = loadAllEntries(hippoRoot);
+
+  // Sort by strength desc, then retrieval count, so we keep the most valuable copy
+  entries.sort((a, b) => {
+    const sDiff = (b.strength ?? 0) - (a.strength ?? 0);
+    if (Math.abs(sDiff) > 0.01) return sDiff;
+    return (b.retrieval_count ?? 0) - (a.retrieval_count ?? 0);
+  });
+
+  const removed = new Set<string>();
+  const pairs: DedupPair[] = [];
+
+  for (let i = 0; i < entries.length; i++) {
+    if (removed.has(entries[i].id)) continue;
+    for (let j = i + 1; j < entries.length; j++) {
+      if (removed.has(entries[j].id)) continue;
+
+      const similarity = textOverlap(entries[i].content, entries[j].content);
+      if (similarity <= threshold) continue;
+
+      removed.add(entries[j].id);
+      pairs.push({
+        kept: entries[i].id,
+        keptContent: entries[i].content,
+        keptLayer: entries[i].layer,
+        keptStrength: entries[i].strength ?? 0,
+        removed: entries[j].id,
+        removedContent: entries[j].content,
+        removedLayer: entries[j].layer,
+        removedStrength: entries[j].strength ?? 0,
+        similarity,
+      });
+    }
+  }
+
+  if (!dryRun) {
+    for (const id of removed) {
+      deleteEntry(hippoRoot, id);
+    }
+  }
+
+  return { removed: removed.size, pairs };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.11.2';
+export const PACKAGE_VERSION = '1.11.3';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/api-context-sleep-contracts.test.ts
+++ b/tests/api-context-sleep-contracts.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Type-level contract tests for the api.ts refactor (Episode A, Task 2).
+ *
+ * Assert the public shape of `getContext`, `sleep`, and
+ * `outcomeForLastRecall` exists in `src/api.ts`. Runtime behavior is
+ * covered separately in:
+ *   - tests/api-outcome-for-last-recall.test.ts (Task 3)
+ *   - tests/api-sleep.test.ts (Task 4)
+ *   - tests/api-context.test.ts (Task 5)
+ *   - tests/cli-context-render-snapshot.test.ts (Task 5 CLI byte-identical gate)
+ */
+
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  Context,
+  ContextOpts,
+  ContextResult,
+  ContextResultEntry,
+  SleepOpts,
+  SleepResult,
+} from '../src/api.js';
+import { getContext, sleep, outcomeForLastRecall } from '../src/api.js';
+
+describe('api contract types — Episode A scaffolding', () => {
+  it('getContext is an async function returning ContextResult', () => {
+    expectTypeOf(getContext).toBeFunction();
+    expectTypeOf(getContext).parameter(0).toMatchTypeOf<Context>();
+    expectTypeOf(getContext).parameter(1).toMatchTypeOf<ContextOpts | undefined>();
+    expectTypeOf(getContext).returns.toMatchTypeOf<Promise<ContextResult>>();
+  });
+
+  it('sleep is an async function returning SleepResult', () => {
+    expectTypeOf(sleep).toBeFunction();
+    expectTypeOf(sleep).parameter(0).toMatchTypeOf<Context>();
+    expectTypeOf(sleep).parameter(1).toMatchTypeOf<SleepOpts | undefined>();
+    expectTypeOf(sleep).returns.toMatchTypeOf<Promise<SleepResult>>();
+  });
+
+  it('outcomeForLastRecall returns { applied, ids }', () => {
+    expectTypeOf(outcomeForLastRecall).toBeFunction();
+    expectTypeOf(outcomeForLastRecall).parameter(0).toMatchTypeOf<Context>();
+    expectTypeOf(outcomeForLastRecall).parameter(1).toMatchTypeOf<boolean>();
+    expectTypeOf(outcomeForLastRecall).returns.toMatchTypeOf<{
+      applied: number;
+      ids: string[];
+    }>();
+  });
+
+  it('ContextOpts exposes the documented flag set', () => {
+    expectTypeOf<ContextOpts>().toMatchTypeOf<{
+      q?: string;
+      auto?: boolean;
+      budget?: number;
+      limit?: number;
+      pinnedOnly?: boolean;
+      framing?: 'observe' | 'suggest' | 'assert';
+      format?: 'markdown' | 'json' | 'additional-context';
+      scope?: string;
+      includeRecent?: number;
+    }>();
+  });
+
+  it('SleepOpts exposes dryRun + noLearn + noShare', () => {
+    expectTypeOf<SleepOpts>().toMatchTypeOf<{
+      dryRun?: boolean;
+      noLearn?: boolean;
+      noShare?: boolean;
+    }>();
+  });
+
+  it('ContextResultEntry exposes entry + score + tokens', () => {
+    expectTypeOf<ContextResultEntry>().toMatchTypeOf<{
+      score: number;
+      tokens: number;
+      isGlobal?: boolean;
+      isFreshTail?: boolean;
+    }>();
+  });
+
+  it('SleepResult exposes the consolidation counters', () => {
+    expectTypeOf<SleepResult>().toMatchTypeOf<{
+      active: number;
+      removed: number;
+      mergedEpisodic: number;
+      newSemantic: number;
+      dryRun: boolean;
+    }>();
+  });
+});

--- a/tests/api-context-sleep-contracts.test.ts
+++ b/tests/api-context-sleep-contracts.test.ts
@@ -46,15 +46,12 @@ describe('api contract types — Episode A scaffolding', () => {
     }>();
   });
 
-  it('ContextOpts exposes the documented flag set', () => {
+  it('ContextOpts exposes the data-loading flag set (rendering opts CLI-only)', () => {
     expectTypeOf<ContextOpts>().toMatchTypeOf<{
       q?: string;
-      auto?: boolean;
       budget?: number;
       limit?: number;
       pinnedOnly?: boolean;
-      framing?: 'observe' | 'suggest' | 'assert';
-      format?: 'markdown' | 'json' | 'additional-context';
       scope?: string;
       includeRecent?: number;
     }>();

--- a/tests/api-context-sleep-contracts.test.ts
+++ b/tests/api-context-sleep-contracts.test.ts
@@ -60,10 +60,9 @@ describe('api contract types — Episode A scaffolding', () => {
     }>();
   });
 
-  it('SleepOpts exposes dryRun + noLearn + noShare', () => {
+  it('SleepOpts exposes dryRun + noShare (auto-learn is CLI-only)', () => {
     expectTypeOf<SleepOpts>().toMatchTypeOf<{
       dryRun?: boolean;
-      noLearn?: boolean;
       noShare?: boolean;
     }>();
   });

--- a/tests/api-context.test.ts
+++ b/tests/api-context.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Runtime tests for api.getContext (Episode A, Task 5).
+ *
+ * Coverage:
+ *   - empty store -> empty result
+ *   - '*' fallback returns strongest memories within budget
+ *   - budget cap is honored (tight budget excludes lower-scored entries)
+ *   - tenant scoping: cross-tenant memories invisible
+ *   - includeRecent populates the pinnedOnly path
+ *   - activeSnapshot returned when set
+ *
+ * Auto-detect (git diff -> query) and rendering (markdown/json/additional-
+ * context) are NOT covered here per the T5 scope narrow — those are CLI-side
+ * concerns. The CLI integration is verified by the full test suite + manual
+ * smokes (see Verify section of the plan).
+ *
+ * Real-DB per project convention. Each test isolates BOTH:
+ *   - local hippoRoot: mkdtempSync (passed as ctx.hippoRoot)
+ *   - global hippoRoot: HIPPO_HOME points to a SEPARATE uninitialized dir
+ *     so hasGlobal=false and the test stays local-only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, saveActiveTaskSnapshot } from '../src/store.js';
+import { remember, getContext, type Context } from '../src/api.js';
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-api-ctx-'));
+  initStore(home);
+  // Per-test HIPPO_HOME override pointing to a separate UNINITIALIZED dir
+  // so hasGlobal=false inside api.getContext. Keeps the test local-only and
+  // prevents any global writes from leaking into the shared baseline.
+  const globalTmp = mkdtempSync(join(tmpdir(), 'hippo-api-ctx-global-'));
+  const origHippoHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = globalTmp;
+  return {
+    home,
+    restore: () => {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(globalTmp, { recursive: true, force: true });
+      if (origHippoHome !== undefined) {
+        process.env.HIPPO_HOME = origHippoHome;
+      } else {
+        delete process.env.HIPPO_HOME;
+      }
+    },
+  };
+}
+
+describe('api.getContext', () => {
+  it('returns an empty result on an empty store', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      const result = await getContext(ctx, {});
+      expect(result.entries).toEqual([]);
+      expect(result.tokens).toBe(0);
+      expect(result.activeSnapshot).toBeFalsy();
+      expect(result.sessionHandoff).toBeFalsy();
+    } finally {
+      restore();
+    }
+  });
+
+  it("'*' fallback returns memories within budget, strongest first", async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      for (let i = 0; i < 5; i++) {
+        remember(ctx, {
+          content: `getcontext-fallback-mem-${i}`,
+          kind: 'distilled',
+        });
+      }
+
+      const result = await getContext(ctx, { budget: 1500 });
+
+      expect(result.entries.length).toBeGreaterThan(0);
+      expect(result.entries.length).toBeLessThanOrEqual(5);
+      expect(result.tokens).toBeGreaterThan(0);
+      expect(result.tokens).toBeLessThanOrEqual(1500);
+      // Strongest first ordering
+      for (let i = 1; i < result.entries.length; i++) {
+        expect(result.entries[i - 1].score).toBeGreaterThanOrEqual(result.entries[i].score);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('honors a tight budget cap (excludes overflow entries)', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      // Seed 10 longish memories so total tokens >> tight budget
+      for (let i = 0; i < 10; i++) {
+        remember(ctx, {
+          content: `padding ${'x'.repeat(200)} content number ${i}`,
+          kind: 'distilled',
+        });
+      }
+
+      const result = await getContext(ctx, { budget: 50 });
+
+      expect(result.tokens).toBeLessThanOrEqual(50);
+      // At a 50-token budget, only the smallest-or-fewest memories fit
+      expect(result.entries.length).toBeLessThan(10);
+    } finally {
+      restore();
+    }
+  });
+
+  it('tenant scoping: tenant_a does not see tenant_b memories', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctxA: Context = {
+        hippoRoot: home,
+        tenantId: 'tenant_a',
+        actor: 'cli',
+      };
+      const ctxB: Context = {
+        hippoRoot: home,
+        tenantId: 'tenant_b',
+        actor: 'cli',
+      };
+      remember(ctxA, { content: 'belongs-to-tenant-A', kind: 'distilled' });
+      remember(ctxB, { content: 'belongs-to-tenant-B', kind: 'distilled' });
+
+      const resultA = await getContext(ctxA, { budget: 1500 });
+      const resultB = await getContext(ctxB, { budget: 1500 });
+
+      const idsA = resultA.entries.map((e) => e.entry.content);
+      const idsB = resultB.entries.map((e) => e.entry.content);
+
+      expect(idsA).toContain('belongs-to-tenant-A');
+      expect(idsA).not.toContain('belongs-to-tenant-B');
+      expect(idsB).toContain('belongs-to-tenant-B');
+      expect(idsB).not.toContain('belongs-to-tenant-A');
+    } finally {
+      restore();
+    }
+  });
+
+  it('returns activeSnapshot when one is set for the active session', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      saveActiveTaskSnapshot(home, ctx.tenantId, {
+        task: 'Test task for api.getContext',
+        summary: 'Stub for the activeSnapshot return path',
+        next_step: 'Verify result.activeSnapshot is populated',
+        source: 'test',
+        session_id: 'sess-ctxtest',
+        scope: null,
+      });
+      remember(ctx, { content: 'snapshot-test-mem', kind: 'distilled' });
+
+      const result = await getContext(ctx, { budget: 1500 });
+
+      expect(result.activeSnapshot).toBeTruthy();
+      expect(result.activeSnapshot?.session_id).toBe('sess-ctxtest');
+      expect(result.activeSnapshot?.task).toBe('Test task for api.getContext');
+    } finally {
+      restore();
+    }
+  });
+
+  it('budget=0 short-circuits to an empty result', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      remember(ctx, { content: 'budget-zero-test', kind: 'distilled' });
+
+      const result = await getContext(ctx, { budget: 0 });
+
+      expect(result.entries).toEqual([]);
+      expect(result.tokens).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/api-outcome-for-last-recall.test.ts
+++ b/tests/api-outcome-for-last-recall.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Runtime tests for api.outcomeForLastRecall (Episode A, Task 3).
+ *
+ * Validates the documented contract:
+ *   - empty last_retrieval_ids returns {applied: 0, ids: []}
+ *   - multi-id last_retrieval_ids forwards to api.outcome and reports applied count
+ *   - cross-tenant ids in last_retrieval_ids are silently skipped (matches MCP semantics)
+ *   - one audit_log row per affected id, tagged with ctx.actor
+ *
+ * Real-DB per project convention (mkdtempSync + initStore + rmSync cleanup).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, loadIndex, saveIndex } from '../src/store.js';
+import { remember, outcomeForLastRecall, type Context } from '../src/api.js';
+
+function tmpHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-api-ofr-'));
+  initStore(home);
+  return home;
+}
+
+function cleanup(home: string): void {
+  rmSync(home, { recursive: true, force: true });
+}
+
+function seedMemory(home: string, content: string, tenantId = 'default'): string {
+  const res = remember(
+    { hippoRoot: home, tenantId, actor: 'cli' },
+    { content, kind: 'distilled' },
+  );
+  return res.id;
+}
+
+function seedLastRetrievalIds(home: string, ids: string[]): void {
+  const idx = loadIndex(home);
+  idx.last_retrieval_ids = ids;
+  saveIndex(home, idx);
+}
+
+describe('api.outcomeForLastRecall', () => {
+  it('returns {applied:0, ids:[]} when last_retrieval_ids is empty', () => {
+    const home = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      const result = outcomeForLastRecall(ctx, true);
+      expect(result).toEqual({ applied: 0, ids: [] });
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  it('applies a positive outcome to every id from the last recall', () => {
+    const home = tmpHome();
+    try {
+      const id1 = seedMemory(home, 'last-recall-mem-1');
+      const id2 = seedMemory(home, 'last-recall-mem-2');
+      const id3 = seedMemory(home, 'last-recall-mem-3');
+      seedLastRetrievalIds(home, [id1, id2, id3]);
+
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      const result = outcomeForLastRecall(ctx, true);
+
+      expect(result.applied).toBe(3);
+      expect(result.ids).toEqual([id1, id2, id3]);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  it('silently skips cross-tenant ids in last_retrieval_ids (returns id but applied=0)', () => {
+    const home = tmpHome();
+    try {
+      // The id belongs to tenant_b. last_retrieval_ids is hippoRoot-level
+      // (NOT tenant-scoped at the index layer) so the cross-tenant id can
+      // legally appear there. outcome() then filters via readEntry(..., tenantId)
+      // and silently skips the row — matches existing MCP outcome semantics.
+      const tenantBId = seedMemory(home, 'belongs-to-tenant-b', 'tenant_b');
+      seedLastRetrievalIds(home, [tenantBId]);
+
+      const ctxA: Context = {
+        hippoRoot: home,
+        tenantId: 'tenant_a',
+        actor: 'cli',
+      };
+      const result = outcomeForLastRecall(ctxA, true);
+
+      expect(result.applied).toBe(0);
+      expect(result.ids).toEqual([tenantBId]);
+    } finally {
+      cleanup(home);
+    }
+  });
+
+  it('emits one audit_log row per applied id, tagged with ctx.actor', async () => {
+    const home = tmpHome();
+    try {
+      const id1 = seedMemory(home, 'audit-target-1');
+      const id2 = seedMemory(home, 'audit-target-2');
+      seedLastRetrievalIds(home, [id1, id2]);
+
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'api_key:hk_ofr_test',
+      };
+      const result = outcomeForLastRecall(ctx, false);
+      expect(result.applied).toBe(2);
+
+      const { openHippoDb, closeHippoDb } = await import('../src/db.js');
+      const { queryAuditEvents } = await import('../src/audit.js');
+      const db = openHippoDb(home);
+      try {
+        const events = queryAuditEvents(db, {
+          tenantId: 'default',
+          op: 'outcome',
+        });
+        expect(events.length).toBe(2);
+        expect(events.every((e) => e.actor === 'api_key:hk_ofr_test')).toBe(true);
+        const targetIds = events.map((e) => e.targetId).sort();
+        expect(targetIds).toEqual([id1, id2].sort());
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      cleanup(home);
+    }
+  });
+});

--- a/tests/api-sleep.test.ts
+++ b/tests/api-sleep.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Runtime tests for api.sleep (Episode A, Task 4).
+ *
+ * Validates the documented contract of the narrowed sleep API:
+ *   - dryRun returns early after consolidate; dedup/audit/share/ambient skipped
+ *   - non-dry-run runs the full pure-storage pipeline
+ *   - empty store returns the well-formed zero SleepResult
+ *   - noShare prevents auto-share regardless of config.autoShareOnSleep
+ *
+ * Auto-learn is intentionally NOT covered here — it stays CLI-side per the
+ * option-B factoring (uses process.cwd() / os.homedir() which are not
+ * api-layer concerns).
+ *
+ * Real-DB per project convention. Each test isolates BOTH:
+ *   - local hippoRoot: mkdtempSync (passed as ctx.hippoRoot)
+ *   - global hippoRoot: HIPPO_HOME env override (autoShare promotes to global)
+ * Restores HIPPO_HOME on cleanup. Per _real-store-guard.ts conventions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { remember, sleep, type Context } from '../src/api.js';
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-api-sleep-'));
+  initStore(home);
+  // api.sleep's auto-share phase promotes memories to the GLOBAL store
+  // (resolved via HIPPO_HOME). Without per-test override, those writes
+  // leak into the shared baseline HIPPO_HOME and fail the isolation guard.
+  const origHippoHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = home;
+  return {
+    home,
+    restore: () => {
+      rmSync(home, { recursive: true, force: true });
+      if (origHippoHome !== undefined) {
+        process.env.HIPPO_HOME = origHippoHome;
+      } else {
+        delete process.env.HIPPO_HOME;
+      }
+    },
+  };
+}
+
+describe('api.sleep', () => {
+  it('dryRun returns SleepResult.dryRun=true and skips dedup/audit/share/ambient', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      remember(ctx, { content: 'sleep-dry-mem-1', kind: 'distilled' });
+
+      const result = await sleep(ctx, { dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      // dryRun returns immediately after consolidate; no other phases run.
+      expect(result.deduped).toBeUndefined();
+      expect(result.audit).toBeUndefined();
+      expect(result.shared).toBeUndefined();
+      expect(result.ambient).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('returns a well-formed zero SleepResult on an empty store', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+
+      const result = await sleep(ctx, { dryRun: false });
+
+      expect(result.dryRun).toBe(false);
+      expect(result.active).toBe(0);
+      expect(result.removed).toBe(0);
+      expect(result.mergedEpisodic).toBe(0);
+      expect(result.newSemantic).toBe(0);
+      // No entries -> dedup pairs empty, audit issues empty
+      expect(result.deduped).toBeUndefined();
+      expect(result.audit).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it('runs the full pipeline on a populated store (counts present and numeric)', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      for (let i = 0; i < 5; i++) {
+        remember(ctx, {
+          content: `unique memory ${i} with some distinct content here for testing`,
+          kind: 'distilled',
+        });
+      }
+
+      const result = await sleep(ctx, { dryRun: false });
+
+      expect(result.dryRun).toBe(false);
+      expect(typeof result.active).toBe('number');
+      expect(typeof result.removed).toBe('number');
+      expect(typeof result.mergedEpisodic).toBe('number');
+      expect(typeof result.newSemantic).toBe('number');
+      expect(Array.isArray(result.details)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it('noShare prevents the auto-share phase (shared remains undefined)', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'cli',
+      };
+      remember(ctx, {
+        content: 'high-value-pattern that might trigger auto-share',
+        kind: 'distilled',
+      });
+
+      const result = await sleep(ctx, { dryRun: false, noShare: true });
+
+      expect(result.shared).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
Episode A of 3 (sequential A then B then C) for the Python SDK rollout. This PR is the internal `src/api.ts` refactor that unblocks Episode B (HTTP routes for /v1/outcome, /v1/context, /v1/sleep) and Episode C (Python SDK to PyPI).

## What changed

Three new exports added to `src/api.ts`:

- `getContext(ctx, opts): Promise<ContextResult>` extracted from `cmdContext` (~315 inline lines collapsed). Covers pinnedOnly fast path, '*' fallback, hybrid search. Renamed from `context` to avoid collision with the `Context` interface.
- `sleep(ctx, opts): Promise<SleepResult>` extracted from `cmdSleepCore` Phase 2-6 (consolidate / dedup / audit / share / ambient). Auto-learn (Phase 1) stays CLI-side (intrinsically host-bound). `deduplicateStore` moved to `src/dedupe.ts`.
- `outcomeForLastRecall(ctx, good): {applied, ids}` thin wrapper over `outcome()` resolving `last_retrieval_ids` first.

Three CLI commands rewired:
- `cmdContext` thin-wraps `api.getContext`; existing print helpers (printContextMarkdown, printActiveTaskSnapshot, printHandoff, printSessionEvents) stay CLI-side because they are shared with cmdRecall / cmdSnapshot / cmdHandoffShow.
- `cmdSleepCore` thin-wraps `api.sleep` via a new `renderSleepResult` helper. Auto-learn block stays in cmdSleepCore.
- `cmdOutcome` thin-wraps `api.outcomeForLastRecall` + `api.outcome`.

## Behavior fix (in scope)

`hippo outcome` now emits one `audit_log` row per affected memory (op='outcome', actor='cli'), matching the MCP `outcome` tool path. Previously the CLI bypassed `api.outcome` and silently skipped the audit emission. Downstream consumers of `audit_log` will see new rows from CLI `outcome` invocations going forward; filter on the `actor` field if CLI vs MCP distinction matters.

## Out of scope (planned for v1.11.4 / v0.1.0)

- HTTP routes /v1/outcome, /v1/context, /v1/sleep (Episode B, v1.11.4)
- Python SDK on PyPI as `hippo-memory` (Episode C, v0.1.0)
- Shared `api.renderContext` (Episode B can extract if Python SDK wants server-rendered output)

## Scope narrows caught at execute

The plan-eng-critic missed two cli-private dependencies that surfaced during execute. Both narrows are documented in the plan + commit messages:
- T4 (sleep): 3 cmdSleepCore helpers (learnFromRepo, learnFromMemoryMd, deduplicateStore) are cli-private and host-bound. Option B factoring: api.sleep covers Phase 2-6 only, auto-learn stays CLI. SleepOpts drops noLearn, SleepResult drops autoLearned.
- T5 (getContext): print helpers (printContextMarkdown etc.) are shared with cmdRecall / cmdSnapshot / cmdHandoffShow. ContextOpts drops format / framing / auto, ContextResult drops rendered. CLI keeps rendering. Episode B can extract api.renderContext if needed.

## Test plan

- [x] tsc --noEmit clean
- [x] Full suite: 1628 tests passed, 4 skipped, 0 failed (29s wall)
- [x] 4 new test files: api-context-sleep-contracts (7 type-level), api-outcome-for-last-recall (4 real-DB), api-sleep (4 real-DB), api-context (6 real-DB)
- [x] Manual smoke: `hippo sleep --dry-run` + `hippo sleep` (byte-identical structure)
- [x] Manual smoke: `hippo context --budget 500` (markdown) + `--format json` + `--pinned-only`
- [x] `hippo --version` reports 1.11.3
- [x] 6 manifests bumped: package.json, package-lock.json (2 sites), src/version.ts, openclaw.plugin.json, extensions/openclaw-plugin/{openclaw.plugin.json, package.json}

## Plan

Full plan at `docs/plans/2026-05-23-api-refactor-context-sleep-outcome.md`. Reviewed by plan-eng-critic (pass at score 78, must_fix empty); revised twice at execute for the option-B factoring narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
