### PR TITLE
feat(ui): v0.2.3 local graph view: focus on N-hop neighborhood (E3 of 4 Obsidian-inspired graph upgrades)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,124 @@
 # Changelog
 
+## ui-brain-observatory v0.2.3 (2026-05-25): local graph view (Obsidian-inspired graph upgrades, E3 of 4)
+
+Adds the Obsidian-most-used feature: click a memory, click the new
+"focus" button in the DetailPanel, and the graph collapses to that
+memory plus its N-hop neighborhood (default depth 2) via the explicit
+edges added in E2. Esc clears both the focus AND the selection together.
+
+E3 of 4 in the Obsidian-inspired graph upgrades stack:
+- v0.2.1 E1 color-by-tag (PR #61)
+- v0.2.2 E2 real edges (PR #62)
+- v0.2.3 E3 local graph view (this release)
+- v0.2.4 E4 force-directed layout (queued)
+
+### What shipped
+
+**`FilterState` extension.**
+- New `LocalViewState { centerId, depth }` interface + `localView` field on
+  `FilterState`. View AND filter state: included in `isFilterActive` (drives
+  scene.setFiltered line-visibility filter) and cleared by `resetFilters`
+  (matches "reset = back to full graph").
+- `deriveVisibleIds` gains optional 3rd arg `localNeighborhood?: Set<string>`.
+  When state.localView is set AND the Set is provided, intersects visible
+  memories with the neighborhood. Safe degradation when set but Set is
+  undefined.
+
+**Pure helper: `ui/src/engine/localNeighborhood.ts`.**
+- `buildAdjacency(memories, conflicts)` unions conflict pairs (both
+  directions) + shared-tag pairs from E2's `computeSharedTagPairs`. Hoisted
+  to a `useMemo` in LivingMap so it rebuilds only when memories or
+  conflicts change (not per localView toggle).
+- `computeLocalNeighborhood(adjacency, centerId, depth)` BFS visited-on-
+  enqueue, depth-capped at 5 internally, with a NEIGHBORHOOD_CAP of 60
+  nodes that triggers a depth-1 fallback (with `cappedFrom` payload) when
+  exceeded. Pure + deterministic. Performance budget: <5ms BFS at depth=2
+  on a 1373-memory + ~3000-edge adjacency (verified at test time).
+
+**Scene engine extension (Obsidian default: both endpoints must be visible).**
+- `BrainScene.setFiltered` extends to filter line visibility too: a line
+  is visible only when both endpoint IDs are in the visible set. No frayed
+  half-lines. Applies to conflictLines + sharedTagEdges + tendrils (the
+  latter is defensive for E4 force-layout).
+- `buildConflictLines` userData payload merged: `{status, aId, bId}`.
+- `buildSharedTagEdges` userData payload added: `{aId, bId}`.
+
+**`FocusButton` component (DetailPanel header LEFT, distinct from esc on right).**
+- Three labels: `focus` (idle) / `focused` (this memory is the center, rust
+  accent, non-interactive) / `recenter here` (focus active elsewhere, rust
+  text). aria-labels disambiguate each state for screen readers.
+- Click sets `{centerId: memory.id, depth: 2}`. Click on "focused" is a
+  no-op (`if (isCenter) return`).
+
+**BottomBar dynamic affordance.**
+- `buildAffordance` gains an optional 3rd arg `localView?: {size, cappedFrom?}`.
+  When local view is active, appends `view = local (N)` to the affordance
+  string (or `view = local (N, capped from M)` when the depth-1 fallback
+  triggered). Orientation cue when DetailPanel is closed.
+
+**Esc-clears-both wire.**
+- `onClickMemory(null)` is the convergence point for all 3 selection-clear
+  paths (Esc key via scene.deselect, esc button via DetailPanel onClose,
+  click-empty-space via scene.handleClick). All three paths clear both
+  `selectedMemory` and `localView`. Stepped Esc deferred to v0.3.0+.
+
+**Stale-centerId guard.**
+- App.tsx `setLocalView` callback verifies `centerId` exists in current
+  `memories` at set-time. LivingMap `useEffect` clears `localView` if the
+  memory is later deleted from the visible set. Both windows covered.
+
+### Plan
+
+`docs/plans/2026-05-25-local-view.md` (v1 to v2 through 2 plan critic
+rounds).
+
+### Critic record
+
+| Critic | Round | Verdict | Score |
+|---|---|---|---|
+| plan-eng-critic | R1 | fail | 62 |
+| plan-design-critic | R1 | fail | 58 |
+| plan-eng-critic | R2 | PASS | 88 |
+| plan-design-critic | R2 | PASS | 84 |
+| code-review-critic | R1 | PASS | 88 |
+| independent-review-critic | R1 | PASS | 89 |
+
+### Tests
+
+- `ui/src/engine/localNeighborhood.test.ts`: 15 tests covering
+  `buildAdjacency` (conflict-only / shared-tag-only / mixed / path-prefix
+  exclusion), `computeLocalNeighborhood` (centerId-not-in-adjacency,
+  depth=0, depth=1 on line graph, depth=2 on line graph, triangle via
+  shared tags, determinism, HARD_DEPTH_CAP=5 enforcement), neighborhood
+  cap fallback (3 cases: no-fallback / falls-back / under-cap), and AC8
+  perf budget enforcement (<5ms BFS at depth=2 on 1373-node synthesized
+  adjacency).
+- `ui/src/state/filterState.test.ts`: 8 new tests for `localView`
+  composition with other filters, `isFilterActive` branch, safe
+  degradation, `resetFilters` clears, survives `setColorMode` change.
+- `ui/src/components/BottomBar.test.tsx`: 5 new tests for the
+  `view = local (N)` affordance clause, cap-fallback annotation,
+  composition with edge counts + color mode, ordering before the bail
+  hint.
+
+Full repo: 1846 tests pass / 4 skipped / 252 test files.
+UI: 147 tests pass / 10 test files.
+Build: vite clean, 60 modules, three chunk 510KB (no regression vs E2).
+
+### Out of scope (follow-ups)
+
+- Depth slider (1-3): hardcoded depth=2 for v1; v0.3.0+.
+- Stepped Esc (first clears focus, second clears selection): v0.3.0+ if
+  user feedback wants separation.
+- Animated zoom-to-cluster: v0.3.0 polish.
+- Breadcrumb history (drill into a neighbor of a neighbor): v0.3.0+.
+- Sidebar status row: BottomBar covers orientation; defer Sidebar
+  duplicate.
+- scene.ts unit tests: needs WebGL stubs; deferred.
+- Conflict info in Drawer / MemoryTooltip for a11y completeness:
+  deferred.
+
 ## ui-brain-observatory v0.2.2 (2026-05-25): real edges (Obsidian-inspired graph upgrades, E2 of 4)
 
 Adds explicit edges to the 3D graph: open + resolved conflict lines (shape-

--- a/docs/plans/2026-05-25-local-view.md
+++ b/docs/plans/2026-05-25-local-view.md
@@ -1,0 +1,519 @@
+# 2026-05-25 — Local graph view (E3 of Obsidian-inspired graph upgrades stack)
+
+**Status:** Draft v2 (addressing R1 must-fix from plan-eng-critic + plan-design-critic)
+**Episode:** 01KSFCYZDM6JG73N0C3XZNZ9WX
+**Branch:** feat-local-view (off feat-real-edges, rebases when E2 PR #62 lands)
+**Owner:** Claude (Keith review)
+
+## Changes from v1 (R1 must-fix incorporated)
+
+Engineering (plan-eng-critic R1, 5 must-fix):
+- **S6 Esc wire FIXED** — `setLocalView(null)` lives at the `onClickMemory(null)` convergence point in `LivingMap.tsx`, NOT in DetailPanel `onClose`. All three selection-clear paths (Escape key, esc button, click-empty-space) route through this point — so all three clear both selection and localView consistently. AC3 verifiable.
+- **S6 Esc handler site CORRECTED** — actual location is `useCanvasEngine.ts:177-179` (`scene.handleKeyDown` returned + attached at `LivingMap.tsx:213 onKeyDown`). NOT App.tsx (which has F-key handler at L110-118 only).
+- **S2/S5 perf budget RESOLVED** — adjacency is hoisted to a `useMemo` over `[memories, conflicts]` in `LivingMap.tsx`. `computeSharedTagPairs` runs ONCE per memories/conflicts change (not per localView change). Helper `computeLocalNeighborhood` takes prebuilt adjacency + does only BFS. New perf budget: BFS <5ms on 1373-memory adjacency at depth=2 (helper); adjacency build <100ms one-shot (covered by E2's existing perf test, NOT a new gate).
+- **S2 BFS visited-on-enqueue SPECIFIED** — visited set marked when node enters queue, not on dequeue. Prevents re-expansion of well-connected hubs.
+- **S4(b) tendril invariant** — tendril lines also iterated with same endpoint-id guard. Tendrils don't currently get `userData.aId/bId` (they bail on n>500 so never built on live fixture), but adding the iteration is defensive: if E4 force-layout ever rebuilds tendrils for n>500, the visibility filter works without a second pass.
+
+Design (plan-design-critic R1, 7 must-fix):
+- **NEW S8 BottomBar affordance update — IN scope** — `buildAffordance` appends ` · view = local (N)` when localView active (N = neighborhood size). Removes the "DetailPanel-closed orientation gap" the critic flagged.
+- **S6 focus button — three labels, not active/inactive flicker** — button text changes:
+  - Idle (no focus active): `focus`
+  - This memory IS the center: `focused` (rust accent — matches freeze active pattern)
+  - Focus active on a different memory: `recenter here` (text-only, rust foreground, no border) — clicking re-centers focus on this memory
+  Eliminates the "active-state lies on re-mount" inconsistency.
+- **S4 frayed half-line CHANGED → Obsidian default** — both endpoints must be visible to draw a line. Eliminates the half-line-reads-as-bug risk. (v1's "frayed extends off-frame" was unjustified.)
+- **NEW S9 neighborhood size hard cap** — if `computeLocalNeighborhood(..., depth=2)` returns > 60 ids, helper falls back to `depth=1` (same algorithm, smaller depth). Returns a `{ memoryIds: Set<string>, depthUsed: number, cappedFrom?: number }` shape so UI can show "Showing depth 1 (28 nodes); depth 2 would have shown 152 — defer slider to v0.3.0" hint in BottomBar.
+- **S6 focusBtnStyle CONCRETE** — `background: 'var(--ink-faint)', border: '1px solid var(--glass-border)', color: 'var(--dim)', borderRadius: 4, padding: '4px 12px', fontFamily: 'var(--font-mono)', fontSize: 11` for idle (distinct from esc button which uses no border + smaller padding). Active state bumps to `border: '1px solid var(--accent)', background: 'rgba(196, 92, 60, 0.18)'` (alpha 0.18 not 0.10 per critic).
+- **Esc dual-clear COMMITTED** — single press of Esc (or esc button or empty-space click) clears BOTH selectedMemory AND localView. Documented design rule: "closing the inspector closes its focused view." Stepped Esc deferred to v0.3.0 if user feedback wants the separation.
+- **S5 stale-centerId GUARDED** — `setLocalView` callback in App.tsx verifies `memories.some(m => m.id === v.centerId)` before accepting. If centerId not in current memories, callback no-ops. Sidebar empty-state never gets the stale-focus diagnosis (because localView state never becomes invalid).
+
+## Why this exists
+
+E1 (color-by-tag, PR #61) gave the graph multi-axis color so the 1232-episodic blob differentiates. E2 (real-edges, PR #62) gave it explicit conflict + shared-tag edges so the spatial relationships are real, not just PCA proximity. E3 is the Obsidian feature users reach for most: **click a node, see only that node and its neighborhood**, drop the rest of the graph for the duration. Lets the user focus when the 1373-memory view feels too much.
+
+E3 of 4 in the Obsidian-inspired stack:
+1. E1 color-by-tag (PR #61, awaiting Keith merge)
+2. E2 real edges (PR #62, awaiting Keith merge)
+3. **E3 (this plan) — local graph view (N-hop from selected)**
+4. E4 force-directed layout (replaces PCA, queued)
+
+## Goal
+
+Add a **"Focus on neighborhood"** affordance: when the user has a memory selected (via the existing click-to-select + DetailPanel flow), they can click a button to collapse the graph to that memory + its N-hop neighborhood (default depth 2, hard-capped at 60 nodes with depth-1 fallback) via the explicit edges added in E2. Esc clears both the focus AND the selection (matches existing Esc-clears-selection behaviour). BottomBar surfaces the focused state so users don't lose orientation when DetailPanel closes.
+
+## Discover findings (these drive the plan)
+
+```
+Existing selection infrastructure:
+  scene.ts L71  : selectedNode field
+  scene.ts L642 : deselect() resets mesh scale
+  useCanvasEngine.ts L177-179: handleKeyDown returns Esc->scene.deselect()
+  LivingMap.tsx L132: selectedMemory state
+  LivingMap.tsx L180-183: onClickMemory (the convergence point — all clear paths)
+  LivingMap.tsx L316: DetailPanel mount {memory, onClose, open}
+
+Existing filter infrastructure:
+  filterState.ts isFilterActive: drives Sidebar empty-state + scene.setFiltered
+  scene.ts L756 setFiltered: iterates this.nodes only — DOES NOT touch lines
+
+DISCOVER GOTCHA (addressed in S4):
+  setFiltered hides spheres+halos only. conflictLines + sharedTagEdges +
+  tendrils all stay drawn regardless of node visibility. Local view of 5
+  memories renders 5 spheres + ALL lines in the scene including
+  between-hidden-nodes lines. Conflict line.userData has {status} from
+  E2 but NOT endpoint ids. Plan adds aId/bId.
+
+Edge data available:
+  Conflicts: from conflicts[] passed to populate (always available, 1117
+    still-present pairs on live fixture)
+  Shared-tag pairs: from computeSharedTagPairs(memories) (E2 pure helper,
+    tiered cap-bounded, callable on any-n memories)
+
+Existing Esc behaviour:
+  App.tsx ~L104: keyboard F toggles freeze (NOT Esc)
+  useCanvasEngine.ts L177-179: handleKeyDown Esc -> scene.deselect()
+  scene.deselect() -> onClickCb(null) -> onClickMemory(null) at
+    LivingMap.tsx L180-183 -> setSelectedMemory(null)
+  All paths (Esc key, esc button, click empty space) terminate at
+    onClickMemory(null). That's where setLocalView(null) belongs.
+```
+
+## Scope
+
+### S1 — Extend `FilterState` with `localView`
+
+`ui/src/state/filterState.ts`:
+
+```typescript
+export interface LocalViewState {
+  /** Memory ID at the center of the focus. Guaranteed to exist in current
+   * memories at set-time (App.tsx setLocalView guards this). */
+  centerId: string;
+  /** N-hop depth from center. v1 default = 2. Hard-capped by helper at 5. */
+  depth: number;
+}
+
+export interface FilterState {
+  // ...existing fields...
+  /** v0.28+ — when non-null, deriveVisibleIds returns only memories within
+   * `depth` hops of `centerId` via the union of conflict-pairs +
+   * shared-tag-pairs. Composes with other filters (AND).
+   * VIEW state (composes with colorMode); resetFilters DOES clear it
+   * (matches "reset = back to full graph"). */
+  localView: LocalViewState | null;
+}
+
+export const INITIAL_FILTER_STATE: FilterState = {
+  // ...
+  localView: null,
+};
+```
+
+**`isFilterActive`** includes `if (state.localView !== null) return true;`. Same critical wire as E1 `fadingOnly` + E1 carefully NOT-included `colorMode`. Local view IS a filter (it hides memories); colorMode is NOT (it recolors).
+
+**`resetFilters`** clears localView alongside the other filter fields. Preserves frozen + colorMode (E1 carryover):
+```typescript
+const resetFilters = useCallback(() => {
+  setFilterState((prev) => ({
+    ...INITIAL_FILTER_STATE,
+    frozen: prev.frozen,
+    colorMode: prev.colorMode,
+    // localView IS reset (back to null) — matches user model
+  }));
+}, []);
+```
+
+**`deriveVisibleIds`** gains an optional `localNeighborhood?: Set<string>` arg (only one current caller — LivingMap.tsx L139 — verified safe to extend):
+
+```typescript
+export function deriveVisibleIds(
+  memories: Memory[],
+  state: FilterState,
+  localNeighborhood?: Set<string>,
+): Set<string> {
+  // ...existing per-memory filters...
+  if (state.localView !== null && localNeighborhood !== undefined
+      && !localNeighborhood.has(m.id)) continue;
+  // (safe degradation: if state.localView set but neighborhood undefined,
+  //  local-view filter silently skips — tested)
+  // ...
+}
+```
+
+### S2 — Pure helper: `computeLocalNeighborhood`
+
+NEW file `ui/src/engine/localNeighborhood.ts`:
+
+```typescript
+import type { Memory, Conflict } from "../types.js";
+
+export interface LocalViewResult {
+  /** The memory IDs to keep visible (always includes centerId). */
+  memoryIds: Set<string>;
+  /** The depth actually used. If the requested depth exceeded the
+   * neighborhood-size cap, the helper falls back to depth-1. */
+  depthUsed: number;
+  /** Set ONLY when the helper fell back from a higher depth. UI uses
+   * this to show the "showing depth-1 (X nodes); depth-2 would have
+   * shown Y" affordance. */
+  cappedFrom?: { requestedDepth: number; wouldHaveBeen: number };
+}
+
+export interface AdjacencyMap {
+  /** Pre-built undirected adjacency over the union of conflict-pairs +
+   * shared-tag-pairs. Hoisted to a useMemo in LivingMap so localView
+   * changes don't re-pay the build cost. */
+  get(id: string): ReadonlySet<string> | undefined;
+}
+
+const HARD_DEPTH_CAP = 5;       // sanity guard against bad input
+const NEIGHBORHOOD_CAP = 60;    // local view feels local only if <=60 nodes
+
+/**
+ * BFS from centerId via the prebuilt adjacency map. Pure + deterministic.
+ *
+ * Algorithm:
+ *   1. Init visited = new Set([centerId]); queue = [centerId]; depthOf = {centerId: 0}.
+ *   2. While queue: pop u, depth = depthOf[u]. If depth >= cap, continue.
+ *      For each v in adjacency.get(u) ?? []:
+ *        If v not in visited: visited.add(v); depthOf[v] = depth+1;
+ *        queue.push(v). (Mark visited on ENQUEUE, not dequeue.)
+ *   3. After BFS, if |visited| > NEIGHBORHOOD_CAP AND depth > 1:
+ *        Re-run at depth-1 (one recursive call); return result with cappedFrom set.
+ *      Else return {memoryIds: visited, depthUsed: depth}.
+ *
+ * Performance budget: <5ms on the live 1373-memory adjacency at depth=2.
+ * Adjacency build cost is hoisted to LivingMap useMemo (NOT measured here).
+ */
+export function computeLocalNeighborhood(
+  adjacency: AdjacencyMap,
+  centerId: string,
+  depth: number,
+): LocalViewResult { /* impl per algorithm above */ }
+
+/** Build adjacency from conflict-pairs (both directions) + shared-tag pairs. */
+export function buildAdjacency(
+  memories: readonly Memory[],
+  conflicts: readonly Conflict[],
+): AdjacencyMap { /* impl: union of conflict edges + computeSharedTagPairs */ }
+```
+
+### S3 — `deriveVisibleIds` composes `localView`
+
+Already covered in S1 — `deriveVisibleIds` gains optional `localNeighborhood` arg.
+
+### S4 — Scene: extend line visibility to filter both endpoints (Obsidian default)
+
+`ui/src/engine/scene.ts`:
+
+(a) **Store endpoint IDs on `line.userData` at build time** — merge into existing payload:
+- `buildConflictLines` (~L538): existing `line.userData = { status: c.status }` becomes `line.userData = { status: c.status, aId: c.memory_a_id, bId: c.memory_b_id }`.
+- `buildSharedTagEdges` (~L400): adds `line.userData = { aId: p.a, bId: p.b }` (currently no userData).
+
+(b) **Extend `setFiltered` — Obsidian default: BOTH endpoints must be visible:**
+
+```typescript
+setFiltered(visibleIds: Set<string>, filterActive: boolean): void {
+  for (const node of this.nodes) {
+    const visible = !filterActive || visibleIds.has(node.id);
+    node.mesh.visible = visible;
+    node.halo.visible = visible;
+  }
+  // v0.28+ E3 — Obsidian default: a line is visible ONLY when both endpoints
+  // are visible. Otherwise hide (no "frayed half-lines"; eliminates the
+  // reads-as-bug ambiguity flagged by plan-design-critic R1 HIGH).
+  // Includes tendrils for defensive future-proofing (currently bailed on
+  // n>500 so never built, but if E4 force-layout ever rebuilds them with
+  // ids on userData, the filter just works).
+  for (const line of [...this.conflictLines, ...this.sharedTagEdges, ...this.tendrils]) {
+    if (!filterActive) {
+      line.visible = true;
+      continue;
+    }
+    const ud = line.userData as { aId?: string; bId?: string };
+    if (!ud.aId || !ud.bId) {
+      // Lines without endpoint IDs (legacy tendrils) — keep visibility unchanged.
+      continue;
+    }
+    line.visible = visibleIds.has(ud.aId) && visibleIds.has(ud.bId);
+  }
+}
+```
+
+### S5 — LivingMap: hoisted adjacency + neighborhood + threading
+
+`ui/src/views/LivingMap/LivingMap.tsx`:
+
+```typescript
+// NEW: hoist adjacency build to a single useMemo per [memories, conflicts].
+// computeSharedTagPairs runs once per dataset change, NOT per localView change.
+const adjacency = useMemo(
+  () => buildAdjacency(memories, conflicts),
+  [memories, conflicts],
+);
+
+// NEW: compute neighborhood when localView is active. Cheap (BFS only,
+// <5ms on 1373) so the useMemo dep on filterState.localView is fine.
+const localNeighborhood = useMemo(() => {
+  if (!filterState.localView) return undefined;
+  return computeLocalNeighborhood(
+    adjacency,
+    filterState.localView.centerId,
+    filterState.localView.depth,
+  );
+}, [adjacency, filterState.localView]);
+
+const visibleIds = useMemo(
+  () => deriveVisibleIds(memories, filterState, localNeighborhood?.memoryIds),
+  [memories, filterState, localNeighborhood],
+);
+```
+
+**Esc wire fix — `setLocalView(null)` at convergence point:**
+```typescript
+const onClickMemory = useCallback((memory: Memory | null) => {
+  setSelectedMemory(memory);
+  setHoveredMemory(null);
+  if (memory === null) {
+    // ALL clear paths (Esc key via scene.deselect, esc button, empty-space
+    // click via scene.handleClick) terminate here with null. This is the
+    // single correct site for the localView-clear-on-deselect coupling.
+    setLocalView(null);
+  }
+}, [setLocalView]);
+```
+
+**LivingMapProps additions** (enumerated for typecheck safety):
+- `setLocalView: (v: LocalViewState | null) => void`
+
+`filterState.localView` already in `filterState`. Pass `localNeighborhood` to BottomBar for affordance (S8 below).
+
+`App.tsx` adds `setLocalView` with stale-guard:
+```typescript
+const setLocalView = useCallback((v: LocalViewState | null) => {
+  if (v !== null && !memories.some((m) => m.id === v.centerId)) {
+    // Stale centerId — silently no-op. UI should never trigger this
+    // (memories ref is stable per fetch), but guards against race during
+    // a refetch + click in the same tick.
+    return;
+  }
+  setFilterState((prev) => ({ ...prev, localView: v }));
+}, [memories]);
+```
+
+### S6 — DetailPanel: 3-label focus button + Esc semantics
+
+`LivingMap.tsx DetailPanel`: add a focus button in the existing flex header row (next to the layer dot/label on the left), NOT next to esc (avoids the visual conflation flagged by plan-design-critic):
+
+```tsx
+function FocusButton({ memory, localView, setLocalView }: {
+  memory: Memory;
+  localView: LocalViewState | null;
+  setLocalView: (v: LocalViewState | null) => void;
+}) {
+  const isCenter = localView?.centerId === memory.id;
+  const focusActive = localView !== null;
+  // Three states:
+  //   - no focus active     → "focus"          idle (grey)
+  //   - this IS the center  → "focused"        active (rust border+bg)
+  //   - focus on a different memory → "recenter here" (rust text only)
+  let label: string;
+  let style: React.CSSProperties;
+  if (isCenter) {
+    label = "focused";
+    style = { ...focusBtnStyleActive, cursor: "default" };
+  } else if (focusActive) {
+    label = "recenter here";
+    style = focusBtnStyleRecenter;
+  } else {
+    label = "focus";
+    style = focusBtnStyleIdle;
+  }
+  return (
+    <button
+      type="button"
+      aria-label={
+        isCenter ? "This memory is the focused center"
+        : focusActive ? "Recenter the focused view on this memory"
+        : "Focus the graph on this memory's neighborhood (depth 2)"
+      }
+      onClick={() => {
+        if (isCenter) return;
+        setLocalView({ centerId: memory.id, depth: 2 });
+      }}
+      style={style}
+    >
+      {label}
+    </button>
+  );
+}
+
+const focusBtnStyleIdle: React.CSSProperties = {
+  background: "var(--ink-faint)",
+  border: "1px solid var(--glass-border)",
+  color: "var(--dim)",
+  borderRadius: 4,
+  padding: "4px 12px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  cursor: "pointer",
+};
+const focusBtnStyleActive: React.CSSProperties = {
+  ...focusBtnStyleIdle,
+  background: "rgba(196, 92, 60, 0.18)", // alpha 0.18 not 0.10 per critic
+  border: "1px solid var(--accent)",
+  color: "var(--accent)",
+};
+const focusBtnStyleRecenter: React.CSSProperties = {
+  ...focusBtnStyleIdle,
+  background: "transparent",
+  border: "1px solid transparent",
+  color: "var(--accent)",
+};
+```
+
+Position in DetailPanel header (LivingMap.tsx ~L70):
+```tsx
+<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+  <div style={{ width: 8, height: 8, borderRadius: "50%", background: layerColor, boxShadow: `0 0 8px ${layerColor}40` }} />
+  <span>{memory.layer}</span>
+  <FocusButton memory={memory} localView={filterState.localView} setLocalView={setLocalView} />
+</div>
+```
+
+(Idle style distinct from existing esc button: focus has border, esc doesn't.)
+
+**Esc semantics — COMMITTED**: single press of Esc (or esc button or click-empty) clears BOTH selectedMemory AND localView. Wire is at `onClickMemory(null)` per S5. Stepped Esc deferred.
+
+### S7 — Tests
+
+NEW `ui/src/engine/localNeighborhood.test.ts`:
+- `buildAdjacency` correctness on conflict-only / shared-tag-only / mixed fixtures
+- `computeLocalNeighborhood`: centerId not in adjacency → `{memoryIds: Set([centerId]), depthUsed: 0}`
+- depth=0 → `{memoryIds: Set([centerId]), depthUsed: 0}`
+- depth=1 on 3-node line graph (A-B-C via conflicts), from A → `Set([A,B])`, depthUsed=1
+- depth=2 same graph → `Set([A,B,C])`, depthUsed=2
+- Triangle via shared tags → from any → `Set([A,B,C])`
+- Conflicts + shared-tags compose
+- Deterministic (same input → same output)
+- depth>=5 internally capped
+- **Cap behaviour**: build a star graph with centerId connected to 100 nodes at depth 1 → cap=60 triggers, but wait: depth=1 from center already returns 100. The cap is `>NEIGHBORHOOD_CAP AND depth>1` — at depth=1 we accept the result anyway (no smaller depth to fall back to). Test verifies this corner: depth=1 with 100 neighbors returns all 100, `depthUsed=1`, `cappedFrom` undefined.
+- **Cap behaviour 2**: depth=2 yields 80 nodes; cap triggers; falls back to depth=1 which yields 20 nodes; returns `{memoryIds: 20-node set, depthUsed: 1, cappedFrom: {requestedDepth: 2, wouldHaveBeen: 80}}`.
+- **Perf**: <5ms BFS at depth=2 on a synthesized 1373-memory + ~3000-edge adjacency. Adjacency build cost NOT counted (hoisted).
+
+Extend `ui/src/state/filterState.test.ts`:
+- INITIAL state has `localView === null`
+- `isFilterActive` true when only `localView` set
+- `resetFilters` clears `localView` (along with other filter fields)
+- `deriveVisibleIds` with `localView` set + non-null neighborhood returns intersection
+- `deriveVisibleIds` with `localView` set BUT undefined neighborhood silently skips
+- `localView` survives `setColorMode` changes (composes — both VIEW state) (Open Q#5)
+
+Extend `ui/src/components/BottomBar.test.tsx`:
+- Local view active appends ` · view = local (N)` to affordance string
+- Cap-fallback also appends ` (cap fell to depth 1)` indicator
+
+### S8 — BottomBar affordance update (NEW from R1 must-fix)
+
+`ui/src/components/BottomBar.tsx`: extend `EdgeCounts` prop OR add separate `localView` prop. Simpler: add `localView?: { size: number; cappedFrom?: number }` prop.
+
+```typescript
+export function buildAffordance(
+  colorMode: ColorMode,
+  edges: EdgeCounts | undefined,
+  localView?: { size: number; cappedFrom?: number },
+): string {
+  // ... existing parts ...
+  if (localView) {
+    const note = localView.cappedFrom
+      ? `view = local (${localView.size}, capped from ${localView.cappedFrom})`
+      : `view = local (${localView.size})`;
+    parts.push(note);
+  }
+  return parts.join(" · ");
+}
+```
+
+LivingMap passes the `localView` prop to BottomBar derived from `localNeighborhood`:
+```typescript
+<BottomBar
+  // ...existing...
+  localView={localNeighborhood ? {
+    size: localNeighborhood.memoryIds.size,
+    cappedFrom: localNeighborhood.cappedFrom?.wouldHaveBeen,
+  } : undefined}
+/>
+```
+
+### S9 — Neighborhood-size cap behaviour (NEW)
+
+Specified in S2 algorithm + AC. Hard cap = 60 nodes. If depth=2 result exceeds, fall back to depth=1, set `cappedFrom`. BottomBar surfaces. Depth slider for explicit expansion deferred to v0.3.0.
+
+## Acceptance criteria
+
+| # | Criterion | Verifies |
+|---|---|---|
+| AC1 | Clicking "focus" button when a memory is selected sets `localView = {centerId, depth:2}` and renders only the neighborhood | S5/S6 |
+| AC2 | Neighborhood = BFS from center over union of conflict pairs + shared-tag pairs | S2 |
+| AC3 | Esc key OR esc button OR click-empty-space ALL clear both selectedMemory AND localView (via onClickMemory(null) convergence) | S5/S6 |
+| AC4 | `resetFilters` clears localView (alongside other filter fields) | S1/S5 |
+| AC5 | `isFilterActive` returns true when localView is set | S1 |
+| AC6 | Conflict + shared-tag + tendril lines visible only when BOTH endpoints in visibleIds (Obsidian default) | S4 |
+| AC7 | Lines with one visible + one hidden endpoint are HIDDEN (no frayed half-lines) | S4 |
+| AC8 | `computeLocalNeighborhood` BFS <5ms at depth=2 on 1373-memory + 3000-edge synthesized adjacency | S2/S7 perf |
+| AC9 | If depth=2 neighborhood > 60 nodes, helper falls back to depth=1 with `cappedFrom` set | S2/S9 |
+| AC10 | Focus button has three labels (idle "focus" / center "focused" / non-center w/ active focus "recenter here") with distinct styles | S6 |
+| AC11 | BottomBar affordance shows ` · view = local (N)` (or `(N, capped from M)`) when localView active | S8 |
+| AC12 | App.tsx `setLocalView` guards stale centerId (no-op when centerId not in memories) | S5 |
+| AC13 | E1 + E2 features (color modes, conflict edges, shared-tag edges, BottomBar affordance) STILL work | regression |
+| AC14 | No test regressions: full `ui/` + repo-root suites green | regression |
+
+## Risks
+
+| # | Risk | Lik. | Mitigation |
+|---|---|---|---|
+| R1 | Adjacency build (one-time per memories/conflicts change) too slow | L | computeSharedTagPairs already tested <50ms on 500-fixture; on 1373 expect ~150ms one-shot. Acceptable — not on a hot loop. |
+| R2 | Neighborhood-cap fallback to depth-1 confuses users | M | BottomBar `cappedFrom` surfaces the math + names depth-1; affordance is the disambiguation surface |
+| R3 | Three-label focus button confuses users (label changes contextually) | M | aria-label provides screen-reader clarity; visual style distinct per state; manual visual smoke verifies |
+| R4 | Obsidian both-endpoints-must-be-visible hides edges that connect cluster boundary to off-frame structure | M | This is the established Obsidian convention; users expect it. If a future ticket wants the alt, add a Sidebar toggle in v0.3.0 |
+| R5 | Stale centerId still possible if memory deleted AFTER localView set (race) | L | App.tsx setLocalView guards SET-time; for delete-after-set, a useEffect over [memories, localView] can clear localView when centerId no longer present — added to S5 below |
+
+Adding stale-guard useEffect to S5:
+```typescript
+useEffect(() => {
+  if (filterState.localView && !memories.some(m => m.id === filterState.localView!.centerId)) {
+    setLocalView(null);
+  }
+}, [memories, filterState.localView]);
+```
+
+## Out of scope (named, deferred)
+
+- **Depth slider (1-3)** — hardcoded depth=2; v0.3.0
+- **Stepped Esc** (first clears focus, second clears selection) — single-press dual-clear committed; v0.3.0 if user wants separation
+- **Animated zoom-to-cluster** — v0.3.0 polish
+- **Breadcrumb history** (drill into a neighbor of a neighbor) — v0.3.0+
+- **Sidebar status row** for local view — BottomBar covers orientation; defer the Sidebar duplicate
+- **Edge-class toggle in local view** — defer
+- **Sidebar empty-state localView-aware variant** — stale guard makes this case unreachable; if it ever fires, generic empty-state is acceptable
+
+## Rollback
+
+Single PR:
+- Revert → `localView` field disappears, FocusButton + localNeighborhood + buildAdjacency removed, setFiltered reverts to spheres-only, BottomBar affordance loses local-view clause.
+- No DB change; no existing API removed.
+
+## Cost estimate
+
+- Coding: ~5-6 hours (filterState + 2 pure helpers + scene setFiltered extend + FocusButton + setLocalView stale-guard + BottomBar update + tests)
+- Critic rounds: ~1-1.5 hours
+- Visual smoke: ~30 min
+- Total: ~1.5 days (up from v1's ~1d after the 12 must-fix items folded in)
+
+## Resolved open questions (from v1)
+
+1. ~~Frayed-half-line: keep or switch?~~ → **Switch to Obsidian default (both endpoints visible to draw).**
+2. ~~Focus button position: header next to esc OR body?~~ → **Header LEFT next to layer label** (distinct from esc on the right; reduces conflation).
+3. ~~Default depth=2 too much on hub memories?~~ → **Cap at 60 nodes; fall back to depth-1.** BottomBar surfaces the cap.
+4. ~~Esc semantics: dual-clear or stepped?~~ → **Single-press dual-clear committed.** Stepped deferred.
+5. ~~localView survives colorMode change?~~ → **Yes, both VIEW state, compose.** Test covers.

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-brain-observatory",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import type { Memory, Stats, Conflict, EmbeddingIndex } from "./types.js";
 import { fetchMemories, fetchStats, fetchConflicts, fetchEmbeddings } from "./api/client.js";
 import { LivingMap } from "./views/LivingMap/LivingMap.js";
-import { INITIAL_FILTER_STATE, type FilterState, type Layer, type Confidence, type ColorMode } from "./state/filterState.js";
+import { INITIAL_FILTER_STATE, type FilterState, type Layer, type Confidence, type ColorMode, type LocalViewState } from "./state/filterState.js";
 
 /**
  * E5 S6 — Origin of the current freeze state. Lets the freeze button surface
@@ -92,6 +92,18 @@ export function App() {
   const setColorMode = useCallback((colorMode: ColorMode) => {
     setFilterState((prev) => ({ ...prev, colorMode }));
   }, []);
+
+  // v0.28+ (E3 local view) — focus-on-neighborhood setter. Guards stale
+  // centerId at set-time (no-op if memory was deleted in a race). A
+  // useEffect in LivingMap also clears localView if the memory is deleted
+  // AFTER set-time. Together they cover both windows. (plan-design-critic
+  // R1 must-fix #7.)
+  const setLocalView = useCallback((v: LocalViewState | null) => {
+    if (v !== null && !memories.some((m) => m.id === v.centerId)) {
+      return; // stale centerId — silently ignore
+    }
+    setFilterState((prev) => ({ ...prev, localView: v }));
+  }, [memories]);
 
   // v0.26.1 design-critic MED: auto-clear fadingOnly when at_risk drops to 0
   // (e.g. user pinned the last fading memory) so they're not stranded with
@@ -227,6 +239,7 @@ export function App() {
         setAgeMaxDays={setAgeMaxDays}
         setFadingOnly={setFadingOnly}
         setColorMode={setColorMode}
+        setLocalView={setLocalView}
         resetFilters={resetFilters}
       />
       {/* v0.26.1 — aria-live announcement for auto-clear (design-critic LOW). */}

--- a/ui/src/components/BottomBar.test.tsx
+++ b/ui/src/components/BottomBar.test.tsx
@@ -87,6 +87,46 @@ describe("buildAffordance (BottomBar dynamic copy)", () => {
   });
 });
 
+// v0.28+ (E3 local view) — affordance localView clause
+describe("buildAffordance + localView (v0.28+ E3)", () => {
+  it("local view active appends 'view = local (N)' to affordance", () => {
+    const copy = buildAffordance("layer", NO_EDGES, { size: 12 });
+    expect(copy).toBe("size = retrievals · opacity = strength · view = local (12)");
+  });
+
+  it("local view with cap-fallback appends 'view = local (N, capped from M)'", () => {
+    const copy = buildAffordance("layer", NO_EDGES, { size: 6, cappedFrom: 152 });
+    expect(copy).toBe("size = retrievals · opacity = strength · view = local (6, capped from 152)");
+  });
+
+  it("local view composes with color mode + edge counts", () => {
+    const copy = buildAffordance("tag",
+      { ...NO_EDGES, openConflicts: 3, resolvedConflicts: 5, sharedTag: 12 },
+      { size: 18 },
+    );
+    expect(copy).toBe(
+      "size = retrievals · opacity = strength · lines = conflicts (open) / conflicts (resolved) / shared tags · color = tag · view = local (18)",
+    );
+  });
+
+  it("no localView arg = no view clause (back-compat)", () => {
+    const copy = buildAffordance("layer", NO_EDGES);
+    expect(copy).toBe("size = retrievals · opacity = strength");
+    expect(copy).not.toContain("view = local");
+  });
+
+  it("localView clause appears BEFORE the bail hint when both apply", () => {
+    const copy = buildAffordance("layer",
+      { ...NO_EDGES, sharedTagBailed: true, sharedTag: 0 },
+      { size: 5 },
+    );
+    // affordance string ends with bail hint; view = local sits before it
+    expect(copy).toContain("view = local (5)");
+    expect(copy).toContain("filter to <500 for tag edges");
+    expect(copy.indexOf("view = local")).toBeLessThan(copy.indexOf("filter to <500"));
+  });
+});
+
 describe("BottomBar component", () => {
   it("renders the dynamic affordance string", () => {
     render(

--- a/ui/src/components/BottomBar.tsx
+++ b/ui/src/components/BottomBar.tsx
@@ -32,6 +32,14 @@ interface BottomBarProps {
    * Default = no-edges state for tests + back-compat.
    */
   edgeCounts?: EdgeCounts;
+  /**
+   * v0.28+ (E3 local view) — when local view is active, this carries
+   * the resulting neighborhood size + whether the depth-2 fallback
+   * triggered. Drives the `view = local (N)` (or `view = local (N,
+   * capped from M)`) clause in the affordance string. Default undefined
+   * = no local view = no clause (back-compat).
+   */
+  localView?: { size: number; cappedFrom?: number };
 }
 
 /**
@@ -42,6 +50,7 @@ interface BottomBarProps {
 export function buildAffordance(
   colorMode: ColorMode,
   edges: EdgeCounts | undefined,
+  localView?: { size: number; cappedFrom?: number },
 ): string {
   const parts: string[] = ["size = retrievals", "opacity = strength"];
 
@@ -54,6 +63,15 @@ export function buildAffordance(
   if (lineKinds.length > 0) parts.push(`lines = ${lineKinds.join(" / ")}`);
 
   if (colorMode !== "layer") parts.push(`color = ${colorMode}`);
+
+  // v0.28+ (E3 local view) — orientation cue when DetailPanel is closed.
+  // Matches the existing `size = retrievals` / `color = path` pattern.
+  if (localView) {
+    const note = localView.cappedFrom !== undefined
+      ? `view = local (${localView.size}, capped from ${localView.cappedFrom})`
+      : `view = local (${localView.size})`;
+    parts.push(note);
+  }
 
   let copy = parts.join(" · ");
 
@@ -88,8 +106,8 @@ const LAYERS: Array<{ key: keyof typeof LAYER_COLORS; label: string }> = [
   { key: "semantic", label: "semantic" },
 ];
 
-export function BottomBar({ drawerOpen, onToggleDrawer, visibleCount, colorMode = "layer", edgeCounts }: BottomBarProps) {
-  const affordance = buildAffordance(colorMode, edgeCounts);
+export function BottomBar({ drawerOpen, onToggleDrawer, visibleCount, colorMode = "layer", edgeCounts, localView }: BottomBarProps) {
+  const affordance = buildAffordance(colorMode, edgeCounts, localView);
   return (
     <div style={{
       position: "absolute",

--- a/ui/src/engine/localNeighborhood.test.ts
+++ b/ui/src/engine/localNeighborhood.test.ts
@@ -1,0 +1,269 @@
+/**
+ * v0.28+ (E3 local view) — buildAdjacency + computeLocalNeighborhood tests.
+ *
+ * Pure-helper tests (no WebGL). Cover the BFS correctness, depth-cap
+ * fallback, stale-centerId edge case, and the perf budget on a
+ * synthesized 1373-memory fixture.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { Memory, Conflict } from "../types.js";
+import { buildAdjacency, computeLocalNeighborhood } from "./localNeighborhood.js";
+
+function mem(over: Partial<Memory> & { id: string }): Memory {
+  return {
+    id: over.id,
+    content: over.content ?? `content-${over.id}`,
+    tags: over.tags ?? [],
+    layer: over.layer ?? "episodic",
+    strength: over.strength ?? 0.5,
+    half_life_days: over.half_life_days ?? 30,
+    retrieval_count: over.retrieval_count ?? 1,
+    schema_fit: over.schema_fit ?? 0.5,
+    emotional_valence: over.emotional_valence ?? "neutral",
+    confidence: over.confidence ?? "inferred",
+    pinned: over.pinned ?? false,
+    created: over.created ?? "2026-05-25T00:00:00Z",
+    last_retrieved: over.last_retrieved ?? "2026-05-25T00:00:00Z",
+    age_days: over.age_days ?? 1,
+    projected_strength_7d: over.projected_strength_7d ?? 0.5,
+    projected_strength_30d: over.projected_strength_30d ?? 0.5,
+  };
+}
+
+let _conflictId = 0;
+function conflict(a: string, b: string, status: "open" | "resolved" = "open"): Conflict {
+  return { id: ++_conflictId, memory_a_id: a, memory_b_id: b, reason: "test", score: 0.5, status };
+}
+
+describe("buildAdjacency", () => {
+  it("includes conflict edges in both directions", () => {
+    const memories: Memory[] = [mem({ id: "A" }), mem({ id: "B" })];
+    const conflicts = [conflict("A", "B")];
+    const adj = buildAdjacency(memories, conflicts);
+    expect(adj.get("A")).toEqual(new Set(["B"]));
+    expect(adj.get("B")).toEqual(new Set(["A"]));
+  });
+
+  it("includes shared-tag edges (>=2 non-path tags)", () => {
+    const memories: Memory[] = [
+      mem({ id: "A", tags: ["x", "y"] }),
+      mem({ id: "B", tags: ["x", "y"] }),
+    ];
+    const adj = buildAdjacency(memories, []);
+    expect(adj.get("A")?.has("B")).toBe(true);
+    expect(adj.get("B")?.has("A")).toBe(true);
+  });
+
+  it("unions conflict + shared-tag edges", () => {
+    const memories: Memory[] = [
+      mem({ id: "A", tags: ["x", "y"] }),
+      mem({ id: "B", tags: ["x", "y"] }),
+      mem({ id: "C" }),
+    ];
+    const adj = buildAdjacency(memories, [conflict("A", "C")]);
+    expect(adj.get("A")).toEqual(new Set(["B", "C"]));
+    expect(adj.get("C")).toEqual(new Set(["A"]));
+  });
+
+  it("path:* tags do not contribute to shared-tag adjacency", () => {
+    const memories: Memory[] = [
+      mem({ id: "A", tags: ["path:hippo", "path:foo"] }),
+      mem({ id: "B", tags: ["path:hippo", "path:foo"] }),
+    ];
+    const adj = buildAdjacency(memories, []);
+    expect(adj.size).toBe(0);
+  });
+});
+
+describe("computeLocalNeighborhood", () => {
+  it("centerId not in adjacency: returns {Set([centerId]), depthUsed=cappedDepth}", () => {
+    const adj = new Map();
+    const result = computeLocalNeighborhood(adj, "X", 2);
+    expect(result.memoryIds).toEqual(new Set(["X"]));
+    expect(result.cappedFrom).toBeUndefined();
+  });
+
+  it("depth=0 returns only the center", () => {
+    const adj = new Map([["A", new Set(["B"])]]);
+    const result = computeLocalNeighborhood(adj, "A", 0);
+    expect(result.memoryIds).toEqual(new Set(["A"]));
+    expect(result.depthUsed).toBe(0);
+  });
+
+  it("depth=1 over a 3-node line graph A-B-C from A returns {A, B}", () => {
+    const adj = new Map<string, Set<string>>([
+      ["A", new Set(["B"])],
+      ["B", new Set(["A", "C"])],
+      ["C", new Set(["B"])],
+    ]);
+    const result = computeLocalNeighborhood(adj, "A", 1);
+    expect(result.memoryIds).toEqual(new Set(["A", "B"]));
+    expect(result.depthUsed).toBe(1);
+  });
+
+  it("depth=2 over a 3-node line graph A-B-C from A returns {A, B, C}", () => {
+    const adj = new Map<string, Set<string>>([
+      ["A", new Set(["B"])],
+      ["B", new Set(["A", "C"])],
+      ["C", new Set(["B"])],
+    ]);
+    const result = computeLocalNeighborhood(adj, "A", 2);
+    expect(result.memoryIds).toEqual(new Set(["A", "B", "C"]));
+    expect(result.depthUsed).toBe(2);
+  });
+
+  it("triangle (A-B-C all connected) from any node returns all 3", () => {
+    const adj = new Map<string, Set<string>>([
+      ["A", new Set(["B", "C"])],
+      ["B", new Set(["A", "C"])],
+      ["C", new Set(["A", "B"])],
+    ]);
+    expect(computeLocalNeighborhood(adj, "A", 1).memoryIds).toEqual(new Set(["A", "B", "C"]));
+    expect(computeLocalNeighborhood(adj, "B", 2).memoryIds).toEqual(new Set(["A", "B", "C"]));
+  });
+
+  it("deterministic: same input -> same output", () => {
+    const adj = new Map<string, Set<string>>([
+      ["A", new Set(["B"])],
+      ["B", new Set(["A", "C"])],
+      ["C", new Set(["B"])],
+    ]);
+    const r1 = computeLocalNeighborhood(adj, "B", 2);
+    const r2 = computeLocalNeighborhood(adj, "B", 2);
+    expect([...r1.memoryIds].sort()).toEqual([...r2.memoryIds].sort());
+  });
+
+  it("depth >= HARD_DEPTH_CAP (5) is internally capped", () => {
+    // 7-node line; depth=10 capped at 5, so only 6 nodes reachable
+    const adj = new Map<string, Set<string>>([
+      ["A", new Set(["B"])],
+      ["B", new Set(["A", "C"])],
+      ["C", new Set(["B", "D"])],
+      ["D", new Set(["C", "E"])],
+      ["E", new Set(["D", "F"])],
+      ["F", new Set(["E", "G"])],
+      ["G", new Set(["F"])],
+    ]);
+    const result = computeLocalNeighborhood(adj, "A", 10);
+    // depth capped at 5; A->B->C->D->E->F is 5 hops = 6 nodes
+    expect(result.memoryIds.size).toBe(6);
+    expect(result.depthUsed).toBe(5);
+  });
+
+  describe("neighborhood cap fallback (plan-design R1 must-fix #4)", () => {
+    it("depth=1 with 100 neighbors returns all 100 (no fallback available)", () => {
+      // Star: center connected to 100 leaves at depth 1
+      const adj = new Map<string, Set<string>>();
+      const leaves = new Set<string>();
+      for (let i = 0; i < 100; i++) leaves.add(`leaf-${i}`);
+      adj.set("center", leaves);
+      for (const leaf of leaves) adj.set(leaf, new Set(["center"]));
+
+      const result = computeLocalNeighborhood(adj, "center", 1);
+      // depth=1, can't fall back lower; accept the result
+      expect(result.memoryIds.size).toBe(101);
+      expect(result.depthUsed).toBe(1);
+      expect(result.cappedFrom).toBeUndefined();
+    });
+
+    it("depth=2 with >60 nodes falls back to depth=1 with cappedFrom set", () => {
+      // Center connected to 5 hubs at depth 1; each hub connected to 20
+      // distinct leaves at depth 2. Total depth-2 = 1+5+100 = 106; depth-1 = 6.
+      const adj = new Map<string, Set<string>>();
+      const hubs = ["h1", "h2", "h3", "h4", "h5"];
+      adj.set("center", new Set(hubs));
+      for (const hub of hubs) {
+        const hubNeighbors = new Set<string>(["center"]);
+        for (let i = 0; i < 20; i++) {
+          const leaf = `${hub}-leaf-${i}`;
+          hubNeighbors.add(leaf);
+          adj.set(leaf, new Set([hub]));
+        }
+        adj.set(hub, hubNeighbors);
+      }
+
+      const result = computeLocalNeighborhood(adj, "center", 2);
+      // 106 > 60 -> fall back to depth=1
+      expect(result.depthUsed).toBe(1);
+      expect(result.memoryIds.size).toBe(6); // center + 5 hubs
+      expect(result.cappedFrom).toBeDefined();
+      expect(result.cappedFrom?.requestedDepth).toBe(2);
+      expect(result.cappedFrom?.wouldHaveBeen).toBe(106);
+    });
+
+    it("depth=2 with <60 nodes does not fall back", () => {
+      // Center -> 3 hubs -> 3 leaves each. Depth-2 = 1+3+9 = 13.
+      const adj = new Map<string, Set<string>>();
+      const hubs = ["h1", "h2", "h3"];
+      adj.set("center", new Set(hubs));
+      for (const hub of hubs) {
+        const hubNeighbors = new Set<string>(["center"]);
+        for (let i = 0; i < 3; i++) {
+          const leaf = `${hub}-leaf-${i}`;
+          hubNeighbors.add(leaf);
+          adj.set(leaf, new Set([hub]));
+        }
+        adj.set(hub, hubNeighbors);
+      }
+
+      const result = computeLocalNeighborhood(adj, "center", 2);
+      expect(result.depthUsed).toBe(2);
+      expect(result.memoryIds.size).toBe(13);
+      expect(result.cappedFrom).toBeUndefined();
+    });
+  });
+
+  describe("performance (AC8)", () => {
+    it("BFS <5ms at depth=2 on a synthesized 1373-memory + ~3000-edge adjacency", () => {
+      // Build a realistic-ish adjacency: 1373 nodes, each with 2-5 random
+      // neighbors. Total edges ~3000-4000.
+      const adj = new Map<string, Set<string>>();
+      const N = 1373;
+      const rng = mulberry32(42);
+      for (let i = 0; i < N; i++) {
+        const id = `m${i}`;
+        const degree = 2 + Math.floor(rng() * 4); // 2-5 neighbors
+        const neighbors = new Set<string>();
+        while (neighbors.size < degree) {
+          const j = Math.floor(rng() * N);
+          if (j !== i) neighbors.add(`m${j}`);
+        }
+        adj.set(id, neighbors);
+      }
+      // Symmetrize
+      for (const [u, nbrs] of adj) {
+        for (const v of nbrs) {
+          let vSet = adj.get(v);
+          if (!vSet) {
+            vSet = new Set();
+            adj.set(v, vSet);
+          }
+          (vSet as Set<string>).add(u);
+        }
+      }
+
+      const runs: number[] = [];
+      for (let r = 0; r < 3; r++) {
+        const t0 = performance.now();
+        computeLocalNeighborhood(adj, "m0", 2);
+        runs.push(performance.now() - t0);
+      }
+      const avg = runs.reduce((a, b) => a + b, 0) / runs.length;
+      expect(avg).toBeLessThan(5);
+    });
+  });
+});
+
+// Deterministic seeded RNG for reproducible perf tests
+function mulberry32(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s |= 0;
+    s = (s + 0x6d2b79f5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/ui/src/engine/localNeighborhood.ts
+++ b/ui/src/engine/localNeighborhood.ts
@@ -1,0 +1,147 @@
+/**
+ * v0.28+ (E3 local graph view) — pure helper for the "Focus on
+ * neighborhood" feature.
+ *
+ * Two responsibilities:
+ *   1. `buildAdjacency` — combines conflict pairs + shared-tag pairs into
+ *      an undirected adjacency map. Hoisted to a useMemo in LivingMap so
+ *      it rebuilds only when `memories` or `conflicts` change (not per
+ *      localView toggle).
+ *   2. `computeLocalNeighborhood` — BFS from `centerId` depth-limited,
+ *      with a hard cap on neighborhood size (60 nodes; falls back to
+ *      depth-1 if exceeded).
+ *
+ * Pure + deterministic. Same inputs => same outputs across calls.
+ */
+
+import type { Memory, Conflict } from "../types.js";
+import { computeSharedTagPairs } from "./sharedTagPairs.js";
+
+/** Sanity guard against bad input. v1 default depth=2; this prevents
+ * catastrophic BFS on a degenerate caller passing depth=999. */
+const HARD_DEPTH_CAP = 5;
+/** When BFS at requested depth yields > NEIGHBORHOOD_CAP, fall back to
+ * depth-1. "Local" view ceases to feel local above ~60 nodes per
+ * plan-design-critic R1 HIGH. */
+const NEIGHBORHOOD_CAP = 60;
+
+export interface LocalViewResult {
+  /** The memory IDs to keep visible. Always includes centerId. */
+  memoryIds: Set<string>;
+  /** The depth actually used. May be less than requested if the cap
+   * triggered a depth-1 fallback. */
+  depthUsed: number;
+  /** Set ONLY when the helper fell back from a higher requested depth.
+   * BottomBar uses this to show the "view = local (N, capped from M)"
+   * hint so the user understands why their depth-2 click produced fewer
+   * nodes than expected. */
+  cappedFrom?: { requestedDepth: number; wouldHaveBeen: number };
+}
+
+/**
+ * Undirected adjacency over the union of conflict-pairs + shared-tag
+ * pairs. Built once per (memories, conflicts) change in LivingMap.tsx.
+ */
+export type AdjacencyMap = ReadonlyMap<string, ReadonlySet<string>>;
+
+/** Build adjacency from conflicts (both directions) + shared-tag pairs
+ * (computeSharedTagPairs from E2 — tiered cap-bounded, callable on
+ * any-n memories). */
+export function buildAdjacency(
+  memories: readonly Memory[],
+  conflicts: readonly Conflict[],
+): AdjacencyMap {
+  const adj = new Map<string, Set<string>>();
+  const link = (a: string, b: string): void => {
+    if (a === b) return;
+    let s = adj.get(a);
+    if (s === undefined) {
+      s = new Set();
+      adj.set(a, s);
+    }
+    s.add(b);
+  };
+
+  // Conflict edges — both directions.
+  for (const c of conflicts) {
+    link(c.memory_a_id, c.memory_b_id);
+    link(c.memory_b_id, c.memory_a_id);
+  }
+
+  // Shared-tag edges — same tiered-cap options as scene.buildSharedTagEdges
+  // so the local-view adjacency matches what the canvas renders.
+  const sharedPairs = computeSharedTagPairs(memories, {
+    excludePrefix: "path:",
+    softCap: 50,
+    hardCap: 300,
+    perTagTopK: 15,
+    minShared: 2,
+  });
+  for (const p of sharedPairs) {
+    link(p.a, p.b);
+    link(p.b, p.a);
+  }
+
+  return adj;
+}
+
+/**
+ * BFS from `centerId` over the prebuilt adjacency. Returns the visited
+ * set + depth used + cap-fallback metadata.
+ *
+ * Algorithm:
+ *   - Visited marked on ENQUEUE (not dequeue) so well-connected hubs
+ *     don't re-expand. (plan-eng-critic R1 MED.)
+ *   - depth capped at HARD_DEPTH_CAP=5 internally.
+ *   - If visited.size > NEIGHBORHOOD_CAP AND depth > 1: re-run at
+ *     depth-1 (single recursive call). Returns the smaller result with
+ *     cappedFrom set so the UI can surface "(N, capped from M)".
+ *
+ * Performance: BFS is O(V+E) over adjacency; on the live 1373-memory
+ * fixture with ~1117 conflicts + ~1000 shared-tag pairs, expect <5ms at
+ * depth=2. Adjacency build cost is not part of this budget (hoisted).
+ */
+export function computeLocalNeighborhood(
+  adjacency: AdjacencyMap,
+  centerId: string,
+  depth: number,
+): LocalViewResult {
+  const cappedDepth = Math.min(Math.max(0, depth), HARD_DEPTH_CAP);
+  const visited = bfs(adjacency, centerId, cappedDepth);
+
+  if (visited.size > NEIGHBORHOOD_CAP && cappedDepth > 1) {
+    // Cap triggered — fall back to depth-1 and report the would-have-been.
+    const fallback = bfs(adjacency, centerId, 1);
+    return {
+      memoryIds: fallback,
+      depthUsed: 1,
+      cappedFrom: { requestedDepth: cappedDepth, wouldHaveBeen: visited.size },
+    };
+  }
+  return {
+    memoryIds: visited,
+    depthUsed: cappedDepth,
+  };
+}
+
+/** Pure BFS: visited-on-enqueue, depth-limited, always includes centerId. */
+function bfs(adjacency: AdjacencyMap, centerId: string, depth: number): Set<string> {
+  const visited = new Set<string>([centerId]);
+  if (depth <= 0) return visited;
+  let frontier: string[] = [centerId];
+  for (let d = 0; d < depth; d++) {
+    const next: string[] = [];
+    for (const u of frontier) {
+      const neighbors = adjacency.get(u);
+      if (!neighbors) continue;
+      for (const v of neighbors) {
+        if (visited.has(v)) continue;
+        visited.add(v); // mark on ENQUEUE
+        next.push(v);
+      }
+    }
+    if (next.length === 0) break;
+    frontier = next;
+  }
+  return visited;
+}

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -400,6 +400,10 @@ export class BrainScene {
         depthWrite: false,
       });
       const line = new THREE.Line(geo, mat);
+      // v0.28+ (E3) — endpoint IDs on userData so setFiltered's
+      // both-endpoints-visible check can hide cross-region lines under
+      // local view.
+      line.userData = { aId: p.a, bId: p.b };
       this.scene.add(line);
       this.sharedTagEdges.push(line);
     }
@@ -546,7 +550,10 @@ export class BrainScene {
       line.computeLineDistances();
       // v0.28 (E2) — stash status on userData so getEdgeCounts() can count
       // open vs resolved without re-querying the source array.
-      line.userData = { status: c.status };
+      // v0.28+ (E3) — also stash endpoint IDs so setFiltered's
+      // both-endpoints-visible check can hide cross-region lines under
+      // local view.
+      line.userData = { status: c.status, aId: c.memory_a_id, bId: c.memory_b_id };
       this.scene.add(line);
       this.conflictLines.push(line);
     }
@@ -758,6 +765,25 @@ export class BrainScene {
       const visible = !filterActive || visibleIds.has(node.id);
       node.mesh.visible = visible;
       node.halo.visible = visible;
+    }
+    // v0.28+ (E3 local view) — Obsidian default: a line is visible ONLY
+    // when both endpoints are visible. No "frayed half-lines" — eliminates
+    // the reads-as-bug ambiguity flagged by plan-design-critic R1.
+    // Tendrils included for defensive future-proofing (currently bailed at
+    // n>500 so never built; when E4 force-layout populates them with
+    // aId/bId on userData, this filter just works).
+    for (const line of [...this.conflictLines, ...this.sharedTagEdges, ...this.tendrils]) {
+      if (!filterActive) {
+        line.visible = true;
+        continue;
+      }
+      const ud = line.userData as { aId?: string; bId?: string };
+      if (!ud.aId || !ud.bId) {
+        // Lines without endpoint IDs (legacy tendrils today) — keep
+        // visibility unchanged so we don't accidentally hide them.
+        continue;
+      }
+      line.visible = visibleIds.has(ud.aId) && visibleIds.has(ud.bId);
     }
   }
 

--- a/ui/src/state/filterState.test.ts
+++ b/ui/src/state/filterState.test.ts
@@ -258,6 +258,74 @@ describe("deriveVisibleIds + fadingOnly (v0.26.1)", () => {
 });
 
 // v0.27 — colorMode is VIEW state, not a filter. Plan v3 S1.
+// v0.28+ (E3 local view)
+describe("localView + isFilterActive + deriveVisibleIds (v0.28+ E3)", () => {
+  it("INITIAL state has localView === null", () => {
+    expect(INITIAL_FILTER_STATE.localView).toBeNull();
+  });
+
+  it("isFilterActive returns true when only localView is set", () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, localView: { centerId: "A", depth: 2 } };
+    expect(isFilterActive(state)).toBe(true);
+  });
+
+  it("localView survives a colorMode change (both VIEW state, compose)", () => {
+    const state1: FilterState = { ...INITIAL_FILTER_STATE, localView: { centerId: "A", depth: 2 }, colorMode: "layer" };
+    const state2: FilterState = { ...state1, colorMode: "tag" };
+    expect(state2.localView).toEqual({ centerId: "A", depth: 2 });
+    expect(isFilterActive(state2)).toBe(true);
+  });
+
+  it("deriveVisibleIds with localView + neighborhood returns intersection", () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, localView: { centerId: "A", depth: 1 } };
+    const neighborhood = new Set<string>(["A", "B"]);
+    expect(ids(deriveVisibleIds(FIXTURE, state, neighborhood))).toEqual(["A", "B"]);
+  });
+
+  it("deriveVisibleIds with localView set but undefined neighborhood: silently skips (safe degradation)", () => {
+    const state: FilterState = { ...INITIAL_FILTER_STATE, localView: { centerId: "A", depth: 1 } };
+    // No neighborhood arg -> filter skips, returns all (only localView is active)
+    expect(ids(deriveVisibleIds(FIXTURE, state, undefined))).toEqual(["A", "B", "C", "D", "E"]);
+  });
+
+  it("deriveVisibleIds without localView ignores neighborhood arg", () => {
+    const neighborhood = new Set<string>(["A"]);
+    expect(ids(deriveVisibleIds(FIXTURE, INITIAL_FILTER_STATE, neighborhood)).length).toBe(5);
+  });
+
+  it("resetFilters clears localView (plan AC4)", () => {
+    // Simulate the App.tsx resetFilters pattern: spread INITIAL with
+    // preserved frozen + colorMode. Since INITIAL.localView is null, the
+    // spread MUST clear localView regardless of prior value.
+    const stateWithFocus: FilterState = {
+      ...INITIAL_FILTER_STATE,
+      localView: { centerId: "A", depth: 2 },
+      colorMode: "tag",
+      frozen: true,
+    };
+    const resetState: FilterState = {
+      ...INITIAL_FILTER_STATE,
+      frozen: stateWithFocus.frozen,
+      colorMode: stateWithFocus.colorMode,
+    };
+    expect(resetState.localView).toBeNull();
+    expect(resetState.colorMode).toBe("tag");
+    expect(resetState.frozen).toBe(true);
+    expect(isFilterActive(resetState)).toBe(false);
+  });
+
+  it("localView + other filter composes (AND)", () => {
+    const state: FilterState = {
+      ...INITIAL_FILTER_STATE,
+      localView: { centerId: "A", depth: 1 },
+      layers: new Set(["episodic"]),
+    };
+    const neighborhood = new Set<string>(["A", "C", "D"]);
+    // A is buffer (excluded by layer filter); C is episodic; D is episodic
+    expect(ids(deriveVisibleIds(FIXTURE, state, neighborhood))).toEqual(["C", "D"]);
+  });
+});
+
 describe("colorMode + isFilterActive (v0.27)", () => {
   it("INITIAL state has colorMode = 'layer'", () => {
     expect(INITIAL_FILTER_STATE.colorMode).toBe("layer");

--- a/ui/src/state/filterState.ts
+++ b/ui/src/state/filterState.ts
@@ -23,6 +23,21 @@ export type Confidence = "verified" | "observed" | "inferred" | "stale";
  */
 export type ColorMode = "layer" | "tag" | "path";
 
+/**
+ * v0.28+ (E3 local view) — when set, scene + Sidebar derive visibleIds
+ * intersected with the N-hop neighborhood of `centerId`. View AND filter
+ * state (it composes with other filters AND hides memories); included in
+ * isFilterActive and CLEARED by resetFilters.
+ */
+export interface LocalViewState {
+  /** Memory ID at the center of the focus. App.tsx setLocalView guards
+   * that this exists in current memories at set-time; a useEffect in
+   * LivingMap also clears it if the memory is later deleted. */
+  centerId: string;
+  /** N-hop depth from center. v1 default = 2. Hard-capped by helper at 5. */
+  depth: number;
+}
+
 export interface FilterState {
   /** E2 — search input substring; matched against content + tags. */
   query: string;
@@ -48,6 +63,14 @@ export interface FilterState {
    * choice.
    */
   colorMode: ColorMode;
+  /**
+   * v0.28+ (E3 local view) — when non-null, deriveVisibleIds intersects
+   * with the N-hop neighborhood of centerId via explicit edges (conflicts
+   * + shared-tag pairs). IS a filter (hides memories), so DOES appear in
+   * isFilterActive AND is cleared by resetFilters. Composes with colorMode
+   * (both VIEW state).
+   */
+  localView: LocalViewState | null;
 }
 
 export const INITIAL_FILTER_STATE: FilterState = {
@@ -59,6 +82,7 @@ export const INITIAL_FILTER_STATE: FilterState = {
   frozen: false,
   fadingOnly: false,
   colorMode: "layer",
+  localView: null,
 };
 
 /**
@@ -99,6 +123,10 @@ export function isFilterActive(state: FilterState): boolean {
   // no-op the engine + Sidebar + BottomBar + Drawer + TagCloud which all
   // gate on filterActive (plan-eng-critic R1 HIGH #1).
   if (state.fadingOnly) return true;
+  // v0.28+ (E3) — local view IS a filter (hides memories outside the
+  // N-hop neighborhood). Same trap as fadingOnly: without this branch,
+  // line-visibility extension in scene.setFiltered would silently no-op.
+  if (state.localView !== null) return true;
   return false;
 }
 
@@ -124,7 +152,19 @@ export function matchesQuery(memory: { content: string; tags: string[] }, q: str
  * for now (LivingMap.tsx still derives matchCount inline for the header
  * pill). E3 PR will unify both paths through this function.
  */
-export function deriveVisibleIds(memories: Memory[], state: FilterState): Set<string> {
+export function deriveVisibleIds(
+  memories: Memory[],
+  state: FilterState,
+  /**
+   * v0.28+ (E3 local view) — when state.localView is set AND this Set is
+   * provided, filter memories to those in the neighborhood. Caller
+   * (LivingMap) builds this via computeLocalNeighborhood + useMemo so
+   * deriveVisibleIds stays pure. If state.localView is set but this is
+   * undefined, the local-view filter silently skips (safe degradation;
+   * tested).
+   */
+  localNeighborhood?: Set<string>,
+): Set<string> {
   const ids = new Set<string>();
   const filterLayers = state.layers.size > 0;
   const filterConfidences = state.confidences.size > 0;
@@ -139,6 +179,10 @@ export function deriveVisibleIds(memories: Memory[], state: FilterState): Set<st
     if (filterStrength && (m.strength < strMin || m.strength > strMax)) continue;
     if (filterAge && state.ageMaxDays !== null && m.age_days > state.ageMaxDays) continue;
     if (state.fadingOnly && !isFading(m)) continue;
+    // v0.28+ (E3) — local-view filter. Only apply when both the state flag
+    // AND the neighborhood Set are present (safe degradation otherwise).
+    if (state.localView !== null && localNeighborhood !== undefined
+        && !localNeighborhood.has(m.id)) continue;
     ids.add(m.id);
   }
   return ids;

--- a/ui/src/views/LivingMap/LivingMap.tsx
+++ b/ui/src/views/LivingMap/LivingMap.tsx
@@ -17,9 +17,11 @@ import {
   type Layer,
   type Confidence,
   type ColorMode,
+  type LocalViewState,
 } from "../../state/filterState.js";
 import type { BrainScene } from "../../engine/scene.js";
 import { pickColorTag } from "../../engine/tagPalette.js";
+import { buildAdjacency, computeLocalNeighborhood } from "../../engine/localNeighborhood.js";
 
 interface LivingMapProps {
   memories: Memory[];
@@ -38,6 +40,8 @@ interface LivingMapProps {
   setFadingOnly: (v: boolean) => void;
   /** v0.27 color-by-tag — drives ViewPanel segmented radio. */
   setColorMode: (mode: ColorMode) => void;
+  /** v0.28+ (E3 local view) — set/clear focus on a memory's neighborhood. */
+  setLocalView: (v: LocalViewState | null) => void;
   resetFilters: () => void;
 }
 
@@ -52,7 +56,85 @@ function StrengthBar({ value }: { value: number }) {
   );
 }
 
-function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose: () => void; open: boolean }) {
+/**
+ * v0.28+ (E3 local view) — three-label button.
+ * - idle (no focus active): "focus"
+ * - this memory IS the focus center: "focused" (rust accent, non-interactive)
+ * - focus active on a different memory: "recenter here" (rust text)
+ *
+ * Styling distinct from the esc button (border vs no border, position
+ * LEFT next to layer label vs esc on RIGHT) so the two buttons don't
+ * read as a single segmented control (plan-design-critic R1 must-fix #5).
+ */
+function FocusButton({ memory, localView, setLocalView }: {
+  memory: Memory;
+  localView: LocalViewState | null;
+  setLocalView: (v: LocalViewState | null) => void;
+}) {
+  const isCenter = localView?.centerId === memory.id;
+  const focusActive = localView !== null;
+  let label: string;
+  let style: React.CSSProperties;
+  let aria: string;
+  if (isCenter) {
+    label = "focused";
+    style = { ...focusBtnStyleActive, cursor: "default" };
+    aria = "This memory is the focused center";
+  } else if (focusActive) {
+    label = "recenter here";
+    style = focusBtnStyleRecenter;
+    aria = "Recenter the focused view on this memory";
+  } else {
+    label = "focus";
+    style = focusBtnStyleIdle;
+    aria = "Focus the graph on this memory's neighborhood (depth 2)";
+  }
+  return (
+    <button
+      type="button"
+      aria-label={aria}
+      title={aria}
+      onClick={() => {
+        if (isCenter) return;
+        setLocalView({ centerId: memory.id, depth: 2 });
+      }}
+      style={style}
+    >
+      {label}
+    </button>
+  );
+}
+
+const focusBtnStyleIdle: React.CSSProperties = {
+  background: "var(--ink-faint)",
+  border: "1px solid var(--glass-border)",
+  color: "var(--dim)",
+  borderRadius: 4,
+  padding: "4px 12px",
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  cursor: "pointer",
+};
+const focusBtnStyleActive: React.CSSProperties = {
+  ...focusBtnStyleIdle,
+  background: "rgba(196, 92, 60, 0.18)",
+  border: "1px solid var(--accent)",
+  color: "var(--accent)",
+};
+const focusBtnStyleRecenter: React.CSSProperties = {
+  ...focusBtnStyleIdle,
+  background: "transparent",
+  border: "1px solid transparent",
+  color: "var(--accent)",
+};
+
+function DetailPanel({ memory, onClose, open, localView, setLocalView }: {
+  memory: Memory | null;
+  onClose: () => void;
+  open: boolean;
+  localView: LocalViewState | null;
+  setLocalView: (v: LocalViewState | null) => void;
+}) {
   if (!memory && !open) return null;
   const layerColor = memory ? LAYER_COLORS[memory.layer] : "var(--accent)";
 
@@ -73,6 +155,9 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
             <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
               <div style={{ width: 8, height: 8, borderRadius: "50%", background: layerColor, boxShadow: `0 0 8px ${layerColor}40` }} />
               <span style={{ color: "var(--dim)", fontSize: 10, fontFamily: "var(--font-mono)", letterSpacing: "0.5px", textTransform: "uppercase" }}>{memory.layer}</span>
+              {/* v0.28+ (E3) — Focus button. Position LEFT (with layer label),
+                  distinct from esc on right. */}
+              <FocusButton memory={memory} localView={localView} setLocalView={setLocalView} />
             </div>
             <button onClick={onClose} style={{
               background: "var(--ink-faint)", border: "none", borderRadius: 4,
@@ -124,7 +209,7 @@ function DetailPanel({ memory, onClose, open }: { memory: Memory | null; onClose
 export function LivingMap({
   memories, embeddings, stats, conflicts, filterState, frozenOrigin,
   setQuery, setFrozen, setLayers, setStrengthRange, setConfidences, setAgeMaxDays, setFadingOnly,
-  setColorMode, resetFilters,
+  setColorMode, setLocalView, resetFilters,
 }: LivingMapProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
@@ -134,9 +219,46 @@ export function LivingMap({
   // FilterState (FilterState is for data filters, not viewport chrome).
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // v0.28+ (E3 local view) — hoist adjacency build to a single useMemo per
+  // [memories, conflicts]. computeSharedTagPairs runs once per dataset
+  // change, NOT per localView change. (plan-eng-critic R1 must-fix #3.)
+  const adjacency = useMemo(
+    () => buildAdjacency(memories, conflicts),
+    [memories, conflicts],
+  );
+
+  // v0.28+ (E3) — compute neighborhood only when localView is active.
+  // Cheap (BFS only, <5ms on 1373) so the dep on filterState.localView is fine.
+  const localNeighborhood = useMemo(() => {
+    if (!filterState.localView) return undefined;
+    return computeLocalNeighborhood(
+      adjacency,
+      filterState.localView.centerId,
+      filterState.localView.depth,
+    );
+  }, [adjacency, filterState.localView]);
+
+  // v0.28+ (E3) — stale-guard: if the centerId memory was deleted AFTER
+  // setLocalView was called (race between refetch + previous click), clear
+  // localView. setLocalView's identity churns on memory refetch (App.tsx
+  // useCallback deps include [memories]) — eslint-disable is correct
+  // anyway: the effect already re-runs on [memories, localView] and closes
+  // over the latest setLocalView at each render.
+  useEffect(() => {
+    if (filterState.localView && !memories.some((m) => m.id === filterState.localView!.centerId)) {
+      setLocalView(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memories, filterState.localView]);
+
   // E3: derive the visible-id set once per render so Sidebar (tag cloud +
   // stats) and the scene filter wiring share the same source of truth.
-  const visibleIds = useMemo(() => deriveVisibleIds(memories, filterState), [memories, filterState]);
+  // v0.28+ (E3 local view) — passes localNeighborhood.memoryIds (if set)
+  // so deriveVisibleIds composes the local-view filter.
+  const visibleIds = useMemo(
+    () => deriveVisibleIds(memories, filterState, localNeighborhood?.memoryIds),
+    [memories, filterState, localNeighborhood],
+  );
 
   // E4 proper: code-review-critic HIGH #1 — disambiguate "no filter" from
   // "filter matched zero". Passed to useCanvasEngine + Sidebar.
@@ -180,7 +302,14 @@ export function LivingMap({
   const onClickMemory = useCallback((memory: Memory | null) => {
     setSelectedMemory(memory);
     setHoveredMemory(null);
-  }, []);
+    // v0.28+ (E3 local view) — Esc-clears-both wire. ALL selection-clear
+    // paths (Escape key via scene.deselect, esc button via DetailPanel
+    // onClose, click-empty-space via scene.handleClick) terminate here
+    // with null. Plan v2 S5 / AC3.
+    if (memory === null) {
+      setLocalView(null);
+    }
+  }, [setLocalView]);
 
   const { containerRef, handleMouseMove, handleClick, handleKeyDown, edgeCounts } = useCanvasEngine({
     memories, embeddings, conflicts, width: size.width, height: size.height,
@@ -313,7 +442,19 @@ export function LivingMap({
         />
       )}
 
-      <DetailPanel memory={selectedMemory} onClose={() => setSelectedMemory(null)} open={panelOpen} />
+      <DetailPanel
+        memory={selectedMemory}
+        onClose={() => {
+          setSelectedMemory(null);
+          // v0.28+ (E3) — esc-button-click path ALSO clears localView,
+          // mirroring the Esc-key + empty-space-click paths that go
+          // through onClickMemory(null).
+          setLocalView(null);
+        }}
+        open={panelOpen}
+        localView={filterState.localView}
+        setLocalView={setLocalView}
+      />
 
       {/* E5 S1: drawer mirror. Always rendered (CSS transform-hide), so SR
           users always have access. */}
@@ -339,6 +480,13 @@ export function LivingMap({
         visibleCount={filterActive ? visibleIds.size : memories.length}
         colorMode={filterState.colorMode}
         edgeCounts={edgeCounts}
+        // v0.28+ (E3 local view) — surface "view = local (N)" in the
+        // affordance string so users have an orientation cue even when
+        // DetailPanel is closed (plan-design-critic R1 must-fix #1).
+        localView={localNeighborhood ? {
+          size: localNeighborhood.memoryIds.size,
+          cappedFrom: localNeighborhood.cappedFrom?.wouldHaveBeen,
+        } : undefined}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Adds the Obsidian-most-used feature: click a memory, click the new **"focus"** button in the DetailPanel, and the graph collapses to that memory + its N-hop neighborhood (default depth 2) via E2's explicit conflict + shared-tag edges. Esc clears both the focus AND the selection together.

**Stacked on PR #62 (E2 real edges)** — rebases onto master cleanly when #62 merges. Base = `feat-real-edges` for now; please merge #62 first.

## E3 of 4 in the Obsidian-inspired stack

1. v0.2.1 E1 color-by-tag (PR #61)
2. v0.2.2 E2 real edges (PR #62)
3. **v0.2.3 E3 local graph view (this PR)**
4. v0.2.4 E4 force-directed layout (queued)

## What ships

**State:**
- New `LocalViewState` + `FilterState.localView` field. View AND filter state: included in `isFilterActive`, cleared by `resetFilters`.
- `deriveVisibleIds` gains optional 3rd arg `localNeighborhood`.

**Pure helper (`ui/src/engine/localNeighborhood.ts`):**
- `buildAdjacency` unions conflict pairs + shared-tag pairs from E2. Hoisted to a LivingMap useMemo so it rebuilds only when memories/conflicts change.
- `computeLocalNeighborhood` BFS visited-on-enqueue, depth-capped at 5, with `NEIGHBORHOOD_CAP=60` + depth-1 fallback (with `cappedFrom` payload) when exceeded. Pure + deterministic.
- Performance: <5ms BFS at depth=2 on 1373-memory + 3000-edge synthesized adjacency (verified at test time).

**Scene engine (Obsidian default: both endpoints must be visible):**
- `BrainScene.setFiltered` extends to filter line visibility too. A line is visible only when both endpoint IDs are in the visible set. No frayed half-lines.
- Conflict + shared-tag edges stamp `userData.aId` + `userData.bId` at build time.

**UI:**
- `FocusButton` in DetailPanel header LEFT (distinct from esc on right). **Three labels**: `focus` (idle) / `focused` (this memory is the center, rust accent, non-interactive) / `recenter here` (focus active elsewhere). aria-labels per state.
- `BottomBar.buildAffordance` gains 3rd arg `localView`; appends `view = local (N)` (or `(N, capped from M)` on fallback). Orientation cue when DetailPanel is closed.

**Esc-clears-both wire:**
- `onClickMemory(null)` is the convergence for Esc-key + esc-button + empty-space-click. All paths clear both `selectedMemory` and `localView`.

**Stale-centerId guard:**
- `App.tsx setLocalView` verifies centerId in current memories at set-time. LivingMap useEffect clears localView if memory deleted post-set.

## Critic record

| Critic | Round | Verdict | Score |
|---|---|---|---|
| plan-eng-critic | R1 | fail | 62 |
| plan-design-critic | R1 | fail | 58 |
| plan-eng-critic | R2 | **PASS** | **88** |
| plan-design-critic | R2 | **PASS** | **84** |
| code-review-critic | R1 | **PASS** | **88** |
| independent-review-critic | R1 | **PASS** | **89** |

## Tests

- `ui/src/engine/localNeighborhood.test.ts`: 15 tests (BFS correctness, depth/cap edge cases, neighborhood-cap fallback, AC8 perf budget).
- `ui/src/state/filterState.test.ts`: 8 new tests for `localView` composition + `isFilterActive` branch + safe degradation + `resetFilters` clears + survives `setColorMode`.
- `ui/src/components/BottomBar.test.tsx`: 5 new tests for the `view = local (N)` affordance clause + cap-fallback annotation + composition + ordering.

**Test plan:**
- [x] `npm test` (repo): 1846 pass / 4 skipped / 252 files
- [x] `cd ui && npm test`: 147 pass / 10 files
- [x] `npm run build`: vite clean, 60 modules, three 510KB (no regression)
- [ ] Manual visual smoke: click focus on a hub memory; verify lines filter to both-endpoints-visible; press Esc to exit; verify BottomBar `view = local (N)` appears + disappears

## Out of scope (follow-ups)

- Depth slider (1-3): hardcoded depth=2 for v1; v0.3.0+
- Stepped Esc (first clears focus, second clears selection): v0.3.0+
- Animated zoom-to-cluster: v0.3.0 polish
- Breadcrumb history (drill into neighbor of neighbor): v0.3.0+
- Sidebar status row: BottomBar covers orientation; defer
- scene.ts unit tests: needs WebGL stubs; deferred
- Force-directed layout (replaces PCA): **E4**

🤖 Generated with [Claude Code](https://claude.com/claude-code)