### PR TITLE
feat(slack): v1.12.8 multi-workspace tenant-routing e2e coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 1.12.8 (2026-05-24): multi-workspace tenant-routing e2e coverage
+
+Closes a coherent test story after this week's Slack multi-workspace
+work: v1.12.5 (workspaces CLI) added the registration surface, v1.12.6 B4
+fixed parse-failure tenant attribution, and v1.12.8 now locks the
+happy-path e2e: registered team → webhook → memory written with the
+mapped tenant_id.
+
+### Shipped
+- **`tests/slack-webhook-multi-workspace-tenant.test.ts`** (4 new cases):
+  - Registered team routes the ingested memory to the mapped tenant
+    (NOT HIPPO_TENANT fallback when slack_workspaces is non-empty)
+  - Two-workspace isolation: team-A messages NEVER produce tenant-B
+    memories, and vice versa (explicit cross-tenant leak guard)
+  - Foreign team (not registered, table non-empty) does NOT leak into
+    HIPPO_TENANT — fail-closed contract per v0.39 commit 3
+  - Single-workspace install (empty slack_workspaces) preserves
+    HIPPO_TENANT fallback ergonomics
+
+### Coverage map after this release
+
+| Layer | Test |
+|---|---|
+| `resolveTenantForTeam` unit | `tests/slack-tenant-routing.test.ts` |
+| Workspaces CLI add/list/remove unit | `tests/slack-workspaces.test.ts` |
+| Workspaces CLI integration | `tests/slack-workspaces-cli.test.ts` |
+| Unroutable foreign team → DLQ | `tests/v039-slack-hardening.test.ts` |
+| Parse-failure tenant attribution | `tests/slack-webhook-parse-failure-tenant.test.ts` |
+| **e2e happy path + isolation** | **`tests/slack-webhook-multi-workspace-tenant.test.ts` (NEW)** |
+
+### Tests
+
+1795 passed / 4 skipped / 0 failed across 249 files.
+
+### Notes
+
+- No code changes — additive test coverage only. Closes the TODOS gap
+  "Multi-workspace tenant-routing e2e test" surfaced in v0.38 Slack tail.
+- 12th ship of the 2026-05-24 session arc; natural high-water mark.
+
 ## 1.12.7 (2026-05-24): migration v27 self-heal for partial-v16 DB state
 
 Fixes a real user-facing bug: on a hippo DB where migration v16 had

--- a/TODOS.md
+++ b/TODOS.md
@@ -360,7 +360,7 @@ ranking improvements; none are correctness blockers.
 
 - [x] **`ingestMessage` skipped→duplicate status string.** SHIPPED v1.12.6 — option (a) chosen (unify), not (b) document. `src/connectors/slack/ingest.ts:50` now returns `status: 'skipped'` (not `'duplicate'`) when `lookupMemoryByEvent` returns null on a hasSeenEvent hit (the cached memory_id IS NULL discriminator). Non-null cached memory_id still returns `'duplicate'` (an actual memory was written before). Existing `tests/slack-ingest.test.ts:46` updated to assert the new contract; 3 new cases at `tests/slack-ingest-empty-body-replay.test.ts` cover first-call/replay/real-content paths.
 
-- [ ] **Multi-workspace tenant-routing e2e test.** `tests/slack-tenant-routing.test.ts` covers the helper unit; no end-to-end webhook test populates `slack_workspaces` and asserts the resolved tenant lands on the memory row. Add one webhook test that mints a row in `slack_workspaces` and asserts the ingested memory's `tenant_id` matches.
+- [x] **Multi-workspace tenant-routing e2e test.** SHIPPED v1.12.8 — `tests/slack-webhook-multi-workspace-tenant.test.ts` (4 cases): registered team → memory in mapped tenant; two-workspace isolation (no cross-tenant leak); foreign team fail-closed (no HIPPO_TENANT leak); single-workspace install env-fallback preserved. Closes the gap left after v1.12.5 (workspaces CLI) + v1.12.6 B4 (parse-failure tenant attribution).
 
 ---
 

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.7",
+  "version": "1.12.8",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.12.7';
+export const PACKAGE_VERSION = '1.12.8';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/slack-webhook-multi-workspace-tenant.test.ts
+++ b/tests/slack-webhook-multi-workspace-tenant.test.ts
@@ -1,0 +1,237 @@
+/**
+ * v1.12.8 — e2e webhook test: registered teams route memories to correct tenant.
+ *
+ * Closes the test gap explicitly tracked in TODOS.md:
+ *
+ *   "Multi-workspace tenant-routing e2e test. tests/slack-tenant-routing.test.ts
+ *   covers the helper unit; no end-to-end webhook test populates slack_workspaces
+ *   and asserts the resolved tenant lands on the memory row. Add one webhook test
+ *   that mints a row in slack_workspaces and asserts the ingested memory's
+ *   tenant_id matches."
+ *
+ * Existing coverage map (what we already had):
+ *   - tests/slack-tenant-routing.test.ts: resolveTenantForTeam helper unit only
+ *   - tests/v039-slack-hardening.test.ts: unroutable foreign team → __unroutable__ DLQ
+ *   - tests/slack-webhook-parse-failure-tenant.test.ts (v1.12.6 B4): parse-failure paths
+ *   - tests/slack-workspaces-cli.test.ts (v1.12.5): CLI add/list/remove unit
+ *
+ * What was missing (and is added here):
+ *   - happy path: registered team → webhook arrives with valid envelope →
+ *     ingestMessage writes a memory → memory.tenant_id matches the
+ *     workspace's mapped tenant
+ *   - two-tenant isolation: webhooks from team A only produce memories for
+ *     tenant A, never tenant B
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHmac } from 'node:crypto';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const SECRET = 'shhh-test-secret';
+
+function sign(ts: string, body: string): string {
+  return `v0=${createHmac('sha256', SECRET).update(`v0:${ts}:${body}`).digest('hex')}`;
+}
+
+function registerWorkspace(root: string, teamId: string, tenantId: string): void {
+  const db = openHippoDb(root);
+  try {
+    db.prepare(
+      `INSERT INTO slack_workspaces (team_id, tenant_id, added_at) VALUES (?, ?, ?)`,
+    ).run(teamId, tenantId, new Date().toISOString());
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+async function postEvent(
+  port: number,
+  body: string,
+): Promise<{ status: number; body: unknown }> {
+  const ts = String(Math.floor(Date.now() / 1000));
+  const res = await fetch(`http://127.0.0.1:${port}/v1/connectors/slack/events`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-slack-request-timestamp': ts,
+      'x-slack-signature': sign(ts, body),
+    },
+    body,
+  });
+  let parsed: unknown = null;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = await res.text();
+  }
+  return { status: res.status, body: parsed };
+}
+
+function makeMessageEvent(opts: {
+  teamId: string;
+  channel: string;
+  user: string;
+  text: string;
+  ts: string;
+  eventId: string;
+}): string {
+  return JSON.stringify({
+    type: 'event_callback',
+    team_id: opts.teamId,
+    event_id: opts.eventId,
+    event_time: Math.floor(Date.now() / 1000),
+    event: {
+      type: 'message',
+      channel: opts.channel,
+      channel_type: 'channel',
+      user: opts.user,
+      text: opts.text,
+      ts: opts.ts,
+    },
+  });
+}
+
+describe('POST /v1/connectors/slack/events multi-workspace tenant routing (v1.12.8)', () => {
+  let root: string;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-multi-ws-'));
+    initStore(root);
+    process.env.SLACK_SIGNING_SECRET = SECRET;
+    handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
+  });
+
+  afterEach(async () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    delete process.env.HIPPO_TENANT;
+    await handle.stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function entriesByTenant(tenantId: string) {
+    return loadAllEntries(root)
+      .filter((e) => e.tags.includes('source:slack'))
+      .filter((e) => e.tenantId === tenantId);
+  }
+
+  it('registered team routes the ingested memory to the mapped tenant', async () => {
+    process.env.HIPPO_TENANT = 'deployment-fallback';
+    registerWorkspace(root, 'T_ACME', 'acme');
+
+    const res = await postEvent(
+      handle.port,
+      makeMessageEvent({
+        teamId: 'T_ACME',
+        channel: 'C1',
+        user: 'U_alice',
+        text: 'multi-workspace alpha sentinel',
+        ts: '1716800000.000100',
+        eventId: 'Ev_acme_001',
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const acmeEntries = entriesByTenant('acme');
+    expect(acmeEntries).toHaveLength(1);
+    expect(acmeEntries[0]!.content).toContain('multi-workspace alpha sentinel');
+    expect(acmeEntries[0]!.kind).toBe('raw');
+
+    // Critical isolation: nothing leaked into the deployment fallback tenant.
+    expect(entriesByTenant('deployment-fallback')).toHaveLength(0);
+  });
+
+  it('two workspaces isolate: team-A messages NEVER produce tenant-B memories', async () => {
+    registerWorkspace(root, 'T_ACME', 'acme');
+    registerWorkspace(root, 'T_GLOBEX', 'globex');
+
+    await postEvent(
+      handle.port,
+      makeMessageEvent({
+        teamId: 'T_ACME',
+        channel: 'C1',
+        user: 'U_alice',
+        text: 'acme private payload bravo',
+        ts: '1716800100.000100',
+        eventId: 'Ev_acme_002',
+      }),
+    );
+    await postEvent(
+      handle.port,
+      makeMessageEvent({
+        teamId: 'T_GLOBEX',
+        channel: 'C2',
+        user: 'U_bob',
+        text: 'globex private payload charlie',
+        ts: '1716800200.000100',
+        eventId: 'Ev_globex_001',
+      }),
+    );
+
+    const acme = entriesByTenant('acme');
+    const globex = entriesByTenant('globex');
+    expect(acme).toHaveLength(1);
+    expect(globex).toHaveLength(1);
+    expect(acme[0]!.content).toContain('acme private payload bravo');
+    expect(globex[0]!.content).toContain('globex private payload charlie');
+
+    // Cross-tenant leak guard: no acme message in globex's tenant, no globex
+    // message in acme's tenant.
+    expect(acme.find((e) => e.content?.includes('globex'))).toBeUndefined();
+    expect(globex.find((e) => e.content?.includes('acme'))).toBeUndefined();
+  });
+
+  it('foreign team (not in slack_workspaces, non-empty table) does NOT leak into HIPPO_TENANT', async () => {
+    process.env.HIPPO_TENANT = 'deployment-fallback';
+    registerWorkspace(root, 'T_KNOWN', 'known-tenant');
+
+    // T_FOREIGN is not registered. Per resolveTenantForTeam's fail-closed
+    // contract (v0.39 commit 3), this should NOT fall back to HIPPO_TENANT —
+    // the foreign team is unroutable and the event lands in DLQ.
+    const res = await postEvent(
+      handle.port,
+      makeMessageEvent({
+        teamId: 'T_FOREIGN',
+        channel: 'C1',
+        user: 'U_unknown',
+        text: 'foreign leak attempt delta',
+        ts: '1716800300.000100',
+        eventId: 'Ev_foreign_001',
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    // No memory in any of the three tenants.
+    expect(entriesByTenant('known-tenant')).toHaveLength(0);
+    expect(entriesByTenant('deployment-fallback')).toHaveLength(0);
+    expect(loadAllEntries(root).filter((e) => e.tags.includes('source:slack'))).toHaveLength(0);
+  });
+
+  it('single-workspace install (empty slack_workspaces) routes via HIPPO_TENANT', async () => {
+    // No registerWorkspace call → slack_workspaces is empty → env fallback
+    // is safe per resolveTenantForTeam.
+    process.env.HIPPO_TENANT = 'single-deployment';
+
+    const res = await postEvent(
+      handle.port,
+      makeMessageEvent({
+        teamId: 'T_ANY',
+        channel: 'C1',
+        user: 'U_alice',
+        text: 'single workspace echo',
+        ts: '1716800400.000100',
+        eventId: 'Ev_single_001',
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const entries = entriesByTenant('single-deployment');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.content).toContain('single workspace echo');
+  });
+});


### PR DESCRIPTION
## What

Closes the e2e test gap explicitly tracked in `TODOS.md` (v0.38 E1.3 v2 tail):
no end-to-end webhook test asserted that a registered `slack_workspaces`
row routes the ingested memory to the mapped `tenant_id`.

## Coherent story across the week

| Release | What | Test layer |
|---|---|---|
| v1.12.5 | Workspaces CLI (`hippo slack workspaces add/list/remove`) | CLI unit + integration |
| v1.12.6 B4 | Parse-failure tenant attribution (root-cause code fix) | HTTP parse-fail path |
| **v1.12.8 (this)** | **e2e happy path + isolation** | **webhook → memory write** |

## 4 new tests in `tests/slack-webhook-multi-workspace-tenant.test.ts`

1. Registered team routes memory to mapped tenant (NOT HIPPO_TENANT)
2. Two-workspace isolation: team-A messages NEVER produce tenant-B memories (explicit cross-tenant leak guard, both directions)
3. Foreign team (table non-empty) → fail-closed, no leak into HIPPO_TENANT
4. Single-workspace install (empty table) → HIPPO_TENANT fallback preserved

## Test plan

- [x] 4 new test cases, all passing on first run
- [x] Manifest parity green (5 manifests synced to 1.12.8)
- [x] No code changes; additive coverage only
- [x] **Full suite: 1795 passed / 4 skipped / 0 failed across 249 files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)