### PR TITLE
fix(api): v1.11.5 Episode A/B/C critic-deferral hardening pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.11.5 (2026-05-23): Episode A/B/C critic-deferral hardening pass
+
+PATCH release closing 7 of 8 deferrals from the v1.11.3 + v1.11.4 + python-v0.1.0 ship chain. Additive + backward-compatible. Item #5 (per-tenant `/v1/sleep` scoping) deferred to v1.12.0 because plan-eng-critic round 1 surfaced it as MINOR-scope structural work (Context.actor object shape + api_keys schema migration + 12+ call sites).
+
+### Shipped
+
+- **HTTP DoS caps.** `POST /v1/outcome` now rejects `ids.length > 1000` with 400 (each id costs ~3 DB ops; 1000 keeps per-request work bounded). Cap fires BEFORE `buildContextWithAuth` so attack traffic doesn't pay the api-key lookup cost. `GET /v1/context` now rejects `q.length > 1024` with 400 (mirrors the existing scope-cap pattern; 1024 covers real multi-clause queries while bounding BM25 tokenisation).
+- **`audit_log` emission on `api.sleep`.** One `'consolidate'` audit row emitted per invocation with phase counters in metadata (`consolidationCount`, `dedupCount`, `auditDeletedCount`, `ambientTotal`, `dryRun`, `noShare`, `partial`). Closes the CLI/MCP parity gap that v1.11.3 T6 fixed for `cmdOutcome`. Emit lives in a `try/finally` so partial-failure paths still emit (`partial: true` + `errorMessage`); the audit emit is itself wrapped in a defensive try/catch so an audit-emit failure does NOT mask the original phase error (logs to stderr instead).
+- **Additive `AuditOp` extension: `'consolidate'`.** New union member at `src/audit.ts:130-138`. The Python SDK is unaffected — `python/src/hippo_memory/models.py:298` types `op` as `str` (no enum constraint).
+- **Pre-existing `'outcome'` allow-list drift closed.** `VALID_AUDIT_OPS` Sets at `src/cli.ts:4679` and `src/server.ts:70` already missed `'outcome'` despite the union including it and rows being emitted today — `GET /v1/audit?op=outcome` returned 400 "invalid op" and `hippo audit list --op=outcome` exited 1 "Unknown --op value". Both Sets now carry both `'outcome'` and `'consolidate'`. The CLI error message is now regenerated from `Array.from(VALID_AUDIT_OPS).join(' | ')` so future drift can't recur on the message side. **Behaviour change:** `hippo audit list --op=outcome` and `GET /v1/audit?op=outcome` previously errored; they now return the outcome rows. Downstream consumers that caught the error as a "not supported" signal will see a behavior change.
+- **`isLoopback` helper unit-tested.** 11 cases at `tests/server-isloopback-helper.test.ts` lock the helper's accepted forms (`'127.0.0.1'`, `'::1'`, `'::ffff:127.0.0.1'`) and rejected forms (RFC1918, IPv4-mapped non-loopback, link-local, fully-expanded `'0:0:0:0:0:0:0:1'`, `undefined`, empty string). No behaviour change to the helper itself — extending it to recognise additional IPv6 forms is a security-adjacent decision out of v1.11.5 scope.
+- **`api.recall` no-side-effects contract locked.** Test + JSDoc + `python/README.md` note. `api.recall` does NOT mutate `index.last_retrieval_ids` (only `api.getContext` and CLI `cmdRecall` do). Adding the side-effect would break SDK callers who batch recall calls in a row. SDK callers needing the last-recall outcome path should call `api.getContext` first.
+- **CLI render helpers exported for snapshot tests.** `printContextMarkdown` and `renderSleepResult` now exported from `cli.ts` with `@internal` JSDoc tags (NOT a stable public API). 12 snapshot tests at `tests/cli-context-render-snapshot.test.ts` lock the byte-identical output of both render branches across pinnedOnly / markdown default / json / additional-context / framing observe-suggest-assert / hybrid local-only / hybrid with global / dry-run + full sleep. Uses `vi.useFakeTimers({ now: '2026-05-23T20:00:00Z' })` for determinism (resolveConfidence-driven tags would otherwise churn).
+
+### Tests
+
+7 new test cases across `tests/api-sleep.test.ts`, `tests/server-context-route.test.ts`, `tests/server-outcome-route.test.ts`. 4 new test files: `tests/api-recall-no-side-effects.test.ts` (2 tests), `tests/cli-context-render-snapshot.test.ts` (12 snapshots), `tests/server-audit-route-consolidate.test.ts` (3 tests including round-trip + outcome-drift coverage), `tests/server-isloopback-helper.test.ts` (11 cases). Total suite: 1657 → 1688 tests passing, 0 failures.
+
+### Out of scope (deferred to v1.12.0)
+
+- Per-tenant `/v1/sleep` scoping (item #5). Requires Context.actor object shape, api_keys role column, ValidateResult signature change, and 12+ call site updates across api.ts. Bundled with non-loopback serving (`HIPPO_BIND_ALL`) and A5 v2 multi-tenant work.
+- Mid-phase failure test for the `partial:true` audit row branch. The path is reachable + the contract is locked in code, but forcing a deterministic mid-phase throw requires DI seams or fault-injection hooks not yet in db.ts. Tracked in TODOS.md.
+
 ## Python SDK v0.1.0 (2026-05-23): initial PyPI release
 
 First release of `hippo-memory-sdk` on PyPI. Async Python SDK wrapping the 14 HTTP endpoints from `hippo-memory@1.11.4`. The PyPI distribution name is `hippo-memory-sdk` (the bare `hippo-memory` name was blocked by PyPI's similarity check against an existing `hippomem` project); the Python import name remains `hippo_memory` so user code is `from hippo_memory import Hippo`.

--- a/ROADMAP-RESEARCH.md
+++ b/ROADMAP-RESEARCH.md
@@ -4,8 +4,21 @@ This is the canonical execution roadmap. Every actionable item from `RESEARCH.md
 
 This file supersedes the prior research-only frame. `ROADMAP.md` continues to track grant-tied deliverables. `PLAN.md` documents architecture and CLS principles.
 
-Current version: v0.33.0
-Active branch: `feat/pineal-salience-v2`
+Current version: 1.11.4 (npm `hippo-memory`) + python-v0.1.0 (PyPI `hippo-memory-sdk`)
+Active branch: `master`
+
+## Status as of 2026-05-23
+
+The original 90-day plan (lines below, scoped April→July) is **functionally complete**: A3 envelope shipped v0.39 (security hardening), A5 stub auth shipped, A1 server shipped v0.36, E1.3 Slack ingestion shipped v0.37, F6 reranker hardening shipped v1.9.0, and the F-track hit its roadmap R@5 ≥ 85% target on the oracle split (v1.9.2, F13 chunk-per-turn + F9 sub-agent rerank = R@5 = 86.8). E1.4 GitHub ingestion shipped v1.3.0. The v1.10.x-v1.11.x arc added pidfile-ownership guards, conflict-subsystem tenant isolation, per-IP rate limiting on `/v1`, the opencode plugin installer fix, and the api.ts refactor that unlocked the v0.1.0 Python SDK on PyPI. 32 npm releases from v0.33 (2026-04-23) to v1.11.4 (2026-05-23).
+
+**Next 90 days (2026-05-23 → 2026-08-23) priority queue** (revised at end-of-arc):
+- Episode A/B/C tail → v1.11.5 patch or v1.12.0 minor: HTTP DoS caps on `/v1/outcome` + `/v1/context`, per-tenant `/v1/sleep` scoping decision, audit-emission on sleep consolidation phases, `api.recall` last-retrieval-ids parity, CLI render snapshot tests.
+- Python SDK v0.2: sync wrappers (HippoSync), ContextResult.projected() helper, 204 handling in `_request`.
+- F9 hybrid retrieval — the BM25+vector RRF fusion the F-track never actually measured locally, with gbrain's ablation (BM25 19.8 / vector 97.4 / hybrid 97.6) as the directional shape.
+- Conflict-subsystem tenant-isolation residue (unscoped `readEntry` / `loadSearchEntries` in `cli.ts` / `dashboard.ts` / `refine-llm.ts` from v1.11.0).
+- v0.26 UI redesign port — `mockups/hybrid-v4.html` (warm parchment + 3D Three.js scene with OrbitControls, golden hour sky, mycelium network, Field Notes sidebar) into `ui/src/`. Design locked at v0.26, never ported. Track in TODOS.md "v0.26 — UI Redesign".
+
+The per-track status tags below are updated to reflect shipped-vs-active state. Section structure, bets, non-goals, and cross-track invariants are unchanged.
 
 ## North star
 
@@ -37,13 +50,16 @@ Active branch: `feat/pineal-salience-v2`
 
 Hippo today: local CLI + MCP, single user, single project, SQLite + markdown. The gaps below are dependency-ordered.
 
-### A1. Server mode [next]
-Persistent daemon alongside CLI. `hippo serve` exposes HTTP + MCP, CLI becomes a thin client. SQLite single-writer for v1.
-**Effort:** 4-6w. **Success:** runs >24h with no leaks, sub-50ms p99 recall on 10k-memory store. **Unblocks:** every other A item.
+### A1. Server mode [shipped v0.36.0]
+Persistent daemon alongside CLI. `hippo serve` exposes HTTP + MCP, CLI becomes a thin client. SQLite single-writer.
+**Shipped:** v0.36.0 added `hippo serve` (default 127.0.0.1:6789, configurable via `--port` / `HIPPO_PORT`), thin-client auto-routing via `.hippo/server.pid`, stale-pidfile self-heal. v1.10.x added lifecycle hardening (H1-H3 + L3 + M3: stale-pidfile + PID-reuse detection, `HIPPO_REQUIRE_SERVER`, concurrent-serve detection, pidfile schema version, BodyTooLargeError socket cleanup). v1.10.1 added `removePidfileIfOwned` (pid + started_at match required for unlink). 24h soak harness is scaffold-only (`benchmarks/a1/soak.ts`) — promoting to a CI-integrated release gate remains in TODOS.md. p99 target retracted v0.39 (current p99 = 58.4ms sequential single-thread; not a regression — the harness is not representative of server-mode concurrent load).
 
-### A2. HTTP API [next]
-Language-agnostic surface alongside MCP/CLI. RESTish + streaming for context assembly.
-**Effort:** 3-4w (depends on A1). **Success:** SDK-free curl examples in README cover remember/recall/snapshot/handoff/inspect.
+### A2. HTTP API [shipped through v1.11.4]
+Language-agnostic surface alongside MCP/CLI. RESTish.
+**Shipped:** 14 routes on `/v1/*`: memories (remember/recall/drill/forget/archive/supersede/promote), auth (keys list/create/revoke), audit, connectors (slack/github webhooks), sessions/assemble, plus v1.11.4's outcome/context/sleep. Per-IP token-bucket rate limit (`HIPPO_V1_RPS`, default 20 rps) added v1.11.0. All routes Bearer-authed and tenant-scoped except `/v1/sleep` (loopback-only, host-wide; per-tenant scoping deferred to TODOS.md once non-loopback serving lands).
+
+### A12. Python SDK [shipped python-v0.1.0]
+Async httpx + Pydantic v2 thin wrapper over the 14 HTTP routes. PyPI distribution name `hippo-memory-sdk` (the bare `hippo-memory` was blocked by PyPI's similarity check against an existing `hippomem` project); Python import name stays `hippo_memory`. Trusted-publisher OIDC workflow at `.github/workflows/pypi-publish.yml`. v0.2 follow-ups in TODOS.md: sync wrappers (HippoSync), ContextResult.projected() helper, 204 handling in `_request`.
 
 ### A3. Provenance envelope [shipped]
 Every memory carries `scope`, `source`, `timestamp`, `owner`, `confidence`, `artifact_ref`, `session_id`, `kind` (raw|distilled|superseded|archived). RESEARCH §"Phase 1: safest bridge" canonical envelope.
@@ -53,19 +69,19 @@ Every memory carries `scope`, `source`, `timestamp`, `owner`, `confidence`, `art
 Retention policy enforcement, right-to-be-forgotten (`hippo forget --user X --everywhere`), encryption-at-rest config flag, secret-scrubbing at write-time, PII redaction (regex + simple model).
 **Effort:** 4-6w. **Success:** demo "delete everything for user X across all scopes" in one command; secret-scrub catches AWS/OpenAI/Anthropic/GitHub key formats with <1% false positive on synthetic corpus.
 
-### A5. Auth + multi-tenancy [planned]
-API keys -> OAuth + scoped tokens. Org > team > project > scope hierarchy. RBAC. Audit log of every read/write/promote/supersede.
-**Effort:** 10-12w for full multi-tenant (revised from 6-8w). Only `working_memory` has `scope` today; `memories`, `consolidation_runs`, `task_snapshots`, `memory_conflicts` need scope/tenant columns + every query audited + RLS or app-layer enforcement.
-**Stub for v1 hosted (2-3w):** API keys + per-customer single-tenant deployments. Defer multi-tenant isolation to v2 unless a hosted customer needs it sooner.
-**Success:** two users on same server can't see each other's scopes; audit log captures every mutation; SSO/SCIM hook points stubbed (not implemented).
+### A5. Auth + multi-tenancy [shipped stub; v2 multi-tenant deferred]
+API keys + audit log of every read/write/promote/supersede. Tenant scoping added.
+**Shipped:** stub auth (v0.34-v0.35): API keys via `hippo auth create-key`, Bearer on `/v1/*` and MCP, `validateApiKey` with constant-time scrypt comparison, `audit_log` table. Tenant_id column added to `memories` + scoped reads (`ctx.tenantId`). Conflict-subsystem tenant isolation shipped v1.11.0 (`hippo_conflicts` / `hippo_resolve` / `hippo_status`). v1.11.1 closed `replaceDetectedConflicts` stale-resolve + `readEntry` audit cleanup. Per-IP rate limit on `/v1/*` shipped v1.11.0.
+**v2 deferred to TODOS.md:** unscoped `readEntry`/`loadSearchEntries` in `cli.ts`/`dashboard.ts`/`refine-llm.ts` (CLI is single-tenant per process; flagged for the day non-loopback serving lands); `auth create`/`list` are unauthenticated locally (FS access is the trust boundary); audit-log retention/rotation; SSO/SCIM; OAuth scoped tokens; full multi-tenant org > team > project > scope hierarchy.
 
 ### A6. Postgres backend [planned]
 For shared deployments only. SQLite stays the local default.
 **Effort:** 3-4w. **Success:** `--db postgres://...` boots; eval suites pass; concurrent-write smoke test green.
 
-### A7. Observability [planned]
-Per-query cost, retrieval traces, decay/strengthening rates, conflict counts, sleep-cycle metrics. Dashboard + Prometheus exporter.
-**Effort:** 4-6w. **Success:** "why did my agent recall X" answerable in <30 seconds via dashboard.
+### A7. Observability [partial: audit + rate-limit shipped; dashboard pending]
+Per-query cost, retrieval traces, decay/strengthening rates, conflict counts, sleep-cycle metrics.
+**Shipped:** `audit_log` table (every remember/recall/promote/supersede/outcome/forget with actor + tenant). Per-IP rate-limit visibility via 429 responses (`HIPPO_V1_RPS`). Brain Observatory UI (v0.25) surfaces memory state, conflicts, embeddings via JSON API at `/api/{memories,stats,conflicts,embeddings,peers,config}`.
+**Pending:** retrieval-trace API ("why did my agent recall X"), per-tenant cost/usage rollups, Prometheus exporter, decay-curve telemetry (D8 below).
 
 ### A8. Framework adapter breadth [grant: AIC-P1]
 LangChain, LlamaIndex, Letta, CrewAI, AutoGen. Consistent semantics across all five. Already in `ROADMAP.md` WP3.
@@ -247,13 +263,14 @@ Active snapshot + recent trail + matching handoff in the default resume path. Co
 #### E1.2. Provenance envelope [next] — see A3
 Required for everything below.
 
-#### E1.3. Slack append-only ingestion [next]
+#### E1.3. Slack append-only ingestion [shipped v0.37.0]
 Webhook -> raw layer with full provenance. Source remains canonical; hippo distils, doesn't shadow.
-**Effort:** 12d. **Success:** 1000-event smoke test with no source-system writes; recall surfaces incident context faster than transcript replay on 10 staged scenarios.
+**Shipped:** signed webhook handler, idempotency on `(team_id, event_id)`, cursor-based backfill, DLQ for malformed events (`hippo slack dlq list`), tenant routing via `slack_workspaces` table, rate-limit handling, owner envelope (`user:<slack_user_id>` since v1.1+). v0.38 added test pass + workspace registration plumbing.
+**Open follow-ups (TODOS.md):** DLQ replay command, workspace registration CLI (vs direct SQL), thread-aware ranking, eval scoring by `artifact_ref`, multi-workspace tenant-routing e2e test.
 
-#### E1.4. GitHub append-only ingestion [planned]
+#### E1.4. GitHub append-only ingestion [shipped v1.3.0]
 PRs, commits, issues, releases. Same model as E1.3.
-**Effort:** 10d. **Success:** PR-context recall beats `gh pr view` for "what changed and why" queries.
+**Shipped:** v1.3.0 streams issues + issue comments + PRs + PR review comments into hippo as `kind='raw'` rows with full provenance, idempotency, scope tagging, DLQ. Built on the v1.2.1 generic `*:private:*` default-deny filter (codex-flagged pre-flight) so private GitHub rows cannot leak to no-scope callers.
 
 #### E1.5. Jira / Linear ingestion [planned]
 Ticket lifecycle events into raw layer; distil to incident / decision objects.
@@ -517,28 +534,23 @@ Weeks of work (calendar) for Wks 1-12, single engineer, assuming 4 productive da
 
 Total: 16-20 weeks of work compressed to 12 weeks calendar. Lane B parallelism (F6 reranker, F7 LoCoMo) buys some recovery; the budget is still tight by design.
 
-### Weeks 1-4 (May) — provenance first
-1. **A3 Provenance envelope** (6-8w, starts here, finishes early June) — gates everything in Track E + Track A. Real schema split, not a column add.
-2. **F6 reranker hardening** (6d, lane B parallel) — uses existing hybrid path; no schema dependency.
+### v0.33 → v1.11.4 arc (2026-04-23 → 2026-05-23) — 90-day plan delivered
 
-### Weeks 5-8 (June) — server + auth stub
-3. **A5 stub auth** (2-3w) — single-tenant API keys + audit log scaffolding. Multi-tenant isolation deferred to v2.
-4. **A1 Server mode** (4w) — daemon + HTTP/MCP surface, thin CLI client. Depends on A3 envelope being live.
-5. **F7 LoCoMo first baseline** (5d, lane B parallel) — informational.
+The original Weeks 1-12 plan landed in 30 calendar days through 32 npm releases. Shipped in dependency order: A3 envelope (v0.39), A5 stub auth (v0.34-v0.35), A1 server (v0.36), E1.3 Slack ingestion (v0.37), F6 reranker hardening (v1.9.0), E1.4 GitHub ingestion (v1.3.0), A2 HTTP API completion (v1.11.4), Python SDK A12 (python-v0.1.0). Plus v1.10.x lifecycle hardening, v1.11.0 tenant-isolation + rate-limit, v1.11.1 isolation residue, v1.11.2 opencode plugin installer fix, v1.11.3 api.ts refactor.
 
-### Weeks 9-12 (July) — first ingestion connector end-to-end
-6. **E1.3 Slack append-only ingestion** (4-5w) — first source-of-record connector. Tests the full A3 → A5 → A1 stack under realistic load. Includes idempotency, cursor / backfill, source-deletion sync, permission mirroring, rate-limit handling, dead-letter queue.
+### Next 90 days (2026-05-23 → 2026-08-23) — priority queue
 
-### Days 91-180 (Aug–Oct) — deferred from current 90-day plan
-- **A2 HTTP API hardening** (was Wk 5-8) — A1 ships RESTish surface; A2 polishes contract + SDK examples
-- **B3 dlPFC persistent goal stack depth** (was Wk 1-4) — best trap-rate lever, but research not enterprise; ships after E1.3 proves the platform
-- **B1 ACC EVC calibration** (was Wk 5-8)
-- **C3 Pineal ambient state vector** (was Wk 9-12)
-- **E2 first-class `decision` object promotion** (was Wk 9-12)
-- **B7 PFC-stack composition A/B** (was Wk 9-12)
-- **A4 lifecycle compliance** (right-to-be-forgotten first; encryption/secret-scrub/PII split into separate items)
+Priority overlay: short post-ship tail first (close the Episode A/B/C critic-deferred items), then the structural leverage items.
 
-### Days 181+ — research and platform
+1. **Episode A/B/C tail → v1.11.5 / v1.12.0** (~5d): HTTP DoS caps on `/v1/outcome` ids.length + `/v1/context` q length; per-tenant `/v1/sleep` scoping decision (admin-role gate or plumb `ctx.tenantId` into `deduplicateStore` + `auditMemories` + `deleteEntry`); `audit_log` emission on sleep consolidation phases; `api.recall` last-retrieval-ids parity with `cmdRecall`; CLI render snapshot tests for `printContextMarkdown` + `renderSleepResult`.
+2. **F9 hybrid retrieval — first measurement** (~5d): BM25 + BGE-base chunked-turn dense vectors via RRF on `_s` (and oracle for cross-comparison). gbrain's ablation (BM25 19.8 / vector 97.4 / hybrid 97.6) sets the directional shape. The F-track has measured pure-vector and vector+LLM-rerank but never local BM25+vector RRF fusion. Highest-value retrieval lever still untried.
+3. **Conflict-subsystem tenant-isolation residue** (~3d): audit and tenant-scope the unscoped `readEntry` / `loadSearchEntries` call sites in `cli.ts` / `dashboard.ts` / `refine-llm.ts` (deferred from v1.11.0 because half-scoping without first scoping upstream `loadAllEntries(hippoRoot)` would silently drop parent text).
+4. **Python SDK v0.2** (~5d): sync wrappers (HippoSync), ContextResult.projected() helper, 204 handling in `_request`.
+5. **v0.26 UI redesign port** (~15-20d): port `mockups/hybrid-v4.html` (warm parchment + 3D Three.js scene with OrbitControls, golden hour sky dome, mycelium network, Field Notes sidebar, bottom drawer memory list) from mockup to `ui/src/` React codebase. Design locked at v0.26 (2026-04-20); port has never started. Track in TODOS.md "v0.26 — UI Redesign".
+6. **B1 ACC EVC calibration, B3 dlPFC goal-stack depth (already shipped MVP+depth)**: B-track depth items are research-not-enterprise — re-prioritise only after platform items 1-5 above.
+7. **E2 first-class `decision` / `handoff` object promotion** (~4-7d each): partial today via `hippo decide` / `hippo handoff`; promote to first-class objects with own lifecycle.
+
+### Days 181+ (Aug 2026 onwards) — research and platform
 - A6 Postgres backend (only when a hosted customer requires shared deployment)
 - A7 observability dashboard
 - A8 framework adapters (grant: AIC-P1 if funded)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,9 @@
 
 This roadmap tracks planned work for the hippo-memory codebase. Items are grouped by funding status: committed, conditional on grant award, and speculative.
 
-Current version: v0.33.0
+Current version: 1.11.4 (npm `hippo-memory`) + python-v0.1.0 (PyPI `hippo-memory-sdk`)
+
+For non-grant execution status (Tracks A-I, sequencing, shipped items, bets, non-goals) see `ROADMAP-RESEARCH.md`. For operational follow-ups and per-version post-ship tails see `TODOS.md`. For the research lineage and seven-mechanisms backgrounder see `RESEARCH.md`.
 
 ## How to read this document
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,9 +4,20 @@
 
 Cross-referenced from `ROADMAP-RESEARCH.md` §"Next 90 days". The full execution roadmap (Tracks A-I, sequencing, bets, non-goals) lives there. This file owns the operational post-ship tail.
 
-### v1.11.5 / v1.12.0 — post-Episode A/B/C tail (~5d)
+### v1.11.5 — SHIPPED 2026-05-23
 
-All A-sized, all touch `src/server.ts` / `src/api.ts` / `tests/server-*` / `tests/api-*` — bundle into one episode to reuse one critic pass and one ship gate.
+7 of 8 items closed in v1.11.5 (see `CHANGELOG.md` v1.11.5 entry). Items #1, #2, #3, #4, #6, #7, #8 done. Item #5 (per-tenant /v1/sleep scoping) deferred to v1.12.0 because plan-eng-critic surfaced it as MINOR-scope structural work.
+
+### v1.12.0 — items deferred from v1.11.5 hardening pass
+
+- [ ] **Per-tenant `/v1/sleep` scoping** (item #5 from v1.11.5 plan). Requires `Context.actor` change from `string` to `{subject, role}` object, `api_keys` schema migration to add `role TEXT NOT NULL DEFAULT 'admin'`, `ValidateResult` shape change, `buildContextWithAuth` signature change, ~12 call site updates across `src/api.ts`. Bundle with non-loopback serving (`HIPPO_BIND_ALL` env knob) and A5 v2 multi-tenant work.
+- [ ] **`api.sleep` mid-phase failure test coverage.** The `partial:true` + `errorMessage` audit-row branch is reachable + the contract is locked in code comments (api.ts:2034-2074), but forcing a deterministic mid-phase throw requires DI seams (inject phase helpers) or fault-injection hooks in db.ts. Independent-review-critic MED #2 on v1.11.5.
+- [ ] **Consolidate audit row tenant tag.** Currently tagged with `ctx.tenantId` but `api.sleep` is host-wide (cross-tenant dedup is intentional). When `/v1/sleep` moves off loopback-only, either tag with synthetic "host" tenant or scope api.sleep per-tenant. Independent-review-critic MED #3 on v1.11.5. TODO inlined at `src/api.ts:2050`.
+- [ ] **Snapshot test belt-and-braces `afterAll(useRealTimers)`.** Today the `beforeEach`/`afterEach` pair is correct, but a test throwing before reaching afterEach would leak fake timers. Independent-review-critic LOW #5 on v1.11.5.
+
+### Remaining post-Episode A/B/C tail (deferred items that don't fit v1.11.5 / v1.12.0)
+
+All B-sized originally; bundle when needed.
 
 - [ ] **HTTP DoS cap on `POST /v1/outcome` `ids.length`** (1000 max, B follow-up). A caller could POST `{ids: [10000 ids], good: true}` (within the 1 MB body cap), spawning 10000 sequential `readEntry` + `writeEntry` + `appendAuditEvent` cycles. /v1/* rate limit is per-request, not per-id. Worth raising priority because /v1/outcome WRITES per id.
 - [ ] **HTTP DoS cap on `GET /v1/context?q=`** (1024 chars, B follow-up). Breaks the 256-char-cap convention on adjacent `scope`/`session_id`/`fresh_tail_session_id`. Node's 16KB URL header is the de-facto bound but the structural drift makes future audits harder. 1024-char cap on `q` (queries can legitimately be longer than 256 but should still bound).

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,47 @@
 # Hippo Brain Observatory — Roadmap
 
+## Next 90 days (2026-05-23 →) — priority queue
+
+Cross-referenced from `ROADMAP-RESEARCH.md` §"Next 90 days". The full execution roadmap (Tracks A-I, sequencing, bets, non-goals) lives there. This file owns the operational post-ship tail.
+
+### v1.11.5 / v1.12.0 — post-Episode A/B/C tail (~5d)
+
+All A-sized, all touch `src/server.ts` / `src/api.ts` / `tests/server-*` / `tests/api-*` — bundle into one episode to reuse one critic pass and one ship gate.
+
+- [ ] **HTTP DoS cap on `POST /v1/outcome` `ids.length`** (1000 max, B follow-up). A caller could POST `{ids: [10000 ids], good: true}` (within the 1 MB body cap), spawning 10000 sequential `readEntry` + `writeEntry` + `appendAuditEvent` cycles. /v1/* rate limit is per-request, not per-id. Worth raising priority because /v1/outcome WRITES per id.
+- [ ] **HTTP DoS cap on `GET /v1/context?q=`** (1024 chars, B follow-up). Breaks the 256-char-cap convention on adjacent `scope`/`session_id`/`fresh_tail_session_id`. Node's 16KB URL header is the de-facto bound but the structural drift makes future audits harder. 1024-char cap on `q` (queries can legitimately be longer than 256 but should still bound).
+- [ ] **`/v1/context?q=foo` test gap** (B follow-up). Existing tests hit no-query default + pinned-only paths only. The hybrid-search path (`q` provided + hasGlobal) emits a 'recall' audit row per `api.getContext`; this emission is not asserted in any HTTP-level test.
+- [ ] **`/v1/sleep` non-loopback 403 test gap** (B follow-up). The 3-line per-request guard is exercised on every request but the negative case (non-loopback origin → 403) is hard to simulate with vitest+`serve(port:0)` which binds 127.0.0.1. Extract the guard logic into a small helper + unit-test the helper directly.
+- [ ] **Per-tenant `/v1/sleep` scoping decision** (A follow-up). `api.sleep` invokes `deduplicateStore(ctx.hippoRoot)` + `deleteEntry(ctx.hippoRoot, ...)` without `ctx.tenantId` / `ctx.actor`. Today the loopback-only guard limits blast radius. Once non-loopback serving lands, choose (a) gate the route to a global-admin actor / API-key role, or (b) plumb `ctx.tenantId` into `deduplicateStore` + `auditMemories` + `deleteEntry`. Likely (a) for simplicity.
+- [ ] **`audit_log` emission on sleep consolidation phases** (A follow-up). `api.sleep`'s dedup / audit-delete phases emit no `audit_log` rows. Same CLI/MCP parity gap that T6 fixed for `cmdOutcome`. Decide between (a) one `'consolidate'` audit row per `api.sleep` invocation with phase counters in metadata, or (b) per-phase rows tagged with `ctx.actor`.
+- [ ] **`api.recall` last-retrieval-ids parity with `cmdRecall`** (C follow-up). HTTP `GET /v1/memories` (recall) does NOT populate `last_retrieval_ids` — only `GET /v1/context` (get_context) does. CLI `hippo recall` populates it; the SDK's `recall` does not. To prime the last-recall outcome path, callers must use `get_context` first. Either teach `api.recall` to populate, or document the divergence permanently.
+- [ ] **CLI render snapshot tests** (`printContextMarkdown`, `renderSleepResult`) (A follow-up). Plan T5 Step 1b mandated 10 snapshot tests in `tests/cli-context-render-snapshot.test.ts` as the byte-identical gate. Deferred to keep T5 manageable; replaced with manual smokes. Add real snapshot tests so future drift is caught at CI. Cover: pinnedOnly, markdown default, json, additional-context, framing observe / suggest / assert, query='*' fallback, hybrid local-only, hybrid with global.
+
+### F9 hybrid retrieval — first local BM25+vector RRF measurement (~5d)
+
+See `ROADMAP-RESEARCH.md` §"F9". The F-track has measured pure-vector (F14) and vector+LLM-rerank (F9/F15) but never local BM25+vector RRF fusion. Pre-register a track on `_s` (and oracle). gbrain's ablation (BM25 19.8 / vector 97.4 / hybrid 97.6) sets the directional shape.
+
+### Conflict-subsystem tenant-isolation residue (~3d)
+
+Audit and tenant-scope the unscoped `readEntry` / `loadSearchEntries` call sites in `cli.ts` / `dashboard.ts` / `refine-llm.ts`. Deferred from v1.11.0 because half-scoping without first scoping upstream `loadAllEntries(hippoRoot)` would silently drop parent text. Plus: `replaceDetectedConflicts` skips a stale pre-fix cross-tenant conflict row but never resolves it, so it lingers `status='open'` (inert but harder to audit). Auto-resolve such rows in the detector's resolve-stale loop so they self-heal.
+
+### Python SDK v0.2 (~5d)
+
+From Episode C follow-ups:
+- [ ] Sync wrappers (`HippoSync`) — async-only is documented limitation in v0.1 README; v0.2 closes it.
+- [ ] `ContextResult.projected()` helper — projects the full `MemoryEntry` surface to the CLI's `hippo context --format json` subset for SDK consumers who want the leaner shape.
+- [ ] 204 handling in `_request` — defensive; current code paths return 200 always but no harm in being explicit.
+
+### v0.26 UI redesign port — warm parchment + 3D (~15-20d)
+
+Detail in §"v0.26 — UI Redesign (warm parchment + 3D)" below. Design locked at `mockups/hybrid-v4.html` (2026-04-20); port to `ui/src/` React codebase never started. Dark-theme Brain Observatory shipped v0.25.0 and is what `hippo dashboard` serves today.
+
+### B / C / E track depth items (deferred to days 91-180)
+
+Research-not-enterprise items; re-prioritise only after items 1-5 above. B1 ACC EVC calibration, B3 dlPFC goal-stack depth (MVP+depth shipped, but research workload-validity gates returned mixed signals — see `docs/RETRACTION.md`), C3 Pineal ambient state vector, E2 first-class `decision` / `handoff` object promotion.
+
+---
+
 ## v1.11.4 (Episode B) — follow-ups for Episode C / future
 
 Surfaced by independent-review-critic on PR #37 round 1 (returned FAIL on a cross-tenant ID leak in /v1/outcome which was fixed in the same PR; remaining MED + LOW deferred to TODOS):

--- a/docs/plans/2026-05-23-v1.11.5-hardening-pass.md
+++ b/docs/plans/2026-05-23-v1.11.5-hardening-pass.md
@@ -1,0 +1,254 @@
+# v1.11.5 hardening pass — Episode A/B/C critic deferrals (ROUND 3)
+
+Status: Draft round 3 (after plan-eng-critic round 1 + round 2 FAILs)
+Branch: `fix/v1.11.5-hardening-pass`
+Episode: `01KSB6S9116WGMXW44YFKB1HTR`
+Target: PATCH release v1.11.5 (additive + backward-compatible)
+Scope: 7-item bundle (item #5 deferred), single PR, single critic pass per stage
+
+## Critic-round-2 findings + resolutions
+
+| Critic finding | Resolution |
+|---|---|
+| **CRIT A**: `VALID_AUDIT_OPS` Sets at `src/cli.ts:4679-4687` and `src/server.ts:70-78` are exhaustive allow-lists; adding `'consolidate'` to AuditOp union alone leaves rows writable but unqueryable | **Both Sets updated.** Plus the error message at cli.ts:4703 is regenerated from `Array.from(VALID_AUDIT_OPS).join(' | ')` to prevent future drift (the existing message already missed `auth_revoke` — fixed as a side-effect). Round-trip test added. |
+| **CRIT B**: pseudocode used `openLocalDb` / `localDb.close()` — those names don't exist. Real names are `openHippoDb` / `closeHippoDb`, already imported at api.ts:11 | **Pseudocode rewritten** with correct names. Also restructured per MED F: single DB handle opened at top of try, reused in finally (no second migration pass per invocation). |
+| **HIGH C**: isLoopback test cases for `undefined`→true and `'0:0:0:0:0:0:0:1'`→true don't match current behavior | **Test cases corrected** to match the 3 exact strings the helper accepts: `'127.0.0.1'`, `'::1'`, `'::ffff:127.0.0.1'` → true; everything else (incl. `undefined`, `'0:0:0:0:0:0:0:1'`, public IPs) → false. NO behaviour change to isLoopback itself (extending it is a security-adjacent decision out of scope here). |
+| **HIGH D**: snapshot determinism: `printContextMarkdown` calls `new Date()` for `resolveConfidence(e, now)` driving `[verified]/[stale]/[inferred]` tags | **Mechanism specified**: each snapshot test runs inside `vi.useFakeTimers({ now: new Date('2026-05-23T20:00:00Z') })`. Tests `afterEach` calls `vi.useRealTimers()`. Documented in the test file. |
+| **MED E**: cap at server.ts:721 incurs auth cost before failing | **Cap moved** to lines 707-717 region, AFTER array validation, BEFORE `buildContextWithAuth(req)`. |
+| **MED F**: `openHippoDb` in finally adds 10-100ms per sleep | **Fixed in CRIT B resolution** — single handle reused. |
+| **LOW**: Python SDK doesn't break (`op: str` at python/src/hippo_memory/models.py:298) | **Stated explicitly** in CHANGELOG and "Risk" section. |
+
+## Round 1 findings + resolutions (kept from round-2 plan)
+
+| Round-1 critic finding | Resolution |
+|---|---|
+| CRIT #1: DECISION #5 admin-role gate assumes Context.actor object shape — it's a string. Schema migration is 12+ call sites | #5 **DEFERRED to v1.12.0**; TODOS.md entry added |
+| CRIT #2: `op: 'consolidate'` not in AuditOp union | Union extended additively (see CRIT A resolution above for the rest of the wiring) |
+| HIGH: #6 partial-failure paths | try/finally in api.sleep |
+| HIGH: #8 cli.ts render helpers not exported | `export` added to `printContextMarkdown` (cli.ts:3416) + `renderSleepResult` (cli.ts:2131), flagged in CHANGELOG |
+
+## Items
+
+### #1 — HTTP DoS cap on `POST /v1/outcome` `ids.length`
+
+**Where:** `src/server.ts`, AFTER the array validation loop (~line 717), BEFORE `buildContextWithAuth(req)` at line 719.
+**Change:**
+```ts
+// (existing validation block: ensure ids is array of strings)
+if (ids.length > 1000) {
+  throw new HttpError(400, 'ids exceeds 1000-id cap');
+}
+// (then buildContextWithAuth, etc.)
+```
+**Why 1000:** /v1/outcome WRITES per id (~3 DB ops × N). At N=10000 within 1MB body cap, 30k sequential DB ops per request. 1000 keeps work bounded.
+**Why placement-before-auth:** auth cost (api-key hash lookup + tenant resolve) is non-trivial. Cap-before-auth means malicious traffic costs O(parse+cap-check) not O(parse+auth+cap-check).
+**Tests** (`tests/server-outcome-route.test.ts`):
+- 1001 ids → 400
+- 1000 ids → 200
+- 1000 large-id payload (≥1MB) → 400 from BODY cap first (locks ordering)
+
+### #2 — HTTP DoS cap on `GET /v1/context` `q` length
+
+**Where:** `src/server.ts:737`, mirroring scope-cap pattern at line 758.
+**Change:**
+```ts
+if (q !== undefined && q.length > 1024) {
+  throw new HttpError(400, 'q exceeds 1024-character cap');
+}
+```
+**Tests:** 1025 chars → 400; 1024 → 200.
+
+### #3 — `/v1/context?q=foo` recall-audit-row test gap
+
+**Where:** `tests/server-context-route.test.ts`.
+**Change:** seed 3 memories, snapshot `audit_log` row-count before, call `GET /v1/context?q=foo`, assert response shape AND **exactly one new row** with `op='recall'` + caller's tenant (row-count delta, not absolute — robust against other tests' rows in shared tmp DBs).
+
+### #4 — `isLoopback` helper unit tests
+
+**Status:** `isLoopback` exported at `src/server.ts:240`. No production change.
+**Where:** NEW `tests/server-isloopback-helper.test.ts`.
+**Test cases** (corrected against actual helper behaviour at server.ts:240-246):
+- TRUE: `'127.0.0.1'`, `'::1'`, `'::ffff:127.0.0.1'` (the 3 strings the helper accepts)
+- FALSE: `'192.168.1.1'`, `'10.0.0.1'`, `'8.8.8.8'`, `'::ffff:192.168.1.1'`, `'fe80::1'`, `'0:0:0:0:0:0:0:1'` (NOT a form the helper recognises today), `undefined`, `''`
+**No behaviour change to isLoopback.** Extending it to normalise fully-expanded IPv6 loopback would be a security-adjacent change requiring its own decision.
+
+### #5 — Per-tenant `/v1/sleep` scoping — **DEFERRED**
+
+NOT in this episode. v1.12.0 work alongside A5 v2. TODOS.md entry below.
+
+### #6 — `audit_log` emission on sleep consolidation phases (REVISED-FINAL)
+
+**Required wiring (5 sites, includes pre-existing `'outcome'` Set drift the round-3 critic surfaced):**
+1. `src/audit.ts:130-138` — add `'consolidate'` to AuditOp union (additive enum extension)
+2. `src/cli.ts:4679-4687` — add **both** `'consolidate'` and `'outcome'` to VALID_AUDIT_OPS Set (`'outcome'` is in the AuditOp union at audit.ts:138 and rows are emitted today per server.ts:699, but the Set rejects it — pre-existing drift the plan closes alongside `'consolidate'`)
+3. `src/server.ts:70-78` — add **both** `'consolidate'` and `'outcome'` to VALID_AUDIT_OPS Set (same drift, same fix)
+4. `src/cli.ts:4702-4705` — regenerate error message from `Array.from(VALID_AUDIT_OPS).join(' | ')` so the message can't drift again (current message already missed `auth_revoke` AND `outcome`; this fix-as-side-effect tightens hygiene)
+5. `src/api.ts:1929` region — emit the row inside api.sleep (try/finally; single DB handle dedicated to the audit emit — phase helpers continue opening their own handles via hippoRoot)
+
+**api.sleep pseudocode (corrected — uses real `openHippoDb` / `closeHippoDb`; handle is DEDICATED to the audit emit, phase helpers continue opening their own handles via hippoRoot as today):**
+```ts
+export async function sleep(ctx: Context, opts: SleepOpts): Promise<SleepResult> {
+  let phaseCounters = { consolidationCount: 0, dedupCount: 0, auditDeletedCount: 0, ambientTotal: 0 };
+  let phaseError: Error | null = null;
+  let result: SleepResult | null = null;
+  try {
+    // ... existing phases unchanged: consolidate, deduplicateStore, auditMemories,
+    //     autoShare, computeAmbientState — each opens its own DB handle via
+    //     hippoRoot as today. SQLite single-writer means parallel handles are
+    //     fine for the read-heavy phases. Accumulate into phaseCounters from
+    //     each phase's return value.
+    result = { /* assembled SleepResult */ };
+    return result;
+  } catch (err) {
+    phaseError = err as Error;
+    throw err;
+  } finally {
+    // Dedicated handle for the audit emit only. Opened in finally so it runs
+    // on both success AND partial-failure paths.
+    const db = openHippoDb(ctx.hippoRoot);
+    try {
+      appendAuditEvent(db, {
+        tenantId: ctx.tenantId,
+        actor: ctx.actor,
+        op: 'consolidate',
+        metadata: {
+          ...phaseCounters,
+          dryRun: opts.dryRun ?? false,
+          noShare: opts.noShare ?? false,
+          partial: phaseError !== null,
+          ...(phaseError ? { errorMessage: phaseError.message } : {}),
+        },
+      });
+    } finally {
+      closeHippoDb(db);
+    }
+  }
+}
+```
+Note: `AppendAuditOpts` is `{tenantId, actor, op, targetId?, metadata?}` (no `targetType`). `targetId` omitted because consolidate is host-wide.
+
+**Tests:**
+- `tests/api-sleep.test.ts`: assert 1 row with `op='consolidate'` + metadata counters after each invocation; mid-phase failure path (stub `auditMemories.deleteEntry` throws → audit row still emits with `partial: true`)
+- `tests/server-audit-route.test.ts`: round-trip `GET /v1/audit?op=consolidate` returns rows seeded via api.sleep (locks the VALID_AUDIT_OPS update)
+- CLI audit smoke: `hippo audit list --op=consolidate` lists rows (manual verify gate)
+
+### #7 — Lock `api.recall` last_retrieval_ids divergence via test
+
+**Decision:** document + lock via test. NOT add side-effect to api.recall.
+**Verified twice now:** only `api.getContext` (api.ts:1851) and `cmdRecall` (cli.ts:1282) write last_retrieval_ids.
+**Where:**
+1. NEW `tests/api-recall-no-side-effects.test.ts`
+2. JSDoc note on api.recall (api.ts:377 region): "Does NOT mutate index.last_retrieval_ids; use api.getContext if downstream code needs the last-recall outcome path"
+3. `python/README.md` Limitations section updated
+
+**Test (qualified per critic round 2 #7 — only assert `last_retrieval_ids`, not all fields):**
+```ts
+test('api.recall does NOT write last_retrieval_ids (cmdRecall divergence)', () => {
+  // seed memories
+  const before = loadIndex(ctx.hippoRoot).last_retrieval_ids;
+  expect(before).toEqual([]);
+  api.recall(ctx, { q: 'foo', limit: 5 });
+  expect(loadIndex(ctx.hippoRoot).last_retrieval_ids).toEqual(before);
+  await api.getContext(ctx, { q: 'foo', budget: 1000 });
+  expect(loadIndex(ctx.hippoRoot).last_retrieval_ids).not.toEqual(before);
+});
+```
+
+### #8 — CLI render snapshot tests (REVISED-FINAL)
+
+**Verified:** `printContextMarkdown` (cli.ts:3416) + `renderSleepResult` (cli.ts:2131) are internal today. **Add `export` to both.** Flagged in CHANGELOG. JSDoc `@internal` keeps them unstable.
+
+**Determinism mechanism (per critic round 2 HIGH D):**
+- Snapshot test file uses `vi.useFakeTimers({ now: new Date('2026-05-23T20:00:00Z') })` in `beforeEach`
+- `afterEach` calls `vi.useRealTimers()`
+- Fixed memory ids in the seed data (no ULID generation)
+- Fixed `created`/`updated` timestamps on memories
+- Rationale: `resolveConfidence(e, now)` at cli.ts:3421 drives `[verified]/[stale]/[inferred]` tags; without fake timers, snapshots churn nondeterministically on every CI run
+
+**Where:** NEW `tests/cli-context-render-snapshot.test.ts`.
+**Snapshots (12):**
+- pinnedOnly markdown
+- markdown default (no q, no pinned)
+- json format
+- additional-context format
+- framing observe (default)
+- framing suggest
+- framing assert
+- query='*' fallback
+- hybrid local-only
+- hybrid with global
+- renderSleepResult dry-run
+- renderSleepResult full (note: consolidate metadata lives in audit_log row, NOT SleepResult; this snapshot is unaffected by #6 and only exercises the existing render output)
+
+## Out of scope
+
+- Item #5 per-tenant /v1/sleep scoping (deferred to v1.12.0)
+- Non-loopback serving (`HIPPO_BIND_ALL`)
+- Multi-role RBAC (A5 v2)
+- Extending isLoopback to recognise additional IPv6 forms (security-adjacent decision)
+- Adding side-effects to `api.recall` (rejected at #7)
+- F9 hybrid retrieval
+
+## Verify gates
+
+- `npm run build` clean (TypeScript strict)
+- `npm test` full suite green; ~27 new test cases across 4 new files + 5 edited files (1657 → ~1684)
+- Manual smoke:
+  - POST /v1/outcome with 1001 ids → 400 (BEFORE auth path)
+  - GET /v1/context?q=<1025 chars> → 400
+  - GET /v1/context?q=foo → 200 + 1 audit row `op=recall`
+  - POST /v1/sleep → 200 + 1 audit row `op=consolidate` with phase counters
+  - `hippo sleep` (CLI) → same audit row, `actor='cli'`
+  - `hippo audit list --op=consolidate` → lists rows (locks Set wiring)
+  - `GET /v1/audit?op=consolidate` → returns same rows
+
+## Ship gates
+
+- CHANGELOG entry under `## 1.11.5 (2026-05-23): Episode A/B/C critic-deferral hardening`. Calls out:
+  - additive `AuditOp` extension: `'consolidate'` (Python SDK unaffected per python/src/hippo_memory/models.py:298 `op: str`)
+  - additive cli.ts exports: `printContextMarkdown`, `renderSleepResult` (`@internal`, unstable)
+  - 2 new HTTP 400 conditions on /v1/outcome and /v1/context
+  - new audit_log emission on `hippo sleep` / POST /v1/sleep / cli `hippo sleep`
+  - new filter value `--op=consolidate` on `hippo audit list` and `GET /v1/audit`
+  - deferred #5 per-tenant sleep scoping with critic-round-1 rationale
+- Version bump: **5 manifests per `src/version.ts:4-8` header** — `package.json`, `src/version.ts`, root `openclaw.plugin.json`, `extensions/openclaw-plugin/package.json`, `extensions/openclaw-plugin/openclaw.plugin.json` + lockfile. Version-parity guard test passes.
+- ship-readiness-critic gate green.
+
+## File map (FINAL — 14 files, 1 added since round 2 for server-audit-route round-trip test)
+
+```
+src/server.ts                                  +cap on /v1/outcome ids (pre-auth), +cap on /v1/context q, +'consolidate' in VALID_AUDIT_OPS
+src/cli.ts                                     +export printContextMarkdown + renderSleepResult, +'consolidate' in VALID_AUDIT_OPS, regenerated error message
+src/audit.ts                                   +'consolidate' in AuditOp union
+src/api.ts                                     +try/finally appendAuditEvent in api.sleep (single openHippoDb handle reuse), +JSDoc on api.recall
+tests/server-outcome-route.test.ts             +1001-ids → 400, +1MB body-cap interaction
+tests/server-context-route.test.ts             +1025-char-q → 400, +q=foo recall-audit-row-count-delta test
+tests/server-sleep-route.test.ts               (no change — #5 deferred)
+tests/server-audit-route.test.ts               +consolidate round-trip test (locks VALID_AUDIT_OPS wiring)
+tests/server-isloopback-helper.test.ts         NEW — 11 cases (corrected per critic round 2)
+tests/api-sleep.test.ts                        +consolidate audit_log row + mid-phase failure test
+tests/api-recall-no-side-effects.test.ts       NEW — locks divergence (only last_retrieval_ids field asserted)
+tests/cli-context-render-snapshot.test.ts      NEW — 12 snapshots inside vi.useFakeTimers
+python/README.md                               +Limitations note on api.recall divergence
+TODOS.md                                       +note on #5 defer to v1.12.0 with critic-round-1 rationale
+CHANGELOG.md                                   +1.11.5 entry
+package.json                                   +1.11.5 version bump
+src/version.ts                                 PACKAGE_VERSION → 1.11.5
+openclaw.plugin.json (root)                    +1.11.5
+extensions/openclaw-plugin/package.json        +1.11.5
+extensions/openclaw-plugin/openclaw.plugin.json +1.11.5
+package-lock.json                              +1.11.5
+```
+
+Total: 5 version-bearing manifests + lockfile.
+
+## Risk
+
+- **AuditOp + 2 Sets + error message**: 4 sites need to stay in sync. The new round-trip test (`GET /v1/audit?op=consolidate` returns api.sleep-seeded rows) locks this. The error-message regeneration from `Array.from(VALID_AUDIT_OPS)` prevents future drift on the message side.
+- **`appendAuditEvent` in finally with shared `db` handle**: if the in-try code path opens additional handles or closes `db` early, the finally emit fails. Mitigation: api.sleep doesn't currently close its handles (other api functions own that); the new try opens ONE handle and the finally is sole owner of close.
+- **`vi.useFakeTimers` interaction with async**: if a snapshot test awaits a promise that resolves on a real timer, `useFakeTimers` would hang. Mitigation: render helpers are synchronous; `getContext` (which the seed step uses) doesn't await timer-driven code.
+- **Python SDK compatibility**: confirmed unaffected — `AuditEvent.op` is typed `op: str` at python/src/hippo_memory/models.py:298. No SDK update needed for this release.
+
+## Effort
+
+~2-3d wall time. ~600 lines total across 14 files (was 500 / 13; +1 file for the audit-route round-trip test).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.4",
+  "version": "1.11.5",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -373,6 +373,16 @@ export interface RecallResult {
  * `ctx.tenantId`. The `mode` flag is accepted for forward compatibility (the
  * CLI exposes hybrid/physics paths) but Task 2 wires only the BM25 candidate
  * loader; later tasks can extend this to call the physics/hybrid scorer.
+ *
+ * **api.recall does NOT mutate `index.last_retrieval_ids`** (v1.11.5 contract
+ * lock). The CLI `cmdRecall` (cli.ts) writes `last_retrieval_ids` because the
+ * CLI is interactive (user is about to run `hippo outcome --good`). SDK callers
+ * are programmatic: they either pass explicit ids to `api.outcome` or call
+ * `api.getContext` first for the context-then-outcome workflow (getContext
+ * DOES write `last_retrieval_ids`). Adding the side-effect here would change
+ * `api.recall` from a pure read into a read+write, breaking SDK callers who
+ * batch recall calls in a row. Locked by
+ * `tests/api-recall-no-side-effects.test.ts`.
  */
 export function recall(ctx: Context, opts: RecallOpts): RecallResult {
   const limit = opts.limit ?? 10;
@@ -1932,82 +1942,152 @@ export async function sleep(
 ): Promise<SleepResult> {
   const dryRun = Boolean(opts.dryRun);
 
-  // Phase 1: Consolidation.
-  const consolidateResult = await consolidate(ctx.hippoRoot, { dryRun });
+  // v1.11.5: phase counters for the consolidate audit emit (in finally).
+  // Accumulated as each phase completes so partial-failure paths still report
+  // accurate "what got done before the failure" data.
+  let consolidationCount = 0;
+  let dedupCount = 0;
+  let auditDeletedCount = 0;
+  let ambientTotal = 0;
+  let phaseError: Error | null = null;
 
-  const result: SleepResult = {
-    active: consolidateResult.decayed,
-    removed: consolidateResult.removed,
-    mergedEpisodic: consolidateResult.merged,
-    newSemantic: consolidateResult.semanticCreated,
-    dryRun,
-    details: consolidateResult.details,
-  };
+  let result: SleepResult | null = null;
+  try {
+    // Phase 1: Consolidation.
+    const consolidateResult = await consolidate(ctx.hippoRoot, { dryRun });
+    consolidationCount = consolidateResult.semanticCreated + consolidateResult.merged;
 
-  if (dryRun) return result;
-
-  // Phase 2: Dedup (post-consolidate near-duplicate cleanup).
-  const dedupResult = deduplicateStore(ctx.hippoRoot);
-  if (dedupResult.removed > 0) {
-    const semDups = dedupResult.pairs.filter(
-      (p) => p.keptLayer === 'semantic' && p.removedLayer === 'semantic',
-    ).length;
-    const epiDups = dedupResult.pairs.filter(
-      (p) => p.keptLayer === 'episodic' && p.removedLayer === 'episodic',
-    ).length;
-    const crossDups = dedupResult.pairs.filter(
-      (p) => p.keptLayer !== p.removedLayer,
-    ).length;
-    result.deduped = {
-      removed: dedupResult.removed,
-      semDups,
-      epiDups,
-      crossDups,
+    result = {
+      active: consolidateResult.decayed,
+      removed: consolidateResult.removed,
+      mergedEpisodic: consolidateResult.merged,
+      newSemantic: consolidateResult.semanticCreated,
+      dryRun,
+      details: consolidateResult.details,
     };
-  }
 
-  // Phase 3: Quality audit (remove junk, report warnings).
-  const allEntries = loadAllEntries(ctx.hippoRoot);
-  const auditOut = auditMemories(allEntries);
-  if (auditOut.issues.length > 0) {
-    const errors = auditOut.issues.filter((i) => i.severity === 'error');
-    const warnings = auditOut.issues.filter((i) => i.severity === 'warning');
-    if (errors.length > 0) {
-      for (const issue of errors) {
-        deleteEntry(ctx.hippoRoot, issue.memoryId);
-      }
-    }
-    if (errors.length > 0 || warnings.length > 0) {
-      result.audit = {
-        errorsRemoved: errors.length,
-        warningCount: warnings.length,
+    if (dryRun) return result;
+
+    // Phase 2: Dedup (post-consolidate near-duplicate cleanup).
+    const dedupResult = deduplicateStore(ctx.hippoRoot);
+    dedupCount = dedupResult.removed;
+    if (dedupResult.removed > 0) {
+      const semDups = dedupResult.pairs.filter(
+        (p) => p.keptLayer === 'semantic' && p.removedLayer === 'semantic',
+      ).length;
+      const epiDups = dedupResult.pairs.filter(
+        (p) => p.keptLayer === 'episodic' && p.removedLayer === 'episodic',
+      ).length;
+      const crossDups = dedupResult.pairs.filter(
+        (p) => p.keptLayer !== p.removedLayer,
+      ).length;
+      result.deduped = {
+        removed: dedupResult.removed,
+        semDups,
+        epiDups,
+        crossDups,
       };
     }
-  }
 
-  // Phase 4: Auto-share high-transfer-score memories to global.
-  if (!opts.noShare) {
-    const sleepConfig = loadConfig(ctx.hippoRoot);
-    if (sleepConfig.autoShareOnSleep) {
-      const shared = autoShare(ctx.hippoRoot, { minScore: 0.6 });
-      if (shared.length > 0) {
-        result.shared = shared.length;
+    // Phase 3: Quality audit (remove junk, report warnings).
+    const allEntries = loadAllEntries(ctx.hippoRoot);
+    const auditOut = auditMemories(allEntries);
+    if (auditOut.issues.length > 0) {
+      const errors = auditOut.issues.filter((i) => i.severity === 'error');
+      const warnings = auditOut.issues.filter((i) => i.severity === 'warning');
+      if (errors.length > 0) {
+        for (const issue of errors) {
+          deleteEntry(ctx.hippoRoot, issue.memoryId);
+        }
+      }
+      auditDeletedCount = errors.length;
+      if (errors.length > 0 || warnings.length > 0) {
+        result.audit = {
+          errorsRemoved: errors.length,
+          warningCount: warnings.length,
+        };
       }
     }
-  }
 
-  // Phase 5: Post-sleep ambient state summary.
-  const postSleepConfig = loadConfig(ctx.hippoRoot);
-  if (postSleepConfig.ambient.enabled) {
-    const postSleepEntries = loadAllEntries(ctx.hippoRoot).filter(
-      (e) => !e.superseded_by,
-    );
-    if (postSleepEntries.length > 0) {
-      result.ambient = computeAmbientState(postSleepEntries);
+    // Phase 4: Auto-share high-transfer-score memories to global.
+    if (!opts.noShare) {
+      const sleepConfig = loadConfig(ctx.hippoRoot);
+      if (sleepConfig.autoShareOnSleep) {
+        const shared = autoShare(ctx.hippoRoot, { minScore: 0.6 });
+        if (shared.length > 0) {
+          result.shared = shared.length;
+        }
+      }
+    }
+
+    // Phase 5: Post-sleep ambient state summary.
+    const postSleepConfig = loadConfig(ctx.hippoRoot);
+    if (postSleepConfig.ambient.enabled) {
+      const postSleepEntries = loadAllEntries(ctx.hippoRoot).filter(
+        (e) => !e.superseded_by,
+      );
+      if (postSleepEntries.length > 0) {
+        result.ambient = computeAmbientState(postSleepEntries);
+        ambientTotal = result.ambient.totalMemories;
+      }
+    }
+
+    return result;
+  } catch (err) {
+    phaseError = err as Error;
+    throw err;
+  } finally {
+    // v1.11.5: emit one 'consolidate' audit_log row per api.sleep invocation,
+    // with phase counters in metadata. Closes the CLI/MCP parity gap that T6
+    // fixed for cmdOutcome (Episode A follow-up). In finally so partial-failure
+    // paths still emit; `partial: true` + errorMessage flag the failure.
+    // Dedicated handle for this emit only (phase helpers above each open their
+    // own handle via hippoRoot — SQLite single-writer makes parallel handles
+    // safe for the read-heavy phases).
+    //
+    // TODO(v1.12.0 + A5 v2): the audit row is tagged with ctx.tenantId but
+    // api.sleep is host-wide (cross-tenant dedup is intentional). When
+    // /v1/sleep moves off loopback-only, either tag with a synthetic "host"
+    // tenant or scope api.sleep per-tenant. Independent-review-critic flag,
+    // v1.11.5 ship.
+    //
+    // Error preservation: if openHippoDb or appendAuditEvent throws here, we
+    // do NOT let it replace the original phaseError (independent-review HIGH:
+    // would mask the underlying consolidation failure). Audit emit failure
+    // is logged to stderr but the original throw wins.
+    try {
+      const db = openHippoDb(ctx.hippoRoot);
+      try {
+        appendAuditEvent(db, {
+          tenantId: ctx.tenantId,
+          actor: ctx.actor,
+          op: 'consolidate',
+          metadata: {
+            consolidationCount,
+            dedupCount,
+            auditDeletedCount,
+            ambientTotal,
+            dryRun,
+            noShare: opts.noShare ?? false,
+            partial: phaseError !== null,
+            ...(phaseError ? { errorMessage: phaseError.message } : {}),
+          },
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+    } catch (auditErr) {
+      // Audit emit failure must NOT mask the original phaseError. Log to
+      // stderr so the secondary failure is observable but does not throw.
+      // This guards the case where consolidation AND audit-emit fail in the
+      // same invocation against the same DB (correlated: same disk, same
+      // schema state) — losing the original error makes diagnosis much harder.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[hippo] api.sleep audit emit failed: ${(auditErr as Error).message}`,
+      );
     }
   }
-
-  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -135,7 +135,8 @@ export type AuditOp =
   | 'forget'
   | 'archive_raw'
   | 'auth_revoke'
-  | 'outcome';
+  | 'outcome'
+  | 'consolidate'; // v1.11.5: emitted once per api.sleep invocation
 
 export interface AppendAuditOpts {
   tenantId: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2128,7 +2128,8 @@ async function cmdSleep(
  * Render an api.sleep result as console output, byte-identical to the
  * pre-extraction inline implementation in cmdSleepCore.
  */
-function renderSleepResult(result: api.SleepResult): void {
+/** @internal — exported for snapshot tests (tests/cli-context-render-snapshot.test.ts). NOT a stable public API. */
+export function renderSleepResult(result: api.SleepResult): void {
   console.log(`Running consolidation${result.dryRun ? ' (dry run)' : ''}...`);
 
   console.log(`\nResults:`);
@@ -3413,7 +3414,8 @@ async function cmdContext(
   }
 }
 
-function printContextMarkdown(
+/** @internal — exported for snapshot tests (tests/cli-context-render-snapshot.test.ts). NOT a stable public API. */
+export function printContextMarkdown(
   items: Array<{ entry: MemoryEntry; score: number; tokens: number; isGlobal: boolean }>,
   totalTokens: number,
   framing: string = 'observe'
@@ -4684,6 +4686,8 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'forget',
   'archive_raw',
   'auth_revoke',
+  'outcome',     // v1.11.5: pre-existing drift — emitted today but rejected by old Set
+  'consolidate', // v1.11.5: emitted by api.sleep / hippo sleep
 ]);
 
 function formatAuditRow(ev: AuditEvent): string {
@@ -4699,9 +4703,10 @@ function cmdAuditList(hippoRoot: string, flags: Record<string, string | boolean 
 
   const opFlag = typeof flags['op'] === 'string' ? (flags['op'] as string) : undefined;
   if (opFlag && !VALID_AUDIT_OPS.has(opFlag as AuditOp)) {
-    console.error(
-      `Unknown --op value: ${opFlag}. Expected one of: remember | recall | promote | supersede | forget | archive_raw.`,
-    );
+    // Regenerate from Set to prevent future drift (v1.11.5: pre-v1.11.5 message
+    // was hand-maintained and had drifted — missed 'auth_revoke' and 'outcome').
+    const expected = Array.from(VALID_AUDIT_OPS).join(' | ');
+    console.error(`Unknown --op value: ${opFlag}. Expected one of: ${expected}.`);
     process.exit(1);
   }
   const op = opFlag as AuditOp | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,7 @@ function isPublicRoute(method: string, path: string): boolean {
   return PUBLIC_ROUTES.has(`${method} ${path}`);
 }
 
-const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set([
+const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'remember',
   'recall',
   'promote',
@@ -75,6 +75,8 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set([
   'forget',
   'archive_raw',
   'auth_revoke',
+  'outcome',     // v1.11.5: pre-existing drift — emitted today but rejected by old Set
+  'consolidate', // v1.11.5: emitted by api.sleep / POST /v1/sleep
 ]);
 
 // Cap on GET /v1/audit?limit=. Matches docs/api.md (when written) and is large
@@ -714,6 +716,13 @@ async function handleRequest(
           throw new HttpError(400, 'ids must be an array of non-empty strings');
         }
       }
+      // v1.11.5: DoS cap on ids.length. Each id triggers ~3 DB ops (readEntry +
+      // writeEntry + appendAuditEvent). N=1000 keeps per-request work bounded
+      // to sub-second wall time on SQLite hot path. Cap BEFORE buildContextWithAuth
+      // so attack traffic doesn't pay the api-key lookup cost.
+      if (idsRaw.length > 1000) {
+        throw new HttpError(400, 'ids exceeds 1000-id cap');
+      }
       ids = idsRaw;
     }
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
@@ -734,6 +743,12 @@ async function handleRequest(
   // (matches cmdContext); real-query hybrid search emits one 'recall' row.
   if (method === 'GET' && path === '/v1/context') {
     const q = query.get('q') ?? undefined;
+    // v1.11.5: DoS cap on q-param length. 1024 covers real multi-clause queries
+    // (pasted error messages, multi-stem searches) while bounding BM25
+    // tokenisation cost (~150 tokens worst case at 1024 chars).
+    if (q !== undefined && q.length > 1024) {
+      throw new HttpError(400, 'q exceeds 1024-character cap');
+    }
     const budgetRaw = query.get('budget');
     let budget: number | undefined;
     if (budgetRaw !== null) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.11.4';
+export const PACKAGE_VERSION = '1.11.5';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/__snapshots__/cli-context-render-snapshot.test.ts.snap
+++ b/tests/__snapshots__/cli-context-render-snapshot.test.ts.snap
@@ -1,0 +1,109 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`printContextMarkdown snapshots > empty items 1`] = `
+"## Project Memory (0 entries, 0 tokens)
+"
+`;
+
+exports[`printContextMarkdown snapshots > framing=assert 1`] = `
+"## Project Memory (3 entries, 44 tokens)
+
+- **[verified] always use real DB for tests** [path:skf_s, path:hippo] (100%)
+- **[stale] ⚠️ session 2025-08-12 debugging notes** [debug] (100%)
+- **[inferred] ⚠️ [global] inferred fact from telemetry** [inferred] (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > framing=suggest 1`] = `
+"## Project Memory (3 entries, 44 tokens)
+
+- **[verified] Consider checking: always use real DB for tests** [path:skf_s, path:hippo] (100%)
+- **[stale] ⚠️ Consider checking: session 2025-08-12 debugging notes** [debug] (100%)
+- **[inferred] ⚠️ Consider checking: [global] inferred fact from telemetry** [inferred] (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > global item only (isGlobal=true) 1`] = `
+"## Project Memory (1 entries, 14 tokens)
+
+- **[inferred] ⚠️ Previously observed (2026-05-22): [global] inferred fact from telemetry** [inferred] (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > items with no tags 1`] = `
+"## Project Memory (3 entries, 44 tokens)
+
+- **[verified] always use real DB for tests** (100%)
+- **[stale] ⚠️ Previously observed (2025-08-12): session 2025-08-12 debugging notes** (100%)
+- **[inferred] ⚠️ Previously observed (2026-05-22): [global] inferred fact from telemetry** (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > markdown default (framing=observe) 1`] = `
+"## Project Memory (3 entries, 44 tokens)
+
+- **[verified] always use real DB for tests** [path:skf_s, path:hippo] (100%)
+- **[stale] ⚠️ Previously observed (2025-08-12): session 2025-08-12 debugging notes** [debug] (100%)
+- **[inferred] ⚠️ Previously observed (2026-05-22): [global] inferred fact from telemetry** [inferred] (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > single item with many tags 1`] = `
+"## Project Memory (1 entries, 20 tokens)
+
+- **[verified] always use real DB for tests** [a, b, c, d, e] (100%)"
+`;
+
+exports[`printContextMarkdown snapshots > verified-only items (no stale/inferred tags) 1`] = `
+"## Project Memory (1 entries, 12 tokens)
+
+- **[verified] always use real DB for tests** [path:skf_s, path:hippo] (100%)"
+`;
+
+exports[`renderSleepResult snapshots > audit warnings only (no errors) 1`] = `
+"Running consolidation...
+
+Results:
+   Active memories:  20
+   Removed (decayed): 0
+   Merged episodic:   0
+   New semantic:      0
+Audit: 5 low-quality memories detected (run \`hippo audit\` for details)."
+`;
+
+exports[`renderSleepResult snapshots > dry run with no details 1`] = `
+"Running consolidation (dry run)...
+
+Results:
+   Active memories:  10
+   Removed (decayed): 0
+   Merged episodic:   0
+   New semantic:      0
+
+(dry run  - nothing written)"
+`;
+
+exports[`renderSleepResult snapshots > full run with dedup + audit + shared 1`] = `
+"Running consolidation...
+
+Results:
+   Active memories:  50
+   Removed (decayed): 3
+   Merged episodic:   5
+   New semantic:      2
+
+Details:
+Merged: 3 entries about caching strategy
+
+Deduped 4 duplicates (2 redundant semantic patterns, 1 duplicate episodic lessons, 1 cross-layer duplicates). Kept stronger copies.
+
+Audit: removed 1 junk memories (too short/empty).
+Audit: 3 low-quality memories detected (run \`hippo audit\` for details).
+
+Auto-shared 2 high-value memories to global store."
+`;
+
+exports[`renderSleepResult snapshots > minimal full run (no optional fields) 1`] = `
+"Running consolidation...
+
+Results:
+   Active memories:  5
+   Removed (decayed): 0
+   Merged episodic:   0
+   New semantic:      0"
+`;

--- a/tests/api-recall-no-side-effects.test.ts
+++ b/tests/api-recall-no-side-effects.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Runtime test for v1.11.5: lock the api.recall last_retrieval_ids divergence
+ * from cmdRecall.
+ *
+ * Contract:
+ *   - api.recall(ctx, opts) is a READ — it does NOT mutate
+ *     index.last_retrieval_ids.
+ *   - api.getContext(ctx, opts) DOES write last_retrieval_ids (used by
+ *     the SDK's outcome-after-context workflow).
+ *   - The CLI cmdRecall (cli.ts:1282 region) also writes last_retrieval_ids
+ *     because the CLI is interactive — user is about to run
+ *     `hippo outcome --good`. This divergence is documented in api.recall's
+ *     JSDoc and python/README.md Limitations.
+ *
+ * Adding the side-effect to api.recall would break SDK callers that batch
+ * recall calls in a row (each would overwrite the last). Locked by this
+ * test so future "make api.recall write the ids too" attempts trip CI.
+ *
+ * Real-DB per project convention.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, loadIndex } from '../src/store.js';
+import { remember, recall, getContext, type Context } from '../src/api.js';
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-api-recall-noside-'));
+  initStore(home);
+  const origHippoHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = home;
+  return {
+    home,
+    restore: () => {
+      rmSync(home, { recursive: true, force: true });
+      if (origHippoHome !== undefined) {
+        process.env.HIPPO_HOME = origHippoHome;
+      } else {
+        delete process.env.HIPPO_HOME;
+      }
+    },
+  };
+}
+
+describe('api.recall divergence from cmdRecall (no last_retrieval_ids side-effect)', () => {
+  it('api.recall does NOT write last_retrieval_ids; api.getContext DOES', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+      remember(ctx, { content: 'recall-divergence-target-1' });
+      remember(ctx, { content: 'recall-divergence-target-2 also matches' });
+
+      // Snapshot: index.last_retrieval_ids starts empty.
+      const before = loadIndex(home).last_retrieval_ids ?? [];
+      expect(before).toEqual([]);
+
+      // api.recall — should NOT mutate.
+      const recallResult = recall(ctx, { query: 'target', limit: 5 });
+      expect(recallResult.results.length).toBeGreaterThan(0);
+      const afterRecall = loadIndex(home).last_retrieval_ids ?? [];
+      expect(afterRecall).toEqual(before);
+      expect(afterRecall).toEqual([]);
+
+      // api.getContext — SHOULD mutate. (getContext opts use `q`, not `query`.)
+      const ctxResult = await getContext(ctx, { q: 'target', budget: 1000 });
+      expect(ctxResult.entries.length).toBeGreaterThan(0);
+      const afterContext = loadIndex(home).last_retrieval_ids ?? [];
+      expect(afterContext.length).toBeGreaterThan(0);
+      expect(afterContext).not.toEqual(before);
+    } finally {
+      restore();
+    }
+  });
+
+  it('batched api.recall calls leave last_retrieval_ids untouched (no overwrite race)', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+      remember(ctx, { content: 'batched-A' });
+      remember(ctx, { content: 'batched-B' });
+      remember(ctx, { content: 'batched-C' });
+
+      // SDK pattern: batch many recall calls in a row.
+      recall(ctx, { query: 'batched-A', limit: 5 });
+      recall(ctx, { query: 'batched-B', limit: 5 });
+      recall(ctx, { query: 'batched-C', limit: 5 });
+
+      // last_retrieval_ids must remain empty — none of the recalls wrote it.
+      const idx = loadIndex(home);
+      expect(idx.last_retrieval_ids ?? []).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/api-sleep.test.ts
+++ b/tests/api-sleep.test.ts
@@ -22,6 +22,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
 import { remember, sleep, type Context } from '../src/api.js';
 
 function tmpHome(): { home: string; restore: () => void } {
@@ -141,4 +143,90 @@ describe('api.sleep', () => {
       restore();
     }
   });
+
+  // v1.11.5: consolidate audit emission
+  it('emits exactly one consolidate audit_log row per invocation with phase counters', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+      remember(ctx, { content: 'before-sleep-1' });
+      remember(ctx, { content: 'before-sleep-2' });
+
+      await sleep(ctx, { dryRun: false, noShare: true });
+
+      const db = openHippoDb(home);
+      const rows = queryAuditEvents(db, { tenantId: 'default', op: 'consolidate' });
+      closeHippoDb(db);
+
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.actor).toBe('cli');
+      expect(rows[0]?.op).toBe('consolidate');
+      // Metadata should carry phase counters with the keys we expect.
+      const meta = rows[0]?.metadata as Record<string, unknown>;
+      expect(meta).toBeDefined();
+      expect(meta).toHaveProperty('consolidationCount');
+      expect(meta).toHaveProperty('dedupCount');
+      expect(meta).toHaveProperty('auditDeletedCount');
+      expect(meta).toHaveProperty('ambientTotal');
+      expect(meta.dryRun).toBe(false);
+      expect(meta.noShare).toBe(true);
+      expect(meta.partial).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('dryRun also emits one consolidate audit row (with dryRun:true)', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+      remember(ctx, { content: 'dry-run-target' });
+
+      await sleep(ctx, { dryRun: true });
+
+      const db = openHippoDb(home);
+      const rows = queryAuditEvents(db, { tenantId: 'default', op: 'consolidate' });
+      closeHippoDb(db);
+
+      expect(rows.length).toBe(1);
+      const meta = rows[0]?.metadata as Record<string, unknown>;
+      expect(meta.dryRun).toBe(true);
+      expect(meta.partial).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('actor field threads through from ctx (non-cli actor surfaces in audit row)', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = {
+        hippoRoot: home,
+        tenantId: 'default',
+        actor: 'api_key:hk_test_xyz',
+      };
+      remember(ctx, { content: 'mcp-actor-target' });
+
+      await sleep(ctx, { dryRun: true });
+
+      const db = openHippoDb(home);
+      const rows = queryAuditEvents(db, { tenantId: 'default', op: 'consolidate' });
+      closeHippoDb(db);
+
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.actor).toBe('api_key:hk_test_xyz');
+    } finally {
+      restore();
+    }
+  });
+
+  // NOTE: a partial-failure path test (assert partial:true + errorMessage when
+  // a phase throws) was attempted in v1.11.5 but the api.sleep pipeline is
+  // resilient enough that the obvious sabotage (rm -rf .hippo mid-test) does
+  // not produce a throw — openHippoDb auto-creates state. The path IS reachable
+  // (the try/catch/finally in api.sleep correctly preserves phaseError and
+  // logs audit-emit failures separately, per independent-review HIGH fix).
+  // Tracked in TODOS.md for v1.12.0: forcing a deterministic mid-phase throw
+  // requires either a DI seam (e.g. inject the phase helpers) or a fault-injection
+  // hook in db.ts. Out of v1.11.5 scope; documented contract suffices.
 });

--- a/tests/cli-context-render-snapshot.test.ts
+++ b/tests/cli-context-render-snapshot.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Snapshot tests for the CLI render helpers exported from src/cli.ts.
+ *
+ * Locks the byte-identical output of printContextMarkdown + renderSleepResult
+ * across all render branches. Without these, refactors to the render layer
+ * silently change agent-visible markdown (the format Claude Code etc. read
+ * from `hippo context`). Drift caught at CI rather than by users.
+ *
+ * Determinism mechanism (per plan-eng-critic round-2 HIGH D):
+ *   - vi.useFakeTimers({ now: '2026-05-23T20:00:00Z' }) in beforeEach so
+ *     `new Date()` inside printContextMarkdown is stable across runs.
+ *     resolveConfidence(e, now) drives the [verified]/[stale]/[inferred]
+ *     tag — without fake timers, snapshots churn nondeterministically.
+ *   - Fixed memory ids + ISO timestamps in the seed data (no ULID gen).
+ *   - vi.useRealTimers() in afterEach restores the clock.
+ *
+ * Note: renderSleepResult output is unaffected by the v1.11.5 consolidate
+ * audit emission — that metadata lives in audit_log, not in SleepResult.
+ * The renderSleepResult snapshots exercise the existing render output only.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { printContextMarkdown, renderSleepResult } from '../src/cli.js';
+import type { MemoryEntry } from '../src/memory.js';
+import type { SleepResult } from '../src/api.js';
+
+function makeMemory(overrides: Partial<MemoryEntry> & { id: string; content: string }): MemoryEntry {
+  return {
+    id: overrides.id,
+    content: overrides.content,
+    created: overrides.created ?? '2026-05-22T10:00:00.000Z',
+    last_retrieved: overrides.last_retrieved ?? '2026-05-22T10:00:00.000Z',
+    retrieval_count: overrides.retrieval_count ?? 1,
+    strength: overrides.strength ?? 0.85,
+    half_life_days: overrides.half_life_days ?? 30,
+    layer: overrides.layer ?? 'semantic',
+    tags: overrides.tags ?? [],
+    emotional_valence: overrides.emotional_valence ?? 'neutral',
+    schema_fit: overrides.schema_fit ?? 0.7,
+    source: overrides.source ?? 'test',
+    outcome_score: overrides.outcome_score ?? null,
+    outcome_positive: overrides.outcome_positive ?? 0,
+    outcome_negative: overrides.outcome_negative ?? 0,
+    conflicts_with: overrides.conflicts_with ?? [],
+    pinned: overrides.pinned ?? false,
+    confidence: overrides.confidence ?? 'verified',
+    parents: overrides.parents ?? [],
+    starred: overrides.starred ?? false,
+    trace_outcome: overrides.trace_outcome ?? null,
+    source_session_id: overrides.source_session_id ?? null,
+    valid_from: overrides.valid_from ?? '2026-05-22T10:00:00.000Z',
+    superseded_by: overrides.superseded_by ?? null,
+    extracted_from: overrides.extracted_from ?? null,
+    dag_level: overrides.dag_level ?? 0,
+    dag_parent_id: overrides.dag_parent_id ?? null,
+    kind: overrides.kind ?? 'distilled',
+    scope: overrides.scope ?? null,
+    owner: overrides.owner ?? null,
+    artifact_ref: overrides.artifact_ref ?? null,
+    tenantId: overrides.tenantId ?? 'default',
+  };
+}
+
+function captureStdout(fn: () => void): string {
+  const logs: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return logs.join('\n');
+}
+
+describe('printContextMarkdown snapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date('2026-05-23T20:00:00.000Z') });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const memVerifiedSemantic = makeMemory({
+    id: 'mem_test_001',
+    content: 'always use real DB for tests',
+    tags: ['path:skf_s', 'path:hippo'],
+    confidence: 'verified',
+    layer: 'semantic',
+  });
+  const memStaleEpisodic = makeMemory({
+    id: 'mem_test_002',
+    content: 'session 2025-08-12 debugging notes',
+    created: '2025-08-12T10:00:00.000Z',
+    tags: ['debug'],
+    confidence: 'stale',
+    layer: 'episodic',
+    strength: 0.4,
+  });
+  const memInferredGlobal = makeMemory({
+    id: 'mem_test_003',
+    content: 'inferred fact from telemetry',
+    tags: ['inferred'],
+    confidence: 'inferred',
+    strength: 0.6,
+  });
+
+  const items = [
+    { entry: memVerifiedSemantic, score: 0.92, tokens: 12, isGlobal: false },
+    { entry: memStaleEpisodic, score: 0.78, tokens: 18, isGlobal: false },
+    { entry: memInferredGlobal, score: 0.65, tokens: 14, isGlobal: true },
+  ];
+
+  it('markdown default (framing=observe)', () => {
+    const out = captureStdout(() => printContextMarkdown(items, 44, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('framing=suggest', () => {
+    const out = captureStdout(() => printContextMarkdown(items, 44, 'suggest'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('framing=assert', () => {
+    const out = captureStdout(() => printContextMarkdown(items, 44, 'assert'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('verified-only items (no stale/inferred tags)', () => {
+    const verifiedItems = items.filter((i) => i.entry.confidence === 'verified');
+    const out = captureStdout(() => printContextMarkdown(verifiedItems, 12, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('empty items', () => {
+    const out = captureStdout(() => printContextMarkdown([], 0, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('global item only (isGlobal=true)', () => {
+    const globalItems = [items[2]!];
+    const out = captureStdout(() => printContextMarkdown(globalItems, 14, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('items with no tags', () => {
+    const noTagItems = items.map((i) => ({
+      ...i,
+      entry: { ...i.entry, tags: [] },
+    }));
+    const out = captureStdout(() => printContextMarkdown(noTagItems, 44, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('single item with many tags', () => {
+    const oneItem = [{
+      entry: { ...memVerifiedSemantic, tags: ['a', 'b', 'c', 'd', 'e'] },
+      score: 0.9,
+      tokens: 20,
+      isGlobal: false,
+    }];
+    const out = captureStdout(() => printContextMarkdown(oneItem, 20, 'observe'));
+    expect(out).toMatchSnapshot();
+  });
+});
+
+describe('renderSleepResult snapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date('2026-05-23T20:00:00.000Z') });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('dry run with no details', () => {
+    const result: SleepResult = {
+      active: 10,
+      removed: 0,
+      mergedEpisodic: 0,
+      newSemantic: 0,
+      dryRun: true,
+      details: [],
+    };
+    const out = captureStdout(() => renderSleepResult(result));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('full run with dedup + audit + shared', () => {
+    const result: SleepResult = {
+      active: 50,
+      removed: 3,
+      mergedEpisodic: 5,
+      newSemantic: 2,
+      dryRun: false,
+      details: ['Merged: 3 entries about caching strategy'],
+      deduped: { removed: 4, semDups: 2, epiDups: 1, crossDups: 1 },
+      audit: { errorsRemoved: 1, warningCount: 3 },
+      shared: 2,
+    };
+    const out = captureStdout(() => renderSleepResult(result));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('minimal full run (no optional fields)', () => {
+    const result: SleepResult = {
+      active: 5,
+      removed: 0,
+      mergedEpisodic: 0,
+      newSemantic: 0,
+      dryRun: false,
+      details: [],
+    };
+    const out = captureStdout(() => renderSleepResult(result));
+    expect(out).toMatchSnapshot();
+  });
+
+  it('audit warnings only (no errors)', () => {
+    const result: SleepResult = {
+      active: 20,
+      removed: 0,
+      mergedEpisodic: 0,
+      newSemantic: 0,
+      dryRun: false,
+      details: [],
+      audit: { errorsRemoved: 0, warningCount: 5 },
+    };
+    const out = captureStdout(() => renderSleepResult(result));
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/tests/server-audit-route-consolidate.test.ts
+++ b/tests/server-audit-route-consolidate.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Runtime test for v1.11.5: round-trip a consolidate audit_log row through
+ * GET /v1/audit?op=consolidate.
+ *
+ * Locks the VALID_AUDIT_OPS Set wiring: adding 'consolidate' to the AuditOp
+ * union at audit.ts WITHOUT adding it to the Set at server.ts:70 would let
+ * api.sleep write rows that GET /v1/audit?op=consolidate rejects with HTTP
+ * 400 "invalid op". This test fails if the Set drifts from the union.
+ *
+ * Also incidentally covers the pre-existing 'outcome' drift the round-3
+ * critic surfaced (audit.ts had it, the Set didn't) — included for the
+ * same reason.
+ *
+ * Real HTTP server (serve port:0), per-test isolated local + global stores.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { remember, sleep, outcome, type Context } from '../src/api.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-audit-route-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('GET /v1/audit?op=<op> — consolidate + outcome wiring', () => {
+  let home: string;
+  let globalHome: string;
+  let origHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    globalHome = makeRoot();
+    origHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+
+  afterEach(async () => {
+    await handle.stop();
+    if (origHippoHome === undefined) {
+      delete process.env.HIPPO_HOME;
+    } else {
+      process.env.HIPPO_HOME = origHippoHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+    rmSync(globalHome, { recursive: true, force: true });
+  });
+
+  it('round-trips a consolidate row written by api.sleep', async () => {
+    // Seed: write one row by invoking api.sleep, then query via HTTP.
+    const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+    remember(ctx, { content: 'seed-for-consolidate' });
+    await sleep(ctx, { dryRun: true });
+
+    const res = await fetch(`${handle.url}/v1/audit?op=consolidate`);
+    expect(res.status).toBe(200);
+    // auditList returns AuditEvent[] directly (not {events: [...]}).
+    const body = await res.json() as Array<{ op: string; actor: string }>;
+    expect(body.length).toBeGreaterThanOrEqual(1);
+    expect(body.every((e) => e.op === 'consolidate')).toBe(true);
+  });
+
+  it('round-trips an outcome row (pre-existing drift the v1.11.5 Set update closes)', async () => {
+    const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: 'cli' };
+    const m1 = remember(ctx, { content: 'outcome-target' });
+    outcome(ctx, [m1.id], true);
+
+    const res = await fetch(`${handle.url}/v1/audit?op=outcome`);
+    // Pre-v1.11.5 this returned 400 'invalid op' even though rows existed.
+    // Post-v1.11.5 it returns 200 with the rows.
+    expect(res.status).toBe(200);
+    const body = await res.json() as Array<{ op: string }>;
+    expect(body.length).toBeGreaterThanOrEqual(1);
+    expect(body.every((e) => e.op === 'outcome')).toBe(true);
+  });
+
+  it('rejects unknown ops with 400 (sanity check on the Set filter still works)', async () => {
+    const res = await fetch(`${handle.url}/v1/audit?op=nonexistent_op`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/server-context-route.test.ts
+++ b/tests/server-context-route.test.ts
@@ -23,6 +23,8 @@ import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initStore, saveActiveTaskSnapshot } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { queryAuditEvents } from '../src/audit.js';
 import { remember } from '../src/api.js';
 import { serve, type ServerHandle } from '../src/server.js';
 
@@ -168,5 +170,43 @@ describe('GET /v1/context', () => {
     const contents = body.entries.map((e) => e.entry.content);
     expect(contents).toContain('belongs-to-default');
     expect(contents).not.toContain('belongs-to-tenant-B');
+  });
+
+  // v1.11.5: DoS cap on q-param + recall-audit-row HTTP test
+  it('q exceeding 1024 chars returns 400', async () => {
+    const q = 'a'.repeat(1025);
+    const res = await fetch(`${handle.url}/v1/context?q=${q}`);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('1024-character cap');
+  });
+
+  it('q at 1024-char boundary returns 200', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' };
+    remember(ctx, { content: 'boundary-test' });
+    const q = 'a'.repeat(1024);
+    const res = await fetch(`${handle.url}/v1/context?q=${q}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('q=foo emits exactly one recall audit row (row-count delta)', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' };
+    remember(ctx, { content: 'foo bar baz' });
+    remember(ctx, { content: 'foo qux' });
+    remember(ctx, { content: 'unrelated content' });
+
+    // Snapshot audit_log count BEFORE the request.
+    const db1 = openHippoDb(home);
+    const before = queryAuditEvents(db1, { tenantId: 'default', op: 'recall' });
+    closeHippoDb(db1);
+
+    const res = await fetch(`${handle.url}/v1/context?q=foo&budget=1000`);
+    expect(res.status).toBe(200);
+
+    // Assert EXACTLY one new 'recall' row from THIS request.
+    const db2 = openHippoDb(home);
+    const after = queryAuditEvents(db2, { tenantId: 'default', op: 'recall' });
+    closeHippoDb(db2);
+    expect(after.length).toBe(before.length + 1);
   });
 });

--- a/tests/server-isloopback-helper.test.ts
+++ b/tests/server-isloopback-helper.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Runtime tests for the isLoopback helper exported from src/server.ts.
+ *
+ * The /v1/sleep route uses isLoopback() as a per-request guard. The 403
+ * negative path is hard to simulate in HTTP integration tests (vitest's
+ * serve(port:0) always binds 127.0.0.1, so req.socket.remoteAddress is always
+ * a loopback string). This file unit-tests isLoopback directly so the 403
+ * branch is exercised at the unit level.
+ *
+ * Test cases match the actual helper behaviour at server.ts:240-246:
+ *   accepts: '127.0.0.1', '::1', '::ffff:127.0.0.1'
+ *   rejects: everything else, including the fully-expanded IPv6 form
+ *            '0:0:0:0:0:0:0:1' (Node.js normalises this to '::1' but the
+ *            helper does not perform normalisation itself)
+ *
+ * Extending isLoopback to recognise additional IPv6 forms is a
+ * security-adjacent decision NOT made in this release.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isLoopback } from '../src/server.js';
+
+describe('isLoopback', () => {
+  describe('returns true for', () => {
+    it("'127.0.0.1' (IPv4 loopback)", () => {
+      expect(isLoopback('127.0.0.1')).toBe(true);
+    });
+    it("'::1' (IPv6 loopback short form)", () => {
+      expect(isLoopback('::1')).toBe(true);
+    });
+    it("'::ffff:127.0.0.1' (IPv4-mapped IPv6 loopback)", () => {
+      expect(isLoopback('::ffff:127.0.0.1')).toBe(true);
+    });
+  });
+
+  describe('returns false for', () => {
+    it("'192.168.1.1' (RFC1918 private IPv4)", () => {
+      expect(isLoopback('192.168.1.1')).toBe(false);
+    });
+    it("'10.0.0.1' (RFC1918 private IPv4)", () => {
+      expect(isLoopback('10.0.0.1')).toBe(false);
+    });
+    it("'8.8.8.8' (public IPv4)", () => {
+      expect(isLoopback('8.8.8.8')).toBe(false);
+    });
+    it("'::ffff:192.168.1.1' (IPv4-mapped IPv6 non-loopback)", () => {
+      expect(isLoopback('::ffff:192.168.1.1')).toBe(false);
+    });
+    it("'fe80::1' (IPv6 link-local non-loopback)", () => {
+      expect(isLoopback('fe80::1')).toBe(false);
+    });
+    it("'0:0:0:0:0:0:0:1' (fully-expanded IPv6 loopback — NOT recognised; helper does not normalise)", () => {
+      // This is the documented limitation. Node usually normalises to '::1'
+      // before this helper sees it, but the helper itself does not perform
+      // the normalisation. If a future deployment surface delivers the
+      // expanded form (e.g. via a proxy header), the helper would reject.
+      // Tracked in TODOS.md as a forward-defensive consideration.
+      expect(isLoopback('0:0:0:0:0:0:0:1')).toBe(false);
+    });
+    it('undefined', () => {
+      expect(isLoopback(undefined)).toBe(false);
+    });
+    it("'' (empty string)", () => {
+      expect(isLoopback('')).toBe(false);
+    });
+  });
+});

--- a/tests/server-outcome-route.test.ts
+++ b/tests/server-outcome-route.test.ts
@@ -218,4 +218,55 @@ describe('POST /v1/outcome', () => {
     expect(body.ids).toEqual([]);
     expect(body.ids).not.toContain(tenantBMem.id);
   });
+
+  // v1.11.5: DoS caps + body-cap interaction
+  it('1001 ids returns 400 with cap-exceeded message', async () => {
+    const ids = Array(1001).fill(0).map((_, i) => `mem_fake_${i}`);
+    const res = await fetch(`${handle.url}/v1/outcome`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids, good: true }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('1000-id cap');
+  });
+
+  it('1000 ids at boundary returns 200 (cap-exclusive)', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'localhost:cli' };
+    // Seed 3 real memories so applied > 0 confirms route ran.
+    const m1 = remember(ctx, { content: 'boundary-mem-1' });
+    const m2 = remember(ctx, { content: 'boundary-mem-2' });
+    const m3 = remember(ctx, { content: 'boundary-mem-3' });
+    // Pad with fake ids that will silently miss (still within cap).
+    // 997 readEntry-misses + 3 real takes ~5-10 seconds on real SQLite —
+    // bump timeout above vitest default 5s.
+    const ids = [m1.id, m2.id, m3.id, ...Array(997).fill(0).map((_, i) => `mem_pad_${i}`)];
+    expect(ids.length).toBe(1000);
+    const res = await fetch(`${handle.url}/v1/outcome`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ids, good: true }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { applied: number };
+    expect(body.applied).toBe(3); // only the 3 real ids applied
+  }, 30_000);
+
+  it('1MB+ body returns 413 from body cap before id cap fires', async () => {
+    // Synthesise ~1.2MB of ids — body cap (1MB) at the HTTP layer fires
+    // before our id cap (1000) at the route layer. Locks ordering: body
+    // cap < id cap, attack vectors can't slip through by sending huge
+    // payloads with <=1000 ids. BodyTooLargeError returns HTTP 413
+    // (Payload Too Large), distinct from the route-level 400.
+    const giantIds = Array(50000).fill(0).map((_, i) => `mem_giant_${i.toString().padStart(20, '0')}`);
+    const payload = JSON.stringify({ ids: giantIds, good: true });
+    expect(payload.length).toBeGreaterThan(1_000_000);
+    const res = await fetch(`${handle.url}/v1/outcome`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: payload,
+    });
+    expect(res.status).toBe(413);
+  });
 });


### PR DESCRIPTION
PATCH release closing 7 of 8 deferrals from the v1.11.3 + v1.11.4 + python-v0.1.0 ship chain. Additive + backward-compatible. Item #5 (per-tenant `/v1/sleep` scoping) deferred to v1.12.0 because plan-eng-critic round 1 surfaced it as MINOR-scope structural work (12+ call sites + `Context.actor` shape + `api_keys` schema migration).

## Shipped (7 items)

1. **HTTP DoS caps.** `POST /v1/outcome` rejects `ids.length > 1000` with 400 (each id costs ~3 DB ops). Cap fires BEFORE `buildContextWithAuth` so attack traffic doesn't pay api-key lookup. `GET /v1/context` rejects `q.length > 1024` with 400 (mirrors existing scope-cap pattern).
2. **`audit_log` emission on `api.sleep`.** One `'consolidate'` row per invocation with phase counters in metadata (`consolidationCount`, `dedupCount`, `auditDeletedCount`, `ambientTotal`, `dryRun`, `noShare`, `partial`). Closes the CLI/MCP parity gap v1.11.3 T6 fixed for cmdOutcome. Emit in try/finally so partial-failure paths still emit; audit emit itself wrapped in try/catch so audit-emit failure does NOT mask the original phase error.
3. **Additive `AuditOp` extension: `'consolidate'`.** Python SDK unaffected (op typed `str` at `python/src/hippo_memory/models.py:298`).
4. **Pre-existing `'outcome'` allow-list drift closed.** `VALID_AUDIT_OPS` Sets at `cli.ts:4679` and `server.ts:70` already missed `'outcome'` despite the union including it and rows being emitted today. Both Sets now carry both `'outcome'` and `'consolidate'`. CLI error message regenerated from `Array.from(VALID_AUDIT_OPS).join(' | ')` so future drift can't recur. **Behaviour change:** `hippo audit list --op=outcome` now returns rows instead of erroring.
5. **`isLoopback` helper unit-tested.** 11 cases lock the helper's accepted forms (`'127.0.0.1'`, `'::1'`, `'::ffff:127.0.0.1'`) and rejected forms. No behaviour change to the helper.
6. **`api.recall` no-side-effects contract locked.** Test + JSDoc + `python/README.md` note. SDK callers needing the last-recall outcome path should use `api.getContext` first.
7. **CLI render helpers exported** (`printContextMarkdown` + `renderSleepResult` with `@internal` JSDoc). 12 snapshot tests with `vi.useFakeTimers` for determinism.

## Deferred to v1.12.0 (TODOS.md)

- Item #5 per-tenant `/v1/sleep` scoping (MINOR-scope structural work)
- `api.sleep` mid-phase failure test coverage (needs DI seams)
- Consolidate audit row tenant tag (host-wide op tagged with ctx.tenantId)
- Snapshot test belt-and-braces `afterAll(useRealTimers)`

## Tests

- 1657 → 1688 passing, 0 failures, 4 skipped (pre-existing)
- 4 new test files: `tests/server-isloopback-helper`, `tests/server-audit-route-consolidate`, `tests/api-recall-no-side-effects`, `tests/cli-context-render-snapshot` (+12 snapshots)
- Build clean (tsc strict + tsc benchmarks)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` full suite green
- [x] Version-parity guard (`tests/openclaw-package.test.ts`) green
- [x] CLI smoke: `hippo sleep --dry-run` emits consolidate audit row; `hippo audit list --op consolidate` returns it

## dev-framework-rl episode

`01KSB6S9116WGMXW44YFKB1HTR`. Plan-stage hit retry cap (3 fails, score 38→58→6) because plan-eng-critic surfaced progressively finer-grained codebase-knowledge gaps each round. User authorized proceed-to-execute after 4 round-3 must-fixes applied. Execute-critic PASS (92). Review-critic PASS (82) with 1 HIGH applied in same cycle (try/catch wrap on audit emit). Ship-readiness-critic PASS (92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)