### PR TITLE
feat(ui): E1 - wire parchment tokens + CI drift guard (stacked on E0)

### DIFF
--- a/scripts/check-token-drift.mjs
+++ b/scripts/check-token-drift.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Token drift CI guard (E1 deliverable of the hybrid-v4 revamp).
+ *
+ * Fails if any legacy dark-observatory hex codes appear outside the canonical
+ * token sources (ui/src/tokens.ts, ui/src/tokens.css). Prevents the same
+ * 4-surface drift caught by plan-eng-critic round 1 from recurring.
+ *
+ * Usage:
+ *   node scripts/check-token-drift.mjs           # exit 1 on drift
+ *   node scripts/check-token-drift.mjs --quiet   # only print drift lines
+ *
+ * Wire into ui/ test script or pre-commit hook.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep, resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Banned patterns — legacy dark-observatory tokens that must not reappear.
+// ---------------------------------------------------------------------------
+
+const LEGACY_HEX_PATTERNS = [
+  // Dark observatory body bg + gradients (particles.ts L112-114 originals)
+  /#0c0e14\b/g,
+  /#080a10\b/g,
+  /#050709\b/g,
+  // Dark observatory ui/index.html :root originals
+  /#0a0c10\b/g,
+  /#14161e\b/g,
+  /#e1e4ed\b/g,
+  /#6b7084\b/g,
+  // Old purple accent (was --accent, now --buffer)
+  /#7c5cff\b/g,
+  /0x7c5cff\b/gi,
+  // Old episodic orange (now blue)
+  /#f0a030\b/g,
+  /0xf0a030\b/gi,
+  // Old conflict red
+  /#ff4466\b/g,
+  /0xff4466\b/gi,
+  // Old semantic green (replaced by darker parchment-friendly green)
+  /#34d399\b/g,
+  /0x34d399\b/gi,
+  // Old dashboardHTML drifted tokens (the 7/10 mismatches the migration
+  // map called out — these never matched ui/index.html and are now deleted)
+  /#0f1117\b/g,
+  /#1a1d27\b/g,
+  /#2a2d3a\b/g,
+  /#8b8fa3\b/g,
+  /#6c8cff\b/g,
+  /#4ade80\b/g,
+  /#fbbf24\b/g,
+  /#8aa4ff\b/g,
+];
+
+// ---------------------------------------------------------------------------
+// Files to scan + files exempted (canonical sources).
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+
+const SCAN_PATHS = [
+  'ui/index.html',
+  'ui/src',
+  'src/dashboard.ts',
+];
+
+const EXEMPT_FILES = new Set([
+  // The canonical token sources — they SHOULD contain the new parchment
+  // hex codes, but not legacy ones. The patterns above are all legacy.
+  'ui/src/tokens.ts',
+  'ui/src/tokens.css',
+  // Migration map documents the old→new mapping; exempt by extension below.
+]);
+
+const EXEMPT_EXTENSIONS = new Set([
+  '.md', // migration map + design docs cite legacy hex for reference
+  '.png', '.jpg', '.gif', '.svg', '.ico', '.woff2', // binaries
+  '.json', // package-lock noise
+]);
+
+function shouldScan(filePath) {
+  const rel = relative(REPO_ROOT, filePath).split(sep).join('/');
+  if (EXEMPT_FILES.has(rel)) return false;
+  for (const ext of EXEMPT_EXTENSIONS) {
+    if (filePath.toLowerCase().endsWith(ext)) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Walk + scan
+// ---------------------------------------------------------------------------
+
+function walk(p) {
+  const out = [];
+  const st = statSync(p);
+  if (st.isFile()) {
+    if (shouldScan(p)) out.push(p);
+  } else if (st.isDirectory()) {
+    for (const entry of readdirSync(p)) {
+      if (entry === 'node_modules' || entry === 'dist' || entry === 'dist-ui') continue;
+      out.push(...walk(join(p, entry)));
+    }
+  }
+  return out;
+}
+
+const quiet = process.argv.includes('--quiet');
+const drifts = [];
+
+for (const target of SCAN_PATHS) {
+  const abs = join(REPO_ROOT, target);
+  for (const file of walk(abs)) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const lines = content.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const pattern of LEGACY_HEX_PATTERNS) {
+        const matches = line.match(pattern);
+        if (matches) {
+          drifts.push({
+            file: relative(REPO_ROOT, file),
+            line: i + 1,
+            match: matches[0],
+            content: line.trim().slice(0, 100),
+          });
+        }
+        pattern.lastIndex = 0; // reset global regex state between lines
+      }
+    }
+  }
+}
+
+if (drifts.length === 0) {
+  if (!quiet) {
+    console.log('✓ check-token-drift: 0 legacy hex codes outside canonical sources');
+  }
+  process.exit(0);
+}
+
+console.error(`✗ check-token-drift: ${drifts.length} legacy hex code(s) found:\n`);
+for (const d of drifts) {
+  console.error(`  ${d.file}:${d.line}  ${d.match}`);
+  if (!quiet) {
+    console.error(`    | ${d.content}`);
+  }
+}
+console.error(`\nFix: replace with imports from ui/src/tokens.ts or var(--*) from ui/src/tokens.css.`);
+console.error(`Migration map: docs/plans/2026-05-24-ui-token-migration-map.md`);
+process.exit(1);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -156,211 +156,6 @@ function buildDashboardData(hippoRoot: string): DashboardData {
   };
 }
 
-function dashboardHTML(data: DashboardData): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Hippo Dashboard</title>
-<style>
-  :root {
-    --bg: #0f1117; --surface: #1a1d27; --border: #2a2d3a;
-    --text: #e1e4ed; --muted: #8b8fa3; --accent: #6c8cff;
-    --green: #4ade80; --yellow: #fbbf24; --red: #f87171; --purple: #a78bfa;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: var(--bg); color: var(--text); padding: 24px; max-width: 1200px; margin: 0 auto; }
-  h1 { font-size: 24px; margin-bottom: 4px; }
-  h1 span { font-size: 14px; color: var(--muted); font-weight: normal; margin-left: 8px; }
-  h2 { font-size: 16px; color: var(--muted); margin-bottom: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin-bottom: 24px; }
-  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
-  .card .label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
-  .card .value { font-size: 28px; font-weight: 600; margin-top: 4px; }
-  .card .sub { font-size: 12px; color: var(--muted); margin-top: 2px; }
-  .bar-chart { display: flex; gap: 4px; align-items: flex-end; height: 120px; margin-top: 8px; }
-  .bar { flex: 1; min-width: 4px; background: var(--accent); border-radius: 2px 2px 0 0; position: relative; transition: background 0.2s; cursor: default; }
-  .bar:hover { background: #8aa4ff; }
-  .bar .tooltip { display: none; position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%); background: var(--surface); border: 1px solid var(--border); padding: 4px 8px; border-radius: 4px; font-size: 11px; white-space: nowrap; z-index: 10; }
-  .bar:hover .tooltip { display: block; }
-  .strength-high { background: var(--green); }
-  .strength-mid { background: var(--yellow); }
-  .strength-low { background: var(--red); }
-  table { width: 100%; border-collapse: collapse; font-size: 13px; }
-  th { text-align: left; padding: 8px; border-bottom: 2px solid var(--border); color: var(--muted); font-size: 11px; text-transform: uppercase; }
-  td { padding: 8px; border-bottom: 1px solid var(--border); vertical-align: top; }
-  tr:hover { background: rgba(108, 140, 255, 0.05); }
-  .tag { display: inline-block; padding: 2px 6px; border-radius: 4px; font-size: 11px; background: var(--border); color: var(--muted); margin: 1px; }
-  .tag-error { background: rgba(248, 113, 113, 0.15); color: var(--red); }
-  .strength-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; }
-  .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; }
-  .pill-pinned { background: rgba(167, 139, 250, 0.15); color: var(--purple); }
-  .pill-stale { background: rgba(251, 191, 36, 0.15); color: var(--yellow); }
-  .content-preview { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .section { margin-bottom: 32px; }
-  .conflict-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 12px; margin-bottom: 8px; }
-  .conflict-card .reason { color: var(--muted); font-size: 12px; }
-  .search { width: 100%; padding: 8px 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 14px; margin-bottom: 12px; outline: none; }
-  .search:focus { border-color: var(--accent); }
-  .tabs { display: flex; gap: 4px; margin-bottom: 16px; }
-  .tab { padding: 6px 14px; border-radius: 6px; font-size: 13px; cursor: pointer; background: var(--surface); border: 1px solid var(--border); color: var(--muted); }
-  .tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
-  .footer { text-align: center; color: var(--muted); font-size: 12px; margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); }
-</style>
-</head>
-<body>
-<h1>Hippo Dashboard <span>v0.25.0</span></h1>
-<p style="color: var(--muted); margin-bottom: 24px;">Memory health at a glance. Auto-refreshes on page load.</p>
-
-<div class="section">
-  <h2>Overview</h2>
-  <div class="grid" id="stats-grid"></div>
-</div>
-
-<div class="section">
-  <h2>Strength Distribution</h2>
-  <div class="card">
-    <div class="bar-chart" id="strength-chart"></div>
-    <div style="display: flex; justify-content: space-between; margin-top: 8px; font-size: 11px; color: var(--muted);">
-      <span>Weakest</span><span>Strongest</span>
-    </div>
-  </div>
-</div>
-
-<div class="section" id="conflicts-section" style="display:none;">
-  <h2>Open Conflicts</h2>
-  <div id="conflicts-list"></div>
-</div>
-
-<div class="section" id="peers-section" style="display:none;">
-  <h2>Shared Memory Peers</h2>
-  <div id="peers-list"></div>
-</div>
-
-<div class="section">
-  <h2>Memories</h2>
-  <input type="text" class="search" id="search" placeholder="Filter by content or tag...">
-  <div class="tabs" id="tabs">
-    <div class="tab active" data-filter="all">All</div>
-    <div class="tab" data-filter="strong">Strong (&gt;0.5)</div>
-    <div class="tab" data-filter="atrisk">At Risk (&lt;0.1)</div>
-    <div class="tab" data-filter="pinned">Pinned</div>
-    <div class="tab" data-filter="errors">Errors</div>
-  </div>
-  <table>
-    <thead><tr><th></th><th>Content</th><th>Tags</th><th>Strength</th><th>Half-life</th><th>Retrievals</th><th>Age</th></tr></thead>
-    <tbody id="memory-table"></tbody>
-  </table>
-</div>
-
-<div class="footer">Hippo Memory — biologically-inspired memory for AI agents</div>
-
-<script>
-const DATA = ${JSON.stringify(data)};
-
-function strengthColor(s) {
-  if (s >= 0.5) return 'var(--green)';
-  if (s >= 0.1) return 'var(--yellow)';
-  return 'var(--red)';
-}
-function strengthClass(s) {
-  if (s >= 0.5) return 'strength-high';
-  if (s >= 0.1) return 'strength-mid';
-  return 'strength-low';
-}
-
-// Stats grid
-const statsGrid = document.getElementById('stats-grid');
-const stats = DATA.stats;
-const cards = [
-  { label: 'Total Memories', value: stats.total, sub: stats.pinned + ' pinned' },
-  { label: 'Avg Strength', value: stats.avg_strength.toFixed(2), sub: stats.at_risk + ' at risk' },
-  { label: 'Avg Half-life', value: stats.avg_half_life.toFixed(1) + 'd', sub: 'default: ' + DATA.config.defaultHalfLifeDays + 'd' },
-  { label: 'Error Memories', value: stats.errors, sub: Math.round(stats.errors / Math.max(1, stats.total) * 100) + '% of total' },
-  { label: 'Embedding Coverage', value: Math.round(stats.embedding_coverage * 100) + '%', sub: DATA.config.embeddingsEnabled === 'auto' ? 'auto mode' : String(DATA.config.embeddingsEnabled) },
-  { label: 'Open Conflicts', value: stats.open_conflicts, sub: stats.open_conflicts > 0 ? 'needs resolution' : 'all clear' },
-];
-statsGrid.innerHTML = cards.map(c => '<div class="card"><div class="label">' + c.label + '</div><div class="value">' + c.value + '</div><div class="sub">' + c.sub + '</div></div>').join('');
-
-// Strength chart
-const chart = document.getElementById('strength-chart');
-const sorted = [...DATA.memories].sort((a, b) => a.strength - b.strength);
-if (sorted.length > 0) {
-  const maxBars = Math.min(sorted.length, 100);
-  const step = Math.max(1, Math.floor(sorted.length / maxBars));
-  const sampled = [];
-  for (let i = 0; i < sorted.length; i += step) sampled.push(sorted[i]);
-  chart.innerHTML = sampled.map(m => {
-    const h = Math.max(2, Math.round(m.strength * 100));
-    return '<div class="bar ' + strengthClass(m.strength) + '" style="height:' + h + '%"><div class="tooltip">' + m.id + ': ' + m.strength.toFixed(2) + '</div></div>';
-  }).join('');
-}
-
-// Conflicts
-if (DATA.conflicts.length > 0) {
-  document.getElementById('conflicts-section').style.display = '';
-  document.getElementById('conflicts-list').innerHTML = DATA.conflicts.map(c =>
-    '<div class="conflict-card"><strong>conflict_' + c.id + '</strong> (score: ' + c.score.toFixed(2) + ')<br>' +
-    '<code>' + c.memory_a_id + '</code> vs <code>' + c.memory_b_id + '</code><br>' +
-    '<span class="reason">' + c.reason + '</span></div>'
-  ).join('');
-}
-
-// Peers
-if (DATA.peers.length > 0) {
-  document.getElementById('peers-section').style.display = '';
-  document.getElementById('peers-list').innerHTML = '<div class="card"><table><thead><tr><th>Project</th><th>Memories</th><th>Latest</th></tr></thead><tbody>' +
-    DATA.peers.map(p => '<tr><td>' + p.project + '</td><td>' + p.count + '</td><td>' + p.latest.slice(0, 10) + '</td></tr>').join('') +
-    '</tbody></table></div>';
-}
-
-// Memory table
-function renderTable(filter, search) {
-  const tbody = document.getElementById('memory-table');
-  let mems = DATA.memories;
-  if (filter === 'strong') mems = mems.filter(m => m.strength >= 0.5);
-  else if (filter === 'atrisk') mems = mems.filter(m => m.strength < 0.1 && !m.pinned);
-  else if (filter === 'pinned') mems = mems.filter(m => m.pinned);
-  else if (filter === 'errors') mems = mems.filter(m => m.tags.includes('error'));
-  if (search) {
-    const q = search.toLowerCase();
-    mems = mems.filter(m => m.content.toLowerCase().includes(q) || m.tags.some(t => t.includes(q)));
-  }
-  mems.sort((a, b) => b.strength - a.strength);
-  tbody.innerHTML = mems.slice(0, 200).map(m => {
-    const dot = '<span class="strength-dot" style="background:' + strengthColor(m.strength) + '"></span>';
-    const pills = [];
-    if (m.pinned) pills.push('<span class="pill pill-pinned">pinned</span>');
-    if (m.confidence === 'stale') pills.push('<span class="pill pill-stale">stale</span>');
-    const tags = m.tags.map(t => '<span class="tag' + (t === 'error' ? ' tag-error' : '') + '">' + t + '</span>').join(' ');
-    return '<tr><td>' + dot + pills.join(' ') + '</td>' +
-      '<td class="content-preview" title="' + m.content.replace(/"/g, '&quot;') + '">' + m.content.slice(0, 80) + (m.content.length > 80 ? '...' : '') + '</td>' +
-      '<td>' + tags + '</td>' +
-      '<td>' + m.strength.toFixed(2) + '</td>' +
-      '<td>' + m.half_life_days + 'd</td>' +
-      '<td>' + m.retrieval_count + '</td>' +
-      '<td>' + m.age_days + 'd</td></tr>';
-  }).join('');
-}
-
-let activeFilter = 'all';
-document.getElementById('tabs').addEventListener('click', e => {
-  const tab = e.target.closest('.tab');
-  if (!tab) return;
-  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-  tab.classList.add('active');
-  activeFilter = tab.dataset.filter;
-  renderTable(activeFilter, document.getElementById('search').value);
-});
-document.getElementById('search').addEventListener('input', e => {
-  renderTable(activeFilter, e.target.value);
-});
-renderTable('all', '');
-</script>
-</body>
-</html>`;
-}
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -459,10 +254,18 @@ export function serveDashboard(hippoRoot: string, port: number = 3333): http.Ser
       if (serveStaticFile(res, indexPath)) return;
     }
 
-    // --- Legacy inline HTML fallback ---
-    const data = buildDashboardData(hippoRoot);
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-    res.end(dashboardHTML(data));
+    // --- SPA not built: prompt to build (the dashboardHTML SSR fallback
+    // was removed in the hybrid-v4 revamp E1 since dist-ui/ is now the
+    // sole UI surface). ---
+    res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(`<!doctype html>
+<html lang="en"><head><title>Hippo Dashboard</title><meta charset="utf-8"></head>
+<body style="font-family:Georgia,'Palatino Linotype',serif;max-width:640px;margin:60px auto;padding:24px;line-height:1.6;background:#f4efe6;color:#3a3228">
+<h1 style="color:#c45c3c">Hippo Dashboard</h1>
+<p>The React UI bundle is not built yet. Run:</p>
+<pre style="background:#faf7f2;padding:16px;border:1px solid #c4b9a8;border-radius:3px;font-family:Consolas,monospace">cd ui && npm install && npm run build</pre>
+<p>Then refresh this page. The dashboard server will serve <code>dist-ui/index.html</code> automatically once present.</p>
+</body></html>`);
   });
 
   server.listen(port, '127.0.0.1', () => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,28 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hippo Brain Observatory</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/src/tokens.css" />
     <style>
-      :root {
-        --bg: #0a0c10;
-        --surface: #14161e;
-        --border: rgba(255, 255, 255, 0.06);
-        --text: #e1e4ed;
-        --muted: #6b7084;
-        --accent: #7c5cff;
-        --green: #34d399;
-        --yellow: #f0a030;
-        --red: #f87171;
-        --purple: #a78bfa;
-        --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
-        --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-        --glass-bg: rgba(10, 12, 16, 0.82);
-        --glass-blur: blur(16px);
-        --glass-border: 1px solid rgba(255, 255, 255, 0.06);
-      }
-
       * {
         margin: 0;
         padding: 0;
@@ -34,6 +14,7 @@
 
       body {
         background: var(--bg);
+        background-image: var(--texture-cross-hatch);
         color: var(--text);
         font-family: var(--font-body);
         overflow: hidden;

--- a/ui/src/engine/particles.ts
+++ b/ui/src/engine/particles.ts
@@ -1,6 +1,15 @@
 import type { Memory } from "../types.js";
 import type { Particle } from "./types.js";
 import { LAYER_COLORS } from "./types.js";
+import {
+  COLOR_ACCENT_DIM,
+  COLOR_BG_GRADIENT_INNER,
+  COLOR_BG_GRADIENT_MID,
+  COLOR_BG_GRADIENT_OUTER,
+  COLOR_BUFFER,
+  COLOR_EPISODIC,
+  COLOR_SEMANTIC,
+} from "../tokens.js";
 
 function hexToRgb(hex: string): [number, number, number] {
   return [
@@ -109,9 +118,10 @@ export class ParticleEngine {
 
   private renderDeep(ctx: CanvasRenderingContext2D, w: number, h: number, time: number): void {
     const bg = ctx.createRadialGradient(w * 0.5, h * 0.45, 0, w * 0.5, h * 0.45, Math.max(w, h) * 0.75);
-    bg.addColorStop(0, "#0c0e14");
-    bg.addColorStop(0.6, "#080a10");
-    bg.addColorStop(1, "#050709");
+    // Parchment bg gradient (inner brightest, outer warm parchment)
+    bg.addColorStop(0, COLOR_BG_GRADIENT_INNER);
+    bg.addColorStop(0.6, COLOR_BG_GRADIENT_MID);
+    bg.addColorStop(1, COLOR_BG_GRADIENT_OUTER);
     ctx.fillStyle = bg;
     ctx.fillRect(0, 0, w, h);
 
@@ -197,10 +207,12 @@ export class ParticleEngine {
     ctx.textBaseline = "middle";
     ctx.font = "10px 'JetBrains Mono', monospace";
 
+    // Zones use the parchment layer tints with low alpha. Tints come from
+    // tokens.ts so any future palette change cascades here automatically.
     const zones: [number, string, string][] = [
-      [0.18, "BUFFER", "rgba(124,92,255,0.09)"],
-      [0.50, "EPISODIC", "rgba(240,160,48,0.09)"],
-      [0.82, "SEMANTIC", "rgba(52,211,153,0.09)"],
+      [0.18, "BUFFER", colorAlpha(COLOR_BUFFER, 0.12)],
+      [0.50, "EPISODIC", colorAlpha(COLOR_EPISODIC, 0.12)],
+      [0.82, "SEMANTIC", colorAlpha(COLOR_SEMANTIC, 0.12)],
     ];
 
     for (const [yFrac, label, color] of zones) {
@@ -234,9 +246,9 @@ export class ParticleEngine {
 
       const alpha = 0.15 + c.score * 0.4;
       const grad = ctx.createLinearGradient(a.x, a.y, b.x, b.y);
-      grad.addColorStop(0, colorAlpha("#ff4466", alpha * 0.3));
-      grad.addColorStop(0.5, colorAlpha("#ff4466", alpha));
-      grad.addColorStop(1, colorAlpha("#ff4466", alpha * 0.3));
+      grad.addColorStop(0, colorAlpha(COLOR_ACCENT_DIM, alpha * 0.3));
+      grad.addColorStop(0.5, colorAlpha(COLOR_ACCENT_DIM, alpha));
+      grad.addColorStop(1, colorAlpha(COLOR_ACCENT_DIM, alpha * 0.3));
 
       ctx.save();
       ctx.strokeStyle = grad;

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -5,6 +5,13 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import type { Memory, Conflict } from "../types.js";
 import { LAYER_COLORS } from "./types.js";
+import {
+  COLOR_BG,
+  COLOR_ACCENT_HEX,
+  COLOR_AMBIENT_LIGHT_HEX,
+  COLOR_GRID_HEX,
+  COLOR_CONFLICT_HEX,
+} from "../tokens.js";
 
 const SPREAD = 20;
 const LAYER_Y_OFFSET: Record<string, number> = { buffer: 6, episodic: 0, semantic: -6 };
@@ -67,13 +74,16 @@ export class BrainScene {
 
   private initScene(): void {
     this.scene = new THREE.Scene();
-    this.scene.background = new THREE.Color("#050709");
-    this.scene.fog = new THREE.FogExp2("#050709", 0.012);
+    this.scene.background = new THREE.Color(COLOR_BG);
+    // Lighter fog density for parchment bg — heavy fog reads as fog of war on
+    // dark, as haze on light; halve density to preserve depth without muddying.
+    this.scene.fog = new THREE.FogExp2(COLOR_BG, 0.008);
 
-    const ambient = new THREE.AmbientLight(0x111122, 0.5);
+    // Warmer + brighter ambient for parchment (was 0x111122 @ 0.5 on dark)
+    const ambient = new THREE.AmbientLight(COLOR_AMBIENT_LIGHT_HEX, 0.65);
     this.scene.add(ambient);
 
-    const point = new THREE.PointLight(0x7c5cff, 0.4, 100);
+    const point = new THREE.PointLight(COLOR_ACCENT_HEX, 0.4, 100);
     point.position.set(0, 15, 10);
     this.scene.add(point);
   }
@@ -115,7 +125,10 @@ export class BrainScene {
   private initGrid(): void {
     this.gridHelper = new THREE.Group();
 
-    const gridMaterial = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.03 });
+    // Parchment grid: warm border color, slightly higher opacity than the
+    // pre-revamp 0xffffff/0.03 (white on dark) since darker-on-light needs
+    // more presence to read at the same visual weight.
+    const gridMaterial = new THREE.LineBasicMaterial({ color: COLOR_GRID_HEX, transparent: true, opacity: 0.06 });
     const size = 40;
     const divisions = 20;
     const step = size / divisions;
@@ -285,7 +298,7 @@ export class BrainScene {
       const points = curve.getPoints(16);
       const geo = new THREE.BufferGeometry().setFromPoints(points);
       const mat = new THREE.LineDashedMaterial({
-        color: 0xff4466,
+        color: COLOR_CONFLICT_HEX,
         transparent: true,
         opacity: 0.3 + c.score * 0.4,
         dashSize: 0.3,

--- a/ui/src/engine/types.ts
+++ b/ui/src/engine/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Engine-internal types. LAYER_COLORS re-exported from the single source of
+ * truth at ui/src/tokens.ts (the parchment palette per hybrid-v4 revamp E1).
+ */
+
 export interface Particle {
   id: string;
   x: number;
@@ -13,8 +18,4 @@ export interface Particle {
   selected: boolean;
 }
 
-export const LAYER_COLORS = {
-  buffer: "#7c5cff",
-  episodic: "#f0a030",
-  semantic: "#34d399",
-} as const;
+export { LAYER_COLORS, LAYER_COLORS_HEX } from "../tokens.js";


### PR DESCRIPTION
## What

E1 of the UI hybrid-v4 revamp. Wires E0's `tokens.ts`/`tokens.css` into all 4 token surfaces, deletes the drifted SSR fallback, adds a CI drift guard.

**Stacked PR:** base is `ui-revamp-e0-tokens` (#53), not master. Merge #53 first, then this rebases on master automatically.

## Surface-by-surface

| Surface | Change |
|---|---|
| `ui/index.html` | Legacy dark `:root` block replaced with `<link>` to `/src/tokens.css`. Added cross-hatch body texture (parchment paper grain). |
| `ui/src/engine/scene.ts` | 6 hex literals replaced. Fog density 0.012 -> 0.008 (heavy fog reads as fog of war on dark, as haze on light). Ambient light brighter and warmer. Grid opacity 0.03 -> 0.06 (warm-on-light needs more presence). |
| `ui/src/engine/particles.ts` | 4 hex literals + zone-label rgba inlines replaced with token imports + `colorAlpha()` calls. |
| `ui/src/engine/types.ts` | `LAYER_COLORS` re-exported from `tokens.ts`. |
| `src/dashboard.ts` | `dashboardHTML()` deleted (205 lines, was 159-363). `/dashboard` now serves `dist-ui/` only; missing-build fallback shows parchment-styled build prompt. |

## New CI guard

`scripts/check-token-drift.mjs` greps 22 legacy dark-observatory hex patterns across `ui/index.html`, `ui/src/`, `src/dashboard.ts`. Exempts canonical `tokens.ts/css`. Exits 1 + line refs on drift, 0 on clean.

## Test plan

- [x] `cd ui && npm run build` clean (51 modules, CSS chunk now emitted)
- [x] `npm run build` (root) clean (tsc + benchmarks tsc both pass)
- [x] `node scripts/check-token-drift.mjs` exits 0 (zero drift)
- [x] `cd ui && npm test` exits 0 (no tests yet, passWithNoTests honored)
- [ ] Manual: `hippo dashboard --port 3333` shows parchment LivingMap (deferred to Keith)
- [ ] Manual: `/dashboard` returns 404 + build prompt when `dist-ui/` absent (deferred to Keith)

## Files changed

6 files, +217/-250 (net -33 because dashboardHTML deletion).

## Next

E1.5 (engine API extension audit) is the next episode on stack. Adds `BrainScene.setReducedMotion(bool)`, `setFiltered(ids)`, `onRender(cb)`, `getCamera()` per plan. ~0.5d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
