### PR TITLE
fix(db): v1.12.7 migration v27 self-heal for partial-v16 DB state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 1.12.7 (2026-05-24): migration v27 self-heal for partial-v16 DB state
+
+Fixes a real user-facing bug: on a hippo DB where migration v16 had
+partial-applied (api_keys + audit_log tables missing despite
+schema_version recorded as >= 16), every `hippo context` invocation
+printed `Error: no such table: api_keys` to stderr. Surfaced on Keith's
+~/.hippo/hippo.db on 2026-05-24, visible as repeated noise on every
+UserPromptSubmit hook firing.
+
+### Shipped
+
+- **Migration v27 self-heal.** Re-asserts the v16 schema via
+  `CREATE TABLE IF NOT EXISTS api_keys + audit_log` plus their indexes.
+  Idempotent — zero cost for DBs without the bug, fixes any DB that has it
+  on next open. Also includes the v26 `role` column directly in the
+  CREATE so v26's ALTER doesn't have to run on this heal path.
+- **Migration v26 defensive guard.** Added `tableExists(db, 'api_keys')`
+  check to v26's existing `tableHasColumn` guard. Without this, v26's
+  ALTER would crash on the partial-v16-state and block v27 (the heal)
+  from ever running. Now v26 no-ops gracefully when api_keys is missing.
+
+### Root cause investigation
+
+Surprising finding: the migration runner has wrapped each migration's
+`up()` in `BEGIN ... COMMIT` since the very first SQLite commit
+(`2cf72e7`). So the partial-apply on Keith's DB did NOT happen through
+missing atomicity — the wrapping has always been correct. Possible causes
+of the observed state:
+
+1. `DROP TABLE api_keys` issued post-migration (operator action or
+   external SQL).
+2. Restore / import from a pre-v16 backup over a v16+ schema_version.
+3. Some edge case the BEGIN/COMMIT wrapping doesn't catch (unknown).
+
+Without forensic logs the precise cause stays unknown. The fix is the
+same regardless: v27 heals the symptom, v26 won't crash on the input.
+
+### Tests
+- 5 cases in `tests/db-migration-v27-self-heal.test.ts`: heals
+  partial-v16 state, api_keys has role column, audit_log has v16 shape,
+  v27 is no-op on healthy DB, v26 ALTER no-ops when api_keys is missing.
+- 18 brittle `.toBe(26)` assertions across 8 test files bumped to
+  `.toBe(27)` for the new schema head.
+
+### Full suite
+
+1791 passed / 4 skipped / 0 failed across 248 files.
+
+### Notes
+
+- No min_compatible_binary bump — v27 is a heal migration, not a
+  contract-breaking change. Old binaries can still open the DB; they
+  just won't see the heal (and don't need to).
+- Long-term: `TODOS.md` carries a follow-up to investigate WHY v16
+  partial-applied in the first place (transaction wrapping is intact;
+  cause unknown).
+
 ## 1.12.6 (2026-05-24): D-batch hardening pass — 5 follow-ups
 
 Bundles 5 long-deferred B-sized items from `TODOS.md` per the

--- a/TODOS.md
+++ b/TODOS.md
@@ -498,19 +498,34 @@ v0.39 could ship the CRITICAL cross-tenant fixes without scope creep.
   the same version, so the drift cannot recur. All five were synced to
   `1.10.1` in that release.
 
-- [ ] **Migration runner: wrap each migration in BEGIN/COMMIT to prevent
-  partial-apply.** Surfaced 2026-05-24 on Keith's `~/.hippo/hippo.db`. Schema
-  version was recorded as 25, but tables from migration v16 (`api_keys` +
-  `audit_log`) were missing — the v16 `ALTER TABLE` statements succeeded but
-  the `CREATE TABLE` statements somehow didn't, and `schema_version` was bumped
-  to 16 regardless. Every later migration ran on top of the partial state,
-  shipping it forward through v25. Symptom: every `hippo context` invocation
-  (the UserPromptSubmit hook) printed "no such table: api_keys" to stderr.
-  Fixed Keith's DB by manually creating the two tables (CREATE statements
-  lifted from `src/db.ts` v16 migration body — idempotent).
-  **Root-cause fix:** wrap every migration `up()` body in `BEGIN IMMEDIATE` /
-  `COMMIT` so a mid-migration failure rolls back ALL its statements AND the
-  `schema_version` bump together. Add a regression test that injects a
-  forced-fail mid-migration and asserts the DB returns to the prior version.
-  Audit existing migrations for non-idempotent statements that would fail on
-  re-run after this fix lands.
+- [x] **Migration v16 partial-apply self-heal.** SHIPPED v1.12.7 — migration
+  v27 re-asserts the v16 schema (`api_keys` + `audit_log` + indexes,
+  CREATE IF NOT EXISTS). Idempotent, zero cost for healthy DBs, fixes any
+  DB in the partial state on next open. v26's ALTER also got a
+  defensive `tableExists` guard so it can't crash on the partial state
+  before v27 can heal. 5 tests at `tests/db-migration-v27-self-heal.test.ts`.
+
+  **Correction to the original 2026-05-24 TODO entry** (which proposed
+  wrapping each migration in BEGIN/COMMIT as the root-cause fix): the
+  runner has ALWAYS wrapped each migration in BEGIN/COMMIT (since the
+  first SQLite commit `2cf72e7`). So atomicity was NOT the bug.
+  Possible causes of the observed partial state: (1) `DROP TABLE
+  api_keys` issued post-migration (operator action or external SQL),
+  (2) restore / import from a pre-v16 backup over a v16+
+  schema_version, (3) some edge case the wrapping doesn't catch. Cause
+  unknown without forensic logs. The v27 self-heal fixes the symptom
+  for all paths.
+
+- [ ] **Migration robustness: investigate why v16 partial-applied at all.**
+  The BEGIN/COMMIT wrapping is intact since `2cf72e7`. SQLite DDL inside
+  a transaction should be atomic. The partial state on Keith's
+  ~/.hippo/hippo.db suggests EITHER (a) the bug exists in some
+  SQLite/Node-SQLite edge case we don't understand, OR (b) the partial
+  state was induced post-migration (DROP TABLE / restore / import).
+  Defense-in-depth options if (a): add a post-migration validation
+  step that checks expected tables exist for the current
+  schema_version, log a warning + auto-heal if anything's missing.
+  This would catch future cases where someone drops a table or
+  restores from a stale backup. Low priority since v27 already
+  self-heals the known broken table-pair; revisit if a different
+  partial-apply surfaces.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.6",
+  "version": "1.12.7",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/db.ts
+++ b/src/db.ts
@@ -23,7 +23,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 26;
+const CURRENT_SCHEMA_VERSION = 27;
 
 type Migration = {
   version: number;
@@ -868,7 +868,70 @@ const MIGRATIONS: Migration[] = [
       // No min_compatible_binary bump: old binaries (v1.11.x) ignore the
       // column on SELECTs that don't name it; new binaries on old data run
       // this migration at openHippoDb time before any createApiKey call.
-      if (!tableHasColumn(db, 'api_keys', 'role')) {
+      //
+      // v1.12.7 defensive: also guard on tableExists. If a DB landed in the
+      // partial-v16-state (api_keys table missing despite schema_version >= 16),
+      // running ALTER TABLE here would crash and block all later migrations.
+      // The v27 heal below recreates api_keys with the role column already
+      // present, so this ALTER becomes a no-op anyway for that path. Defense
+      // in depth: guard so v26 never crashes on the partial-apply state.
+      if (tableExists(db, 'api_keys') && !tableHasColumn(db, 'api_keys', 'role')) {
+        db.exec(`ALTER TABLE api_keys ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'`);
+      }
+    },
+  },
+  {
+    version: 27,
+    up: (db) => {
+      // v1.12.7 self-heal — re-assert the v16 schema (api_keys + audit_log).
+      //
+      // Surfaced 2026-05-24 on Keith's ~/.hippo/hippo.db: schema_version
+      // recorded as 25 but api_keys and audit_log tables were missing from
+      // migration v16. Root cause unknown — the migration runner has wrapped
+      // each migration in BEGIN/COMMIT since the first SQLite commit, so
+      // atomicity isn't the bug. Possible causes: DROP TABLE post-migration,
+      // SQL import / restore from a pre-v16 backup over a v16+ schema_version,
+      // or some edge case the wrapping doesn't catch. Cause may be operator
+      // action; either way the practical fix is the same.
+      //
+      // All CREATE IF NOT EXISTS — zero-cost no-op for users without the
+      // bug, fixes anyone who has it. Includes the role column from the
+      // start so it matches v26's intent without needing v26 to ALTER on
+      // this heal path.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS api_keys (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          key_id TEXT UNIQUE NOT NULL,
+          key_hash TEXT NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'default',
+          label TEXT,
+          created_at TEXT NOT NULL,
+          revoked_at TEXT,
+          role TEXT NOT NULL DEFAULT 'admin'
+        )
+      `);
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_api_keys_tenant_active
+        ON api_keys(tenant_id) WHERE revoked_at IS NULL
+      `);
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS audit_log (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ts TEXT NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'default',
+          actor TEXT NOT NULL,
+          op TEXT NOT NULL,
+          target_id TEXT,
+          metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_audit_log_tenant_ts ON audit_log(tenant_id, ts DESC)`);
+
+      // Belt-and-braces: if api_keys existed before this migration WITHOUT
+      // the role column (i.e. v16-shape table that v26's ALTER skipped due
+      // to tableExists=false on an earlier broken run, then someone manually
+      // CREATEd it without role), backfill role.
+      if (tableExists(db, 'api_keys') && !tableHasColumn(db, 'api_keys', 'role')) {
         db.exec(`ALTER TABLE api_keys ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'`);
       }
     },

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.12.6';
+export const PACKAGE_VERSION = '1.12.7';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(26);
+    expect(getCurrentSchemaVersion()).toBe(27);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(26);
+    expect(getSchemaVersion(db)).toBe(27);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
-      expect(getCurrentSchemaVersion()).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
+      expect(getCurrentSchemaVersion()).toBe(27);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(26);
+    expect(getCurrentSchemaVersion()).toBe(27);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
-      expect(getCurrentSchemaVersion()).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
+      expect(getCurrentSchemaVersion()).toBe(27);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(26);
+    expect(getCurrentSchemaVersion()).toBe(27);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -1,0 +1,155 @@
+/**
+ * v1.12.7 (B6) regression test for migration v27 self-heal.
+ *
+ * Surfaced 2026-05-24 on Keith's ~/.hippo/hippo.db: schema_version recorded
+ * as 25 but api_keys and audit_log tables were missing. Root cause unknown
+ * (BEGIN/COMMIT wrapping has been in place since the first SQLite commit),
+ * but the symptom is real and reproducible. Migration v27 re-asserts the
+ * v16 schema with CREATE IF NOT EXISTS — fixes affected DBs on next open,
+ * zero-cost for DBs that already have the tables.
+ *
+ * Also covers v26 defensive guard: when api_keys is missing, v26's ALTER
+ * must no-op rather than crash and block all later migrations.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from '../src/db.js';
+
+function tableNames(db: DatabaseSyncLike): string[] {
+  return (db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+    .all() as Array<{ name: string }>)
+    .map((r) => r.name);
+}
+
+function getMeta(db: DatabaseSyncLike, key: string): string | undefined {
+  const row = db
+    .prepare(`SELECT value FROM meta WHERE key = ?`)
+    .get(key) as { value?: string } | undefined;
+  return row?.value;
+}
+
+function setMeta(db: DatabaseSyncLike, key: string, value: string): void {
+  db.prepare(`INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)`).run(key, value);
+}
+
+describe('migration v27 self-heal — partial-applied v16 state', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-v27-heal-'));
+    initStore(root);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function simulatePartialV16State(): void {
+    // Get the DB to a state matching Keith's ~/.hippo/hippo.db on 2026-05-24:
+    // - schema_version = 25 (later migrations applied)
+    // - api_keys + audit_log tables missing (v16 partial-apply)
+    const db = openHippoDb(root);
+    try {
+      db.exec('DROP TABLE IF EXISTS api_keys');
+      db.exec('DROP TABLE IF EXISTS audit_log');
+      // Roll schema_version back to 25 so the next open re-runs v26 and v27.
+      setMeta(db, 'schema_version', '25');
+    } finally {
+      closeHippoDb(db);
+    }
+  }
+
+  it('re-opening a DB in Keith\'s partial-v16 state heals it to v27', () => {
+    simulatePartialV16State();
+
+    // Re-open triggers runMigrations which should run v26 (no-op on missing
+    // api_keys per the defensive guard) then v27 (creates both tables).
+    const db = openHippoDb(root);
+    try {
+      const tables = tableNames(db);
+      expect(tables).toContain('api_keys');
+      expect(tables).toContain('audit_log');
+      expect(getMeta(db, 'schema_version')).toBe('27');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('api_keys created by v27 has the role column already (no extra ALTER needed)', () => {
+    simulatePartialV16State();
+
+    const db = openHippoDb(root);
+    try {
+      const cols = (db
+        .prepare(`PRAGMA table_info(api_keys)`)
+        .all() as Array<{ name: string }>)
+        .map((r) => r.name);
+      expect(cols).toContain('role');
+      expect(cols).toContain('key_id');
+      expect(cols).toContain('key_hash');
+      expect(cols).toContain('tenant_id');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('audit_log created by v27 has the expected v16 shape', () => {
+    simulatePartialV16State();
+
+    const db = openHippoDb(root);
+    try {
+      const cols = (db
+        .prepare(`PRAGMA table_info(audit_log)`)
+        .all() as Array<{ name: string }>)
+        .map((r) => r.name);
+      expect(cols).toEqual(
+        expect.arrayContaining(['id', 'ts', 'tenant_id', 'actor', 'op', 'target_id', 'metadata_json']),
+      );
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('v27 is a no-op on a healthy DB (CREATE IF NOT EXISTS)', () => {
+    // Open + close once to apply all migrations to current head.
+    closeHippoDb(openHippoDb(root));
+
+    // Roll schema_version back to 26 to force v27 to re-run on a DB that
+    // already has the tables. v27 must not error.
+    const db1 = openHippoDb(root);
+    try {
+      setMeta(db1, 'schema_version', '26');
+    } finally {
+      closeHippoDb(db1);
+    }
+
+    // Re-open re-runs v27; should be a no-op + bump schema_version to 27.
+    const db2 = openHippoDb(root);
+    try {
+      const tables = tableNames(db2);
+      expect(tables).toContain('api_keys');
+      expect(tables).toContain('audit_log');
+      expect(getMeta(db2, 'schema_version')).toBe('27');
+    } finally {
+      closeHippoDb(db2);
+    }
+  });
+
+  it('v26 ALTER no-ops when api_keys table is missing (defensive guard)', () => {
+    // This test specifically locks the v26 fix: tableExists guard added
+    // alongside the existing tableHasColumn guard. Without it, v26 would
+    // crash on the partial-apply state before v27 could heal.
+    simulatePartialV16State();
+
+    // Should not throw — v26 sees api_keys missing and no-ops.
+    expect(() => {
+      const db = openHippoDb(root);
+      closeHippoDb(db);
+    }).not.toThrow();
+  });
+});

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
-      expect(getCurrentSchemaVersion()).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
+      expect(getCurrentSchemaVersion()).toBe(27);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(26);
+    expect(getCurrentSchemaVersion()).toBe(27);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(26);
+      expect(getSchemaVersion(db2)).toBe(27);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(26);
+      expect(getSchemaVersion(db2)).toBe(27);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(26);
+    expect(getCurrentSchemaVersion()).toBe(27);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(26);
+      expect(getSchemaVersion(db)).toBe(27);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
## What

Fixes a real user-facing bug surfaced on Keith's `~/.hippo/hippo.db`
2026-05-24: every `hippo context` invocation (the UserPromptSubmit hook
on Claude Code) printed `Error: no such table: api_keys` to stderr.

The DB had `schema_version=25` recorded in `meta` but the `api_keys` and
`audit_log` tables from migration v16 were missing — partial-applied
state that all later migrations ran on top of.

## The fix

- **Migration v27** re-asserts the v16 schema (CREATE TABLE IF NOT EXISTS).
  Idempotent. Zero cost for users without the bug, fixes any DB that has it
  on next open.
- **Migration v26 defensive guard** — without `tableExists(api_keys)`
  check, v26's ALTER would crash on the partial state before v27 could
  heal. Now no-ops gracefully.

## Root cause (surprising finding)

The migration runner has wrapped each migration in BEGIN/COMMIT since
the very first SQLite commit (`2cf72e7`). So atomicity is NOT the bug.
Three possible causes of the observed state:

1. `DROP TABLE api_keys` issued post-migration (operator action or external SQL).
2. Restore / import from a pre-v16 backup over v16+ schema_version.
3. Some edge case the BEGIN/COMMIT wrapping doesn't catch.

Cause unknown without forensic logs. v27 fixes the symptom for all paths.

## Test plan

- [x] 5 new tests in `tests/db-migration-v27-self-heal.test.ts`:
  - re-opening a DB in partial-v16 state heals it to v27
  - api_keys created by v27 has the role column
  - audit_log created by v27 has the v16 shape
  - v27 is a no-op on a healthy DB
  - v26 ALTER no-ops when api_keys is missing
- [x] 18 brittle `.toBe(26)` schema_version assertions bumped to `.toBe(27)` across 8 test files
- [x] Manifest parity test green (5 manifests synced to 1.12.7)
- [x] **Full suite: 1791 passed / 4 skipped / 0 failed across 248 files**

## Version

1.12.6 → 1.12.7 (patch — additive heal, no contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)