### PR TITLE
v1.12.4: auth_create audit emit (closes v1.12.3 deferral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.12.4 (2026-05-24): auth_create audit emit (closes v1.12.3 deferral)
+
+PATCH release. Closes the v1.12.3 CHANGELOG-flagged deferral (auth_create un-audited). Mirrors the existing `auth_revoke` audit pattern in `authRevoke` — one audit row per successful mint, plaintext NEVER logged.
+
+### Shipped
+
+- **`api.authCreate` emits `auth_create` audit row** on every successful mint. Same try/catch guard as `authRevoke` so audit failure can't crash a successful mint. Metadata: `{ label, role }`. `targetId`: the new `key_id`. `actor`: `ctx.actor.subject`.
+- **`'auth_create'` added to `AuditOp` union** (`src/audit.ts`) + both `VALID_AUDIT_OPS` Sets (`src/cli.ts:4712`, `src/server.ts:71`). `hippo audit list --op auth_create` and `GET /v1/audit?op=auth_create` now work.
+
+### Tests
+- 6 cases in `tests/auth-create-audit.test.ts`:
+  - Default emit: label + role in metadata, targetId matches keyId, actor matches ctx.
+  - Default role logs admin; explicit member logs member.
+  - Null label logs `label: null` (not the string `"undefined"`).
+  - **Security invariant: plaintext key NEVER appears in audit metadata** (asserted by full JSON-stringified scan).
+  - Mint + revoke pair: 1 `auth_create` row + 1 `auth_revoke` row, both `targetId` match.
+- Full suite: 1730 passed + 4 skipped + 0 failures.
+
+### Migration notes
+- **No DB migration.** `audit_log` table already supports the new op (the column is `TEXT`).
+- **No required updates for existing callers.** Audit emit is a side-effect; mint return shape unchanged.
+
 ## 1.12.3 (2026-05-24): hippo auth CLI role surfacing (v1.12.0 sub-1 follow-ups)
 
 PATCH release. Bundles two LOW-priority v1.12.0 sub-1 follow-ups: surface the `api_keys.role` column (added in schema v26 by v1.12.0 sub-1) through the CLI and the HTTP route. Pure additive; no behaviour change for callers omitting the new flag/field.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.3",
+  "version": "1.12.4",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1443,6 +1443,24 @@ export function authCreate(ctx: Context, opts: AuthCreateOpts): AuthCreateResult
   try {
     const role = opts.role ?? 'admin';
     const result = createApiKey(db, { tenantId: ctx.tenantId, label: opts.label, role });
+    // v1.12.4: audit emit (closes the gap v1.12.3 CHANGELOG flagged as deferred).
+    // Mirrors the auth_revoke pattern at authRevoke — same try/catch so audit
+    // failure can't crash a successful mint. The plaintext is NEVER logged;
+    // metadata carries label + role + the keyId (which is non-secret).
+    try {
+      appendAuditEvent(db, {
+        tenantId: ctx.tenantId,
+        actor: ctx.actor.subject,
+        op: 'auth_create',
+        targetId: result.keyId,
+        metadata: {
+          label: opts.label ?? null,
+          role,
+        },
+      });
+    } catch {
+      // Audit must not crash a successful mint.
+    }
     return { keyId: result.keyId, plaintext: result.plaintext, tenantId: ctx.tenantId, role };
   } finally {
     closeHippoDb(db);

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -135,6 +135,7 @@ export type AuditOp =
   | 'forget'
   | 'archive_raw'
   | 'auth_revoke'
+  | 'auth_create' // v1.12.4: emitted by api.authCreate (closes the gap v1.12.3 CHANGELOG flagged)
   | 'outcome'
   | 'consolidate'; // v1.11.5: emitted once per api.sleep invocation
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4717,6 +4717,7 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'forget',
   'archive_raw',
   'auth_revoke',
+  'auth_create', // v1.12.4: emitted by api.authCreate
   'outcome',     // v1.11.5: pre-existing drift — emitted today but rejected by old Set
   'consolidate', // v1.11.5: emitted by api.sleep / hippo sleep
 ]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,7 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'forget',
   'archive_raw',
   'auth_revoke',
+  'auth_create', // v1.12.4: emitted by api.authCreate
   'outcome',     // v1.11.5: pre-existing drift — emitted today but rejected by old Set
   'consolidate', // v1.11.5: emitted by api.sleep / POST /v1/sleep
 ]);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.12.3';
+export const PACKAGE_VERSION = '1.12.4';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/auth-create-audit.test.ts
+++ b/tests/auth-create-audit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * v1.12.4: tests for the auth_create audit emit.
+ *
+ * Closes the v1.12.3 CHANGELOG-flagged deferral. Mirrors auth_revoke audit
+ * coverage (already locked in tests/audit.test.ts and the M1 fix history).
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { authCreate, authRevoke, adminActor, type Context } from '../src/api.js';
+import { queryAuditEvents } from '../src/audit.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+function newCtx(tenantId = 'default'): { ctx: Context; tmpDir: string; cleanup: () => void } {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'hippo-auth-create-audit-'));
+  const ctx: Context = {
+    hippoRoot: tmpDir,
+    tenantId,
+    actor: adminActor('cli'),
+  };
+  return {
+    ctx,
+    tmpDir,
+    cleanup: () => rmSync(tmpDir, { recursive: true, force: true }),
+  };
+}
+
+function getAuditRows(hippoRoot: string, tenantId: string, op: 'auth_create' | 'auth_revoke'): Array<{
+  actor: string;
+  targetId: string | null;
+  metadata: Record<string, unknown>;
+}> {
+  const db = openHippoDb(hippoRoot);
+  try {
+    return queryAuditEvents(db, { tenantId, op, limit: 50 }).map((r) => ({
+      actor: r.actor,
+      targetId: r.targetId,
+      metadata: r.metadata as Record<string, unknown>,
+    }));
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+describe('v1.12.4 auth_create audit emit', () => {
+  it('authCreate emits one auth_create audit row with label + role metadata', () => {
+    const t = newCtx();
+    try {
+      const result = authCreate(t.ctx, { label: 'cli', role: 'admin' });
+
+      const rows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      expect(rows.length).toBe(1);
+      expect(rows[0].targetId).toBe(result.keyId);
+      expect(rows[0].actor).toBe('cli');
+      expect(rows[0].metadata.label).toBe('cli');
+      expect(rows[0].metadata.role).toBe('admin');
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it('authCreate with default role logs role=admin in audit metadata', () => {
+    const t = newCtx();
+    try {
+      authCreate(t.ctx, { label: 'no-role-passed' });
+      const rows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      expect(rows.length).toBe(1);
+      expect(rows[0].metadata.role).toBe('admin');
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it('authCreate with role=member logs role=member in audit metadata', () => {
+    const t = newCtx();
+    try {
+      authCreate(t.ctx, { label: 'reporter', role: 'member' });
+      const rows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      expect(rows.length).toBe(1);
+      expect(rows[0].metadata.role).toBe('member');
+      expect(rows[0].metadata.label).toBe('reporter');
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it('authCreate with no label logs label=null (not "undefined" string)', () => {
+    const t = newCtx();
+    try {
+      authCreate(t.ctx, {});
+      const rows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      expect(rows.length).toBe(1);
+      expect(rows[0].metadata.label).toBeNull();
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it('audit metadata MUST NOT contain plaintext key (security invariant)', () => {
+    const t = newCtx();
+    try {
+      const result = authCreate(t.ctx, { label: 'security-check' });
+      const rows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      expect(rows.length).toBe(1);
+      // The full JSON-stringified metadata must not contain the plaintext
+      const stringified = JSON.stringify(rows[0].metadata);
+      expect(stringified).not.toContain(result.plaintext);
+      // Sanity: the plaintext starts with 'hk_' + 24 chars + '.' + body
+      expect(result.plaintext).toMatch(/^hk_[a-z2-7]{24}\.[a-z2-7]+$/);
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  it('mint + revoke pair: 1 auth_create row + 1 auth_revoke row, both targetId match', () => {
+    const t = newCtx();
+    try {
+      const mint = authCreate(t.ctx, { label: 'mint-then-revoke' });
+      authRevoke(t.ctx, mint.keyId);
+
+      const createRows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_create');
+      const revokeRows = getAuditRows(t.ctx.hippoRoot, t.ctx.tenantId, 'auth_revoke');
+      expect(createRows.length).toBe(1);
+      expect(revokeRows.length).toBe(1);
+      expect(createRows[0].targetId).toBe(mint.keyId);
+      expect(revokeRows[0].targetId).toBe(mint.keyId);
+    } finally {
+      t.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v1.12.4 PATCH closes the deferral the v1.12.3 CHANGELOG flagged: `auth_create` was un-audited. Now mirrors the existing `auth_revoke` audit pattern — one audit row per successful mint.

## Shipped

- **`api.authCreate` emits `auth_create` audit row** on every successful mint
- Metadata: `{ label, role }` — `targetId`: new `keyId` — `actor`: `ctx.actor.subject`
- Same try/catch guard as `authRevoke` so audit failure can't crash a successful mint
- `'auth_create'` added to `AuditOp` union + both `VALID_AUDIT_OPS` Sets (cli + server)
- `hippo audit list --op auth_create` and `GET /v1/audit?op=auth_create` now work

## Tests

6 cases in `tests/auth-create-audit.test.ts`:
- Default + explicit role emit
- Null label logs as `null` (not the string `"undefined"`)
- **Security invariant: plaintext key NEVER in audit metadata** (full JSON scan)
- Mint + revoke pair: 1 `auth_create` + 1 `auth_revoke` row, both `targetId` match

Full suite: **1730 passed + 4 skipped + 0 failures.**

## Migration

- No DB migration (`audit_log.op` is TEXT)
- No required caller updates (mint return shape unchanged)

## Episode

`01KSCQB9RG57XX18JKMGNYHWT3`. Small-episode pipeline per PIPELINE doc B-trivial exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)