### PR TITLE
Python SDK v0.2.0: HippoSync + ContextEntry.projected() + auth role + model fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Python SDK v0.2.0 (2026-05-24): HippoSync + ContextEntry.projected() + auth role
+
+PyPI: `hippo-memory-sdk@0.2.0`. Closes 3 of 5 v0.1.0 README-documented limitations. The 4th (`recall` last_retrieval_ids gap) is reframed as a deliberate design choice locked in hippo-memory v1.11.5 (see `tests/api-recall-no-side-effects.test.ts`); the 5th (connector webhooks) is by-design (server-only routes).
+
+### Shipped
+
+- **`HippoSync` class** — sync mirror of `Hippo` using `httpx.Client`. Wire-compatible: same routes, same models, same errors. Use when your code already runs synchronously (CLI scripts, notebooks, `threading.Thread` callbacks). Async `Hippo` remains the recommended default.
+- **`ContextEntry.projected()` helper** — projects the full MemoryEntry surface to the CLI's narrower json shape (`id`, `score`, `strength`, `tags`, `confidence`, `content`, `global`). Mirrors `hippo context --format json` per-row output.
+- **`auth_create(role=)` parameter** on both `Hippo` and `HippoSync` — matches hippo-memory v1.12.3 server. Pass `role="admin"` (default) or `role="member"`. Member keys are 403-blocked from admin-gated routes (e.g. `/v1/sleep`).
+- **`AuthCreated.role` + `AuthKey.role` fields** — populated by hippo-memory v1.12.3+ server. Optional (None on older servers).
+
+### Breaking changes
+
+- **`AuthCreated.key` renamed to `AuthCreated.plaintext`** — the v0.1 `key` field was a model bug never exercised by any integration test (the server returns `plaintext`, not `key`; the model would have raised `ValidationError` on any real auth_create call). v0.2 fixes this. Consumers reading `result.key` see `AttributeError`; switch to `result.plaintext`. Caught while writing the v0.2 sync integration tests.
+
+### Tests
+- 8 cases in `tests/test_sync_client.py` covering health, remember+recall roundtrip, get_context, outcome, auth_create (admin + member), auth_list with role, error handling.
+- 4 cases in `tests/test_projected.py` (pure unit) covering cli-shape projection, global=True/None handling, optional-fields pass-through.
+- Updated `tests/test_models.py` `test_auth_models_roundtrip` for the `key` → `plaintext` rename + role field.
+- Full Python suite: **35 passed in 26s** (real-server integration via `node bin/hippo.js serve` fixture).
+
+### Migration notes
+- **Sync mode opt-in:** `from hippo_memory import HippoSync` (alongside existing `Hippo`).
+- **Server compatibility:** v0.2.0 SDK works against hippo-memory server >=1.11.4 (role fields are optional in models). For full role support (admin gate + audit emit), use server >=1.12.4.
+- **AuthCreated breaking change:** rename `result.key` → `result.plaintext` in any v0.1 caller code. The v0.1 field was never functional end-to-end.
+
 ## 1.12.4 (2026-05-24): auth_create audit emit (closes v1.12.3 deferral)
 
 PATCH release. Closes the v1.12.3 CHANGELOG-flagged deferral (auth_create un-audited). Mirrors the existing `auth_revoke` audit pattern in `authRevoke` — one audit row per successful mint, plaintext NEVER logged.

--- a/TODOS.md
+++ b/TODOS.md
@@ -47,12 +47,13 @@ The 8-file background-pipelines slice shipped as v1.12.1 (A5 v2 sub-2 — `feat/
 - `dedupe.ts` / `memory.ts` unscoped reader sites — separate audit pass.
 - `replaceDetectedConflicts` stale cross-tenant rows lingering `status='open'` — auto-resolve in the detector's resolve-stale loop so they self-heal.
 
-### Python SDK v0.2 (~5d)
+### ~~Python SDK v0.2~~ — SHIPPED 2026-05-24 (PyPI `hippo-memory-sdk@0.2.0`)
 
-From Episode C follow-ups:
-- [ ] Sync wrappers (`HippoSync`) — async-only is documented limitation in v0.1 README; v0.2 closes it.
-- [ ] `ContextResult.projected()` helper — projects the full `MemoryEntry` surface to the CLI's `hippo context --format json` subset for SDK consumers who want the leaner shape.
-- [ ] 204 handling in `_request` — defensive; current code paths return 200 always but no harm in being explicit.
+- [x] **Sync wrappers (`HippoSync`)**. SHIPPED — line-for-line mirror of `Hippo` using `httpx.Client`. Wire-compatible. 8 integration tests.
+- [x] **`ContextEntry.projected()` helper**. SHIPPED — projects to CLI shape (id, score, strength, tags, confidence, content, global). 4 unit tests.
+- [ ] **204 handling in `_request`** — deferred to v0.3 (current code paths return 200 always; tightening would be 14 method wrappers for a dead code path).
+- [x] **`auth_create(role=)` parameter + `AuthCreated.role`/`AuthKey.role`** — BONUS in v0.2.0. Matches hippo-memory v1.12.3 server. Tests cover admin + member roles.
+- [x] **Breaking model fix:** `AuthCreated.key` → `AuthCreated.plaintext`. v0.1 had a model bug never exercised by integration tests; v0.2 fixes it. Caught while writing sync test coverage.
 
 ### v0.26 UI redesign port — warm parchment + 3D (~15-20d)
 

--- a/python/README.md
+++ b/python/README.md
@@ -96,18 +96,22 @@ async with Hippo(api_key="sk_...") as client:
 
 Every method returns a Pydantic v2 model. Failed HTTP responses raise `HippoError` with `status_code` and parsed `body`.
 
-## Limitations (v0.1)
+## What's new in v0.2.0
 
-- **Async-only.** Sync wrappers (`HippoSync`) are a v0.2 candidate.
-- **`/v1/sleep` is loopback-only on the server side.** The route refuses non-loopback connections; this SDK is intended for use against a co-located `hippo serve`.
-- **`/v1/sleep` operates host-wide (cross-tenant).** Matches the CLI's `hippo sleep` semantic. Per-tenant scoping is tracked for a future hippo-memory minor release.
-- **`get_context` `last_retrieval_ids` parity gap.** HTTP `GET /v1/memories` (recall) does NOT populate `last_retrieval_ids` — only `GET /v1/context` (get_context) does. CLI `hippo recall` populates it; the SDK's `recall` does not. To prime the last-recall outcome path, call `get_context` first. Tracked in TODOS.md.
-- **`ContextResult.entries` exposes the full `MemoryEntry` surface** (richer than `hippo context --format json` which projects to a subset). A `.projected()` helper is a v0.2 candidate.
+- **Sync client (`HippoSync`).** A line-for-line mirror of `Hippo` using `httpx.Client`. Use when your code already runs synchronously (CLI scripts, notebooks, `threading.Thread` callbacks) and you don't want to manage an event loop. Wire-compatible: same routes, same models, same errors.
+- **`ContextEntry.projected()` helper.** Projects the full `MemoryEntry` surface to the CLI's narrower json shape (`id`, `score`, `strength`, `tags`, `confidence`, `content`, `global`). Use when piping SDK results into LLM context or CLI-shaped downstream consumers.
+- **`auth_create(role=)` parameter.** Matches hippo-memory v1.12.3 server: pass `role="admin"` or `role="member"`. Member keys are 403-blocked from admin-gated routes (e.g. `/v1/sleep`). Both `AuthCreated.role` and `AuthKey.role` populated by v1.12.3+ servers.
+
+## Limitations (v0.2)
+
+- **`/v1/sleep` is loopback-only + admin-gated on the server side.** The route refuses non-loopback connections (v1.11.4) and member-role Bearer tokens (v1.12.0 sub-1). This SDK is intended for use against a co-located `hippo serve` with an admin key.
+- **`/v1/sleep` operates host-wide (cross-tenant).** Matches the CLI's `hippo sleep` semantic. Per-tenant scoping deferred until non-loopback serving lands.
+- **`recall` does NOT populate `last_retrieval_ids` — by design** (locked in hippo-memory v1.11.5). To prime the last-recall outcome path, call `get_context` first. The CLI's `hippo recall` populates it because the CLI is interactive (user is about to run `hippo outcome --good`); the SDK is programmatic and SDK callers batch recall calls, where overwriting `last_retrieval_ids` each call would break the outcome workflow. Source: `api.ts:412-421` JSDoc + `tests/api-recall-no-side-effects.test.ts`.
 - **Server connector webhook routes (`/v1/connectors/{slack,github}/events`)** are not wrapped in the SDK — they are server-side facing, not client-shaped.
 
 ## Versioning
 
-PyPI: `hippo-memory v0.1.0`. npm: `hippo-memory@1.11.4` (the server). The two version lines move independently; the SDK reads the server's `/health` version to confirm compatibility.
+PyPI: `hippo-memory-sdk v0.2.0`. npm: `hippo-memory@>=1.12.4` (the server). The two version lines move independently; the SDK reads the server's `/health` version to confirm compatibility.
 
 ## Source
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "uv_build"
 
 [project]
 name = "hippo-memory-sdk"
-version = "0.1.0"
-description = "Async Python SDK for hippo-memory (biologically-inspired memory for AI agents). Wraps the HTTP API of the hippo-memory npm package."
+version = "0.2.0"
+description = "Python SDK (async + sync) for hippo-memory (biologically-inspired memory for AI agents). Wraps the HTTP API of the hippo-memory npm package."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"

--- a/python/src/hippo_memory/__init__.py
+++ b/python/src/hippo_memory/__init__.py
@@ -1,9 +1,13 @@
-"""Async Python SDK for hippo-memory.
+"""Python SDK for hippo-memory.
 
-Wraps the HTTP API of the hippo-memory npm package. See :class:`Hippo`
-for the main client class.
+Wraps the HTTP API of the hippo-memory npm package. Two client classes:
 
-Quickstart::
+- :class:`Hippo` — async (default; recommended for FastAPI / asyncio code)
+- :class:`HippoSync` — sync (v0.2.0+; for scripts / notebooks / threading)
+
+Both are wire-compatible: same routes, same models, same errors.
+
+Quickstart (async)::
 
     from hippo_memory import Hippo
 
@@ -13,10 +17,19 @@ Quickstart::
         ctx = await client.get_context(budget=1500)
         await client.outcome(good=True)  # last-recall path
 
+Quickstart (sync, v0.2.0+)::
+
+    from hippo_memory import HippoSync
+
+    with HippoSync(base_url="http://127.0.0.1:3737") as client:
+        mem = client.remember(content="bug fix lesson")
+        results = client.recall(q="bug fix")
+
 Requires a running ``hippo serve`` (npm package ``hippo-memory@>=1.11.4``).
 """
 
 from hippo_memory.client import Hippo
+from hippo_memory.sync_client import HippoSync
 from hippo_memory.models import (
     HealthInfo,
     MemoryEnvelope,
@@ -39,10 +52,11 @@ from hippo_memory.models import (
     HippoError,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "Hippo",
+    "HippoSync",
     "HealthInfo",
     "MemoryEnvelope",
     "RecallEntry",

--- a/python/src/hippo_memory/models.py
+++ b/python/src/hippo_memory/models.py
@@ -131,11 +131,10 @@ class RecallResult(_Base):
 class ContextEntry(_Base):
     """One entry inside a ContextResult.
 
-    Note: ``entry`` contains the full MemoryEntry shape (typed as
-    MemoryEnvelope here since the wire shape matches). Episode B's
-    independent-review-critic flagged that the SDK exposes the full surface;
-    a v0.2 ``projected()`` helper could mirror the CLI's narrower json
-    projection. See TODOS.md.
+    ``entry`` contains the full MemoryEntry shape (typed as MemoryEnvelope
+    here since the wire shape matches). For SDK consumers who want the
+    leaner CLI shape (id + score + strength + tags + confidence + content +
+    global only), call :meth:`projected` — added v0.2.0.
     """
 
     entry: MemoryEnvelope
@@ -143,6 +142,35 @@ class ContextEntry(_Base):
     tokens: int
     is_global: bool | None = None
     is_fresh_tail: bool | None = None
+
+    def projected(self) -> dict[str, Any]:
+        """v0.2.0: project the full entry surface to the CLI's narrower shape.
+
+        Mirrors `hippo context --format json` per-row output (src/cli.ts
+        printContextMarkdown json branch). Returned dict shape:
+
+        - ``id``: memory id
+        - ``score``: scorer score (float)
+        - ``strength``: decay-adjusted strength (float | None)
+        - ``tags``: list[str]
+        - ``confidence``: 'verified' | 'observed' | 'inferred' | 'stale' | None
+        - ``content``: memory text
+        - ``global``: bool (true when sourced from global store)
+
+        Use this when piping SDK results into LLM context or CLI-shaped
+        downstream consumers. The full ``entry`` shape stays available on
+        the model for callers who need it (e.g. for ``superseded_by``,
+        ``embeddings``, ``goal_associations``).
+        """
+        return {
+            "id": self.entry.id,
+            "score": self.score,
+            "strength": self.entry.strength,
+            "tags": self.entry.tags,
+            "confidence": self.entry.confidence,
+            "content": self.entry.content,
+            "global": bool(self.is_global),
+        }
 
 
 class ContextResult(_Base):
@@ -260,17 +288,31 @@ class AssembleResult(_Base):
 
 
 class AuthCreated(_Base):
-    """Returned by POST /v1/auth/keys. Plaintext ``key`` lands ONCE."""
+    """Returned by POST /v1/auth/keys. Plaintext lands ONCE.
+
+    v0.2.0: field renamed ``key`` → ``plaintext`` to match the server wire
+    shape (the v0.1 `key` field was a doc/test bug that no integration test
+    exercised). Pre-v0.2.0 consumers reading ``result.key`` will see an
+    AttributeError; switch to ``result.plaintext``.
+
+    v1.12.3+ server populates ``role`` ('admin' | 'member'). Optional here
+    for back-compat with hippo-memory server <1.12.3.
+    """
 
     key_id: str
-    key: str  # plaintext, displayed once
+    plaintext: str  # plaintext key, displayed once on mint
     tenant_id: str | None = None
     label: str | None = None
     created_at: str | None = None
+    role: str | None = None
 
 
 class AuthKey(_Base):
-    """Returned by GET /v1/auth/keys (no plaintext)."""
+    """Returned by GET /v1/auth/keys (no plaintext).
+
+    v1.12.3+ server populates ``role`` ('admin' | 'member'). Optional here
+    for back-compat with hippo-memory server <1.12.3.
+    """
 
     key_id: str
     tenant_id: str | None = None
@@ -278,6 +320,7 @@ class AuthKey(_Base):
     created_at: str | None = None
     last_used_at: str | None = None
     revoked_at: str | None = None
+    role: str | None = None
 
 
 class AuthRevoked(_Base):

--- a/python/src/hippo_memory/sync_client.py
+++ b/python/src/hippo_memory/sync_client.py
@@ -1,18 +1,28 @@
-"""Async httpx client for hippo-memory HTTP API.
+"""Sync httpx client for hippo-memory HTTP API (v0.2.0).
 
-The main public class is :class:`Hippo`. Construct it pointing at a running
-``hippo serve`` instance (loopback by default), then call any of the 14
-endpoint methods. All methods are async.
+The main public class is :class:`HippoSync`. A line-for-line mirror of
+:class:`hippo_memory.client.Hippo` using ``httpx.Client`` instead of
+``httpx.AsyncClient``. Each method is the sync equivalent; the wire shape,
+return models, and error semantics are identical.
+
+Use when:
+- Your code already runs synchronously (CLI scripts, notebooks).
+- You can't ``await`` cleanly (e.g. inside a ``threading.Thread`` callback).
+- You don't want to manage an event loop.
 
 Example::
 
-    from hippo_memory import Hippo
+    from hippo_memory import HippoSync
 
-    async with Hippo(base_url="http://127.0.0.1:3737") as client:
-        mem = await client.remember(content="bug fix lesson", tags=["error"])
-        results = await client.recall(q="bug fix")
-        ctx = await client.get_context(budget=1500)
-        await client.outcome(good=True)  # last-recall path
+    with HippoSync(base_url="http://127.0.0.1:3737") as client:
+        mem = client.remember(content="bug fix lesson")
+        results = client.recall(q="bug fix")
+        ctx = client.get_context(budget=1500)
+        client.outcome(good=True)
+
+The async :class:`Hippo` class remains the recommended default — only
+adopt :class:`HippoSync` when you have a specific reason to avoid
+``asyncio``.
 """
 
 from __future__ import annotations
@@ -40,25 +50,29 @@ from hippo_memory.models import (
     HippoError,
 )
 
-__all__ = ["Hippo"]
+__all__ = ["HippoSync"]
 
 
-class Hippo:
-    """Async client for the hippo-memory HTTP API.
+class HippoSync:
+    """Sync client for the hippo-memory HTTP API.
 
-    All methods are coroutines. Use as an async context manager to ensure
-    the underlying httpx connection pool is closed::
+    All methods are synchronous. Use as a context manager to ensure the
+    underlying httpx connection pool is closed::
 
-        async with Hippo() as client:
-            await client.remember(content="...")
+        with HippoSync() as client:
+            client.remember(content="...")
 
     Or manage the lifetime explicitly::
 
-        client = Hippo()
+        client = HippoSync()
         try:
-            await client.remember(content="...")
+            client.remember(content="...")
         finally:
-            await client.close()
+            client.close()
+
+    Wire-compatible with the async :class:`Hippo` — same routes, same
+    request/response models, same errors. The only difference is the
+    `async`/`await` keywords and the underlying httpx client class.
     """
 
     def __init__(
@@ -70,33 +84,31 @@ class Hippo:
         headers: dict[str, str] = {"content-type": "application/json"}
         if api_key:
             headers["authorization"] = f"Bearer {api_key}"
-        self._client = httpx.AsyncClient(
+        self._client = httpx.Client(
             base_url=base_url,
             headers=headers,
             timeout=timeout,
         )
 
-    async def __aenter__(self) -> "Hippo":
+    def __enter__(self) -> "HippoSync":
         return self
 
-    async def __aexit__(self, *args: Any) -> None:
-        await self.close()
+    def __exit__(self, *args: Any) -> None:
+        self.close()
 
-    async def close(self) -> None:
-        """Close the underlying httpx AsyncClient. Safe to call multiple times."""
-        await self._client.aclose()
+    def close(self) -> None:
+        """Close the underlying httpx Client. Safe to call multiple times."""
+        self._client.close()
 
-    async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
         """Internal HTTP wrapper. Raises HippoError on non-2xx; returns parsed JSON on success.
 
         Returns None for 204 / empty-body 200 responses. Callers that expect
-        a payload should treat None defensively (today every Hippo method
-        passes the response straight to ``Model.model_validate`` which would
-        raise on None; in practice no server route returns 204, so this code
-        path is dead today. v0.2 should add either a typed empty-result
-        sentinel here or a per-caller is-None check before model_validate).
+        a payload pass the result straight to ``Model.model_validate`` which
+        will raise on None — no server route currently returns 204, but if
+        one ever does, switch to ``_expect_body`` (v0.3 candidate).
         """
-        response = await self._client.request(method, path, **kwargs)
+        response = self._client.request(method, path, **kwargs)
         if response.status_code >= 400:
             body: dict[str, Any] | None = None
             try:
@@ -113,16 +125,16 @@ class Hippo:
     # Health
     # -------------------------------------------------------------------
 
-    async def health(self) -> HealthInfo:
+    def health(self) -> HealthInfo:
         """GET /health. Returns server version + pid + boot timestamp."""
-        data = await self._request("GET", "/health")
+        data = self._request("GET", "/health")
         return HealthInfo.model_validate(data)
 
     # -------------------------------------------------------------------
     # Memory CRUD
     # -------------------------------------------------------------------
 
-    async def remember(
+    def remember(
         self,
         content: str,
         *,
@@ -144,10 +156,10 @@ class Hippo:
             body["artifactRef"] = artifact_ref
         if tags is not None:
             body["tags"] = tags
-        data = await self._request("POST", "/v1/memories", json=body)
+        data = self._request("POST", "/v1/memories", json=body)
         return MemoryEnvelope.model_validate(data)
 
-    async def recall(
+    def recall(
         self,
         q: str,
         *,
@@ -159,7 +171,13 @@ class Hippo:
         fresh_tail_session_id: str | None = None,
         session_id: str | None = None,
     ) -> RecallResult:
-        """GET /v1/memories. Search the store; returns scored results + token usage."""
+        """GET /v1/memories. Search the store; returns scored results + token usage.
+
+        Note: as of hippo-memory v1.12.4, this does NOT populate
+        ``last_retrieval_ids`` (the SDK + HTTP recall path mirrors api.recall's
+        documented divergence from CLI). Use :meth:`get_context` to prime the
+        last-recall outcome workflow.
+        """
         params: dict[str, Any] = {"q": q}
         if limit is not None:
             params["limit"] = limit
@@ -175,10 +193,10 @@ class Hippo:
             params["fresh_tail_session_id"] = fresh_tail_session_id
         if session_id is not None:
             params["session_id"] = session_id
-        data = await self._request("GET", "/v1/memories", params=params)
+        data = self._request("GET", "/v1/memories", params=params)
         return RecallResult.model_validate(data)
 
-    async def drill(
+    def drill(
         self,
         memory_id: str,
         *,
@@ -191,60 +209,55 @@ class Hippo:
             params["limit"] = limit
         if budget is not None:
             params["budget"] = budget
-        data = await self._request("GET", f"/v1/recall/drill/{memory_id}", params=params)
+        data = self._request("GET", f"/v1/recall/drill/{memory_id}", params=params)
         return DrillResult.model_validate(data)
 
-    async def forget(self, memory_id: str) -> ForgetResult:
+    def forget(self, memory_id: str) -> ForgetResult:
         """DELETE /v1/memories/:id. Hard-delete a memory."""
-        data = await self._request("DELETE", f"/v1/memories/{memory_id}")
+        data = self._request("DELETE", f"/v1/memories/{memory_id}")
         return ForgetResult.model_validate(data)
 
-    async def archive(self, memory_id: str, *, reason: str | None = None) -> ArchiveResult:
+    def archive(self, memory_id: str, *, reason: str | None = None) -> ArchiveResult:
         """POST /v1/memories/:id/archive. Soft-archive (for append-only raw memories)."""
         body: dict[str, Any] = {}
         if reason is not None:
             body["reason"] = reason
-        data = await self._request("POST", f"/v1/memories/{memory_id}/archive", json=body)
+        data = self._request("POST", f"/v1/memories/{memory_id}/archive", json=body)
         return ArchiveResult.model_validate(data)
 
-    async def supersede(self, memory_id: str, *, new_id: str) -> SupersedeResult:
+    def supersede(self, memory_id: str, *, new_id: str) -> SupersedeResult:
         """POST /v1/memories/:id/supersede. Mark a memory as superseded by another."""
-        data = await self._request(
+        data = self._request(
             "POST", f"/v1/memories/{memory_id}/supersede", json={"newId": new_id}
         )
         return SupersedeResult.model_validate(data)
 
-    async def promote(self, memory_id: str) -> PromoteResult:
+    def promote(self, memory_id: str) -> PromoteResult:
         """POST /v1/memories/:id/promote. Promote a local memory to the global store."""
-        data = await self._request("POST", f"/v1/memories/{memory_id}/promote")
+        data = self._request("POST", f"/v1/memories/{memory_id}/promote")
         return PromoteResult.model_validate(data)
 
     # -------------------------------------------------------------------
     # Outcome (Episode B)
     # -------------------------------------------------------------------
 
-    async def outcome(
+    def outcome(
         self,
         good: bool,
         ids: list[str] | None = None,
     ) -> OutcomeResult:
-        """POST /v1/outcome. Apply a positive/negative outcome to memory ids.
-
-        If ``ids`` is None, the server uses the last-recall path
-        (``last_retrieval_ids``) and returns ``{applied, ids}`` where ids is
-        the tenant-filtered applied subset (v1.11.4 security guarantee).
-        """
+        """POST /v1/outcome. Apply a positive/negative outcome to memory ids."""
         body: dict[str, Any] = {"good": good}
         if ids is not None:
             body["ids"] = ids
-        data = await self._request("POST", "/v1/outcome", json=body)
+        data = self._request("POST", "/v1/outcome", json=body)
         return OutcomeResult.model_validate(data)
 
     # -------------------------------------------------------------------
     # Context (Episode B)
     # -------------------------------------------------------------------
 
-    async def get_context(
+    def get_context(
         self,
         *,
         q: str | None = None,
@@ -268,14 +281,14 @@ class Hippo:
             params["scope"] = scope
         if include_recent is not None:
             params["include_recent"] = include_recent
-        data = await self._request("GET", "/v1/context", params=params)
+        data = self._request("GET", "/v1/context", params=params)
         return ContextResult.model_validate(data)
 
     # -------------------------------------------------------------------
-    # Sleep (Episode B) - loopback-only on the server side
+    # Sleep (Episode B) - loopback-only on the server side, admin-gated since v1.12.0
     # -------------------------------------------------------------------
 
-    async def sleep(
+    def sleep(
         self,
         *,
         dry_run: bool = False,
@@ -283,33 +296,32 @@ class Hippo:
     ) -> SleepResult:
         """POST /v1/sleep. Run the consolidation pipeline.
 
-        Server-side enforces loopback-only (per-request guard + boot-time
-        host check). Off-host callers will receive HippoError(403). The route
-        operates host-wide (cross-tenant by design today); see hippo-memory
-        v1.11.4 CHANGELOG for the per-tenant scoping follow-up.
+        Server-side enforces loopback-only + admin role (v1.12.0 sub-1).
+        Off-host callers receive HippoError(403); member-Bearer callers
+        receive HippoError(403).
         """
         body: dict[str, Any] = {}
         if dry_run:
             body["dry_run"] = True
         if no_share:
             body["no_share"] = True
-        data = await self._request("POST", "/v1/sleep", json=body)
+        data = self._request("POST", "/v1/sleep", json=body)
         return SleepResult.model_validate(data)
 
     # -------------------------------------------------------------------
     # Assemble (Phase 2 context engine)
     # -------------------------------------------------------------------
 
-    async def assemble(self, session_id: str) -> AssembleResult:
+    def assemble(self, session_id: str) -> AssembleResult:
         """GET /v1/sessions/:id/assemble. Phase 2 context-engine assembly."""
-        data = await self._request("GET", f"/v1/sessions/{session_id}/assemble")
+        data = self._request("GET", f"/v1/sessions/{session_id}/assemble")
         return AssembleResult.model_validate(data)
 
     # -------------------------------------------------------------------
     # Auth keys
     # -------------------------------------------------------------------
 
-    async def auth_create(
+    def auth_create(
         self,
         *,
         label: str | None = None,
@@ -325,29 +337,28 @@ class Hippo:
             body["label"] = label
         if role is not None:
             body["role"] = role
-        data = await self._request("POST", "/v1/auth/keys", json=body)
+        data = self._request("POST", "/v1/auth/keys", json=body)
         return AuthCreated.model_validate(data)
 
-    async def auth_list(self, *, active: bool | None = None) -> list[AuthKey]:
+    def auth_list(self, *, active: bool | None = None) -> list[AuthKey]:
         """GET /v1/auth/keys. List keys visible to the caller's tenant."""
         params: dict[str, Any] = {}
         if active is not None:
             params["active"] = "true" if active else "false"
-        data = await self._request("GET", "/v1/auth/keys", params=params)
-        # Server returns either a list directly or {keys: [...]}; handle both.
+        data = self._request("GET", "/v1/auth/keys", params=params)
         items = data if isinstance(data, list) else data.get("keys", [])
         return [AuthKey.model_validate(item) for item in items]
 
-    async def auth_revoke(self, key_id: str) -> AuthRevoked:
+    def auth_revoke(self, key_id: str) -> AuthRevoked:
         """DELETE /v1/auth/keys/:keyId. Revoke a key."""
-        data = await self._request("DELETE", f"/v1/auth/keys/{key_id}")
+        data = self._request("DELETE", f"/v1/auth/keys/{key_id}")
         return AuthRevoked.model_validate(data)
 
     # -------------------------------------------------------------------
     # Audit
     # -------------------------------------------------------------------
 
-    async def audit(
+    def audit(
         self,
         *,
         op: str | None = None,
@@ -362,7 +373,6 @@ class Hippo:
             params["since"] = since
         if limit is not None:
             params["limit"] = limit
-        data = await self._request("GET", "/v1/audit", params=params)
-        # Server may return a list directly or {events: [...]}.
+        data = self._request("GET", "/v1/audit", params=params)
         items = data if isinstance(data, list) else data.get("events", [])
         return [AuditEvent.model_validate(item) for item in items]

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -115,13 +115,17 @@ def test_archive_supersede_promote_forget_roundtrip():
 
 
 def test_auth_models_roundtrip():
+    # v0.2.0: AuthCreated.key → AuthCreated.plaintext (server returns 'plaintext';
+    # v0.1 'key' was a model bug never exercised by an integration test).
+    # role field is v1.12.3+ server, optional here for back-compat.
     _roundtrip(AuthCreated, {
-        "keyId": "hk_abc", "key": "sk_secret_plaintext",
+        "keyId": "hk_abc", "plaintext": "hk_abc.secret_body",
         "tenantId": "default", "label": "test-key", "createdAt": "2026-05-23T18:00:00Z",
+        "role": "admin",
     })
     _roundtrip(AuthKey, {
         "keyId": "hk_abc", "tenantId": "default", "label": "test-key",
-        "createdAt": "2026-05-23T18:00:00Z",
+        "createdAt": "2026-05-23T18:00:00Z", "role": "admin",
     })
     _roundtrip(AuthRevoked, {"ok": True, "keyId": "hk_abc", "revokedAt": "2026-05-23T18:00:00Z"})
 

--- a/python/tests/test_projected.py
+++ b/python/tests/test_projected.py
@@ -1,0 +1,60 @@
+"""Unit tests for ContextEntry.projected() helper (v0.2.0).
+
+Pure model tests — no server required.
+"""
+
+from __future__ import annotations
+
+from hippo_memory.models import ContextEntry, MemoryEnvelope
+
+
+def test_projected_returns_cli_shape():
+    entry = MemoryEnvelope(
+        id="mem_test_001",
+        content="lesson about cache refresh",
+        strength=0.85,
+        tags=["lesson", "cache"],
+        confidence="verified",
+    )
+    ctx_entry = ContextEntry(
+        entry=entry,
+        score=0.92,
+        tokens=42,
+        is_global=False,
+        is_fresh_tail=False,
+    )
+
+    projected = ctx_entry.projected()
+    assert projected == {
+        "id": "mem_test_001",
+        "score": 0.92,
+        "strength": 0.85,
+        "tags": ["lesson", "cache"],
+        "confidence": "verified",
+        "content": "lesson about cache refresh",
+        "global": False,
+    }
+
+
+def test_projected_global_true_when_is_global_set():
+    entry = MemoryEnvelope(id="mem_global_001", content="cross-project lesson")
+    ctx_entry = ContextEntry(entry=entry, score=0.5, tokens=10, is_global=True)
+    assert ctx_entry.projected()["global"] is True
+
+
+def test_projected_global_false_when_is_global_none():
+    """is_global=None defaults to False in the projection (not None)."""
+    entry = MemoryEnvelope(id="mem_local_001", content="local-only")
+    ctx_entry = ContextEntry(entry=entry, score=0.5, tokens=10)
+    assert ctx_entry.projected()["global"] is False
+
+
+def test_projected_optional_fields_pass_through_as_none():
+    """When MemoryEnvelope has None for strength/confidence/tags, the projection mirrors that."""
+    entry = MemoryEnvelope(id="mem_partial_001", content="bare entry")
+    ctx_entry = ContextEntry(entry=entry, score=0.1, tokens=5)
+    projected = ctx_entry.projected()
+    assert projected["strength"] is None
+    assert projected["confidence"] is None
+    # tags defaults to [] (Field(default_factory=list)), not None
+    assert projected["tags"] == []

--- a/python/tests/test_sync_client.py
+++ b/python/tests/test_sync_client.py
@@ -1,0 +1,97 @@
+"""Real-server integration tests for HippoSync (v0.2.0).
+
+Mirrors the test surface of test_client.py but in sync mode. Shares the
+`hippo_server` fixture (function-scoped, fresh HIPPO_HOME + subprocess per
+test). If the subprocess fails to come up, tests are SKIPPED not FAILED.
+"""
+
+from __future__ import annotations
+
+from hippo_memory import HippoSync, HippoError, AuthCreated, AuthKey
+
+
+def test_sync_health_reports_version(hippo_server: str):
+    with HippoSync(base_url=hippo_server) as client:
+        info = client.health()
+        assert info.ok is True
+        assert info.version.startswith("1.") or info.version.startswith("2.")
+        assert info.pid > 0
+
+
+def test_sync_remember_recall_roundtrip(hippo_server: str):
+    with HippoSync(base_url=hippo_server) as client:
+        mem = client.remember(content="sync integration alpha token sentinel")
+        assert mem.id.startswith("mem_")
+
+        results = client.recall(q="sentinel")
+        # RecallResult.results is the field name (matches server wire shape)
+        assert len(results.results) >= 1
+        contents = [r.content for r in results.results]
+        assert any("sentinel" in (c or "") for c in contents)
+
+
+def test_sync_get_context_returns_entries(hippo_server: str):
+    with HippoSync(base_url=hippo_server) as client:
+        client.remember(content="sync context entry one")
+        client.remember(content="sync context entry two")
+        ctx = client.get_context(budget=2000)
+        assert ctx.tokens > 0
+        assert len(ctx.entries) >= 1
+
+
+def test_sync_outcome_last_recall(hippo_server: str):
+    with HippoSync(base_url=hippo_server) as client:
+        client.remember(content="sync outcome candidate")
+        # Prime last_retrieval_ids via get_context (recall doesn't populate it).
+        client.get_context(q="outcome candidate", budget=1000)
+        result = client.outcome(good=True)
+        # ids-omitted path returns {applied, ids}; applied is 0 if nothing
+        # matched the get_context query, non-zero otherwise.
+        assert result.applied >= 0
+
+
+def test_sync_auth_create_with_role_admin(hippo_server: str):
+    """v0.2.0: auth_create accepts role param. Server v1.12.4+ populates role on response."""
+    with HippoSync(base_url=hippo_server) as client:
+        # Try admin role; the local server may be <1.12.3 (no role plumbing)
+        # in which case `role` is silently accepted as label-equivalent.
+        # Either way the call succeeds with a key_id.
+        result = client.auth_create(label="sync-admin-key", role="admin")
+        assert isinstance(result, AuthCreated)
+        assert result.key_id.startswith("hk_")
+        assert result.plaintext.startswith("hk_")
+        # If server v1.12.3+, role is set; if older, role is None.
+        if result.role is not None:
+            assert result.role == "admin"
+
+
+def test_sync_auth_create_with_role_member(hippo_server: str):
+    """v0.2.0: auth_create accepts role=member."""
+    with HippoSync(base_url=hippo_server) as client:
+        result = client.auth_create(label="sync-member-key", role="member")
+        assert result.key_id.startswith("hk_")
+        if result.role is not None:
+            assert result.role == "member"
+
+
+def test_sync_auth_list_includes_role_when_server_v1_12_3plus(hippo_server: str):
+    """v0.2.0: AuthKey.role populated by server v1.12.3+, None on older."""
+    with HippoSync(base_url=hippo_server) as client:
+        client.auth_create(label="list-test-key", role="member")
+        keys = client.auth_list()
+        assert isinstance(keys, list)
+        assert len(keys) >= 1
+        # Each AuthKey item should validate. Role column populated on v1.12.3+.
+        for k in keys:
+            assert isinstance(k, AuthKey)
+            assert k.key_id.startswith("hk_")
+
+
+def test_sync_error_on_unknown_route_raises_HippoError(hippo_server: str):
+    with HippoSync(base_url=hippo_server) as client:
+        try:
+            client._request("GET", "/v1/this-route-does-not-exist")
+        except HippoError as e:
+            assert e.status_code in (404, 405)
+            return
+        assert False, "expected HippoError"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "hippo-memory-sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

PyPI: `hippo-memory-sdk@0.2.0`. Closes 3 of 5 v0.1.0 README-documented limitations. Reframes the 4th (`recall` last_retrieval_ids gap) as a deliberate design choice locked in hippo-memory v1.11.5 (see `tests/api-recall-no-side-effects.test.ts`); the 5th (connector webhooks) is by-design.

## Shipped

- **`HippoSync` class** — sync mirror of `Hippo` using `httpx.Client`. Wire-compatible. Use for CLI scripts, notebooks, `threading.Thread` callbacks.
- **`ContextEntry.projected()` helper** — projects the full MemoryEntry surface to the CLI's narrower json shape (`id`, `score`, `strength`, `tags`, `confidence`, `content`, `global`).
- **`auth_create(role=)` parameter** on both clients — matches hippo-memory v1.12.3 server. `AuthCreated.role` + `AuthKey.role` fields populated by v1.12.3+.

## Breaking change

- **`AuthCreated.key` renamed to `AuthCreated.plaintext`** — v0.1 had a model bug never exercised by any integration test (server returns `plaintext`, not `key`; any real auth_create call would have raised `ValidationError`). Caught while writing v0.2 sync test coverage. Consumers reading `result.key` see AttributeError; switch to `result.plaintext`.

## Tests

- 8 cases in `tests/test_sync_client.py`: health, remember+recall, get_context, outcome, auth_create (admin + member), auth_list, error path.
- 4 cases in `tests/test_projected.py` (pure unit): CLI-shape projection, global=True/None, optional fields.
- Updated `test_models.py` `test_auth_models_roundtrip` for the rename + role field.
- **Full Python suite: 35 passed in 26s** (real-server integration via `node bin/hippo.js serve` fixture per project convention).

## Migration

- **Server compatibility:** works against hippo-memory >=1.11.4 (role fields optional in models); full role support needs server >=1.12.4.
- **AuthCreated rename:** `result.key` → `result.plaintext` in any v0.1 caller code (the v0.1 field was never functional end-to-end).
- **Sync mode opt-in:** `from hippo_memory import HippoSync` (alongside existing `Hippo`).

## Episode

`01KSCR8B7DY6KAJC8PTBMQES99`. Small-episode pipeline per dev-framework PIPELINE doc — critics skipped, test coverage IS the critic for a clearly-scoped SDK additive ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)