### PR TITLE
feat(ui): E1.5 - BrainScene API extensions (setReducedMotion + setFiltered + onRender + getCamera)

### DIFF
--- a/ui/src/components/LayerLegend.tsx
+++ b/ui/src/components/LayerLegend.tsx
@@ -14,7 +14,7 @@ export function LayerLegend() {
       gap: 12,
       fontSize: 9,
       fontFamily: "var(--font-mono)",
-      color: "rgba(255,255,255,0.5)",
+      color: "var(--dim)",
       letterSpacing: "0.3px",
     }}>
       {LAYERS.map(({ key, label }) => (

--- a/ui/src/components/MemoryTooltip.tsx
+++ b/ui/src/components/MemoryTooltip.tsx
@@ -8,7 +8,7 @@ interface MemoryTooltipProps {
 }
 
 export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
-  const preview = memory.content.length > 100 ? memory.content.slice(0, 100) + "\u2026" : memory.content;
+  const preview = memory.content.length > 100 ? memory.content.slice(0, 100) + "…" : memory.content;
   const layerColor = LAYER_COLORS[memory.layer];
 
   return (
@@ -16,16 +16,16 @@ export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
       position: "fixed",
       left: x + 16,
       top: y - 12,
-      background: "rgba(8, 10, 14, 0.92)",
+      background: "var(--glass-bg-strong)",
       backdropFilter: "blur(20px)",
       WebkitBackdropFilter: "blur(20px)",
-      border: "1px solid rgba(255,255,255,0.06)",
+      border: "1px solid var(--glass-border)",
       borderRadius: 12,
       padding: "12px 14px",
       maxWidth: 280,
       pointerEvents: "none" as const,
       zIndex: 100,
-      boxShadow: `0 4px 24px rgba(0,0,0,0.4), 0 0 0 1px rgba(255,255,255,0.02), inset 0 1px 0 rgba(255,255,255,0.03)`,
+      boxShadow: `0 4px 24px var(--ink-shadow), 0 0 0 1px var(--glass-border)`,
     }}>
       <div style={{
         display: "flex",
@@ -41,7 +41,7 @@ export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
           boxShadow: `0 0 6px ${layerColor}60`,
         }} />
         <span style={{
-          color: "var(--muted)",
+          color: "var(--dim)",
           fontSize: 9,
           fontFamily: "var(--font-mono)",
           textTransform: "uppercase",
@@ -49,9 +49,9 @@ export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
         }}>
           {memory.layer}
         </span>
-        <span style={{ color: "rgba(255,255,255,0.1)", fontSize: 9 }}>&middot;</span>
+        <span style={{ color: "var(--text-faint)", fontSize: 9 }}>&middot;</span>
         <span style={{
-          color: "var(--muted)",
+          color: "var(--dim)",
           fontSize: 9,
           fontFamily: "var(--font-mono)",
         }}>
@@ -70,7 +70,7 @@ export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
         marginTop: 8,
         display: "flex",
         gap: 8,
-        color: "rgba(255,255,255,0.2)",
+        color: "var(--text-faint)",
         fontSize: 9,
         fontFamily: "var(--font-mono)",
       }}>

--- a/ui/src/components/SearchBar.tsx
+++ b/ui/src/components/SearchBar.tsx
@@ -18,13 +18,13 @@ export function SearchBar({ value, onChange, memoryCount, matchCount }: SearchBa
         onChange={(e) => onChange(e.target.value)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
-        placeholder="search\u2026"
+        placeholder="search…"
         style={{
           width: "100%",
           padding: "5px 10px",
           paddingRight: matchCount !== null ? 48 : 10,
-          background: focused ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.03)",
-          border: focused ? "1px solid rgba(124,92,255,0.4)" : "1px solid rgba(255,255,255,0.08)",
+          background: focused ? "var(--ink-faint)" : "var(--glass-bg)",
+          border: focused ? "1px solid var(--accent-focus)" : "1px solid var(--glass-border)",
           borderRadius: 8,
           color: "var(--text)",
           fontSize: 11,
@@ -41,7 +41,7 @@ export function SearchBar({ value, onChange, memoryCount, matchCount }: SearchBa
           right: 8,
           top: "50%",
           transform: "translateY(-50%)",
-          color: "rgba(255,255,255,0.25)",
+          color: "var(--text-faint)",
           fontSize: 9,
           fontFamily: "var(--font-mono)",
           pointerEvents: "none",

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -51,6 +51,8 @@ export class BrainScene {
   private onClickCb: ((memory: Memory | null) => void) | null = null;
   private disposed = false;
   private rafId = 0;
+  /** E1.5: per-frame render callbacks for screen-space label overlay (E4). */
+  private onRenderCbs: Array<(camera: THREE.PerspectiveCamera, scene: THREE.Scene) => void> = [];
 
   constructor(private container: HTMLDivElement) {
     this.initRenderer();
@@ -434,8 +436,104 @@ export class BrainScene {
       }
     }
 
+    // E1.5: notify per-frame subscribers (E4's label overlay). Single-line
+    // hot-path insertion per plan v2 round-2 LOW #7 carve-out. Refactoring
+    // this loop is out of scope; only the forEach is in-scope here.
+    if (this.onRenderCbs.length > 0) {
+      for (const cb of this.onRenderCbs) cb(this.camera, this.scene);
+    }
+
     this.composer.render();
   };
+
+  // -------------------------------------------------------------------------
+  // E1.5 — Engine surface API extensions for E2 (freeze), E4 (label overlay),
+  // and E5 (prefers-reduced-motion + drawer mirror).
+  //
+  // Internals (layout algorithm, particle physics, render order) remain
+  // out of scope. Only single-line insertions in animate() are in-scope
+  // per plan v2 round-2 LOW #7 carve-out.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Freeze or restart the animation loop. Used by E2's freeze-toggle and E5's
+   * prefers-reduced-motion media query.
+   *
+   * Implementation note (round-2 HIGH #1 + round-3 HIGH #1 fixes): matches
+   * scene.ts's existing rafId-based loop. Does NOT use Three.js's
+   * setAnimationLoop API (which scene.ts never adopted). When freezing,
+   * snaps particles to their basePosition rather than iterating to convergence
+   * (the sin/cos drift physics at L423-L435 never converges).
+   */
+  setReducedMotion(reduced: boolean): void {
+    if (reduced) {
+      if (this.rafId) {
+        cancelAnimationFrame(this.rafId);
+        this.rafId = 0;
+      }
+      this.snapParticlesToFinal();
+    } else if (!this.rafId) {
+      this.animate(); // restart the existing loop
+    }
+  }
+
+  /**
+   * Toggle node visibility based on a filter set. Used by E3's FilterPanel.
+   * Layout is NOT re-run; filtered nodes are hidden in place. To restore
+   * full visibility, pass an empty set.
+   */
+  setFiltered(visibleIds: Set<string>): void {
+    const filterActive = visibleIds.size > 0;
+    for (const node of this.nodes) {
+      const visible = !filterActive || visibleIds.has(node.id);
+      node.mesh.visible = visible;
+      node.halo.visible = visible;
+    }
+  }
+
+  /**
+   * Register a per-frame render callback. Used by E4's LabelOverlay to
+   * project node world-coords to screen-coords each frame.
+   *
+   * Returns an unsubscribe function. Callbacks fire once per animate()
+   * tick AFTER drift physics + BEFORE composer.render(). Keep them cheap;
+   * with N=1000 nodes the perf budget is ~8ms/frame to hold 60fps.
+   */
+  onRender(cb: (camera: THREE.PerspectiveCamera, scene: THREE.Scene) => void): () => void {
+    this.onRenderCbs.push(cb);
+    return () => {
+      const i = this.onRenderCbs.indexOf(cb);
+      if (i >= 0) this.onRenderCbs.splice(i, 1);
+    };
+  }
+
+  /**
+   * Accessor for the perspective camera. Used by E4's LabelOverlay so it
+   * can call `vector.project(camera)` without reaching into private fields.
+   *
+   * Returns the actual PerspectiveCamera (not the wider THREE.Camera base)
+   * so consumers can access `.aspect`, `.updateProjectionMatrix()`, etc.
+   * (round-3 LOW #4 fix.)
+   */
+  getCamera(): THREE.PerspectiveCamera {
+    return this.camera;
+  }
+
+  /**
+   * Snap drifting particles to their basePosition (freeze pose). Called by
+   * setReducedMotion(true). The drift physics is pure sin oscillation
+   * (L423-L435 of animate) — there is no convergence target other than
+   * basePosition itself, so we copy it directly.
+   */
+  private snapParticlesToFinal(): void {
+    for (const node of this.nodes) {
+      node.mesh.position.copy(node.basePosition);
+      node.halo.position.copy(node.basePosition);
+    }
+    // One final paint so reduced-motion users see the static layout, not
+    // the last animated frame.
+    this.composer.render();
+  }
 
   dispose(): void {
     this.disposed = true;

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -68,8 +68,12 @@ export class BrainScene {
     this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.setSize(this.container.clientWidth, this.container.clientHeight);
-    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    this.renderer.toneMappingExposure = 1.2;
+    // E1 fix: was ACESFilmicToneMapping @ exposure 1.2 — designed for HDR
+    // scenes on dark; on parchment it crushed the light bg into mid-grey.
+    // NoToneMapping preserves linear sRGB values so the parchment clearColor
+    // renders as authored.
+    this.renderer.toneMapping = THREE.NoToneMapping;
+    this.renderer.toneMappingExposure = 1.0;
     this.container.appendChild(this.renderer.domElement);
     this.renderer.domElement.style.display = "block";
   }
@@ -115,13 +119,14 @@ export class BrainScene {
     this.composer = new EffectComposer(this.renderer);
     this.composer.addPass(new RenderPass(this.scene, this.camera));
 
-    const bloom = new UnrealBloomPass(
-      new THREE.Vector2(w, h),
-      1.2,
-      0.5,
-      0.2,
-    );
-    this.composer.addPass(bloom);
+    // E1 fix: bloom disabled for parchment aesthetic. UnrealBloomPass is
+    // designed for "stars in dark sky" — on parchment it whitewashed the
+    // bg and merged adjacent nodes into a single glow cloud. The hybrid-v4
+    // mockup uses crisp spheres without bloom; matching that. If needed
+    // for selected-node emphasis, re-enable with strength <= 0.2 + threshold
+    // >= 0.9 (very selective).
+    // const bloom = new UnrealBloomPass(new THREE.Vector2(w, h), 0.0, 0.4, 0.95);
+    // this.composer.addPass(bloom);
   }
 
   private initGrid(): void {
@@ -197,26 +202,32 @@ export class BrainScene {
       const logRatio = Math.log2(mem.retrieval_count + 1) / Math.log2(maxRetrieval + 1);
       const radius = 0.15 + logRatio * 0.35;
 
+      // E1 fix: solid parchment-friendly spheres. Pre-revamp had emissive
+      // glow + transparency designed for dark-bg "stars in space" look —
+      // on parchment those blurred into a cyan cloud blob. Now: no emissive,
+      // high opacity, slightly higher roughness for matte parchment feel.
       const sphereGeo = new THREE.SphereGeometry(radius, 24, 24);
       const sphereMat = new THREE.MeshStandardMaterial({
         color,
-        emissive: color,
-        emissiveIntensity: 0.6 + mem.strength * 0.8,
-        roughness: 0.3,
-        metalness: 0.1,
+        emissiveIntensity: 0,
+        roughness: 0.55,
+        metalness: 0.05,
         transparent: true,
-        opacity: 0.3 + mem.strength * 0.7,
+        opacity: 0.78 + mem.strength * 0.22,
       });
       const sphere = new THREE.Mesh(sphereGeo, sphereMat);
       sphere.position.set(x, y, z);
       sphere.userData = { memoryId: mem.id };
       this.scene.add(sphere);
 
-      const haloGeo = new THREE.SphereGeometry(radius * 3, 16, 16);
+      // E1 fix: halo near-invisible by default (was 0.06+ which created the
+      // cloud blob on parchment). Hover/select paths still bump opacity in
+      // applyDimming() / hover handlers for the interaction signal.
+      const haloGeo = new THREE.SphereGeometry(radius * 2.2, 16, 16);
       const haloMat = new THREE.MeshBasicMaterial({
         color,
         transparent: true,
-        opacity: 0.06 + mem.strength * 0.08,
+        opacity: 0.015 + mem.strength * 0.025,
         side: THREE.BackSide,
         depthWrite: false,
       });

--- a/ui/src/tokens.css
+++ b/ui/src/tokens.css
@@ -47,6 +47,15 @@
   --radius-lg: 6px;
   --border-w: 1px;
 
+  /* Glass / overlay surfaces (parchment-tinted, replacing dark rgba inlines) */
+  --glass-bg-strong: rgba(244, 239, 230, 0.95);   /* DetailPanel, MemoryTooltip - opaque on canvas */
+  --glass-bg: rgba(250, 247, 242, 0.85);          /* Header bar - translucent over canvas */
+  --glass-border: rgba(58, 50, 40, 0.10);         /* subtle dark-on-parchment separator */
+  --ink-faint: rgba(58, 50, 40, 0.06);            /* tag bg, button bg */
+  --ink-shadow: rgba(58, 50, 40, 0.15);           /* drop shadows */
+  --accent-focus: rgba(196, 92, 60, 0.35);        /* focus ring (rust) */
+  --text-faint: rgba(58, 50, 40, 0.45);           /* hint text, very subtle ids */
+
   /* Cross-hatch texture for body bg */
   --texture-cross-hatch:
     repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(180,170,150,0.015) 2px, rgba(180,170,150,0.015) 3px),

--- a/ui/src/views/LivingMap/LivingMap.tsx
+++ b/ui/src/views/LivingMap/LivingMap.tsx
@@ -15,7 +15,7 @@ interface LivingMapProps {
 
 function StrengthBar({ value }: { value: number }) {
   return (
-    <div style={{ width: "100%", height: 3, background: "rgba(255,255,255,0.06)", borderRadius: 2, overflow: "hidden" }}>
+    <div style={{ width: "100%", height: 3, background: "var(--glass-border)", borderRadius: 2, overflow: "hidden" }}>
       <div style={{
         width: `${value * 100}%`, height: "100%", borderRadius: 2,
         background: `linear-gradient(90deg, var(--accent), ${value > 0.5 ? "var(--green)" : "var(--yellow)"})`,
@@ -31,24 +31,24 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
   return (
     <div role="dialog" aria-label="Memory details" style={{
       position: "absolute", top: 0, right: 0, width: "min(360px, 48vw)", height: "100%",
-      background: "rgba(8, 10, 14, 0.92)", backdropFilter: "blur(24px)", WebkitBackdropFilter: "blur(24px)",
-      borderLeft: "1px solid rgba(255,255,255,0.04)", overflowY: "auto", zIndex: 50,
+      background: "var(--glass-bg-strong)", backdropFilter: "blur(24px)", WebkitBackdropFilter: "blur(24px)",
+      borderLeft: "1px solid var(--glass-border)", overflowY: "auto", zIndex: 50,
       transform: open ? "translateX(0)" : "translateX(100%)",
       transition: "transform 250ms cubic-bezier(0.16, 1, 0.3, 1)",
     }}>
       {memory && (
         <>
           <div style={{
-            padding: "20px 24px 16px", borderBottom: "1px solid rgba(255,255,255,0.04)",
+            padding: "20px 24px 16px", borderBottom: "1px solid var(--glass-border)",
             display: "flex", justifyContent: "space-between", alignItems: "flex-start",
           }}>
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <div style={{ width: 8, height: 8, borderRadius: "50%", background: layerColor, boxShadow: `0 0 8px ${layerColor}40` }} />
-              <span style={{ color: "var(--muted)", fontSize: 10, fontFamily: "var(--font-mono)", letterSpacing: "0.5px", textTransform: "uppercase" }}>{memory.layer}</span>
+              <span style={{ color: "var(--dim)", fontSize: 10, fontFamily: "var(--font-mono)", letterSpacing: "0.5px", textTransform: "uppercase" }}>{memory.layer}</span>
             </div>
             <button onClick={onClose} style={{
-              background: "rgba(255,255,255,0.04)", border: "none", borderRadius: 4,
-              color: "var(--muted)", cursor: "pointer", padding: "4px 10px", fontSize: 11, fontFamily: "var(--font-mono)",
+              background: "var(--ink-faint)", border: "none", borderRadius: 4,
+              color: "var(--dim)", cursor: "pointer", padding: "4px 10px", fontSize: 11, fontFamily: "var(--font-mono)",
             }}>esc</button>
           </div>
           <div style={{ padding: "20px 24px" }}>
@@ -57,7 +57,7 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
             </div>
             <div style={{ marginBottom: 16 }}>
               <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 6 }}>
-                <span style={{ color: "var(--muted)", fontSize: 10, fontFamily: "var(--font-mono)" }}>STRENGTH</span>
+                <span style={{ color: "var(--dim)", fontSize: 10, fontFamily: "var(--font-mono)" }}>STRENGTH</span>
                 <span style={{ color: "var(--text)", fontSize: 11, fontFamily: "var(--font-mono)" }}>{memory.strength.toFixed(3)}</span>
               </div>
               <StrengthBar value={memory.strength} />
@@ -70,7 +70,7 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
                 ["+7d", memory.projected_strength_7d.toFixed(3)], ["+30d", memory.projected_strength_30d.toFixed(3)],
               ] as [string, string][]).map(([label, val]) => (
                 <div key={label}>
-                  <div style={{ color: "var(--muted)", fontSize: 9, fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 2 }}>{label}</div>
+                  <div style={{ color: "var(--dim)", fontSize: 9, fontFamily: "var(--font-mono)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 2 }}>{label}</div>
                   <div style={{ color: "var(--text)", fontFamily: "var(--font-mono)" }}>{val}</div>
                 </div>
               ))}
@@ -78,11 +78,11 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
             {memory.tags.length > 0 && (
               <div style={{ display: "flex", gap: 5, flexWrap: "wrap", marginBottom: 16 }}>
                 {memory.tags.map((tag) => (
-                  <span key={tag} style={{ background: "rgba(255,255,255,0.04)", color: "var(--muted)", padding: "3px 10px", borderRadius: 12, fontSize: 10, fontFamily: "var(--font-mono)" }}>{tag}</span>
+                  <span key={tag} style={{ background: "var(--ink-faint)", color: "var(--dim)", padding: "3px 10px", borderRadius: 12, fontSize: 10, fontFamily: "var(--font-mono)" }}>{tag}</span>
                 ))}
               </div>
             )}
-            <div style={{ fontSize: 10, color: "rgba(255,255,255,0.2)", fontFamily: "var(--font-mono)", borderTop: "1px solid rgba(255,255,255,0.04)", paddingTop: 12 }}>
+            <div style={{ fontSize: 10, color: "var(--text-faint)", fontFamily: "var(--font-mono)", borderTop: "1px solid var(--glass-border)", paddingTop: 12 }}>
               <div>{memory.id}</div>
               <div style={{ marginTop: 4 }}>{new Date(memory.created).toLocaleDateString()} &rarr; {new Date(memory.last_retrieved).toLocaleDateString()}</div>
             </div>
@@ -150,15 +150,15 @@ export function LivingMap({ memories, embeddings, stats, conflicts }: LivingMapP
 
       <div style={{
         position: "absolute", top: 0, left: 0, right: 0, height: 48, zIndex: 20,
-        background: "rgba(8, 10, 14, 0.75)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)",
-        borderBottom: "1px solid rgba(255,255,255,0.06)",
+        background: "var(--glass-bg)", backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)",
+        borderBottom: "1px solid var(--glass-border)",
         display: "flex", alignItems: "center", padding: "0 24px", gap: 20,
         pointerEvents: "auto",
       }}>
         <div style={{ flex: "0 0 auto", display: "flex", alignItems: "baseline", gap: 12 }}>
-          <span style={{ color: "var(--text)", fontSize: 14, fontWeight: 600, fontFamily: "var(--font-mono)", letterSpacing: "0.5px" }}>hippo</span>
-          <span style={{ color: "var(--accent)", fontSize: 10, fontFamily: "var(--font-mono)", opacity: 0.7 }}>brain observatory</span>
-          <span style={{ color: "var(--muted)", fontSize: 10, fontFamily: "var(--font-mono)" }}>{memories.length} memories</span>
+          <span style={{ color: "var(--text)", fontSize: 14, fontWeight: 600, fontFamily: "var(--font-serif)", letterSpacing: "0.3px" }}>hippo</span>
+          <span style={{ color: "var(--accent)", fontSize: 11, fontFamily: "var(--font-serif)", fontStyle: "italic" }}>brain observatory</span>
+          <span style={{ color: "var(--dim)", fontSize: 10, fontFamily: "var(--font-mono)" }}>{memories.length} memories</span>
           {(stats?.at_risk ?? 0) > 0 && (
             <span style={{ color: "var(--yellow)", fontSize: 10, fontFamily: "var(--font-mono)" }}>{stats?.at_risk} fading</span>
           )}
@@ -171,8 +171,8 @@ export function LivingMap({ memories, embeddings, stats, conflicts }: LivingMapP
       {matchCount === 0 && searchQuery.trim().length > 0 && (
         <div style={{
           position: "absolute", top: 56, right: 24, zIndex: 21,
-          background: "rgba(255,255,255,0.03)", padding: "4px 12px", borderRadius: 12,
-          fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--muted)",
+          background: "var(--ink-faint)", padding: "4px 12px", borderRadius: 12,
+          fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--dim)",
         }}>
           no matches
         </div>
@@ -181,7 +181,7 @@ export function LivingMap({ memories, embeddings, stats, conflicts }: LivingMapP
       {showHint && memories.length > 0 && (
         <div style={{
           position: "absolute", bottom: 32, left: "50%", transform: "translateX(-50%)",
-          fontFamily: "var(--font-mono)", fontSize: 10, color: "rgba(255,255,255,0.25)",
+          fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-faint)",
           opacity: showHint ? 1 : 0, transition: "opacity 1s ease-out",
           pointerEvents: "none", zIndex: 5, letterSpacing: "3px",
         }}>


### PR DESCRIPTION
## What

E1.5 of UI hybrid-v4 revamp. Adds 4 BrainScene surface methods that E2 (freeze-toggle), E4 (label overlay), and E5 (reduced-motion + filter mirror) will consume.

**Stacked PR:** base is `ui-revamp-e1-apply-tokens` (#54). Merge #53 → #54 → this in order.

## API additions (all in `ui/src/engine/scene.ts`)

| Method | Used by | Notes |
|---|---|---|
| `setReducedMotion(reduced: boolean)` | E2 freeze-toggle, E5 reduced-motion | Uses `cancelAnimationFrame(this.rafId)` matching scene.ts's existing pattern. Does NOT use Three.js `setAnimationLoop` (round-2 HIGH #1 fix). Calls `snapParticlesToFinal()` to freeze pose. |
| `setFiltered(visibleIds: Set<string>)` | E3 FilterPanel | Toggles `mesh.visible` + `halo.visible`. Layout NOT re-run. Empty set restores full visibility. |
| `onRender(cb)` | E4 LabelOverlay | Returns unsubscribe fn. Single-line `forEach` insertion in `animate()` (round-2 LOW #7 carve-out). |
| `getCamera()` | E4 LabelOverlay | Returns `PerspectiveCamera` (not wider `THREE.Camera` — round-3 LOW #4 fix). |

## Private helper

`snapParticlesToFinal()` copies `basePosition` to `mesh.position` directly. The drift physics at `animate()` L423-L435 is pure `sin`/`cos` oscillation that never converges — basePosition is the only sensible freeze target (round-3 HIGH #1 fix).

## Test plan

- [x] `cd ui && npm run build` clean (51 modules, +0.65 kB for new methods)
- [x] `node scripts/check-token-drift.mjs` exits 0
- [ ] Vitest-jsdom unit tests for the 4 methods (DEFERRED to E3 — needs real component consumers + filter-state composition tests to be meaningful; E1.5 ships as scaffolding)
- [ ] Manual: `hippo dashboard --port 3333` still boots + LivingMap still renders (deferred to Keith)

## Files changed

1 file, +98 lines.

## Next

E2 (Header / search / freeze-toggle) is next. Adds `Header.tsx`, debounced search (150ms), wires freeze button → `setReducedMotion`. ~1d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
