### PR TITLE
feat(ui): v0.2.1 color-by-tag: 3-mode segmented radio (E1 of 4 Obsidian-inspired graph upgrades)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## ui-brain-observatory v0.2.1 (2026-05-24): color-by-tag (Obsidian-inspired graph upgrades, E1 of 4)
+
+Adds a "Color by" segmented radio to the Sidebar so users can recolor the
+3D memory graph by `tag` or project `path` instead of the default `layer`.
+Addresses the "everything looks the same" problem on the live fixture
+(1232 of 1373 memories are episodic, so layer-only mode reads as one blue
+blob). Tag dimension (156 unique tags) was sitting unused.
+
+E1 of 4 in the Obsidian-inspired graph upgrades stack (E2 real edges from
+parents/conflicts/shared-tags, E3 local graph view, E4 force-directed
+layout from real edges are queued).
+
+### What shipped
+
+- **3 view modes**: `layer` (default, unchanged), `tag` (top-10 non-path
+  tags + grey fallback), `path` (top-8 project paths + grey fallback).
+- **`ViewPanel` component** in the Sidebar above the Filters section.
+  Three-button segmented radio with full ARIA semantics (radiogroup,
+  role=radio, aria-checked, descriptive aria-labels).
+- **Stable per-tag palette**: FNV-1a hash with linear-probe collision
+  resolution into a 10-color (TAG) / 8-color (PATH) parchment-tuned
+  palette. Same tag → same color across sessions. All palette colors
+  verified >= 4.5:1 WCAG contrast vs `COLOR_MAP_BG` at test time.
+- **Engine wiring**: `BrainScene.setColorMode(mode, memories)` recolors
+  every node (sphere + halo material) in O(N) without rebuilding geometry
+  or tendrils. `populate()` re-applies the current mode at its tail so
+  memory refreshes never flash layer colors.
+- **A11y non-color channel**: `MemoryTooltip` surfaces `color: <tag>` in
+  tag/path modes; `Drawer` gains a conditional `tag` column (keyboard-
+  navigable rows from E5) so color-blind / keyboard-only users have an
+  equivalent channel.
+- **`BottomBar` affordance key** appends ` · color = <mode>` when non-layer
+  so the active encoding is always visible.
+- **`resetFilters` preserves `colorMode`** alongside `frozen` (view state,
+  not filter state).
+
+### Plan
+
+`docs/plans/2026-05-24-color-by-tag.md`: drafted v1 → v2 → v3 through
+three full `/dev-framework-rl` plan critic rounds (plan-eng + plan-design,
+final score 86 + 86). v3 dropped the proposed `confidence` mode after R2
+caught unavoidable palette-hex collisions with the tag palette; confidence
+remains a filter in the existing FilterPanel.
+
+### Tests
+
+- `tagPalette.test.ts`: palette engine determinism + top-N cap + include/
+  exclude prefix + linear-probe collision uniqueness + pickColorTag rule
+  (shortest tag wins, alpha tiebreak) + resolveColor dispatch + AC10
+  contrast assertions for both TAG_PALETTE and PATH_PALETTE.
+- `contrast.test.ts`: WCAG luminance + contrastRatio helpers.
+- `ViewPanel.test.tsx`: 3-button render + aria-checked + click handler
+  + radiogroup labelling.
+- `filterState.test.ts`: colorMode is NOT in isFilterActive; deriveVisibleIds
+  output is invariant under colorMode change.
+
+97/97 tests pass; vite build clean (60 modules, three chunk 510KB =
+baseline, no regression).
+
+### Out of scope (follow-ups)
+
+- E2 real edges from parents/conflicts/shared-tags
+- E3 local graph view (N-hop neighbourhood from selected)
+- E4 force-directed layout (replaces PCA proximity)
+- Confidence-by-color mode (needs separate hue family, deferred)
+- User-assignable per-tag colors (Obsidian color groups full parity)
+- `colorMode` persistence across sessions (localStorage)
+- `trace` layer color (Layer type doesn't include `trace`; 4 memories
+  affected; separate ticket)
+
 ## ui-brain-observatory v0.2.0 (2026-05-24): hybrid-v4 parchment revamp + a11y
 
 Final ship of the UI hybrid-v4 parchment revamp through 7 stacked PRs

--- a/docs/plans/2026-05-24-color-by-tag.md
+++ b/docs/plans/2026-05-24-color-by-tag.md
@@ -1,0 +1,562 @@
+# 2026-05-24 — Color-by-tag (E1 of Obsidian-inspired graph upgrades stack)
+
+**Status:** Draft v3 (addressing R2 must-fix from plan-eng-critic + plan-design-critic)
+**Episode:** 01KSDY9X4SYYJV0DSN5NJ7GBVY
+**Branch:** feat-color-by-tag (off feat-fading-feature, rebases onto master when PR #60 lands)
+**Owner:** Claude (Keith review)
+
+## Changes from v2 (R2 must-fix incorporated)
+
+**Scope reduction:**
+- **Confidence mode DROPPED from v1.** plan-design-critic R2 caught that any confidence-mode palette would either collide with TAG_PALETTE hex values (the v2 mistake — 3 of 4 confidence colors duplicated tag colors) or fail mutual luminance contrast on parchment. Cleanly fixing requires a fresh design budget for a separate hue family. Confidence remains a FILTER (existing FilterPanel checkbox row); it just isn't a color view in v1. Deferred to v0.28 ticket. **Mode list: layer | tag | path** (3, down from 4).
+
+**Engineering (plan-eng-critic R2):**
+- **S4** — Parallel prop chains made explicit. `UseSceneOptions` interface gains `colorMode: ColorMode`. `DrawerProps`, `BottomBarProps`, `MemoryTooltipProps` all gain `colorMode` (and tooltip also gains `colorTag: string | null`). All call sites in `LivingMap.tsx` enumerated.
+- **S3 / S4** — Populate/setColorMode race fixed: `populate()` ends with a call to `this.setColorMode(this.currentColorMode, memories)`. Single source of truth — re-populate always re-applies the current mode. Eliminates effect-ordering hazard.
+- **S3** — Pseudocode names corrected: class is `BrainScene`, iteration is `for (const node of this.nodes)` (array, not Map).
+- **S5** — ViewPanel uses LOCALLY-DEFINED style consts (no cross-component imports of unexported style objects).
+- **S8** — False "focusable proxy already exists" claim removed. Honest a11y story: tooltip is hover-only for v1 (existing limitation, not a regression); keyboard / color-blind users get the color-driving tag via the Drawer's new "tag" column (Drawer is keyboard-accessible from E5).
+
+**Design (plan-design-critic R2):**
+- **S2** — `#527e2e` (olive, 4.48:1 boundary) darkened to `#4d762a` (~5.0:1) for safety margin.
+- **S5** — ViewPanel position LOCKED: between "Selected memory" section and "Filters" header row in `Sidebar.tsx` (between L93-L96).
+- **S5** — 3 buttons (down from 4) fit 300px content area comfortably. Math: 300/3 = 100px per button > 66px needed for "confidence" (no longer a label anyway).
+- **S5/S6** — Redundant active-mode indicator removed. Only the `filterValue` chip in the label row shows the mode (matches Layer/Strength/Confidence/Age pattern). No second chip below the radio.
+- **Perf budget** — `<10ms` is the only number used everywhere (S3 comment, AC3, R1).
+- **S8 Drawer column** — Conditionally rendered: shown only when `colorMode === "tag" || "path"`. Hidden in layer mode (no empty labelled column).
+
+## Changes from v1 (R1 must-fix incorporated)
+
+Engineering (plan-eng-critic R1):
+- **S1+S4** — App.tsx `resetFilters` explicitly preserves `colorMode` alongside `frozen`.
+- **S3** — Tendril rebuild SKIPPED on mode change (tendrils retain their layer-color midpoint — see Open Q1 resolution). Removes the need for `rebuildTendrils()`/`clearTendrils()` entirely.
+- **S4** — Path corrected: `ui/src/views/LivingMap/useCanvasEngine.ts` (not `ui/src/hooks/`).
+- **S2/S3** — `buildPalette()` is the single helper with a compilable signature: `buildPalette(memories, opts: {includePrefix?, excludePrefix?, topN, palette})`. Path mode passes `{includePrefix:"path:"}`. PATH_PALETTE exported.
+- **S4/S5** — Full prop-drilling chain enumerated: App → LivingMap → Sidebar → FilterPanel.
+- **AC3/R1** — Perf budget reframed: only ~1373 `material.color.set()` calls (tendrils skipped). rAF batching removed.
+- **S7** — `scene.test.ts` dropped from must-have; covered by manual visual smoke.
+
+Design (plan-design-critic R1):
+- **NEW S8** — A11y non-color channel: `MemoryTooltip` shows the color-driving tag; `Drawer` gains a "tag" column; tooltip works via focus (aria-describedby) not just hover.
+- **S6 (rewritten)** — Legend strategy LOCKED: **static layer legend retained always**; active color mode shown as a compact chip directly below the segmented radio control. Dynamic legend deferred to v0.28.
+- **S5 (rewritten)** — Control moved out of FilterPanel into a new **"View"** section in `Sidebar.tsx` ABOVE the existing "Filters" header. Control is a **segmented radio group** (4 buttons), not a native `<select>`. OS-chrome popup risk eliminated.
+- **S2 (rewritten)** — Palette replaced with 10 darker, more saturated colors all > 4.5:1 contrast vs parchment, none in rust hue range. WCAG luminance table baked in.
+- **S2 CONFIDENCE_RAMP** — Replaced with 4 **distinct categorical colors** (commit clarified: ordinality conveyed by the radio control's left-to-right ordering, not by color luminance).
+- **S2 path mode** — Picker rule LOCKED: shortest tag wins, alphabetical tiebreak. tagPalette test covers this.
+- **R5** — AC3 budget revised (tendril skipped; ~5-8ms target).
+- **R6** — colorMode persistence (localStorage) explicitly deferred to v0.28 follow-up.
+- **NEW S9** — `BottomBar` affordance key updated to append `color = <mode>` when mode != layer.
+
+## Why this exists
+
+`recall` against the current dashboard: 1373 memories, 1232 episodic. The only color axis is layer, so 90% of the canvas renders as one blue blob. Tag dimension (156 unique tags, top-12 covers ~70% of memories) is sitting in the data unused.
+
+This is E1 of 4 in the Obsidian-inspired stack picked 2026-05-24:
+1. **E1 (this plan)** — tag-based coloring + per-tag palette
+2. E2 — real edges from `parents`/`conflicts_with`/shared-tags
+3. E3 — local graph view (N-hop from selected, needs E2)
+4. E4 — force-directed layout from real edges (replaces PCA, needs E2)
+
+E1 ships first because it's orthogonal to layout and edges, and the most direct fix to "everything looks the same."
+
+## Goal
+
+Add a "Color by" segmented radio in a new `View` section of the Sidebar with 3 modes:
+
+| Mode | Source | Palette |
+|---|---|---|
+| `layer` (default) | `memory.layer` | LAYER_COLORS (existing, 3 colors) |
+| `tag` | shortest non-`path:*` tag (alpha tiebreak), fallback grey | 10-color parchment-tuned stable palette |
+| `path` | shortest `path:*` tag (alpha tiebreak), fallback grey | 8-color sub-palette |
+
+Switching modes recolors nodes in-place. **Tendrils are NOT recolored** (layer-color midpoint kept; documented). No filter change, no layout change.
+
+(Confidence-by-color deferred to v0.28 — needs a separate hue family that won't collide with the 10-color tag palette. Confidence remains a FILTER in the existing FilterPanel.)
+
+## Discover findings
+
+From `~/.hippo/hippo.db` 2026-05-24:
+
+```
+TOTAL: 1373 memories
+by layer: episodic 1232 / semantic 137 / trace 4 / buffer 0
+by confidence: verified 241 / observed 530 / stale 523 / inferred 79  (balanced)
+unique tags: 156, long-tail (80 count==1)
+top tags (3 namespaces):
+  - path:* (project):  path:skf_s 828, path:quantamental 247, path:hippo 170, path:phzse 155, ...
+  - kind: error 986, git-learned 669, captured 128, rule 96, imported 63, ...
+  - topic: openclaw 162, claude-code-memory 68, x-posting 25, ...
+parents > 0: 0%  (drives E2 scope, not E1)
+conflicts > 0: 0%  (drives E2 scope, not E1)
+```
+
+Decisions driven by this data:
+1. Tag namespaces are real → `path` is its own mode (separate palette).
+2. `trace` (4 memories) has no LAYER_COLORS entry — out of scope, separate ticket.
+3. `buffer` (0 memories) — type kept, palette entry kept.
+4. Top-10 cap (down from 12 in v1 — fewer is more legible).
+
+## Scope
+
+### S1 — Extend `FilterState` with `colorMode`
+
+`ui/src/state/filterState.ts`:
+
+```typescript
+export type ColorMode = "layer" | "tag" | "path";
+
+export interface FilterState {
+  // ...existing fields unchanged...
+  /** v0.27 — view-state, not a filter. NOT included in isFilterActive. */
+  colorMode: ColorMode;
+}
+
+export const INITIAL_FILTER_STATE: FilterState = {
+  // ...existing...
+  colorMode: "layer",
+};
+```
+
+- `isFilterActive` is UNCHANGED. colorMode is a view setting; toggling does not show filter-active UI.
+- `resetFilters` MUST preserve colorMode (see S4 below).
+
+### S2 — Palette engine
+
+New file `ui/src/engine/tagPalette.ts`:
+
+```typescript
+import type { Memory } from "../types.js";
+import type { ColorMode } from "../state/filterState.js";
+
+/**
+ * 10-color tag palette tuned for parchment background.
+ * All colors verified > 4.5:1 contrast vs #faf7f2 (COLOR_MAP_BG) and
+ * > 4.0:1 vs #f0ebe0 (COLOR_SURFACE). None in rust hue range
+ * (avoids selection-halo collision with #c45c3c COLOR_ACCENT).
+ *
+ * WCAG luminance verification (computed via WCAG relative-luminance formula):
+ *
+ * | Hex      | L     | Ratio vs #faf7f2 | Hue family   |
+ * |----------|-------|------------------|--------------|
+ * | #1e5a7d  | 0.10  | 6.4 : 1          | deep blue    |
+ * | #2d5e2b  | 0.10  | 6.5 : 1          | forest green |
+ * | #6b2876  | 0.07  | 8.3 : 1          | purple       |
+ * | #155a5a  | 0.09  | 7.2 : 1          | deep teal    |
+ * | #8a4d2e  | 0.13  | 5.2 : 1          | umber (NOT rust, browner) |
+ * | #6f4f1f  | 0.10  | 6.6 : 1          | deep ochre   |
+ * | #2d4d6b  | 0.09  | 7.0 : 1          | slate blue   |
+ * | #4d762a  | 0.16  | 5.0 : 1          | olive (darkened from #527e2e for AA safety) |
+ * | #7f4848  | 0.11  | 6.0 : 1          | wine         |
+ * | #4a4a72  | 0.08  | 7.6 : 1          | dim indigo   |
+ *
+ * (Verify these in S7 with tagPalette.test.ts contrast assertions —
+ * computed values, not hand-eyeballed.)
+ */
+export const TAG_PALETTE: readonly string[] = [
+  "#1e5a7d", "#2d5e2b", "#6b2876", "#155a5a", "#8a4d2e",
+  "#6f4f1f", "#2d4d6b", "#4d762a", "#7f4848", "#4a4a72",
+] as const;
+
+/** Path-mode sub-palette (8 colors, subset of TAG_PALETTE chosen for
+ * project-grouping legibility — bluer/cooler so paths read as a family). */
+export const PATH_PALETTE: readonly string[] = [
+  "#1e5a7d", "#155a5a", "#2d4d6b", "#4a4a72",
+  "#6b2876", "#2d5e2b", "#4d762a", "#7f4848",
+] as const;
+// (Note: #527e2e in v2 → #4d762a in v3 in both TAG_PALETTE and PATH_PALETTE
+// for AA contrast safety margin — design-critic R3 LOW catch.)
+
+/** Dark grey (not parchment-grey) for memories whose qualifying tag is
+ * outside the top-N. L ≈ 0.14, ratio 4.7 : 1 vs parchment. */
+export const TAG_FALLBACK_COLOR = "#6a6a6a";
+
+// Note: confidence-mode coloring deferred to v0.28 — needs a separate hue
+// family not yet used by TAG_PALETTE/PATH_PALETTE. Confidence remains a
+// filter in FilterPanel.
+
+/** Stable FNV-1a hash → palette index. Same tag always gets same color
+ * across sessions. Linear-probe disambiguation on collision (tested). */
+function fnv1aHash(s: string): number { /* deterministic 32-bit FNV-1a */ }
+
+/** Options for buildPalette. */
+export interface PaletteOpts {
+  /** When set, only tags starting with this prefix are counted (e.g. "path:"). */
+  includePrefix?: string;
+  /** When set, tags starting with this prefix are excluded (e.g. "path:"). */
+  excludePrefix?: string;
+  /** Top-N most frequent tags get distinct palette colors. */
+  topN: number;
+  /** Color palette to assign from. */
+  palette: readonly string[];
+}
+
+/**
+ * Build top-N tag → color map from current memories. Pure + deterministic.
+ * Same input → same output.
+ */
+export function buildPalette(
+  memories: readonly Memory[],
+  opts: PaletteOpts,
+): Map<string, string> { /* count tags meeting include/exclude → top-N → hash-stable assign with linear-probe on collision */ }
+
+/**
+ * Pick the color-driving tag for a memory under a given mode.
+ * Rule: shortest qualifying tag wins; alphabetical tiebreak (deterministic).
+ * Returns null if no qualifying tag → caller uses fallback color.
+ */
+export function pickColorTag(
+  memory: Memory,
+  mode: "tag" | "path",
+): string | null { /* filter tags by mode (exclude/include path:), sort by (length, alpha), return first */ }
+
+/**
+ * Color resolution for one memory + mode. Pure function.
+ */
+export function resolveColor(
+  memory: Memory,
+  mode: ColorMode,
+  tagPalette: Map<string, string>,
+  pathPalette: Map<string, string>,
+): string { /* dispatch on mode; layer=LAYER_COLORS, tag/path=pickColorTag then palette OR fallback */ }
+```
+
+- `buildPalette` is **pure** + deterministic. Same input → same output across calls and sessions (FNV-1a hash + linear-probe collision resolution → identical assignments).
+- `resolveColor` returns the dark-grey fallback for memories with no qualifying tag — never undefined, never throws.
+- `pickColorTag` rule: **shortest tag wins, alphabetical tiebreak** (`[length ASC, alpha ASC]`). Test covers `[path:hippo, path:hippo-memory]` → picks `path:hippo`.
+
+### S3 — Scene engine: switchable color resolution (NO tendril rebuild)
+
+`ui/src/engine/scene.ts`. Class is `BrainScene`; `this.nodes` is `MemoryNode[]` (an array).
+
+```typescript
+class BrainScene {
+  private currentColorMode: ColorMode = "layer";
+  private tagPalette: Map<string, string> = new Map();
+  private pathPalette: Map<string, string> = new Map();
+
+  /** Recompute material color for every node in O(N) without rebuilding
+   * geometry or tendrils. Tendrils remain layer-blended (documented).
+   *
+   * Performance budget: <10ms on the live 1373-memory fixture.
+   * Baseline: 1373 calls to material.color.set() ≈ 3-5ms measured.
+   * Tendril rebuild is SKIPPED — tendrils represent spatial proximity
+   * (layer-agnostic), AND the n>500 early-bail at scene.ts:303 means
+   * tendrils are not drawn on the live fixture anyway. */
+  setColorMode(mode: ColorMode, memories: readonly Memory[]): void {
+    if (mode === "tag") {
+      this.tagPalette = buildPalette(memories, {
+        excludePrefix: "path:",
+        topN: 10,
+        palette: TAG_PALETTE,
+      });
+    }
+    if (mode === "path") {
+      this.pathPalette = buildPalette(memories, {
+        includePrefix: "path:",
+        topN: 8,
+        palette: PATH_PALETTE,
+      });
+    }
+    this.currentColorMode = mode;
+    for (const node of this.nodes) {
+      const color = resolveColor(node.memory, mode, this.tagPalette, this.pathPalette);
+      (node.mesh.material as THREE.MeshStandardMaterial).color.set(color);
+      // Halo color (selection ring) tracks node color via shared material instance.
+      // Tendrils NOT updated — see comment above.
+    }
+  }
+
+  /** populate() ends with a setColorMode call to eliminate the populate-vs-
+   * setColorMode race. When memories refresh and populate rebuilds nodes, the
+   * current mode is automatically re-applied. Single source of truth. */
+  populate(memories, embeddings, conflicts): void {
+    // ...existing populate body unchanged (build nodes with LAYER_COLORS)...
+    // NEW final line:
+    this.setColorMode(this.currentColorMode, memories);
+  }
+}
+```
+
+- **No new tendril methods.** `rebuildTendrils`, `clearTendrils` — neither introduced.
+- **populate() race fix** — populate() now calls setColorMode at its tail with the current mode. Means: refreshing memories never leaves nodes in layer-colors when the user has selected tag/path. Single load-bearing line; documented inline.
+- Performance budget: <10ms target (used consistently in S3, AC3, R1 — no other numbers).
+
+### S4 — Wire colorMode through React → scene (TWO parallel prop chains)
+
+Two independent paths to wire — one for the UI control (Sidebar chain), one for the engine (useCanvasEngine chain). Both originate at `filterState.colorMode` in `App.tsx`.
+
+**Chain A — UI control (App → LivingMap → Sidebar → ViewPanel):**
+
+1. **`ui/src/App.tsx`** — add `setColorMode` callback (uses existing setFilterState pattern); **extend `resetFilters` to preserve colorMode**:
+   ```typescript
+   const setColorMode = useCallback((mode: ColorMode) => {
+     setFilterState((prev) => ({ ...prev, colorMode: mode }));
+   }, []);
+   const resetFilters = useCallback(() => {
+     setFilterState((prev) => ({
+       ...INITIAL_FILTER_STATE,
+       frozen: prev.frozen,
+       colorMode: prev.colorMode, // v0.27 — view state, not filter state
+     }));
+   }, []);
+   ```
+2. **`ui/src/views/LivingMap/LivingMap.tsx`** — accept `setColorMode` + `colorMode` in `LivingMapProps`; thread `setColorMode` to `<Sidebar>` and `colorMode` to engine hook (Chain B) + `<Drawer>` + `<BottomBar>` + `<MemoryTooltip>` (a11y, S8/S9).
+3. **`ui/src/components/Sidebar.tsx`** — accept `setColorMode` prop, add to `SidebarProps`, render new `<ViewPanel>` between L93 (Selected memory) and L96 (Filters header).
+
+**Chain B — Engine (App → LivingMap → useCanvasEngine → scene):**
+
+4. **`ui/src/views/LivingMap/useCanvasEngine.ts`** — extend `UseSceneOptions` interface:
+   ```typescript
+   export interface UseSceneOptions {
+     memories: readonly Memory[];
+     // ...existing fields...
+     colorMode: ColorMode;  // NEW
+   }
+   ```
+   Add a `useEffect` (declared AFTER populate's effect so it runs second on re-render):
+   ```typescript
+   useEffect(() => {
+     scene?.setColorMode(filterState.colorMode, memories);
+   }, [filterState.colorMode, scene, memories]);
+   ```
+   Note: populate's internal setColorMode call (S3) makes this effect mostly redundant on memory-refresh — it remains for the case where ONLY colorMode changes (user clicks ViewPanel) without memories changing.
+
+5. **`ui/src/components/FilterPanel.tsx`** — UNCHANGED (color control lives in ViewPanel per S5).
+
+**Chain C — a11y sidecars (S8 + S9):**
+
+6. **`ui/src/components/Drawer.tsx`** — extend `DrawerProps` with `colorMode: ColorMode`; conditional "tag" column (S8).
+7. **`ui/src/components/BottomBar.tsx`** — extend `BottomBarProps` with `colorMode: ColorMode`; affordance key tail (S9).
+8. **`ui/src/components/MemoryTooltip.tsx`** — extend props with `colorMode: ColorMode` + `colorTag: string | null`. When mode is `"tag"` or `"path"` AND colorTag != null, show `color: <tag>` line at the top of the tooltip body.
+
+The tooltip's colorTag is derived in LivingMap.tsx via `pickColorTag(hoveredMemory, mode)` and passed down.
+
+**Test fixture hygiene:** Drawer.test, BottomBar.test, MemoryTooltip.test fixtures all gain a default `colorMode: "layer"` prop. Default-mode-tested components produce identical output to current behaviour (Drawer column hidden, BottomBar affordance unchanged, tooltip no extra line) so existing snapshot/render assertions stay green.
+
+### S5 — Sidebar: NEW `<ViewPanel>` component with 3-button segmented radio
+
+New file `ui/src/components/ViewPanel.tsx` — defines ALL its style consts locally (no cross-component imports of unexported styles):
+
+```tsx
+import type { FilterState, ColorMode } from "../state/filterState.js";
+
+interface ViewPanelProps {
+  filterState: FilterState;
+  setColorMode: (mode: ColorMode) => void;
+}
+
+const COLOR_MODES: Array<{ key: ColorMode; label: string; aria: string }> = [
+  { key: "layer", label: "layer", aria: "Color nodes by layer (buffer, episodic, semantic)" },
+  { key: "tag",   label: "tag",   aria: "Color nodes by top topic tags" },
+  { key: "path",  label: "path",  aria: "Color nodes by project path" },
+];
+
+export function ViewPanel({ filterState, setColorMode }: ViewPanelProps) {
+  return (
+    <div role="group" aria-label="View settings" style={{ marginBottom: 20 }}>
+      <h3 style={localPanelTitle}>View</h3>
+      <div style={localFilterLabel}>
+        <span>Color by</span>
+        <span style={localFilterValue}>{filterState.colorMode}</span>
+      </div>
+      <div role="radiogroup" aria-label="Color mode" style={segmentedGroup}>
+        {COLOR_MODES.map(({ key, label, aria }) => {
+          const checked = filterState.colorMode === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              aria-label={aria}
+              onClick={() => setColorMode(key)}
+              style={{
+                ...segmentBtn,
+                background: checked ? "rgba(196, 92, 60, 0.10)" : "transparent",
+                color: checked ? "var(--accent)" : "var(--dim)",
+                borderColor: checked ? "var(--accent)" : "var(--glass-border)",
+                fontWeight: checked ? 500 : 400,
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Styles — defined locally to keep ViewPanel.tsx self-contained.
+const localPanelTitle = {
+  fontSize: 11,
+  fontVariant: "small-caps" as const,
+  letterSpacing: "1px",
+  fontWeight: 400,
+  color: "var(--dim)",
+  marginBottom: 10,
+  paddingBottom: 6,
+  borderBottom: "1px solid var(--glass-border)",
+};
+const localFilterLabel = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "baseline",
+  fontSize: 11,
+  fontVariant: "small-caps" as const,
+  letterSpacing: "0.5px",
+  color: "var(--dim)",
+  marginBottom: 5,
+};
+const localFilterValue = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--text)",
+  letterSpacing: 0,
+};
+const segmentedGroup = {
+  display: "flex",
+  gap: 4,
+};
+const segmentBtn = {
+  flex: 1,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  padding: "5px 8px",
+  borderRadius: 3,
+  cursor: "pointer",
+  transition: "color 150ms ease, border-color 150ms ease, background 150ms ease",
+  border: "1px solid",
+};
+```
+
+**ViewPanel insertion point in `Sidebar.tsx`: between line 93 (closing `</div>` of "Selected memory") and line 96 (the "Filters" header row).** That's the literal reading of "above the Filters header" and keeps StatsPanel as the top-most summary.
+
+**Sizing math:** Sidebar is 340px wide with 20px padding each side → 300px content. 3 segments at `flex: 1` with 8px gap = (300 - 16) / 3 ≈ 95px per button. Longest label "layer" is 5 chars × ~6.6px/char Consolas 11px = 33px text + 16px padding = 49px total. Comfortable fit; no truncation risk (300 ÷ 3 = 100px > 49px).
+
+Keyboard nav: Tab enters the radiogroup; Arrow Left/Right moves selection (standard radiogroup semantics, native behaviour with `role="radio"`).
+
+The `filterValue` chip in the label row already shows the active mode — there is NO separate active-mode chip below the radio (removed in v3 per design-critic R2 LOW).
+
+### S6 — Legend: STATIC layer (locked), no separate active-mode chip
+
+**Decision locked: static layer legend stays always.** BottomBar's existing 3-dot layer legend is unchanged.
+
+Active mode is communicated by the `filterValue` chip in the ViewPanel's label row (which says e.g. `layer` or `tag` next to "Color by"). No second redundant chip below the radio. Removed in v3 per design-critic R2 LOW (the value chip in the label row already carries the info — same pattern as Layer/Strength/Confidence/Age rows in FilterPanel).
+
+Dynamic legend (swapping the BottomBar legend on mode change) deferred to v0.28 ticket if user data shows it's needed.
+
+### S7 — Tests
+
+- `tagPalette.test.ts`:
+  - `buildPalette` returns Map sized min(topN, qualifying tag count)
+  - Same input → same output (determinism / hash-stability)
+  - `excludePrefix:"path:"` excludes all `path:*` tags from the result
+  - `includePrefix:"path:"` only counts `path:*` tags
+  - Collision: hash distribution + linear-probe yields N unique colors for the top-N (no two tags share a color in the top-N range)
+  - `pickColorTag` rule: shortest wins, alpha tiebreak. Case: `[path:hippo, path:hippo-memory, error]` mode=path → returns `path:hippo`.
+  - `resolveColor` returns TAG_FALLBACK_COLOR for memories with no qualifying tag
+  - **NEW** — Contrast assertions: `getContrast(TAG_PALETTE[i], COLOR_MAP_BG) >= 4.5` for every i. Computed via WCAG relative-luminance helper (also new — `contrast.ts` 20-line utility). `contrast.test.ts` covers the helper itself with 3-4 known WCAG examples.
+
+- `filterState.test.ts` — add:
+  - INITIAL state has `colorMode === "layer"`
+  - `isFilterActive` returns false when only `colorMode` changes from "layer" (NOT a filter)
+
+- `ViewPanel.test.tsx` — new:
+  - Renders 3 radio buttons with correct aria-checked
+  - Click toggles aria-checked + calls setColorMode
+  - Arrow keys move selection (radiogroup semantics)
+
+- `App.test.tsx` (or `resetFilters.test.ts` if isolated) — new:
+  - `resetFilters` preserves `colorMode` across reset
+
+- Manual visual smoke: load dashboard, switch through 4 modes, verify no console errors, verify selection / hover / fading-ring still work in each mode. Screenshot per mode in PR.
+
+### S8 — A11y non-color channel (NEW, from plan-design-critic R1 must-fix #1; refined in v3)
+
+**Color cannot be the only channel.** Two surfaces gain the color-driving tag:
+
+1. **`MemoryTooltip.tsx`** — accepts new props `colorMode: ColorMode` + `colorTag: string | null` (derived in LivingMap.tsx via `pickColorTag(hoveredMemory, mode)` and passed down). When `colorMode === "tag" || "path"` AND colorTag != null, render `color: <tag>` at the top of the tooltip body in muted mono. Tooltip is **hover-driven** (existing behaviour, unchanged).
+
+   **Honest a11y limitation:** there is no per-node focusable proxy in the canvas, so the tooltip is NOT keyboard-accessible. This is an existing limitation of the canvas, not a regression from this feature. Keyboard / color-blind users get the same info via the Drawer's new "tag" column (#2 below), which IS keyboard-navigable (rows are `tabIndex={0}` per E5 a11y pass — verified in Drawer.tsx L217).
+
+2. **`Drawer.tsx`** — extend `DrawerProps` with `colorMode: ColorMode`. **Conditionally render** a new "tag" column ONLY when `colorMode === "tag" || "path"` (hidden in layer mode, so no empty labelled column). Insertion point: between the existing `layer` `<th>` (Drawer.tsx L205) and `strength` `<th>` (L206) and equivalent `<td>` cells. Shows `pickColorTag(memory, colorMode)` per row. Width: 80px. Right-truncate with `title=<full tag>` for overflow.
+
+Why this matters: 8% of men + 0.5% of women have color-vision deficiency. Without a non-color channel they cannot use this feature; the current 3-layer mode has BottomBar text labels that anchor color meaning, which we must not regress. The Drawer "tag" column (keyboard-accessible) is the primary equivalent-access surface; the tooltip is a hover-convenience on top.
+
+### S9 — BottomBar affordance key update
+
+`ui/src/components/BottomBar.tsx`: extend `BottomBarProps` with `colorMode: ColorMode`. The existing affordance key at L131 (`size = retrievals · opacity = strength · lines = similarity`) is silent on color. When `colorMode !== "layer"`, append ` · color: <mode>` to make the active channel visible.
+
+This is a 5-line edit (interface + prop wiring + conditional template literal), kept in scope because the affordance key would otherwise mislead in non-layer modes.
+
+## Acceptance criteria
+
+| # | Criterion | Verifies |
+|---|---|---|
+| AC1 | Sidebar shows "View" section between "Selected memory" and "Filters" with 3-button segmented radio | S5 |
+| AC2 | Default mode `layer` reproduces current render exactly (visual no-op for default) | back-compat |
+| AC3 | Selecting any non-default mode recolors all 1373 nodes within 10ms (measured); tendrils NOT recolored (documented) | S2, S3, perf |
+| AC4 | `tag` mode: no two top-10 tags share a color (linear-probe collision-free) | S2 |
+| AC5 | `path` mode applies distinct palette to `path:*`-tagged memories; non-path get TAG_FALLBACK_COLOR | S2 |
+| AC6 | Reload page → same tag → same color (hash-stable) | S2 |
+| AC7 | Selection halo, hover emphasis, fading rings all work in every mode | regression |
+| AC8 | `colorMode` is NOT in `isFilterActive`; toggling does not show filter-active UI | semantic correctness |
+| AC9 | `resetFilters` preserves `colorMode` (App.tsx test) | UX |
+| AC10 | Every TAG_PALETTE **and PATH_PALETTE** color has >= 4.5:1 contrast vs COLOR_MAP_BG (computed assertion) | a11y / palette |
+| AC11 | MemoryTooltip shows color-driving tag in tag/path modes when hovered | a11y |
+| AC12 | Drawer "tag" column appears in tag/path modes, hidden in layer mode (column header not shown) | a11y |
+| AC13 | BottomBar affordance key shows `color: <mode>` when non-layer | discoverability |
+| AC14 | Visual smoke pass: 3 modes × screenshot in PR | review |
+| AC15 | populate() re-applies current colorMode at tail; refreshing memories does NOT flash layer colors when user is in tag/path mode | race-fix |
+| AC16 | No test regressions: full `ui/` vitest run green | regression |
+
+## Risks (revised)
+
+| # | Risk | Lik. | Mitigation |
+|---|---|---|---|
+| R1 | 1373-memory recolor still too slow | L | Skip-tendrils removes biggest cost; ~10ms target measured baseline. If exceeded, batch into rAF only then. |
+| R2 | Hash collision in top-N | VL | Linear-probe disambiguation; unit test enforces no-dup in top-N. |
+| R3 | Tag color of a memory's "shortest tag" picks something non-representative | M | Document the rule in the tooltip ("color from tag: X"). User sees what's driving the color. Add follow-up ticket to make this user-controllable if it's a problem. |
+| R4 | TAG_FALLBACK_COLOR dark grey clashes with selection halo in some layouts | L | Halo is rust accent (high luminance contrast vs dark grey). Visual smoke verifies. |
+| R5 | Static layer legend feels "stale" when mode != layer | M | Active-mode chip (S6) explicitly names the current mode. Users learn quickly. |
+| R6 | colorMode lost on page refresh | L | Out of scope v1; v0.28 localStorage persistence ticket. |
+| R7 | Confidence categorical colors don't convey ordinality | L | Radio control left-to-right ordering communicates rank visually; tooltip text confirms. |
+| R8 | Drawer "tag" column takes too much width | L | 80px cap with truncation; layout test verifies horizontal scroll doesn't appear. |
+
+## Out of scope (named, deferred to separate tickets)
+
+- **Trace layer color fix** — `Layer` type lacks `"trace"`. 4 memories affected. Separate ticket.
+- **Confidence-by-color mode** — deferred to v0.28. Needs a separate hue family that won't collide with TAG_PALETTE. Confidence remains a FILTER in FilterPanel.
+- **User-assignable per-tag colors** (Obsidian color groups full parity) — v0.28+.
+- **Auto-cluster coloring** (Jaccard co-occurrence) — defer.
+- **Shape encoding** — defer.
+- **Age gradient as a color mode** — continuous scale needs separate infra.
+- **colorMode persistence across sessions** (localStorage) — v0.28.
+- **Dynamic legend** — only if user data shows the filterValue chip insufficient.
+- **Keyboard-accessible tooltip** — no per-node focusable proxy exists; the canvas is aria-hidden by design. Drawer "tag" column is the equivalent-access surface. Promoting tooltip to keyboard-accessible needs a per-node proxy ticket.
+- **Backend `at_risk_threshold` API exposure** — already in v0.27 cleanup epic.
+
+## Rollback
+
+Single PR, fully revertible:
+- Revert → `colorMode` field disappears, components return to layer-only rendering, no data loss.
+- If palette colors feel off: keep PR, follow-up tweaks TAG_PALETTE / PATH_PALETTE hex values.
+- If A11y additions cause Drawer layout issues: gate the "tag" column behind a feature flag, ship coloring without it (acceptable downgrade).
+
+## Cost estimate
+
+- Coding: ~5-7 hours (tagPalette engine + scene wiring + ViewPanel + tooltip/drawer a11y + tests)
+- Critic rounds: ~1.5 hours
+- Visual verification: ~30 min (4 modes × selection × fading × screenshots)
+- Total: ~1 day
+
+## Resolved open questions (from v1 + v2)
+
+1. ~~Confidence ramp sequential or categorical?~~ → **Confidence-mode DROPPED in v3 (deferred to v0.28).** Avoids unavoidable palette collision with tag palette.
+2. ~~12-color palette too noisy?~~ → **10 colors** (down from 12), all > 4.5:1 contrast verified (olive darkened from #527e2e to #4d762a).
+3. ~~Path picker rule?~~ → **shortest tag wins, alphabetical tiebreak.**
+4. ~~Dropdown or radio?~~ → **3-button segmented radio** (down from 4 since confidence dropped), single row, full-width, ~95px per button.
+5. ~~Legend dynamic or static?~~ → **Static layer legend always.** Active mode shown only by the `filterValue` chip in the ViewPanel label row (matches existing FilterPanel pattern).
+6. ~~populate / setColorMode race?~~ → **populate() calls setColorMode at its tail with the current mode** — single source of truth, no effect-ordering dependency.
+7. ~~Keyboard-accessible tooltip?~~ → **No per-node focusable proxy exists; Drawer "tag" column is the keyboard-accessible equivalent**. Honest a11y limitation, not a regression.

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-brain-observatory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import type { Memory, Stats, Conflict, EmbeddingIndex } from "./types.js";
 import { fetchMemories, fetchStats, fetchConflicts, fetchEmbeddings } from "./api/client.js";
 import { LivingMap } from "./views/LivingMap/LivingMap.js";
-import { INITIAL_FILTER_STATE, type FilterState, type Layer, type Confidence } from "./state/filterState.js";
+import { INITIAL_FILTER_STATE, type FilterState, type Layer, type Confidence, type ColorMode } from "./state/filterState.js";
 
 /**
  * E5 S6 — Origin of the current freeze state. Lets the freeze button surface
@@ -74,13 +74,23 @@ export function App() {
 
   // P4: reset everything except the user's freeze preference (rerunning
   // the simulation just because they cleared filters would surprise).
+  // v0.27 — also preserve colorMode (VIEW state, not filter state).
   const resetFilters = useCallback(() => {
-    setFilterState((prev) => ({ ...INITIAL_FILTER_STATE, frozen: prev.frozen }));
+    setFilterState((prev) => ({
+      ...INITIAL_FILTER_STATE,
+      frozen: prev.frozen,
+      colorMode: prev.colorMode,
+    }));
   }, []);
 
   // v0.26.1: fadingOnly toggle wired from Header pill + FilterPanel toggle.
   const setFadingOnly = useCallback((fadingOnly: boolean) => {
     setFilterState((prev) => ({ ...prev, fadingOnly }));
+  }, []);
+
+  // v0.27: colorMode toggle wired from ViewPanel segmented radio.
+  const setColorMode = useCallback((colorMode: ColorMode) => {
+    setFilterState((prev) => ({ ...prev, colorMode }));
   }, []);
 
   // v0.26.1 design-critic MED: auto-clear fadingOnly when at_risk drops to 0
@@ -216,6 +226,7 @@ export function App() {
         setConfidences={setConfidences}
         setAgeMaxDays={setAgeMaxDays}
         setFadingOnly={setFadingOnly}
+        setColorMode={setColorMode}
         resetFilters={resetFilters}
       />
       {/* v0.26.1 — aria-live announcement for auto-clear (design-critic LOW). */}

--- a/ui/src/components/BottomBar.tsx
+++ b/ui/src/components/BottomBar.tsx
@@ -11,11 +11,19 @@
  */
 
 import { LAYER_COLORS } from "../engine/types.js";
+import type { ColorMode } from "../state/filterState.js";
 
 interface BottomBarProps {
   drawerOpen: boolean;
   onToggleDrawer: () => void;
   visibleCount: number;
+  /**
+   * v0.27 color-by-tag — the active color mode. When != "layer", the
+   * affordance key appends ` · color: <mode>` so users see which channel
+   * is encoding their data right now. Default "layer" preserves the
+   * pre-v0.27 affordance key.
+   */
+  colorMode?: ColorMode;
 }
 
 function Kbd({ children }: { children: React.ReactNode }) {
@@ -43,7 +51,7 @@ const LAYERS: Array<{ key: keyof typeof LAYER_COLORS; label: string }> = [
   { key: "semantic", label: "semantic" },
 ];
 
-export function BottomBar({ drawerOpen, onToggleDrawer, visibleCount }: BottomBarProps) {
+export function BottomBar({ drawerOpen, onToggleDrawer, visibleCount, colorMode = "layer" }: BottomBarProps) {
   return (
     <div style={{
       position: "absolute",
@@ -128,7 +136,7 @@ export function BottomBar({ drawerOpen, onToggleDrawer, visibleCount }: BottomBa
         color: "var(--dim)",
         letterSpacing: "0.2px",
       }}>
-        size = retrievals · opacity = strength · lines = similarity
+        size = retrievals · opacity = strength · lines = similarity{colorMode !== "layer" ? ` · color = ${colorMode}` : ""}
       </div>
     </div>
   );

--- a/ui/src/components/Drawer.tsx
+++ b/ui/src/components/Drawer.tsx
@@ -10,12 +10,20 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { Memory } from "../types.js";
 import { LAYER_COLORS } from "../engine/types.js";
-import { isFading } from "../state/filterState.js";
+import { isFading, type ColorMode } from "../state/filterState.js";
+import { pickColorTag } from "../engine/tagPalette.js";
 
 interface DrawerProps {
   memories: Memory[];
   visibleIds: Set<string>;
   filterActive: boolean;
+  /**
+   * v0.27 color-by-tag — when "tag" or "path", show a conditional "tag"
+   * column with the color-driving tag (non-color a11y channel for
+   * color-blind / keyboard-only users). Hidden in "layer" mode so no
+   * empty labelled column appears. Default "layer" preserves baseline.
+   */
+  colorMode?: ColorMode;
   open: boolean;
   onClose: () => void;
   onMemorySelect: (m: Memory) => void;
@@ -35,12 +43,14 @@ export function Drawer({
   memories,
   visibleIds,
   filterActive,
+  colorMode = "layer",
   open,
   onClose,
   onMemorySelect,
   selectedMemoryId,
   resetFilters,
 }: DrawerProps) {
+  const showTagColumn = colorMode === "tag" || colorMode === "path";
   const rows = useMemo(() => {
     return filterActive ? memories.filter((m) => visibleIds.has(m.id)) : memories;
   }, [memories, visibleIds, filterActive]);
@@ -203,6 +213,9 @@ export function Drawer({
                 <th style={thStyle} scope="col">id</th>
                 <th style={thStyle} scope="col">content</th>
                 <th style={{ ...thStyle, width: 60 }} scope="col">layer</th>
+                {showTagColumn && (
+                  <th style={{ ...thStyle, width: 80 }} scope="col">tag</th>
+                )}
                 <th style={{ ...thStyle, width: 70 }} scope="col">strength</th>
                 <th style={{ ...thStyle, width: 60 }} scope="col">age</th>
               </tr>
@@ -271,6 +284,18 @@ export function Drawer({
                         />
                       )}
                     </td>
+                    {showTagColumn && (() => {
+                      // code-review-critic R1 MED: compute pickColorTag once
+                      // per row instead of twice (cell text + title). Cheap
+                      // per call but adds up across 1373 rows.
+                      const tag = pickColorTag(m, colorMode as "tag" | "path") ?? "";
+                      return (
+                        <td style={{ ...tdStyle, fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--dim)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                            title={tag}>
+                          {tag}
+                        </td>
+                      );
+                    })()}
                     <td style={{ ...tdStyle, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text)" }}>
                       {m.strength.toFixed(2)}
                     </td>

--- a/ui/src/components/MemoryTooltip.tsx
+++ b/ui/src/components/MemoryTooltip.tsx
@@ -1,15 +1,29 @@
 import type { Memory } from "../types.js";
+import type { ColorMode } from "../state/filterState.js";
 import { LAYER_COLORS } from "../engine/types.js";
 
 interface MemoryTooltipProps {
   memory: Memory;
   x: number;
   y: number;
+  /**
+   * v0.27 — current view's color mode. When "tag" or "path" AND colorTag
+   * is non-null, the tooltip surfaces the color-driving tag as a non-color
+   * channel for color-blind users.
+   * Default "layer" preserves pre-v0.27 rendering (no extra line shown).
+   */
+  colorMode?: ColorMode;
+  /**
+   * v0.27 — the color-driving tag for this memory under the current mode
+   * (derived by LivingMap via pickColorTag). Null when no qualifying tag.
+   */
+  colorTag?: string | null;
 }
 
-export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
+export function MemoryTooltip({ memory, x, y, colorMode = "layer", colorTag = null }: MemoryTooltipProps) {
   const preview = memory.content.length > 100 ? memory.content.slice(0, 100) + "…" : memory.content;
   const layerColor = LAYER_COLORS[memory.layer];
+  const showColorTag = colorTag !== null && (colorMode === "tag" || colorMode === "path");
 
   return (
     <div style={{
@@ -58,6 +72,17 @@ export function MemoryTooltip({ memory, x, y }: MemoryTooltipProps) {
           {memory.strength.toFixed(2)} str
         </span>
       </div>
+      {showColorTag && (
+        <div style={{
+          marginBottom: 6,
+          color: "var(--dim)",
+          fontSize: 9,
+          fontFamily: "var(--font-mono)",
+          letterSpacing: "0.4px",
+        }}>
+          color: {colorTag}
+        </div>
+      )}
       <div style={{
         color: "var(--text)",
         fontSize: 12,

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -5,10 +5,11 @@
  */
 
 import type { Memory, Stats } from "../types.js";
-import type { FilterState, Layer, Confidence } from "../state/filterState.js";
+import type { FilterState, Layer, Confidence, ColorMode } from "../state/filterState.js";
 import { StatsPanel } from "./StatsPanel.js";
 import { FilterPanel } from "./FilterPanel.js";
 import { TagCloud } from "./TagCloud.js";
+import { ViewPanel } from "./ViewPanel.js";
 
 interface SidebarProps {
   memories: Memory[];
@@ -23,6 +24,8 @@ interface SidebarProps {
   setConfidences: (confidences: Set<Confidence>) => void;
   setAgeMaxDays: (days: number | null) => void;
   setFadingOnly: (v: boolean) => void;
+  /** v0.27 color-by-tag — drives ViewPanel segmented radio. */
+  setColorMode: (mode: ColorMode) => void;
   /** P4: reset all filters back to INITIAL_FILTER_STATE (keeping frozen flag). */
   resetFilters: () => void;
 }
@@ -40,6 +43,7 @@ export function Sidebar({
   setConfidences,
   setAgeMaxDays,
   setFadingOnly,
+  setColorMode,
   resetFilters,
 }: SidebarProps) {
   // Code-review-critic HIGH #1 fix: when filter is active and matches zero,
@@ -91,6 +95,11 @@ export function Sidebar({
           </div>
         )}
       </div>
+
+      {/* v0.27 — ViewPanel sits between "Selected memory" and "Filters"
+          (plan-design-critic R2 must-fix #3: literal "above the Filters
+          header"). Renders the "Color by" segmented radio. */}
+      <ViewPanel filterState={filterState} setColorMode={setColorMode} />
 
       {/* P4 reset button row */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10, paddingBottom: 6, borderBottom: "1px solid var(--glass-border)" }}>

--- a/ui/src/components/ViewPanel.test.tsx
+++ b/ui/src/components/ViewPanel.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * v0.27 — ViewPanel tests. Verifies the 3-button segmented radio:
+ *
+ *   - 3 buttons render (layer | tag | path), no confidence button
+ *   - aria-checked reflects filterState.colorMode
+ *   - Click invokes setColorMode with the matching ColorMode
+ *   - aria-labels are present on each radio
+ *   - radiogroup role + aria-label present on group
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ViewPanel } from "./ViewPanel.js";
+import { INITIAL_FILTER_STATE, type FilterState } from "../state/filterState.js";
+
+function buildState(overrides: Partial<FilterState> = {}): FilterState {
+  return { ...INITIAL_FILTER_STATE, ...overrides };
+}
+
+describe("ViewPanel", () => {
+  it("renders 3 radio buttons (layer, tag, path)", () => {
+    render(<ViewPanel filterState={buildState()} setColorMode={() => {}} />);
+    const buttons = screen.getAllByRole("radio");
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toHaveTextContent("layer");
+    expect(buttons[1]).toHaveTextContent("tag");
+    expect(buttons[2]).toHaveTextContent("path");
+  });
+
+  it("aria-checked matches the active colorMode (layer default)", () => {
+    render(<ViewPanel filterState={buildState({ colorMode: "layer" })} setColorMode={() => {}} />);
+    const buttons = screen.getAllByRole("radio");
+    expect(buttons[0]?.getAttribute("aria-checked")).toBe("true");
+    expect(buttons[1]?.getAttribute("aria-checked")).toBe("false");
+    expect(buttons[2]?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("aria-checked shifts when colorMode is 'tag'", () => {
+    render(<ViewPanel filterState={buildState({ colorMode: "tag" })} setColorMode={() => {}} />);
+    const buttons = screen.getAllByRole("radio");
+    expect(buttons[0]?.getAttribute("aria-checked")).toBe("false");
+    expect(buttons[1]?.getAttribute("aria-checked")).toBe("true");
+    expect(buttons[2]?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("clicking a button invokes setColorMode with the matching ColorMode", () => {
+    const setColorMode = vi.fn();
+    render(<ViewPanel filterState={buildState()} setColorMode={setColorMode} />);
+    const buttons = screen.getAllByRole("radio");
+    fireEvent.click(buttons[2]!); // path
+    expect(setColorMode).toHaveBeenCalledWith("path");
+    fireEvent.click(buttons[1]!); // tag
+    expect(setColorMode).toHaveBeenCalledWith("tag");
+    fireEvent.click(buttons[0]!); // layer
+    expect(setColorMode).toHaveBeenCalledWith("layer");
+    expect(setColorMode).toHaveBeenCalledTimes(3);
+  });
+
+  it("renders the active mode in the filterValue chip (not just the radio label)", () => {
+    // The filterValue chip is in the label row, NOT a radio role. Use the
+    // structural assertion that "tag" appears more than once in tag mode
+    // (once on the radio button label, once in the filterValue chip).
+    const { rerender } = render(
+      <ViewPanel filterState={buildState({ colorMode: "tag" })} setColorMode={() => {}} />,
+    );
+    expect(screen.getAllByText("tag").length).toBeGreaterThanOrEqual(2);
+    rerender(<ViewPanel filterState={buildState({ colorMode: "path" })} setColorMode={() => {}} />);
+    expect(screen.getAllByText("path").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("radiogroup has aria-label", () => {
+    render(<ViewPanel filterState={buildState()} setColorMode={() => {}} />);
+    const group = screen.getByRole("radiogroup");
+    expect(group).toHaveAttribute("aria-label", "Color mode");
+  });
+
+  it("each radio has a descriptive aria-label", () => {
+    render(<ViewPanel filterState={buildState()} setColorMode={() => {}} />);
+    expect(screen.getByRole("radio", { name: /buffer, episodic, semantic/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /top topic tag/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /project path/i })).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ViewPanel.tsx
+++ b/ui/src/components/ViewPanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * v0.27 — ViewPanel. A new sibling section in Sidebar above "Filters".
+ * Hosts the "Color by" segmented radio (layer | tag | path).
+ *
+ * Architectural note: colorMode is VIEW state, not filter state. It is
+ * not in isFilterActive (toggling does not show filter-active UI), and
+ * resetFilters preserves it (see App.tsx resetFilters). The user picked
+ * a view; clearing filters should not undo their visual choice.
+ *
+ * Styles defined locally rather than imported from FilterPanel/Sidebar
+ * (whose styles are not exported); keeps ViewPanel self-contained.
+ */
+
+import type { FilterState, ColorMode } from "../state/filterState.js";
+
+interface ViewPanelProps {
+  filterState: FilterState;
+  setColorMode: (mode: ColorMode) => void;
+}
+
+const COLOR_MODES: Array<{ key: ColorMode; label: string; aria: string }> = [
+  { key: "layer", label: "layer", aria: "Color nodes by memory layer (buffer, episodic, semantic)" },
+  { key: "tag",   label: "tag",   aria: "Color nodes by their top topic tag" },
+  { key: "path",  label: "path",  aria: "Color nodes by project path" },
+];
+
+export function ViewPanel({ filterState, setColorMode }: ViewPanelProps) {
+  return (
+    <div role="group" aria-label="View settings" style={{ marginBottom: 20 }}>
+      <h3 style={panelTitle}>View</h3>
+      <div style={filterLabel}>
+        <span>Color by</span>
+        <span style={filterValue}>{filterState.colorMode}</span>
+      </div>
+      <div role="radiogroup" aria-label="Color mode" style={segmentedGroup}>
+        {COLOR_MODES.map(({ key, label, aria }) => {
+          const checked = filterState.colorMode === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              aria-label={aria}
+              onClick={() => setColorMode(key)}
+              style={{
+                ...segmentBtn,
+                background: checked ? "rgba(196, 92, 60, 0.10)" : "transparent",
+                color: checked ? "var(--accent)" : "var(--dim)",
+                borderColor: checked ? "var(--accent)" : "var(--glass-border)",
+                fontWeight: checked ? 500 : 400,
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Styles — defined locally to keep ViewPanel self-contained.
+const panelTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontVariant: "small-caps",
+  letterSpacing: "1px",
+  fontWeight: 400,
+  color: "var(--dim)",
+  marginBottom: 10,
+  paddingBottom: 6,
+  borderBottom: "1px solid var(--glass-border)",
+};
+
+const filterLabel: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "baseline",
+  fontSize: 11,
+  fontVariant: "small-caps",
+  letterSpacing: "0.5px",
+  color: "var(--dim)",
+  marginBottom: 5,
+};
+
+const filterValue: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--text)",
+  letterSpacing: "0.5px",
+};
+
+const segmentedGroup: React.CSSProperties = {
+  display: "flex",
+  gap: 4,
+};
+
+const segmentBtn: React.CSSProperties = {
+  flex: 1,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  padding: "5px 8px",
+  borderRadius: 3,
+  cursor: "pointer",
+  transition: "color 150ms ease, border-color 150ms ease, background 150ms ease",
+  border: "1px solid",
+};

--- a/ui/src/engine/contrast.test.ts
+++ b/ui/src/engine/contrast.test.ts
@@ -1,0 +1,54 @@
+/**
+ * WCAG contrast helper tests. Cross-checked against the W3C contrast
+ * checker for the parchment background tokens we care about.
+ */
+
+import { describe, it, expect } from "vitest";
+import { relativeLuminance, contrastRatio } from "./contrast.js";
+
+describe("relativeLuminance", () => {
+  it("black is 0", () => {
+    expect(relativeLuminance("#000000")).toBe(0);
+  });
+
+  it("white is 1", () => {
+    expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 6);
+  });
+
+  it("parchment #faf7f2 is high (>= 0.93)", () => {
+    expect(relativeLuminance("#faf7f2")).toBeGreaterThanOrEqual(0.93);
+  });
+
+  it("known mid-grey #808080", () => {
+    expect(relativeLuminance("#808080")).toBeCloseTo(0.2159, 3);
+  });
+
+  it("throws on invalid hex", () => {
+    expect(() => relativeLuminance("zzz")).toThrow();
+    expect(() => relativeLuminance("#abc")).toThrow();
+  });
+});
+
+describe("contrastRatio", () => {
+  it("black on white is 21:1", () => {
+    expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1);
+  });
+
+  it("white on white is 1:1", () => {
+    expect(contrastRatio("#ffffff", "#ffffff")).toBeCloseTo(1, 6);
+  });
+
+  it("symmetric (order doesn't matter)", () => {
+    const a = contrastRatio("#1e5a7d", "#faf7f2");
+    const b = contrastRatio("#faf7f2", "#1e5a7d");
+    expect(a).toBeCloseTo(b, 6);
+  });
+
+  it("#1e5a7d (deep blue) vs #faf7f2 (parchment) >= 4.5:1", () => {
+    expect(contrastRatio("#1e5a7d", "#faf7f2")).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("#4d762a (darkened olive) vs #faf7f2 (parchment) >= 4.5:1", () => {
+    expect(contrastRatio("#4d762a", "#faf7f2")).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/ui/src/engine/contrast.ts
+++ b/ui/src/engine/contrast.ts
@@ -1,0 +1,45 @@
+/**
+ * WCAG 2.x relative-luminance + contrast-ratio helpers.
+ *
+ * Used by tagPalette to enforce >=4.5:1 contrast vs the parchment background
+ * tokens (COLOR_MAP_BG #faf7f2 + COLOR_SURFACE #f0ebe0). v0.27 color-by-tag.
+ *
+ * Reference: WCAG 2.1 SC 1.4.3 / 1.4.11
+ *   https://www.w3.org/TR/WCAG21/#contrast-minimum
+ */
+
+function parseHex(hex: string): [number, number, number] {
+  const s = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (s.length !== 6) throw new Error(`Expected 6-char hex, got: ${hex}`);
+  const r = parseInt(s.slice(0, 2), 16);
+  const g = parseInt(s.slice(2, 4), 16);
+  const b = parseInt(s.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    throw new Error(`Invalid hex: ${hex}`);
+  }
+  return [r, g, b];
+}
+
+/** Gamma-correct an sRGB channel to its linear-light value. */
+function linearize(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance: 0 (black) to 1 (white). */
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = parseHex(hex);
+  const lr = linearize(r);
+  const lg = linearize(g);
+  const lb = linearize(b);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+/** WCAG contrast ratio between two colors. Returns a value in [1, 21]. */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -13,7 +13,8 @@ import {
   COLOR_GRID_HEX,
   COLOR_CONFLICT_HEX,
 } from "../tokens.js";
-import { isFading } from "../state/filterState.js";
+import { isFading, type ColorMode } from "../state/filterState.js";
+import { buildPalette, resolveColor, TAG_PALETTE, PATH_PALETTE } from "./tagPalette.js";
 
 const SPREAD = 20;
 const LAYER_Y_OFFSET: Record<string, number> = { buffer: 6, episodic: 0, semantic: -6 };
@@ -70,6 +71,15 @@ export class BrainScene {
   private paused = false;
   /** E1.5: per-frame render callbacks for screen-space label overlay (E4). */
   private onRenderCbs: Array<(camera: THREE.PerspectiveCamera, scene: THREE.Scene) => void> = [];
+  /**
+   * v0.27 color-by-tag — current view mode + per-mode palette caches.
+   * Defaults to "layer" so pre-v0.27 render path is back-compat.
+   * Palettes are rebuilt by setColorMode() when memories change or the
+   * mode switches.
+   */
+  private currentColorMode: ColorMode = "layer";
+  private tagPalette: Map<string, string> = new Map();
+  private pathPalette: Map<string, string> = new Map();
 
   constructor(private container: HTMLDivElement) {
     this.initRenderer();
@@ -296,6 +306,50 @@ export class BrainScene {
 
     this.buildTendrils();
     this.buildConflictLines(conflicts);
+
+    // v0.27 color-by-tag: re-apply the current colorMode at populate tail.
+    // Single source of truth for the populate-vs-setColorMode race fix
+    // (plan-eng-critic R2 HIGH #5): when memories refresh and rebuild nodes
+    // via populate(), the current view mode is automatically re-applied so
+    // the user doesn't see a layer-color flash if they're in tag/path mode.
+    this.setColorMode(this.currentColorMode, memories);
+  }
+
+  /**
+   * v0.27 color-by-tag — recompute material color for every node in O(N)
+   * without rebuilding geometry or tendrils.
+   *
+   * Performance: ~1373 calls to material.color.set() targeted under 10ms
+   * on the live fixture. Tendril color rebuild is SKIPPED — tendrils
+   * represent spatial proximity (layer-agnostic), AND scene.ts's n>500
+   * early bail in buildTendrils means tendrils are not drawn on the live
+   * fixture anyway. Plan v3 S3 + AC3.
+   */
+  setColorMode(mode: ColorMode, memories: readonly Memory[]): void {
+    if (mode === "tag") {
+      this.tagPalette = buildPalette(memories, {
+        excludePrefix: "path:",
+        topN: 10,
+        palette: TAG_PALETTE,
+      });
+    }
+    if (mode === "path") {
+      this.pathPalette = buildPalette(memories, {
+        includePrefix: "path:",
+        topN: 8,
+        palette: PATH_PALETTE,
+      });
+    }
+    this.currentColorMode = mode;
+    for (const node of this.nodes) {
+      const hex = resolveColor(node.memory, mode, this.tagPalette, this.pathPalette);
+      const color = hexToColor(hex);
+      (node.mesh.material as THREE.MeshStandardMaterial).color.copy(color);
+      // Halo material is independent — keep it tracking the node color too
+      // so selection/hover halo reads correctly under the new mode.
+      (node.halo.material as THREE.MeshBasicMaterial).color.copy(color);
+      // Tendrils intentionally NOT updated. See class-level comment.
+    }
   }
 
   private buildTendrils(): void {

--- a/ui/src/engine/tagPalette.test.ts
+++ b/ui/src/engine/tagPalette.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tag-palette engine tests. Verifies the contract that plan-eng-critic
+ * R1+R2+R3 locked in:
+ *
+ *   - buildPalette is pure + deterministic
+ *   - top-N capped at min(topN, palette.length)
+ *   - includePrefix / excludePrefix work in both modes
+ *   - linear-probe collision resolution yields N unique colors for top-N
+ *   - pickColorTag rule: shortest tag wins, alphabetical tiebreak
+ *   - resolveColor returns fallback for memories with no qualifying tag
+ *   - every TAG_PALETTE + PATH_PALETTE color has >= 4.5:1 contrast vs
+ *     COLOR_MAP_BG (plan-design R3 LOW: AC10 covers both palettes)
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Memory } from "../types.js";
+import {
+  TAG_PALETTE,
+  PATH_PALETTE,
+  TAG_FALLBACK_COLOR,
+  buildPalette,
+  pickColorTag,
+  resolveColor,
+} from "./tagPalette.js";
+import { contrastRatio } from "./contrast.js";
+import { COLOR_MAP_BG } from "../tokens.js";
+
+function mem(over: Partial<Memory> & { id: string }): Memory {
+  return {
+    id: over.id,
+    content: over.content ?? `content-${over.id}`,
+    tags: over.tags ?? [],
+    layer: over.layer ?? "episodic",
+    strength: over.strength ?? 0.5,
+    half_life_days: over.half_life_days ?? 30,
+    retrieval_count: over.retrieval_count ?? 1,
+    schema_fit: over.schema_fit ?? 0.5,
+    emotional_valence: over.emotional_valence ?? "neutral",
+    confidence: over.confidence ?? "inferred",
+    pinned: over.pinned ?? false,
+    created: over.created ?? "2026-05-01T00:00:00Z",
+    last_retrieved: over.last_retrieved ?? "2026-05-20T00:00:00Z",
+    age_days: over.age_days ?? 10,
+    projected_strength_7d: over.projected_strength_7d ?? 0.5,
+    projected_strength_30d: over.projected_strength_30d ?? 0.5,
+  };
+}
+
+describe("buildPalette", () => {
+  const FIXTURE: Memory[] = [
+    mem({ id: "1", tags: ["error", "path:hippo"] }),
+    mem({ id: "2", tags: ["error", "path:hippo"] }),
+    mem({ id: "3", tags: ["error", "openclaw"] }),
+    mem({ id: "4", tags: ["rule", "path:quantamental"] }),
+    mem({ id: "5", tags: ["openclaw"] }),
+  ];
+
+  it("returns top-N tags, capped at min(topN, palette.length)", () => {
+    const result = buildPalette(FIXTURE, { excludePrefix: "path:", topN: 2, palette: TAG_PALETTE });
+    expect(result.size).toBe(2);
+    expect([...result.keys()]).toEqual(["error", "openclaw"]);
+  });
+
+  it("respects palette.length cap when topN > palette.length", () => {
+    const result = buildPalette(FIXTURE, { excludePrefix: "path:", topN: 99, palette: TAG_PALETTE });
+    expect(result.size).toBeLessThanOrEqual(TAG_PALETTE.length);
+  });
+
+  it("excludePrefix=path: excludes path:* tags from counts", () => {
+    const result = buildPalette(FIXTURE, { excludePrefix: "path:", topN: 10, palette: TAG_PALETTE });
+    for (const tag of result.keys()) {
+      expect(tag.startsWith("path:")).toBe(false);
+    }
+  });
+
+  it("includePrefix=path: counts only path:* tags", () => {
+    const result = buildPalette(FIXTURE, { includePrefix: "path:", topN: 10, palette: PATH_PALETTE });
+    for (const tag of result.keys()) {
+      expect(tag.startsWith("path:")).toBe(true);
+    }
+    expect(result.has("path:hippo")).toBe(true);
+    expect(result.has("path:quantamental")).toBe(true);
+  });
+
+  it("deterministic: same input → same output across calls", () => {
+    const a = buildPalette(FIXTURE, { excludePrefix: "path:", topN: 10, palette: TAG_PALETTE });
+    const b = buildPalette(FIXTURE, { excludePrefix: "path:", topN: 10, palette: TAG_PALETTE });
+    expect([...a.entries()]).toEqual([...b.entries()]);
+  });
+
+  it("linear-probe collision resolution: no two top-N tags share a color", () => {
+    // Generate enough tags to exercise the hash collision path
+    const tags: Memory[] = [];
+    for (let i = 0; i < 50; i++) {
+      tags.push(mem({ id: `m${i}`, tags: [`tag-${i.toString(36)}`] }));
+    }
+    const result = buildPalette(tags, { excludePrefix: "path:", topN: 10, palette: TAG_PALETTE });
+    const colors = [...result.values()];
+    const unique = new Set(colors);
+    expect(unique.size).toBe(colors.length);
+    expect(unique.size).toBe(10);
+  });
+
+  it("sort tiebreak: equal count → alphabetical", () => {
+    // 3 tags each used by 1 memory → tied counts → alphabetical order
+    const tied: Memory[] = [
+      mem({ id: "a", tags: ["zebra"] }),
+      mem({ id: "b", tags: ["apple"] }),
+      mem({ id: "c", tags: ["mango"] }),
+    ];
+    const result = buildPalette(tied, { excludePrefix: "path:", topN: 2, palette: TAG_PALETTE });
+    expect([...result.keys()]).toEqual(["apple", "mango"]);
+  });
+});
+
+describe("pickColorTag", () => {
+  it("tag mode: shortest non-path tag wins", () => {
+    const m = mem({ id: "1", tags: ["a-longer-tag", "short", "another"] });
+    expect(pickColorTag(m, "tag")).toBe("short");
+  });
+
+  it("tag mode: alphabetical tiebreak on equal length", () => {
+    const m = mem({ id: "1", tags: ["zebra", "alpha"] });
+    expect(pickColorTag(m, "tag")).toBe("alpha");
+  });
+
+  it("path mode: shortest path:* tag wins", () => {
+    const m = mem({ id: "1", tags: ["path:hippo-memory", "path:hippo", "error"] });
+    expect(pickColorTag(m, "path")).toBe("path:hippo");
+  });
+
+  it("path mode: returns null when no path:* tag", () => {
+    const m = mem({ id: "1", tags: ["error", "rule"] });
+    expect(pickColorTag(m, "path")).toBeNull();
+  });
+
+  it("tag mode: returns null when only path:* tags", () => {
+    const m = mem({ id: "1", tags: ["path:hippo", "path:quantamental"] });
+    expect(pickColorTag(m, "tag")).toBeNull();
+  });
+
+  it("empty tags: returns null in both modes", () => {
+    const m = mem({ id: "1", tags: [] });
+    expect(pickColorTag(m, "tag")).toBeNull();
+    expect(pickColorTag(m, "path")).toBeNull();
+  });
+});
+
+describe("resolveColor", () => {
+  it("layer mode returns LAYER_COLORS[layer]", () => {
+    const m = mem({ id: "1", layer: "episodic" });
+    const color = resolveColor(m, "layer", new Map(), new Map());
+    expect(color).toBe("#4a8ca3"); // COLOR_EPISODIC per tokens.ts
+  });
+
+  it("tag mode returns palette color when qualifying tag in map", () => {
+    const m = mem({ id: "1", tags: ["error"] });
+    const palette = new Map([["error", TAG_PALETTE[0]!]]);
+    expect(resolveColor(m, "tag", palette, new Map())).toBe(TAG_PALETTE[0]!);
+  });
+
+  it("tag mode returns fallback when qualifying tag not in palette map", () => {
+    const m = mem({ id: "1", tags: ["unmapped-tag"] });
+    expect(resolveColor(m, "tag", new Map(), new Map())).toBe(TAG_FALLBACK_COLOR);
+  });
+
+  it("path mode returns path palette color", () => {
+    const m = mem({ id: "1", tags: ["path:hippo"] });
+    const pathPalette = new Map([["path:hippo", PATH_PALETTE[0]!]]);
+    expect(resolveColor(m, "path", new Map(), pathPalette)).toBe(PATH_PALETTE[0]!);
+  });
+
+  it("returns fallback for memory with no tags", () => {
+    const m = mem({ id: "1", tags: [] });
+    expect(resolveColor(m, "tag", new Map(), new Map())).toBe(TAG_FALLBACK_COLOR);
+    expect(resolveColor(m, "path", new Map(), new Map())).toBe(TAG_FALLBACK_COLOR);
+  });
+
+  it("never returns undefined or throws", () => {
+    const m = mem({ id: "1", tags: [] });
+    expect(() => resolveColor(m, "tag", new Map(), new Map())).not.toThrow();
+    expect(resolveColor(m, "tag", new Map(), new Map())).toBeTypeOf("string");
+  });
+});
+
+// Plan-design-critic R3 LOW: AC10 covers BOTH palettes vs parchment
+describe("palette contrast (AC10)", () => {
+  it("every TAG_PALETTE color has >= 4.5:1 contrast vs COLOR_MAP_BG", () => {
+    for (const color of TAG_PALETTE) {
+      const ratio = contrastRatio(color, COLOR_MAP_BG);
+      expect(ratio, `${color} vs ${COLOR_MAP_BG}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("every PATH_PALETTE color has >= 4.5:1 contrast vs COLOR_MAP_BG", () => {
+    for (const color of PATH_PALETTE) {
+      const ratio = contrastRatio(color, COLOR_MAP_BG);
+      expect(ratio, `${color} vs ${COLOR_MAP_BG}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it("TAG_FALLBACK_COLOR has >= 4.5:1 contrast vs COLOR_MAP_BG", () => {
+    expect(contrastRatio(TAG_FALLBACK_COLOR, COLOR_MAP_BG)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/ui/src/engine/tagPalette.ts
+++ b/ui/src/engine/tagPalette.ts
@@ -1,0 +1,168 @@
+/**
+ * v0.27 color-by-tag — palette engine for the dashboard graph.
+ *
+ * Three palettes:
+ *   - TAG_PALETTE (10 colors) for "color by tag" mode (excludes path:* tags)
+ *   - PATH_PALETTE (8 colors)  for "color by path" mode (only path:* tags)
+ *   - TAG_FALLBACK_COLOR for any memory whose qualifying tag is outside
+ *     the top-N for the active mode
+ *
+ * All hex values verified > 4.5:1 contrast vs COLOR_MAP_BG (#faf7f2) per
+ * WCAG (see contrast.ts). None in the rust hue range (avoids selection
+ * halo COLOR_ACCENT collision).
+ *
+ * Tag selection rule: shortest qualifying tag wins; alphabetical tiebreak.
+ * Stable across sessions via FNV-1a hash with linear-probe collision
+ * resolution into the palette.
+ */
+
+import type { Memory } from "../types.js";
+import type { ColorMode } from "../state/filterState.js";
+import { LAYER_COLORS } from "./types.js";
+
+/**
+ * 10-color tag palette tuned for parchment background.
+ * WCAG luminance table (see contrast.test.ts for runtime assertions):
+ *
+ * | hex      | L     | Ratio vs #faf7f2 |
+ * |----------|-------|------------------|
+ * | #1e5a7d  | 0.10  | 6.4 : 1          |
+ * | #2d5e2b  | 0.10  | 6.5 : 1          |
+ * | #6b2876  | 0.07  | 8.3 : 1          |
+ * | #155a5a  | 0.09  | 7.2 : 1          |
+ * | #8a4d2e  | 0.13  | 5.2 : 1          |
+ * | #6f4f1f  | 0.10  | 6.6 : 1          |
+ * | #2d4d6b  | 0.09  | 7.0 : 1          |
+ * | #4d762a  | 0.16  | 5.0 : 1          | (darkened from #527e2e for AA safety)
+ * | #7f4848  | 0.11  | 6.0 : 1          |
+ * | #4a4a72  | 0.08  | 7.6 : 1          |
+ */
+export const TAG_PALETTE: readonly string[] = [
+  "#1e5a7d", "#2d5e2b", "#6b2876", "#155a5a", "#8a4d2e",
+  "#6f4f1f", "#2d4d6b", "#4d762a", "#7f4848", "#4a4a72",
+] as const;
+
+/** Path-mode sub-palette — 8 colors chosen for project-grouping legibility
+ * (bluer/cooler bias so projects read as a family). Subset of TAG_PALETTE
+ * to keep contrast assertions trivially covered. */
+export const PATH_PALETTE: readonly string[] = [
+  "#1e5a7d", "#155a5a", "#2d4d6b", "#4a4a72",
+  "#6b2876", "#2d5e2b", "#4d762a", "#7f4848",
+] as const;
+
+/** Dark grey (not parchment-grey) for memories whose qualifying tag is
+ * outside the top-N. L = 0.14, ratio 4.7 : 1 vs parchment. */
+export const TAG_FALLBACK_COLOR = "#6a6a6a";
+
+const PATH_PREFIX = "path:";
+
+/** FNV-1a 32-bit hash. Pure + deterministic; identical across sessions. */
+function fnv1aHash(s: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    hash ^= s.charCodeAt(i);
+    // 32-bit multiply via shifts; mask to keep within u32.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+export interface PaletteOpts {
+  /** When set, only tags starting with this prefix are counted (e.g. "path:"). */
+  includePrefix?: string;
+  /** When set, tags starting with this prefix are excluded (e.g. "path:"). */
+  excludePrefix?: string;
+  /** Top-N most frequent qualifying tags get distinct palette colors. */
+  topN: number;
+  /** Color palette to assign from. Tags beyond palette.length get linear-probed. */
+  palette: readonly string[];
+}
+
+/**
+ * Build a tag → color map from the current memories.
+ *
+ * - Counts how many memories carry each qualifying tag.
+ * - Picks the top-N tags (sorted by count DESC, alpha ASC for stability).
+ * - Hash-stable assignment: tag hash modulo palette length, linear-probe
+ *   into the next free slot on collision. Same tag → same color across
+ *   sessions (only depends on FNV-1a hash + palette ordering).
+ *
+ * Pure + deterministic. Returns at most min(topN, palette.length) entries.
+ */
+export function buildPalette(
+  memories: readonly Memory[],
+  opts: PaletteOpts,
+): Map<string, string> {
+  const { includePrefix, excludePrefix, topN, palette } = opts;
+  const cap = Math.min(topN, palette.length);
+
+  // Count qualifying tags
+  const counts = new Map<string, number>();
+  for (const mem of memories) {
+    for (const tag of mem.tags) {
+      if (includePrefix !== undefined && !tag.startsWith(includePrefix)) continue;
+      if (excludePrefix !== undefined && tag.startsWith(excludePrefix)) continue;
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  // Pick top-N: count DESC, alpha ASC (stable tiebreak)
+  const ranked = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, cap)
+    .map(([tag]) => tag);
+
+  // Hash-stable color assignment with linear-probe collision resolution
+  const result = new Map<string, string>();
+  const usedSlots = new Set<number>();
+  for (const tag of ranked) {
+    const start = fnv1aHash(tag) % palette.length;
+    let slot = start;
+    while (usedSlots.has(slot)) {
+      slot = (slot + 1) % palette.length;
+      if (slot === start) break; // palette full (shouldn't happen at cap == palette.length)
+    }
+    usedSlots.add(slot);
+    result.set(tag, palette[slot]!);
+  }
+  return result;
+}
+
+/**
+ * Pick the color-driving tag for a memory under tag/path mode.
+ * Rule: shortest qualifying tag wins; alphabetical tiebreak.
+ * Returns null if no qualifying tag exists → caller uses fallback color.
+ */
+export function pickColorTag(memory: Memory, mode: "tag" | "path"): string | null {
+  const qualifying = memory.tags.filter((tag) => {
+    if (mode === "path") return tag.startsWith(PATH_PREFIX);
+    return !tag.startsWith(PATH_PREFIX);
+  });
+  if (qualifying.length === 0) return null;
+  qualifying.sort((a, b) => a.length - b.length || a.localeCompare(b));
+  return qualifying[0] ?? null;
+}
+
+/**
+ * Resolve the render color for a memory under the active mode.
+ *
+ * - layer: returns LAYER_COLORS[memory.layer] (unchanged from baseline).
+ * - tag:   pickColorTag → tagPalette → fallback grey.
+ * - path:  pickColorTag → pathPalette → fallback grey.
+ *
+ * Pure function. Never throws, never returns undefined.
+ */
+export function resolveColor(
+  memory: Memory,
+  mode: ColorMode,
+  tagPalette: Map<string, string>,
+  pathPalette: Map<string, string>,
+): string {
+  if (mode === "layer") {
+    return LAYER_COLORS[memory.layer] ?? TAG_FALLBACK_COLOR;
+  }
+  const tag = pickColorTag(memory, mode);
+  if (tag === null) return TAG_FALLBACK_COLOR;
+  const palette = mode === "path" ? pathPalette : tagPalette;
+  return palette.get(tag) ?? TAG_FALLBACK_COLOR;
+}

--- a/ui/src/state/filterState.test.ts
+++ b/ui/src/state/filterState.test.ts
@@ -256,3 +256,28 @@ describe("deriveVisibleIds + fadingOnly (v0.26.1)", () => {
     expect(ids(deriveVisibleIds(FADING_FIXTURE, INITIAL_FILTER_STATE))).toHaveLength(5);
   });
 });
+
+// v0.27 — colorMode is VIEW state, not a filter. Plan v3 S1.
+describe("colorMode + isFilterActive (v0.27)", () => {
+  it("INITIAL state has colorMode = 'layer'", () => {
+    expect(INITIAL_FILTER_STATE.colorMode).toBe("layer");
+  });
+
+  it("isFilterActive returns false when only colorMode changes from 'layer'", () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, colorMode: "tag" };
+    expect(isFilterActive(state)).toBe(false);
+  });
+
+  it("isFilterActive remains true when other filters are set alongside colorMode", () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, colorMode: "path", query: "alpha" };
+    expect(isFilterActive(state)).toBe(true);
+  });
+
+  it("colorMode does NOT change deriveVisibleIds output", () => {
+    const a = ids(deriveVisibleIds(FIXTURE, { ...INITIAL_FILTER_STATE, colorMode: "layer" }));
+    const b = ids(deriveVisibleIds(FIXTURE, { ...INITIAL_FILTER_STATE, colorMode: "tag" }));
+    const c = ids(deriveVisibleIds(FIXTURE, { ...INITIAL_FILTER_STATE, colorMode: "path" }));
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+});

--- a/ui/src/state/filterState.ts
+++ b/ui/src/state/filterState.ts
@@ -15,6 +15,14 @@ export type Layer = "buffer" | "episodic" | "semantic";
 // Matches Memory.confidence in ../types.ts
 export type Confidence = "verified" | "observed" | "inferred" | "stale";
 
+/**
+ * v0.27 — color-by-tag (E1 of Obsidian-inspired graph upgrades stack).
+ * Mode determines what axis drives node color in the scene engine.
+ * VIEW state, not filter state — NOT included in isFilterActive, and
+ * resetFilters preserves it.
+ */
+export type ColorMode = "layer" | "tag" | "path";
+
 export interface FilterState {
   /** E2 — search input substring; matched against content + tags. */
   query: string;
@@ -33,6 +41,13 @@ export interface FilterState {
    * memories where isFading(m) is true. Composes (AND) with other filters.
    */
   fadingOnly: boolean;
+  /**
+   * v0.27 — selects which attribute drives node color. "layer" is default
+   * (back-compat with pre-v0.27 render). VIEW state — NOT a filter, so
+   * NOT included in isFilterActive, and resetFilters preserves the user's
+   * choice.
+   */
+  colorMode: ColorMode;
 }
 
 export const INITIAL_FILTER_STATE: FilterState = {
@@ -43,6 +58,7 @@ export const INITIAL_FILTER_STATE: FilterState = {
   ageMaxDays: null,
   frozen: false,
   fadingOnly: false,
+  colorMode: "layer",
 };
 
 /**

--- a/ui/src/views/LivingMap/LivingMap.tsx
+++ b/ui/src/views/LivingMap/LivingMap.tsx
@@ -16,8 +16,10 @@ import {
   type FilterState,
   type Layer,
   type Confidence,
+  type ColorMode,
 } from "../../state/filterState.js";
 import type { BrainScene } from "../../engine/scene.js";
+import { pickColorTag } from "../../engine/tagPalette.js";
 
 interface LivingMapProps {
   memories: Memory[];
@@ -34,6 +36,8 @@ interface LivingMapProps {
   setConfidences: (confidences: Set<Confidence>) => void;
   setAgeMaxDays: (days: number | null) => void;
   setFadingOnly: (v: boolean) => void;
+  /** v0.27 color-by-tag — drives ViewPanel segmented radio. */
+  setColorMode: (mode: ColorMode) => void;
   resetFilters: () => void;
 }
 
@@ -120,7 +124,7 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
 export function LivingMap({
   memories, embeddings, stats, conflicts, filterState, frozenOrigin,
   setQuery, setFrozen, setLayers, setStrengthRange, setConfidences, setAgeMaxDays, setFadingOnly,
-  resetFilters,
+  setColorMode, resetFilters,
 }: LivingMapProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
@@ -185,8 +189,18 @@ export function LivingMap({
     frozen: filterState.frozen,
     visibleIds,
     filterActive,
+    colorMode: filterState.colorMode,
     onSceneReady: setSceneInstance,
   });
+
+  // v0.27 — derive the color-driving tag for the currently hovered memory
+  // so MemoryTooltip can surface it in tag/path mode (a11y non-color channel
+  // per plan-design-critic R1 must-fix #1).
+  const hoveredColorTag = useMemo(() => {
+    if (!hoveredMemory) return null;
+    if (filterState.colorMode === "layer") return null;
+    return pickColorTag(hoveredMemory.memory, filterState.colorMode);
+  }, [hoveredMemory, filterState.colorMode]);
 
   // Uses the shared matchesQuery so this can't drift from deriveVisibleIds.
   const matchCount = filterState.query.trim().length > 0
@@ -275,6 +289,7 @@ export function LivingMap({
         setConfidences={setConfidences}
         setAgeMaxDays={setAgeMaxDays}
         setFadingOnly={setFadingOnly}
+        setColorMode={setColorMode}
         resetFilters={resetFilters}
       />
 
@@ -289,7 +304,13 @@ export function LivingMap({
       )}
 
       {hoveredMemory && !selectedMemory && (
-        <MemoryTooltip memory={hoveredMemory.memory} x={hoveredMemory.x} y={hoveredMemory.y} />
+        <MemoryTooltip
+          memory={hoveredMemory.memory}
+          x={hoveredMemory.x}
+          y={hoveredMemory.y}
+          colorMode={filterState.colorMode}
+          colorTag={hoveredColorTag}
+        />
       )}
 
       <DetailPanel memory={selectedMemory} onClose={() => setSelectedMemory(null)} open={panelOpen} />
@@ -300,6 +321,7 @@ export function LivingMap({
         memories={memories}
         visibleIds={visibleIds}
         filterActive={filterActive}
+        colorMode={filterState.colorMode}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         onMemorySelect={(m) => {
@@ -315,6 +337,7 @@ export function LivingMap({
         drawerOpen={drawerOpen}
         onToggleDrawer={() => setDrawerOpen((prev) => !prev)}
         visibleCount={filterActive ? visibleIds.size : memories.length}
+        colorMode={filterState.colorMode}
       />
     </div>
   );

--- a/ui/src/views/LivingMap/useCanvasEngine.ts
+++ b/ui/src/views/LivingMap/useCanvasEngine.ts
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback } from "react";
 import type { Memory, Conflict, EmbeddingIndex } from "../../types.js";
 import { BrainScene } from "../../engine/scene.js";
 import { projectTo3D } from "../../engine/projection.js";
+import type { ColorMode } from "../../state/filterState.js";
 
 interface UseSceneOptions {
   memories: Memory[];
@@ -23,6 +24,14 @@ interface UseSceneOptions {
    * visibleIds is empty, scene receives empty visible set = hide all.
    */
   filterActive: boolean;
+  /**
+   * v0.27 — color mode for node rendering. Threaded through to
+   * scene.setColorMode(). populate() also re-applies the current mode at
+   * its tail, so this effect is mostly redundant on memory refresh — it
+   * remains for the case where ONLY colorMode changes (user clicks the
+   * ViewPanel radio).
+   */
+  colorMode: ColorMode;
   /** E4 marquee: callback fires when the scene is constructed (and again
    * with null on unmount). LabelOverlay subscribes via this. */
   onSceneReady?: (scene: BrainScene | null) => void;
@@ -40,6 +49,7 @@ export function useCanvasEngine({
   frozen,
   visibleIds,
   filterActive,
+  colorMode,
   onSceneReady,
 }: UseSceneOptions) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -127,6 +137,18 @@ export function useCanvasEngine({
   useEffect(() => {
     sceneRef.current?.setFiltered(visibleIds, filterActive);
   }, [visibleIds, filterActive]);
+
+  // v0.27 color-by-tag: drive scene.setColorMode from filterState.colorMode.
+  // populate() also re-applies the current mode at its tail (single source
+  // of truth for the populate-vs-setColorMode race fix), so this effect
+  // handles ONLY pure mode-change events (user toggles ViewPanel radio).
+  // Memory refreshes go through populate's tail call — no need to listen on
+  // `memories` here too (code-review-critic R1 LOW: removes a redundant
+  // setColorMode call per memory refresh).
+  useEffect(() => {
+    sceneRef.current?.setColorMode(colorMode, memories);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [colorMode]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     sceneRef.current?.handleMouseMove(e.nativeEvent);


### PR DESCRIPTION
## Summary

Adds Sidebar **"Color by"** segmented radio with 3 modes (`layer` | `tag` | `path`) so users can recolor the 3D memory graph by topic tag or project path instead of layer-only. Addresses Keith's observation: the 156-tag dimension was sitting unused while 1232/1373 episodic memories rendered as one blue blob.

**E1 of 4 in the Obsidian-inspired graph upgrades stack** picked 2026-05-24:
1. **E1 (this PR)** — tag-based coloring + per-tag palette
2. E2 — real edges from `parents`/`conflicts_with`/shared-tags
3. E3 — local graph view (N-hop from selected)
4. E4 — force-directed layout from real edges (replaces PCA)

## Branch note

Branched off `feat-fading-feature` (PR #60). Rebases cleanly onto master once #60 merges.

## What shipped

**Engine:**
- `BrainScene.setColorMode(mode, memories)` recolors mesh + halo materials in O(N) without rebuilding geometry. Tendrils intentionally NOT recolored (proximity edges are layer-agnostic).
- `populate()` ends with `this.setColorMode(currentColorMode, memories)` so memory refreshes never flash layer colors when user is in tag/path mode.
- `tagPalette.ts` — FNV-1a hash + linear-probe collision into 10-color TAG / 8-color PATH palette. Pure + deterministic; same tag → same color across sessions.
- `contrast.ts` — WCAG luminance + contrast ratio. **AC10 asserts ≥4.5:1 vs parchment** for both palettes + fallback at test time.

**State:**
- New `ColorMode` type (`'layer' | 'tag' | 'path'`). **View state, NOT in `isFilterActive`.** `resetFilters` preserves it alongside `frozen`.

**UI:**
- `ViewPanel.tsx` — 3-button segmented radio in Sidebar between "Selected memory" and "Filters" header. Full ARIA semantics (radiogroup, role=radio, aria-checked, descriptive aria-labels per radio).
- `MemoryTooltip` — `color: <tag>` line in tag/path modes (non-color a11y channel).
- `Drawer` — conditional "tag" column for color-blind / keyboard-only users (rows already keyboard-navigable from E5).
- `BottomBar` — affordance key appends ` · color = <mode>` when non-layer so the active channel is always visible.

## Plan + critics

Plan: `docs/plans/2026-05-24-color-by-tag.md` (v1 → v2 → v3 through 3 critic rounds).

| Critic | Round | Verdict | Score |
|---|---|---|---|
| plan-eng-critic | R1 | fail | 68 |
| plan-design-critic | R1 | fail | 62 |
| plan-eng-critic | R2 | fail | 78 |
| plan-design-critic | R2 | fail | 71 |
| plan-eng-critic | R3 | **PASS** | **86** |
| plan-design-critic | R3 | **PASS** | **86** |
| code-review-critic | R1 | **PASS** | **88** |
| independent-review-critic | R1 | **PASS** | **90** |

v3 scope reduction: dropped `confidence` mode after R2 caught unavoidable palette-hex collisions with the tag palette. Confidence remains a filter in the existing FilterPanel; deferred to v0.28 with separate hue family design budget.

## Tests

- `tagPalette.test.ts` — determinism, top-N cap, include/exclude prefix, linear-probe collision uniqueness (10/10 distinct colors on 50-tag fixture), pickColorTag rule (shortest tag wins, alpha tiebreak), resolveColor dispatch, AC10 contrast assertions for **both TAG_PALETTE and PATH_PALETTE plus TAG_FALLBACK_COLOR**.
- `contrast.test.ts` — WCAG luminance + contrastRatio helpers (black/white edges, parchment >= 0.93, symmetry, known mid-grey).
- `ViewPanel.test.tsx` — 3-button render + aria-checked tracking + click → setColorMode + radiogroup labelling.
- `filterState.test.ts` — colorMode is NOT in isFilterActive (4 new tests).

**Test plan**
- [x] `npm test` 97/97 pass across 7 test files
- [x] `npm run build` clean (60 modules, three chunk 510KB = no regression)
- [ ] Manual visual smoke: load dashboard, switch through all 3 modes, verify selection/hover/fading-ring still work in each, capture screenshots

## Out of scope (follow-ups)

- E2 real edges from `parents`/`conflicts_with`/shared-tags
- E3 local graph view (N-hop neighbourhood from selected)
- E4 force-directed layout (replaces PCA proximity)
- Confidence-by-color mode (deferred, needs separate hue family)
- User-assignable per-tag colors (Obsidian color groups full parity)
- `colorMode` persistence across sessions (localStorage)
- `trace` layer color (Layer type doesn't include `trace`; 4 memories affected; separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)