### PR TITLE
feat(ui): v0.2.5 per-project anchor forces (E5 of 5 Obsidian-inspired graph upgrades)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,254 @@
 # Changelog
 
+## 1.12.11 (2026-05-25): bundled E1-E5 ui-brain-observatory publish (Obsidian-inspired graph upgrades)
+
+Bundles ui-brain-observatory v0.2.1 through v0.2.5 into one npm release.
+The E1 through E4 commits landed on master at 8d6cc47 across PRs #60-#64
+but were never `npm publish`ed. v1.12.11 makes the cumulative dashboard
+work user-available alongside the v0.2.5 E5 release.
+
+For per-episode detail, see the ui-brain-observatory entries below:
+- v0.2.1 E1: tag-based coloring
+- v0.2.2 E2: real edges (parents / conflicts / shared-tag pairs)
+- v0.2.3 E3: local graph view (N-hop neighborhood)
+- v0.2.4 E4: force-directed layout (replaces PCA on XZ)
+- v0.2.5 E5: per-project anchor forces (this release)
+
+No SDK / HTTP API / CLI / DB / migration / env changes. Pure UI bundle.
+
+### What ships in the tarball
+
+- `dist/` (SDK + CLI), `dist-ui/` (built dashboard), `bin/` (CLI shims).
+- `prepublishOnly` runs `build:all` (root tsc + UI vite build).
+
+## ui-brain-observatory v0.2.5 (2026-05-25): per-project anchor forces (Obsidian-inspired graph upgrades, E5 of 5)
+
+Adds per-project anchor forces to the d3-force layout from E4. Each
+unique `path:*` tag gets a stable position on a golden-angle-packed
+circle around origin; memories carrying that tag get a gentle pull
+toward it (strength 0.08 vs linkStrength 0.4 so edges still dominate).
+A new Sidebar Projects mini-panel lets users read which cluster is which
+project and click to filter. localStorage persists the project ordering
+across sessions, append-only, so existing anchors stay byte-identical
+when new project tags appear.
+
+E5 closes the Obsidian-inspired graph upgrades stack. The E4 R2 critic
+surfaced three anchor-specific HIGH issues (mass-resettle on new tags,
+no in-app legend, no refresh signaling) that demanded proper design
+budget; E5 was spun out of E4 at task #106 and addressed each.
+
+### What shipped
+
+**Pure helper `ui/src/state/projectAnchorOrder.ts`.**
+- `loadProjectAnchorOrder()` reads `hippo:projectAnchorOrder:v1` from
+  localStorage. Two-layer validation: try/catch for JSON.parse, plus
+  explicit shape check (Array.isArray(tags), nextIndex is number, every
+  inner tuple is `[string, finite-number]`). Inner-tuple validation
+  defends against `new Map([['hello']])` silently producing
+  `{key:'hello', value:undefined}` and NaN-propagating through anchor
+  math.
+- `saveProjectAnchorOrder()` JSON-serializes and writes. Silent no-op on
+  QuotaExceededError or disabled storage. Layout still works
+  session-local without persistence.
+- `reconcileProjectOrder(currentTags, order)` appends NEW tags with
+  `nextIndex` (alpha-sorted batch order), leaves existing indices
+  unchanged. Returns SAME object reference when nothing changed, so
+  callers can skip the save call via reference equality.
+- `clearProjectAnchorOrder()` exported as `@internal` for tests / a
+  future Reset Layout button (v0.3.0).
+
+**Pure helper `ui/src/engine/projectAnchors.ts`.**
+- `computeProjectAnchors(memories, order, bound, anchorStrength?)`
+  returns `{byTag, byMemoryId, orderedTags}`.
+- Anchor angle: `(index * GOLDEN_ANGLE) % 2π` where `GOLDEN_ANGLE = π *
+  (3 - sqrt(5))`. Vogel sunflower spiral, dense + collision-free for any
+  N up to ~50 indices. Each index has a permanent fixed angle, so
+  adding new tags leaves existing anchor positions byte-identical (the
+  AC20 stability guarantee, the structural fix for the E4 R2 issue v1
+  reintroduced with a slotCount-mod formula).
+- `EXCLUDED_PATH_TAGS = new Set(["path:skf_s"])` filters the filesystem
+  root tag (60% of memories, would dominate layout).
+- Per-memory anchor pick uses the shared `pickShortestPathTag` helper
+  (path-mode dedup with `pickColorTag`).
+- `orderedTags` lists only tags actually picked as the anchored tag for
+  at least one memory, so the Sidebar legend never shows ghost rows for
+  longer path tags subsumed by a shorter sibling
+  (e.g. `path:hippo-tests` when `path:hippo` is the shorter winner).
+
+**`ui/src/engine/tagPalette.ts` refactor.**
+- New exported `pickShortestPathTag(tags, excludeSet?)` extracted from
+  `pickColorTag`'s "path" branch. Shared with `computeProjectAnchors`
+  (which passes `EXCLUDED_PATH_TAGS` as excludeSet). The "tag" branch
+  keeps its inline filter (excludes path:\*, picks shortest non-path),
+  structurally inverse of the path-tag rule and not worth a second
+  shared helper for one caller.
+
+**`ui/src/engine/forceLayout.ts` extension.**
+- Exports `LAYOUT_BOUND = 30` constant. Consumers (scene.populate,
+  computeProjectAnchors, ProjectsPanel mini-SVG) now share the magic
+  number instead of duplicating `30`.
+- `ForceLayoutConfig.projectAnchors?: Map<string, {x, y, strength}>`.
+  When present and non-empty, registers `forceX` + `forceY` with
+  per-node accessors (memories absent from the map get strength=0).
+  Absent or empty config keeps E4 behavior byte-identical (back-compat).
+
+**`ui/src/engine/scene.ts` wiring.**
+- `populate()` loads the persisted order, reconciles current `path:*`
+  tags, saves only when changed (reference-equality skip), computes
+  AnchorLayout, caches it as `this.projectAnchorLayout`, and passes
+  `projectAnchors.byMemoryId` to `buildForceLayout`. All synchronous,
+  preserving the MUST-STAY-SYNCHRONOUS populate contract.
+- New `getProjectAnchorLayout()` accessor returns the cached layout
+  (same object reference until next populate, safe as a React useMemo
+  dep).
+
+**React state flow `useCanvasEngine.ts` + `LivingMap.tsx`.**
+- `useState<AnchorLayout | null>(null)` in `useCanvasEngine`, set in the
+  same effect as `setEdgeCounts` right after `scene.populate()` returns
+  (the synchronous read on the same render). Returned from the hook.
+  Ref-only reads would never trigger re-render; this is the structural
+  fix for the CRIT-2 race the plan-eng R1 critic caught on v1.
+- `LivingMap` destructures `projectAnchorLayout`, builds a memoized
+  `projectsForSidebar` array (tag, count, anchor target), passes it to
+  Sidebar.
+
+**Sidebar Projects mini-panel `ui/src/components/ProjectsPanel.tsx`.**
+- Lists projects in persistent-anchor-index order (first-seen across
+  sessions). Subtitle `(ordered by first-seen)` so users aren't
+  surprised by non-alpha order.
+- Each row: 20x20 SVG with outer ring + dot at the anchor's screen
+  position (`MINI_CENTER + (anchor.x / LAYOUT_BOUND) * MINI_INNER_RADIUS`),
+  project name (with `path:` prefix stripped), memory count.
+- Button has `aria-label="Filter to project X, N memor(y|ies)"` with
+  grammatical pluralization. Decorative SVG is `aria-hidden`. Click
+  fires `setQuery(tag)` to filter memories to that project.
+- Caps display at 10 rows with passive `+N more` italic label for
+  overflow (cluster still visible on canvas; expansion deferred to
+  v0.3.0).
+- Returns null on empty input so the panel hides itself when no
+  qualifying path tags exist.
+
+**`ui/src/components/Header.tsx` external sync mirror.**
+- The external query sync effect now mirrors ANY non-equal external
+  change into the local input (was: only empty-clear). Click on a
+  ProjectsPanel row sets `filterState.query = "path:hippo"` via
+  `setQuery`; the Header search input now visibly reflects the active
+  query instead of staying blank. Race safety: mirrors only when
+  `filterState.query !== debounced`, so during typing the local input
+  never gets clobbered by an echo of its own pipeline.
+
+**`ui/src/components/Sidebar.tsx`.**
+- New `projects` prop. ProjectsPanel mounted between ViewPanel and the
+  Filters header, matching the established between-section pattern from
+  E1's ViewPanel insertion.
+
+**`ui/src/tokens.css`.**
+- New `.project-row:hover { background: var(--ink-faint); }` rule for
+  the new Sidebar rows. Intentionally NO `:focus-visible` override on
+  this class: the global `*:focus-visible` rule (2px outline) already
+  covers it, and a more-specific rule would downgrade the sitewide
+  focus indicator on these rows (a11y regression).
+
+### Plan
+
+`docs/plans/2026-05-25-project-anchors.md` (v1 -> v2 -> v2.1 across 2
+plan critic rounds + 1 code-review round + 1 independent-review round +
+1 ship-readiness round).
+
+Major v1 -> v2 changes (R1 critic carry-over):
+- Switched anchor angle from `slotCount = max(1, nextIndex)` mod-N
+  formula (which shifts every existing anchor when N grows, the exact
+  E4 R2 bug E5 was spun out to fix) to golden-angle packing where each
+  index has a permanent angle independent of total count.
+- Wired explicit React state for the AnchorLayout in `useCanvasEngine`
+  (ref-only reads at render time would never re-render on populate).
+- Extracted `LAYOUT_BOUND` so the bound is one source of truth for
+  scene + computeProjectAnchors + ProjectsPanel mini-SVG.
+- Added explicit JSON shape validation in load to defend against
+  malformed payloads.
+- Extracted shared `pickShortestPathTag` to remove the path-tag pick
+  duplication between tagPalette and projectAnchors.
+- Fixed `orderedTags` to include only actually-anchored tags.
+- Added aria-label + aria-hidden + first-seen-order subtitle in
+  ProjectsPanel.
+- Fixed SVG mini-map geometry to a single coordinate system.
+
+v2 -> v2.1 surgical (R2 PASS-with-must-fix carry-over):
+- Scoped `pickShortestPathTag` to path-mode only; tag-mode keeps its
+  inline non-path filter.
+- Tightened load validation to verify every inner tuple is
+  `[string, finite-number]`.
+- Dropped a redundant `.project-row:focus-visible` override that would
+  have downgraded the global focus standard.
+
+Review fold-in (independent-review-critic must-fix):
+- Header search input mirrors non-empty external query changes so the
+  ProjectsPanel click affords visible feedback.
+- Pluralization in aria-label: `1 memory` vs `N memories`.
+
+### Critic record
+
+| Critic | Round | Verdict | Score |
+|---|---|---|---|
+| plan-eng-critic | R1 | fail | 4 |
+| plan-design-critic | R1 | PASS-with-fixes | 8 |
+| plan-eng-critic | R2 | PASS-with-fixes | 7 |
+| plan-design-critic | R2 | PASS-with-fixes | 8 |
+| code-review-critic | R1 | fail | 7 |
+| code-review-critic | R2 | PASS | 9 |
+| independent-review-critic | R1 | PASS-with-fixes | 78 |
+| ship-readiness-critic | R1 | PASS-with-fixes | 78 |
+
+plan-eng R1 caught two CRIT issues that would have shipped a broken
+stability guarantee: the slotCount-mod angle formula reintroduced the
+exact mass-resettle bug E5 was created to fix, and the ref-read at
+render time would never trigger a re-render on populate. Both fixed in
+v2 (golden-angle + explicit useState).
+
+code-review R1 caught that the plan's S7 test list (4 forceLayout
+entries to lock AC10/AC11/AC12) was not actually added. R2 folded all
+4 plus 7 direct pickShortestPathTag tests.
+
+independent-review R1 caught the Header search-input desync (clicking a
+ProjectsPanel row filtered memories silently, with no UI feedback in the
+Header search box) and the ungrammatical `1 memories` aria-label. Both
+folded in-stage.
+
+### Tests
+
+`npm test --run` from `ui/`: 220 / 220 pass across 14 test files.
+- `projectAnchorOrder.test.ts` 16 new (load/save, append-only,
+  reference-equality skip, JSON shape, inner-tuple corruption,
+  QuotaExceededError silent-skip).
+- `projectAnchors.test.ts` 10 new (path:skf_s filter, golden-angle
+  formula, AC20 byte-identical stability, multi-tag shortest-wins,
+  orderedTags anchored-only filter, strength override).
+- `ProjectsPanel.test.tsx` 9 new (empty state, top-N truncation, +N
+  more, aria-label with pluralization, SVG aria-hidden, dot position
+  formula, click forwards tag, type='button').
+- `forceLayout.test.ts` 5 new (LAYOUT_BOUND export, projectAnchors
+  config pulls, back-compat byte equality, empty Map no-op, per-node
+  strength=0).
+- `tagPalette.test.ts` 7 new pickShortestPathTag direct (empty, no path,
+  shortest, alpha tiebreak, excludeSet filter, excludeSet excluding
+  all, undefined excludeSet).
+
+`npm run build` clean (~1s). `npx tsc --noEmit` clean.
+
+### Out of scope (named, deferred)
+
+- Reset Layout button to clear localStorage ordering (v0.3.0).
+- Per-project color customization in the Sidebar legend.
+- Drag-to-rearrange projects on the canvas.
+- BottomBar `anchors: N` clause.
+- Animated transition when a new anchor appears.
+- Hover-preview of project spheres on Sidebar-row hover (highlight
+  spheres in canvas).
+- Query input rewrite to a `project: X` chip pill (instead of raw
+  `path:X` text).
+- Cross-tab localStorage sync via the storage event.
+- Cross-session anchor sync (cloud-persisted ordering).
+
 ## ui-brain-observatory v0.2.4 (2026-05-25): force-directed layout (Obsidian-inspired graph upgrades, E4 of 4)
 
 Replaces the PCA-based 3D positioning with a d3-force layout driven by

--- a/docs/plans/2026-05-25-project-anchors.md
+++ b/docs/plans/2026-05-25-project-anchors.md
@@ -1,0 +1,787 @@
+# 2026-05-25 — Per-project anchor forces (E5 of Obsidian-inspired graph upgrades stack)
+
+**Status:** Draft v2.1 (R2 PASS by both critics; surgical fold-ins applied for last 3 must_fixes)
+**Episode:** 01KSFW6KEPY679H2MF4MSDZQ89
+**Branch:** feat-project-anchors (off master; E4 already merged)
+**Owner:** Claude (Keith review)
+
+## Why this exists
+
+E1-E4 shipped. E4 closes the original Obsidian-inspired stack with d3-force layout driven by E2's structural edges. E5 is the spun-out work from E4's plan iteration: **per-project anchor forces**.
+
+Without anchors, memories cluster by structural connections (conflicts + shared-tag pairs). With anchors, memories ALSO cluster by their project membership — each `path:*` tag gets a stable XZ anchor point, and memories carrying that tag get a gentle pull toward it. The visual result is a true "project-split" view: ~17 distinct regions, one per project, structurally interconnected.
+
+This was the option-3 pick from the project-split question. E4 shipped lean (no anchors) because three anchor-specific HIGH design issues surfaced in E4's R2 critic round:
+1. **Sort-index angle assignment** caused mass-resettle on any new project tag (every subsequent anchor shifts → ~1300 memories re-settle)
+2. **No in-app legend** — users see clusters with no way to know which is which project
+3. **No refresh signaling** — settling clause couldn't distinguish initial-load drift from a new-tag re-drift
+
+E5 addresses all three with proper design budget.
+
+## R1 → v2 changes (critic carry-over)
+
+R1 plan-eng-critic FAILed v1 (2 CRIT, 4 HIGH); R1 plan-design-critic PASSed score 8 with 4 must-fix items. v2 addresses:
+
+**CRIT-1 (eng):** v1's `slotCount = max(1, order.nextIndex)` formula shifted EVERY existing anchor when a new tag arrived — the exact bug E5 was spun out to fix. v2 uses **golden-angle packing**: `angle = (i × GOLDEN_ANGLE) mod 2π` where `GOLDEN_ANGLE = π × (3 − √5)`. Each index has a permanent, unique angle independent of N (Vogel sunflower spiral). Existing anchors are byte-identical pre/post any new-tag addition.
+
+**CRIT-2 (eng):** v1's `sceneRef.current?.getProjectAnchorLayout()` ref-read at React render-time would never re-render on populate. v2 wires explicit React state through `useCanvasEngine`: `useState<AnchorLayout | null>(null)` set in the same effect as `setEdgeCounts`, returned from the hook, destructured by `LivingMap`, fed to Sidebar.
+
+**HIGH-1 (eng):** Hardcoded `bound = 30`. v2 exports `LAYOUT_BOUND` from `forceLayout.ts` and threads it through `scene.populate()` → `computeProjectAnchors` → `ProjectsPanel` mini-SVG.
+
+**HIGH-2 (eng):** `loadProjectAnchorOrder` missing shape validation. v2 adds `if (!Array.isArray(parsed?.tags) || typeof parsed?.nextIndex !== 'number') return EMPTY;` before `new Map(parsed.tags)`.
+
+**HIGH-3 (eng):** Helper duplication. v2 extracts `pickShortestPathTag(tags, excludeSet?)` into `tagPalette.ts` for the path-tag pick path. **v2.1 scope-fix:** the helper is `path:`-prefix-specific (filters `t.startsWith("path:")`). `pickColorTag`'s `"tag"` mode (which EXCLUDES path tags and picks shortest non-path) keeps its inline filter; only the `"path"` branch + `computeProjectAnchors` call the shared helper. Two consumers deduped, not three — but the duplication that mattered (path-tag picking) is gone.
+
+**MED (eng) v2.1 inner-tuple validation:** `new Map([['hello']])` silently produces `key='hello', value=undefined` instead of throwing — golden-angle math then NaN-propagates. v2.1 tightens validation: every entry of `parsed.tags` must be `Array.isArray(t) && t.length === 2 && typeof t[0] === 'string' && typeof t[1] === 'number'` before constructing the Map.
+
+**MED (design) v2.1 focus-visible:** `.project-row:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }` is MORE SPECIFIC than the global `*:focus-visible` rule (2px/2px in tokens.css L67-71) and would DOWNGRADE the focus indicator on these rows. v2.1 drops the override — global rule covers it correctly.
+
+**HIGH-4 (eng) / MED orderedTags:** `orderedTags` listed ANY path tag a memory carries; v2 includes only the actually-anchored tag per memory (matches pickShortestPathTag output).
+
+**HIGH-1 (design):** Aria-label missing on ProjectsPanel buttons. v2 adds `aria-label="Filter to project ${X}, ${count} memories"` + `aria-hidden={true}` on the decorative SVG (matches TagCloud precedent).
+
+**HIGH-2 (design):** SVG mini-map geometry was two inconsistent coordinate systems (viewport 20×20 but radius formula assumed 10×10). v2 fixes to: viewport 20×20, center (10,10), inner radius 5, formula `cx = 10 + (anchor.x / LAYOUT_BOUND) × 5`. Dead `cx/cy = 10` lines removed. Outer stroke = `var(--border)` for visibility.
+
+**MED (design) first-seen order:** Subtitle "(ordered by first-seen)" added under panel title in `--dim` so users aren't surprised by non-alpha order.
+
+**MED (design) center-cluster semantic:** Added to Risks: "Unanchored memories cluster at origin via forceCenter — intentional visual nucleus. Revisit if it dominates."
+
+**MED (eng) reference-stability:** Spec'd in S4 — scene caches `AnchorLayout` on populate, returns same ref until next populate. useMemo in S6 depends on it as a stable ref.
+
+**MED (eng) clearProjectAnchorOrder:** Marked test-only export with a `@internal` doc tag.
+
+**MED (eng) anchor strength rollback:** Risks R3 spells out the visual-smoke failure mode: if clusters jam at anchor centroids with no inter-project edges visible, halve to 0.04.
+
+## Goal
+
+Add per-project anchor forces driven by a **persisted append-only project ordering** (so existing anchors never rotate when new project tags arrive). Provide an in-app **Projects mini-panel** in the Sidebar so users can read which cluster is which. Compose cleanly with E4's settling clause via the existing `initial | refresh` discriminator.
+
+## Discover findings (these drive the plan)
+
+```
+Tag distribution (from C:/Users/skf_s/.hippo/hippo.db):
+  18 unique path:* tags total
+  Top tier (>50 mems):
+    path:skf_s             830  ← FILESYSTEM ROOT, not a project (filter out)
+    path:quantamental      247
+    path:hippo             173
+    path:phzse             155
+    path:luminus-dashboard  75
+    path:mure               55
+  Mid tier (10-50): luminus 33, clawd 22, resona 18, production 12, synth 11
+  Tail tier (<10): aegis 8, 2chain 5, part-l-hrt-challenge- 4, boring-maths 3
+  After filtering skf_s: 17 anchor candidates packed by golden-angle on a circle
+
+Existing UI state:
+  No localStorage usage in ui/src — clean slate.
+  Sidebar order: StatsPanel → Selected memory → ViewPanel → Filters → TagCloud.
+  Room for a "Projects" panel between ViewPanel and Filters.
+
+forceLayout (E4) extension surface:
+  ForceLayoutConfig is an interface — cleanly extendable with
+    projectAnchors?: Map<string, { x: number; y: number; strength: number }>
+  Where the key is a memory ID and the value is its anchor target.
+  forceX/forceY accept per-node accessors: `d => projectAnchors.get(d.id)?.x ?? 0`.
+
+ForceNode interface:
+  Extendable; no need for a new field (anchors are external-lookup, not per-node).
+
+E4 settling discriminator:
+  settlingKindRef.current flips "initial" → "refresh" after first done().
+  Anchor changes (new path tag, ordering update) trigger a re-build of
+  forceLayout in scene.populate, which fires settling with source="tick" →
+  React state updates to "refresh" (correct semantic since the user has
+  seen at least one full layout already).
+```
+
+## Scope
+
+### S1 — `projectAnchorOrder.ts` persistence helper
+
+NEW file `ui/src/state/projectAnchorOrder.ts`:
+
+```typescript
+/**
+ * Append-only persisted ordering of project tags. Stable across sessions:
+ * once a project gets an index, that index NEVER moves. New project tags
+ * get the next-after-max index. Deleted tags retain their slot. This is
+ * what prevents the mass-resettle bug E4 R2 caught with sort-index
+ * ordering. Combined with golden-angle anchor packing (S2), existing tags'
+ * anchor positions are byte-identical pre/post any new-tag addition.
+ *
+ * STORAGE_KEY versioning: bump to "...:v2" if the persisted schema
+ * changes; old v1 keys become orphaned (not migrated) — acceptable since
+ * the data is purely UI-state with no canonical value.
+ */
+
+const STORAGE_KEY = "hippo:projectAnchorOrder:v1";
+
+export interface ProjectAnchorOrder {
+  /** Tag → its persistent index (0-based). Stable across sessions. */
+  indexByTag: Map<string, number>;
+  /** Highest index assigned. Next new tag gets nextIndex (= maxIndex + 1). */
+  nextIndex: number;
+}
+
+const EMPTY: ProjectAnchorOrder = { indexByTag: new Map(), nextIndex: 0 };
+
+/**
+ * Load from localStorage. Returns empty on first run, parse error, OR
+ * shape mismatch (legacy / corrupted / hand-edited payload). Two-layer
+ * defense: try/catch for JSON.parse + explicit shape validation before
+ * constructing the Map (which would throw on non-iterable `tags`).
+ */
+export function loadProjectAnchorOrder(): ProjectAnchorOrder {
+  if (typeof window === "undefined") return EMPTY;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY;
+    const parsed = JSON.parse(raw) as unknown;
+    // Shape validation BEFORE constructing Map. Defends against:
+    //   - hand-edited localStorage (developer tools)
+    //   - schema drift from a future v2 left over after a downgrade
+    //   - partially-written entries from a prior aborted save
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray((parsed as { tags?: unknown }).tags) ||
+      typeof (parsed as { nextIndex?: unknown }).nextIndex !== "number"
+    ) {
+      return EMPTY;
+    }
+    const candidateTags = (parsed as { tags: unknown[] }).tags;
+    // v2.1: tighten inner-tuple shape check. new Map([['hello']]) does NOT
+    // throw — it silently produces {key:'hello', value:undefined} and the
+    // undefined index then NaN-propagates through golden-angle math. Reject
+    // any entry that isn't exactly [string, number].
+    if (
+      !candidateTags.every(
+        (t): t is [string, number] =>
+          Array.isArray(t) &&
+          t.length === 2 &&
+          typeof t[0] === "string" &&
+          typeof t[1] === "number" &&
+          Number.isFinite(t[1]),
+      )
+    ) {
+      return EMPTY;
+    }
+    const valid = parsed as { tags: Array<[string, number]>; nextIndex: number };
+    return {
+      indexByTag: new Map(valid.tags),
+      nextIndex: valid.nextIndex,
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+/** Persist to localStorage. Silent no-op if window/storage unavailable. */
+export function saveProjectAnchorOrder(order: ProjectAnchorOrder): void {
+  if (typeof window === "undefined") return;
+  try {
+    const serialized = JSON.stringify({
+      tags: [...order.indexByTag.entries()],
+      nextIndex: order.nextIndex,
+    });
+    window.localStorage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    // localStorage may be full or disabled — silently skip. Layout still
+    // works without persistence; new tags get re-assigned per session.
+  }
+}
+
+/**
+ * Reconcile current project tags with the persisted ordering.
+ * - Tags already in ordering: keep their existing index.
+ * - New tags: assigned nextIndex (alpha-sorted batch order), nextIndex++.
+ * - Tags no longer in current set: index retained in ordering but unused.
+ *
+ * Returns SAME order object reference when nothing changed (reference
+ * equality lets caller skip the save call).
+ */
+export function reconcileProjectOrder(
+  currentTags: readonly string[],
+  order: ProjectAnchorOrder,
+): ProjectAnchorOrder {
+  const sortedTags = [...currentTags].sort(); // deterministic add order
+  const indexByTag = new Map(order.indexByTag);
+  let nextIndex = order.nextIndex;
+  let changed = false;
+  for (const tag of sortedTags) {
+    if (!indexByTag.has(tag)) {
+      indexByTag.set(tag, nextIndex);
+      nextIndex++;
+      changed = true;
+    }
+  }
+  return changed ? { indexByTag, nextIndex } : order;
+}
+
+/**
+ * @internal Reset for tests / future "reset layout" affordance. Not
+ * wired into product code in this episode — exported only so tests can
+ * isolate state between runs. v0.3.0 will wire a button.
+ */
+export function clearProjectAnchorOrder(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch { /* ignore */ }
+}
+```
+
+### S2 — `projectAnchors.ts` per-memory anchor computation
+
+NEW file `ui/src/engine/projectAnchors.ts`:
+
+```typescript
+import type { Memory } from "../types.js";
+import type { ProjectAnchorOrder } from "../state/projectAnchorOrder.js";
+import { pickShortestPathTag } from "./tagPalette.js"; // shared helper (HIGH-3 fix)
+
+/** Filter: which path:* tags are "real projects". Excludes the root
+ *  filesystem dir which is not a project. */
+const EXCLUDED_PATH_TAGS = new Set(["path:skf_s"]);
+
+/**
+ * Vogel sunflower spiral packing angle. Each persistent index gets a
+ * unique fixed angle 2π · i · (1 - 1/φ) where φ is the golden ratio.
+ * Identity: GOLDEN_ANGLE = π · (3 − √5) ≈ 137.508°.
+ *
+ * Property: angles are dense on the unit circle and never collide.
+ * Crucially: the angle for index i depends ONLY on i, not on the total
+ * number of anchors. This is what makes E5's stability AC achievable
+ * (v1's slotCount-mod formula reintroduced the E4 R2 mass-resettle bug).
+ */
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+export interface AnchorTarget {
+  /** Force-layout X (XZ-plane). */
+  x: number;
+  /** Force-layout Y (maps to scene-Z). */
+  y: number;
+  /** Pull strength toward this anchor. 0.08 is gentle (vs linkStrength
+   *  0.4) so anchors compose with edge-driven clustering without
+   *  overwhelming it. See force-balance note below. */
+  strength: number;
+}
+
+export interface AnchorLayout {
+  /** Anchor positions keyed by path tag. */
+  byTag: Map<string, AnchorTarget>;
+  /** Per-memory anchor lookup (memory.id → anchor target, or undefined
+   *  if memory has no qualifying path tag). */
+  byMemoryId: Map<string, AnchorTarget>;
+  /** The unique path tags considered (in their persistent-index order).
+   *  ONLY includes tags that were actually picked as the anchored tag
+   *  for at least one memory (not just "any path tag in tag set").
+   *  Used by the Sidebar Projects panel. */
+  orderedTags: string[];
+}
+
+/**
+ * Default anchor strength. 0.08 chosen so per-node anchor pull (1 pull
+ * per memory) is less than per-link pull (E4's linkStrength 0.4 × ~3-5
+ * links per node = effective 1.2-2.0). Worst case: memory with 1 link
+ * to a different-project cluster + 1 anchor pull → 0.4 vs 0.08 = link
+ * wins 5×. Sum of forces on memory with many anchored neighbors still
+ * favors the link cluster.
+ */
+const DEFAULT_ANCHOR_STRENGTH = 0.08;
+
+/**
+ * Compute per-project anchor positions on a circle of radius `bound × 0.6`
+ * around the origin. Each tag at persistent index `i` is placed at angle
+ * `(i × GOLDEN_ANGLE) mod 2π` — a stable, collision-free packing that
+ * depends only on `i`, not on the total tag count.
+ *
+ * Filters out EXCLUDED_PATH_TAGS (path:skf_s is the filesystem root,
+ * 60% of memories — would dominate the layout).
+ *
+ * Each memory gets the anchor of its shortest qualifying path tag
+ * (alpha tiebreak), matching pickColorTag's rule from E1 tag palette
+ * via the shared pickShortestPathTag helper.
+ */
+export function computeProjectAnchors(
+  memories: readonly Memory[],
+  order: ProjectAnchorOrder,
+  bound: number,
+  anchorStrength: number = DEFAULT_ANCHOR_STRENGTH,
+): AnchorLayout {
+  const radius = bound * 0.6;
+
+  // Build byTag anchor positions via golden-angle packing.
+  const byTag = new Map<string, AnchorTarget>();
+  for (const [tag, index] of order.indexByTag) {
+    if (EXCLUDED_PATH_TAGS.has(tag)) continue;
+    const angle = (index * GOLDEN_ANGLE) % (2 * Math.PI);
+    byTag.set(tag, {
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      strength: anchorStrength,
+    });
+  }
+
+  // Build per-memory lookup AND collect actually-anchored tags for the
+  // orderedTags output. Single pass via pickShortestPathTag (HIGH-3 fix).
+  const byMemoryId = new Map<string, AnchorTarget>();
+  const anchoredTags = new Set<string>();
+  for (const mem of memories) {
+    const tag = pickShortestPathTag(mem.tags, EXCLUDED_PATH_TAGS);
+    if (tag === null) continue;
+    const anchor = byTag.get(tag);
+    if (anchor) {
+      byMemoryId.set(mem.id, anchor);
+      anchoredTags.add(tag);
+    }
+  }
+
+  // Sidebar: only tags that ACTUALLY anchor a memory (not "any path tag
+  // a memory carries"). Memory tagged [path:hippo, path:hippo-tests]
+  // anchors at path:hippo only; the Sidebar won't show a ghost
+  // path:hippo-tests row with no visible cluster.
+  const orderedTags = [...order.indexByTag.entries()]
+    .filter(([tag]) => anchoredTags.has(tag))
+    .sort((a, b) => a[1] - b[1])
+    .map(([tag]) => tag);
+
+  return { byTag, byMemoryId, orderedTags };
+}
+```
+
+### S3 — Extend `forceLayout.ts` with `projectAnchors` config + export `LAYOUT_BOUND`
+
+`ui/src/engine/forceLayout.ts`:
+
+```typescript
+/**
+ * Layout coordinate bound — memories are clamped within ±LAYOUT_BOUND on
+ * each axis. Exported so consumers (scene.populate, projectAnchors,
+ * ProjectsPanel mini-map) share the same magic number.
+ *
+ * v0.28: extracted from internal DEFAULTS.bound for shared use.
+ */
+export const LAYOUT_BOUND = 30;
+
+// In DEFAULTS:
+const DEFAULTS = {
+  bound: LAYOUT_BOUND, // was hardcoded 30
+  // ...
+};
+```
+
+Add optional `projectAnchors?: Map<string, { x: number; y: number; strength: number }>` to `ForceLayoutConfig`. In factory: if provided, add forceX + forceY accessors:
+
+```typescript
+if (config.projectAnchors && config.projectAnchors.size > 0) {
+  const anchors = config.projectAnchors;
+  simulation
+    .force("project-x", d3.forceX<ForceNode>((d) => anchors.get(d.id)?.x ?? 0)
+      .strength((d) => anchors.get(d.id)?.strength ?? 0))
+    .force("project-y", d3.forceY<ForceNode>((d) => anchors.get(d.id)?.y ?? 0)
+      .strength((d) => anchors.get(d.id)?.strength ?? 0));
+}
+```
+
+Memories without a project anchor get strength=0 (no pull). Memories with one get the configured strength (0.08 default).
+
+### S4 — Scene wiring + tagPalette `pickShortestPathTag` extraction
+
+**`ui/src/engine/tagPalette.ts`** — extract shared helper for path-mode pick (HIGH-3 fix, v2.1-scoped):
+
+```typescript
+/**
+ * Pick the SHORTEST qualifying path:* tag from a tag list, with alpha
+ * tiebreak. **Path-mode only** — does not handle the non-path tag-mode
+ * pick (pickColorTag's "tag" branch keeps its own inline filter for
+ * those, which excludes path:* tags and is structurally different).
+ *
+ * Used by:
+ *   - pickColorTag's "path" branch (refactored to call this) — no exclusion
+ *   - computeProjectAnchors — excludes filesystem-root tags via excludeSet
+ */
+export function pickShortestPathTag(
+  tags: readonly string[],
+  excludeSet?: ReadonlySet<string>,
+): string | null {
+  const qualifying = tags.filter(
+    (t) => t.startsWith("path:") && !(excludeSet?.has(t) ?? false),
+  );
+  if (qualifying.length === 0) return null;
+  qualifying.sort((a, b) => a.length - b.length || a.localeCompare(b));
+  return qualifying[0] ?? null;
+}
+
+// Refactor: pickColorTag's "path" mode branch calls pickShortestPathTag(memory.tags).
+// pickColorTag's "tag" mode branch is UNCHANGED — it excludes path:* tags
+// and picks shortest non-path tag, which is the structural inverse of
+// pickShortestPathTag and not worth a second shared helper for one caller.
+```
+
+**`ui/src/engine/scene.ts`**:
+
+```typescript
+import { computeProjectAnchors, type AnchorLayout } from "./projectAnchors.js";
+import { loadProjectAnchorOrder, saveProjectAnchorOrder, reconcileProjectOrder } from "../state/projectAnchorOrder.js";
+import { LAYOUT_BOUND } from "./forceLayout.js";
+
+class BrainScene {
+  // Cached per populate; same reference returned by getProjectAnchorLayout
+  // until next populate. Lets useMemo in LivingMap (S6) skip rebuilds.
+  private projectAnchorLayout: AnchorLayout | null = null;
+
+  populate(memories, positions, conflicts, adjacency) {
+    // ... existing setup ...
+
+    const persistedOrder = loadProjectAnchorOrder();
+    const allPathTags = new Set<string>();
+    for (const m of memories) {
+      for (const t of m.tags) if (t.startsWith("path:")) allPathTags.add(t);
+    }
+    const reconciledOrder = reconcileProjectOrder([...allPathTags], persistedOrder);
+    if (reconciledOrder !== persistedOrder) {
+      saveProjectAnchorOrder(reconciledOrder); // reference-equality skip
+    }
+    const projectAnchors = computeProjectAnchors(memories, reconciledOrder, LAYOUT_BOUND);
+
+    this.forceLayout = buildForceLayout(memories, adjacency, seedPositions, {
+      projectAnchors: projectAnchors.byMemoryId,
+    });
+
+    // Cache for Sidebar consumption. Replaced on next populate; until
+    // then, getProjectAnchorLayout() returns this same reference.
+    this.projectAnchorLayout = projectAnchors;
+
+    // ... existing tail (setColorMode, etc.) ...
+  }
+
+  /**
+   * @returns the latest computed AnchorLayout, or null if populate has
+   * not yet run. Returns the SAME object reference until the next
+   * populate() call — safe to use in React useMemo deps.
+   */
+  getProjectAnchorLayout(): AnchorLayout | null {
+    return this.projectAnchorLayout;
+  }
+}
+```
+
+### S5 — Sidebar Projects mini-panel
+
+NEW file `ui/src/components/ProjectsPanel.tsx`:
+
+```typescript
+import { LAYOUT_BOUND } from "../engine/forceLayout.js";
+
+interface ProjectsPanelProps {
+  /** Projects ordered by their anchor index (first-seen order). */
+  projects: Array<{ tag: string; count: number; anchor: { x: number; y: number } }>;
+  /** Click handler: filter memories to that project (sets search query). */
+  onSelectProject: (tag: string) => void;
+}
+
+const MAX_VISIBLE = 10;
+
+// Mini SVG geometry — single source of truth, no duplicate cx/cy.
+const MINI_SIZE = 20;
+const MINI_CENTER = MINI_SIZE / 2; // 10
+const MINI_RADIUS = 5; // inner ring; dot lives within this on a [-1, +1] scaled coord
+
+export function ProjectsPanel({ projects, onSelectProject }: ProjectsPanelProps) {
+  if (projects.length === 0) return null;
+  const visible = projects.slice(0, MAX_VISIBLE);
+  const hiddenCount = Math.max(0, projects.length - MAX_VISIBLE);
+
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <h3 style={panelTitle}>Projects</h3>
+      <div style={subtitleStyle}>(ordered by first-seen)</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {visible.map(({ tag, count, anchor }) => {
+          // Map anchor.x ∈ [-LAYOUT_BOUND, +LAYOUT_BOUND] → screen-x ∈
+          // [center - MINI_RADIUS, center + MINI_RADIUS]. Single coordinate
+          // system; HIGH-2 dead-code lines removed.
+          const dotX = MINI_CENTER + (anchor.x / LAYOUT_BOUND) * MINI_RADIUS;
+          const dotY = MINI_CENTER + (anchor.y / LAYOUT_BOUND) * MINI_RADIUS;
+          const projectName = tag.replace("path:", "");
+          return (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onSelectProject(tag)}
+              aria-label={`Filter to project ${projectName}, ${count} memories`}
+              className="project-row" // for :hover style in tokens.css
+              style={projectRowStyle}
+            >
+              <svg width={MINI_SIZE} height={MINI_SIZE} aria-hidden={true} style={{ flexShrink: 0 }}>
+                <circle
+                  cx={MINI_CENTER}
+                  cy={MINI_CENTER}
+                  r={MINI_RADIUS + 2}
+                  fill="none"
+                  stroke="var(--border)"
+                  strokeWidth={1}
+                />
+                <circle cx={dotX} cy={dotY} r={2} fill="var(--accent)" />
+              </svg>
+              <span style={{ flex: 1, fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text)" }}>
+                {projectName}
+              </span>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--dim)" }}>
+                {count}
+              </span>
+            </button>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <div style={hiddenCountStyle}>+{hiddenCount} more</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const panelTitle = {
+  fontSize: 11, fontVariant: "small-caps" as const, letterSpacing: "1px",
+  fontWeight: 400, color: "var(--dim)", marginBottom: 4, paddingBottom: 6,
+  borderBottom: "1px solid var(--glass-border)",
+};
+const subtitleStyle = {
+  fontSize: 9, color: "var(--dim)", marginBottom: 8, fontStyle: "italic" as const,
+};
+const projectRowStyle = {
+  display: "flex", alignItems: "center", gap: 8, padding: "4px 6px",
+  background: "transparent", border: "1px solid transparent", borderRadius: 3,
+  cursor: "pointer", transition: "background 150ms ease",
+  width: "100%", textAlign: "left" as const,
+};
+const hiddenCountStyle = {
+  fontSize: 9, color: "var(--dim)", textAlign: "center" as const, marginTop: 4,
+  fontStyle: "italic" as const, opacity: 0.7,
+};
+```
+
+Add to `ui/src/tokens.css`:
+
+```css
+.project-row:hover { background: var(--ink-faint); }
+/* v2.1: NO .project-row:focus-visible override — the global *:focus-visible
+   rule (tokens.css L67-71, 2px/2px) already covers this. A more-specific
+   selector here would DOWNGRADE the focus indicator on these rows vs the
+   rest of the app. Sitewide a11y standard wins. */
+```
+
+Mount in `Sidebar.tsx` between ViewPanel (L102) and the Filters header — same insertion pattern as E1's ViewPanel.
+
+Click handler: `onSelectProject(tag)` → `setQuery(tag)` (uses existing query filter). User clicks "hippo" → query becomes "path:hippo" → graph filters to hippo memories.
+
+> NOTE (deferred): query input shows raw `path:hippo` (jargon) rather than `project: hippo` chip pill. TagCloud strips `path:` but ProjectsPanel does not — minor consistency drift. v0.3.0 will rewrite query display as a chip pill.
+
+### S6 — LivingMap + useCanvasEngine wiring (the React state path)
+
+**`ui/src/views/LivingMap/useCanvasEngine.ts`** — add explicit state for the anchor layout (CRIT-2 fix):
+
+```typescript
+import type { AnchorLayout } from "../../engine/projectAnchors.js";
+
+// In useCanvasEngine body, alongside existing edgeCounts state:
+const [projectAnchorLayout, setProjectAnchorLayout] = useState<AnchorLayout | null>(null);
+
+// In the populate effect (currently sets setEdgeCounts):
+useEffect(() => {
+  const scene = sceneRef.current;
+  if (!scene || memories.length === 0) return;
+  const positions = projectTo3D(embeddings);
+  scene.populate(memories, positions, conflicts, adjacency);
+  // Drive React state from scene state — same effect, same render cycle.
+  setEdgeCounts(scene.getEdgeCounts());
+  setProjectAnchorLayout(scene.getProjectAnchorLayout()); // CRIT-2 wiring
+}, [memories, embeddings, conflicts, adjacency]);
+
+// In return:
+return {
+  containerRef,
+  handleMouseMove,
+  handleClick,
+  handleKeyDown,
+  edgeCounts,
+  forceSettling,
+  projectAnchorLayout, // CRIT-2: surfaced for LivingMap
+};
+```
+
+**`ui/src/views/LivingMap/LivingMap.tsx`** — destructure + memo:
+
+```typescript
+const {
+  containerRef,
+  handleMouseMove,
+  handleClick,
+  handleKeyDown,
+  edgeCounts,
+  forceSettling,
+  projectAnchorLayout,   // CRIT-2 wiring
+} = useCanvasEngine({...});
+
+// Build the Sidebar projects list with counts. Memoized on memories +
+// the anchor-layout reference (which scene caches per populate, so the
+// memo only rebuilds when populate fires).
+const projectsForSidebar = useMemo(() => {
+  if (!projectAnchorLayout) return [];
+  const counts = new Map<string, number>();
+  for (const m of memories) {
+    for (const t of m.tags) {
+      if (projectAnchorLayout.byTag.has(t)) counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+  }
+  return projectAnchorLayout.orderedTags.map((tag) => ({
+    tag,
+    count: counts.get(tag) ?? 0,
+    anchor: projectAnchorLayout.byTag.get(tag)!,
+  }));
+}, [memories, projectAnchorLayout]);
+```
+
+Pass `projects={projectsForSidebar}` + `onSelectProject={setQuery}` to Sidebar → ProjectsPanel.
+
+### S7 — Tests
+
+NEW `ui/src/state/projectAnchorOrder.test.ts`:
+- `loadProjectAnchorOrder` returns empty when localStorage empty / unavailable.
+- `loadProjectAnchorOrder` returns empty when value is non-JSON (parse throw).
+- `loadProjectAnchorOrder` returns empty when JSON shape is invalid (no `tags` array OR no `nextIndex` number) — **HIGH-2 fix coverage**.
+- `loadProjectAnchorOrder` returns empty when `tags` is present but non-iterable (e.g. `tags: "hello"`).
+- `loadProjectAnchorOrder` returns empty when `tags` is an array of NON-tuples (`[["hello"], ["world"]]`, `[[1,2]]`, `[["x", "y"]]`) — **v2.1 inner-tuple validation coverage**; without this, `new Map(...)` silently produces `{key:'hello', value:undefined}` and NaN-propagates through golden-angle math.
+- `saveProjectAnchorOrder` round-trips: save → load → equal.
+- `saveProjectAnchorOrder` silent-skips when localStorage throws (QuotaExceededError).
+- `reconcileProjectOrder` appends new tags with next index.
+- `reconcileProjectOrder` keeps existing tags' indices stable.
+- `reconcileProjectOrder` returns SAME object reference when no change (reference-equality skip-save).
+- `reconcileProjectOrder` with deleted tags: index retained in ordering, slot left empty.
+
+NEW `ui/src/engine/projectAnchors.test.ts`:
+- `computeProjectAnchors` filters `path:skf_s`.
+- Each anchor at `(cos(i × GOLDEN_ANGLE) × radius, sin(i × GOLDEN_ANGLE) × radius)` where `radius = LAYOUT_BOUND × 0.6` — golden-angle formula.
+- Memories with no qualifying path tag → not in `byMemoryId`.
+- Memories with multiple path tags → shortest-wins (alpha tiebreak) via shared `pickShortestPathTag`.
+- `orderedTags` returns tags in persistent-index order.
+- `orderedTags` excludes tags NOT picked as the anchored tag for any memory — **HIGH-4 fix coverage** (memory with [path:hippo, path:hippo-tests] → only path:hippo in orderedTags).
+- **AC14 explicit byte-identical test:** Setup with 3 indices → record positions. Add 4th index → re-compute. Existing 3 positions equal to JS strict `===` (or `toBe` in vitest) byte-identically. The test that v1 would have FAILED.
+
+NEW `ui/src/engine/tagPalette.test.ts` extensions (or existing file):
+- `pickShortestPathTag` returns null for empty / no-path-tags input.
+- `pickShortestPathTag` ignores tags in excludeSet.
+- `pickShortestPathTag` picks shortest, alpha tiebreak.
+- `pickColorTag` (post-refactor) still passes pre-existing tests.
+
+Extend `ui/src/engine/forceLayout.test.ts`:
+- `buildForceLayout` with `projectAnchors` config: forceX/forceY active per node.
+- Without `projectAnchors`: no project forces added (back-compat).
+- Settled positions for an anchored memory cluster near its anchor.
+- `LAYOUT_BOUND` export equals 30.
+
+NEW `ui/src/components/ProjectsPanel.test.tsx`:
+- Renders top-N projects in order.
+- Renders subtitle "(ordered by first-seen)".
+- Each button has aria-label matching `Filter to project X, N memories` — **design HIGH-1 fix coverage**.
+- Each SVG has `aria-hidden="true"`.
+- SVG dot position computes from `anchor.x / LAYOUT_BOUND × MINI_RADIUS + MINI_CENTER` — **design HIGH-2 fix coverage**.
+- Click fires onSelectProject with the tag string.
+- "+N more" affordance when projects.length > 10.
+- Returns null on empty projects.
+
+### S8 — Anchor stability AC (the core E4 R2 fix, now verifiable)
+
+```
+Test: stability across tag-set growth (golden-angle invariant).
+  Setup: 3 memories with tags [path:hippo], [path:quantamental], [path:phzse].
+  Reconcile order → indices {hippo:0, quantamental:1, phzse:2}, nextIndex=3.
+  Run computeProjectAnchors → record anchors{hippo:A, quantamental:B, phzse:C}.
+  Add memory with new tag [path:resona].
+  Reconcile → indices {hippo:0, quantamental:1, phzse:2, resona:3}, nextIndex=4.
+  Run computeProjectAnchors → anchors{hippo:A', quantamental:B', phzse:C', resona:D}.
+  Assert A === A', B === B', C === C' (byte-identical via strict equality
+  on .x and .y for each).
+  Why this passes now: golden-angle formula uses ONLY i, not slotCount.
+  Why v1 FAILed it: slotCount-mod formula shifted every existing index
+  when slotCount grew from 3 to 4.
+```
+
+## Acceptance criteria
+
+| # | Criterion | Verifies |
+|---|---|---|
+| AC1 | `projectAnchorOrder.ts` round-trips through localStorage | S1 |
+| AC2 | `reconcileProjectOrder` appends new tags with next-index | S1 |
+| AC3 | `reconcileProjectOrder` keeps existing tags' indices stable | S1 / S8 stability |
+| AC4 | `reconcileProjectOrder` returns same-reference when no change | S1 perf-skip |
+| AC5 | `loadProjectAnchorOrder` returns empty on shape mismatch (no `tags` array OR no `nextIndex` number OR any entry not a `[string, number]` tuple) | S1 / HIGH-2 + v2.1 inner-tuple |
+| AC6 | `computeProjectAnchors` filters `path:skf_s` | S2 |
+| AC7 | Anchor positions at `(cos(i × GOLDEN_ANGLE) × r, sin(i × GOLDEN_ANGLE) × r)` where r = `LAYOUT_BOUND × 0.6` | S2 / CRIT-1 |
+| AC8 | Memories pick shortest path tag (alpha tiebreak) via shared `pickShortestPathTag` — path-mode dedup only; `pickColorTag`'s "tag" branch keeps its inline non-path filter | S2 + S4 / HIGH-3 (v2.1 scoped) |
+| AC9 | `orderedTags` includes ONLY tags actually picked as anchored tag for ≥1 memory | S2 / HIGH-4 |
+| AC10 | `buildForceLayout` with projectAnchors config adds forceX/forceY | S3 |
+| AC11 | Without projectAnchors config: no project forces (back-compat) | S3 |
+| AC12 | `LAYOUT_BOUND` exported from forceLayout.ts and consumed by scene + ProjectsPanel | S3 / HIGH-1 |
+| AC13 | Scene populate persists order changes to localStorage | S4 |
+| AC14 | Scene `getProjectAnchorLayout()` returns same reference until next populate | S4 / MED ref-stability |
+| AC15 | useCanvasEngine returns `projectAnchorLayout` from React state set in populate effect | S6 / CRIT-2 |
+| AC16 | ProjectsPanel renders top-10 + "+N more" + subtitle "(ordered by first-seen)" | S5 / design MED |
+| AC17 | ProjectsPanel buttons have aria-label `Filter to project X, N memories`; SVG `aria-hidden="true"` | S5 / design HIGH-1 |
+| AC18 | ProjectsPanel SVG dot position: `MINI_CENTER + (anchor.x / LAYOUT_BOUND) × MINI_RADIUS` (single coord system) | S5 / design HIGH-2 |
+| AC19 | Click on a project row sets query to the path tag | S5/S6 |
+| AC20 | **Anchor stability (core)**: adding a new project tag → existing anchors' .x/.y byte-identical pre/post | S8 / CRIT-1 |
+| AC21 | E1-E4 features still work (color modes, edges, local view, force layout, BottomBar) | regression |
+| AC22 | No test regressions: full ui/ + repo-root green | regression |
+
+## Risks
+
+| # | Risk | Lik. | Mitigation |
+|---|---|---|---|
+| R1 | localStorage QuotaExceededError on save | L | try/catch silent skip; layout still works without persistence (anchors stay session-local) |
+| R2 | localStorage disabled (private browsing) | L | `loadProjectAnchorOrder` returns empty; new tags get re-assigned per session |
+| R3 | Anchor strength 0.08 too strong / weak | M | Tunable in config. **Failure mode (visual smoke):** if 17-project clusters collapse to anchor centroids with no inter-project edges visible, halve to 0.04 and re-test. **Worst-case force balance:** a node with 1 cross-project link (0.4 strength) + 1 anchor pull (0.08) → link wins 5×. Sum of edge forces dominates anchor sum for any node with ≥1 inter-project edge. |
+| R4 | Sidebar Projects mini-map too small / cluttered | L | 20×20 SVG with stroke `var(--border)` for visible ring; 2-radius dot. Visual smoke; bump to 32×32 if dot lost. |
+| R5 | Project ordering becomes stale after long sessions (many deleted+added projects → high nextIndex, sparse-feeling list) | L | Golden-angle packing keeps anchors well-distributed regardless of N. List sparseness is purely cosmetic. v0.3.0 "reset layout" button (helper `clearProjectAnchorOrder` already exists as `@internal` test-only export). |
+| R6 | path:skf_s exclusion list grows over time | L | Single exclusion for now (filesystem root). If more "non-project" path tags surface (e.g. path:tmp), add to EXCLUDED_PATH_TAGS — single source of truth. |
+| R7 | reconcileProjectOrder sort-by-alpha for new tags is deterministic per session, NOT cross-user | L | Documented in S1 docstring. Each user's local indices are stable; cross-session anchor sync deferred indefinitely. |
+| R8 | **Unanchored memories cluster at origin** (path:skf_s + memories with no path tag → ~870 memories pulled to (0,0) by forceCenter) | L | **Design choice (M4):** intentional visual nucleus — the un-projected core sits at the center surrounded by project rings. If it dominates the canvas visually (smoke test reveals a giant blob), follow-up: assign a low-strength "general" anchor at a quiet angle, or filter unanchored memories from layout entirely. |
+| R9 | Plan-design first-seen-order surprise (Sidebar list not alpha / by-count) | L | Subtitle "(ordered by first-seen)" makes the rule explicit. |
+
+## Out of scope (named, deferred)
+
+- "Reset layout" affordance button to clear localStorage ordering — v0.3.0 polish. Helper `clearProjectAnchorOrder` exported as `@internal` test-only; wiring is the deferred work.
+- Per-project color customization in the Sidebar legend — separate v0.3.0+ ticket.
+- Drag-to-rearrange projects on the canvas — defer.
+- BottomBar `anchors: N` clause — Sidebar mini-panel covers orientation; defer BottomBar update.
+- Animated transition when a new anchor appears — defer.
+- Sidebar mini-map showing actual cluster positions (rather than just anchor angles) — defer.
+- Cross-session anchor sync (cloud-persisted ordering) — defer indefinitely.
+- Hover-preview of project's spheres on Sidebar-row hover (highlight in canvas) — defer v0.3.0+.
+- Query input rewrite to `project: X` chip pill (instead of raw `path:X` text) — defer v0.3.0+.
+
+## Rollback
+
+Single PR, revertible:
+- Revert → `projectAnchorOrder.ts` + `projectAnchors.ts` + `ProjectsPanel.tsx` + tests deleted; `scene.populate` stops computing anchors; `buildForceLayout`'s `projectAnchors` path becomes dead code (optional config; never set); Sidebar drops ProjectsPanel mount; `LAYOUT_BOUND` export remains harmless. `pickShortestPathTag` extraction stays (cleanup, not a regression). localStorage key remains (harmless residue).
+- No DB change; no API contract change.
+
+## Cost estimate
+
+- Coding: ~5-7 hours (2 new helpers + 1 new component + scene wiring + tagPalette refactor + tests + tuning)
+- Critic rounds: ~1-2 hours (E5 R1 surfaced 2 CRIT + 6 HIGH addressed in v2; R2 should converge)
+- Visual smoke: ~30 min
+- Total: ~1 day
+
+## Open questions for R2 critics
+
+1. **Golden-angle vs fixed-modulus** — golden-angle gives stable per-index angles + maximal distribution (Vogel sunflower). Alternative: `slotCount = 64` fixed modulus (gives integer fractions, easier to reason about visually). Golden-angle picked because stability is the AC and packing is dense for any N up to ~50 indices. Flag if a fixed modulus is preferred for visual reasoning.
+
+2. **Sidebar Projects panel position** — between ViewPanel and Filters (matches E1's ViewPanel insertion pattern). Alternative: above ViewPanel (more prominent). Plan picks between-ViewPanel-and-Filters; flag if wrong.
+
+3. **`path:skf_s` filter** — hard-coded EXCLUDED_PATH_TAGS list. Alternative: heuristic (skip path tags carrying >50% of memories). Hard-coded simpler; revisit if other "root" tags surface.
+
+4. **Click handler `setQuery(tag)`** — uses existing free-text query filter. The raw `path:X` query-text drift is acknowledged + deferred to v0.3.0 chip-pill rewrite. Flag if a dedicated "active project" state is preferred for v1.
+
+5. **`pickShortestPathTag` location** — extracted into `tagPalette.ts` alongside `pickColorTag` (which now calls it). Alternative: dedicated `tagHelpers.ts` module. Picked tagPalette because the helper is currently used by exactly two consumers (pickColorTag + computeProjectAnchors), both in `engine/`.

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-brain-observatory",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -42,10 +42,22 @@ export function Header({ memoryCount, matchCount, stats, filterState, frozenOrig
     if (debounced !== filterState.query) setQuery(debounced);
   }, [debounced]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // External clears (e.g. "esc to clear search") should reset the local input.
-  // Narrow deps intentional: inputValue in deps would loop.
+  // External query changes (esc-to-clear, ProjectsPanel click-to-filter,
+  // tag-cloud chip click, etc.) should mirror into the local input box
+  // so the user sees WHY their memories filtered.
+  //
+  // Race safety: during typing, debounced lags inputValue by 150ms then
+  // catches up to filterState.query. If filterState.query === debounced
+  // we're already in sync (typing-driven change), don't echo it back —
+  // would cause cursor-jump artifacts. Mirror only when the external
+  // query diverges from our own pipeline.
+  //
+  // v0.29 (E5 review HIGH): pre-v0.29 this was `filterState.query === ""`
+  // (clears only), which silently dropped non-empty external syncs like
+  // ProjectsPanel.onSelectProject("path:hippo"). Narrow deps intentional:
+  // inputValue / debounced in deps would loop on every keystroke.
   useEffect(() => {
-    if (filterState.query === "" && inputValue !== "") setInputValue("");
+    if (filterState.query !== debounced) setInputValue(filterState.query);
   }, [filterState.query]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // P5 fix: `/` to focus search, Esc to clear (matches BottomBar shortcut hint).

--- a/ui/src/components/ProjectsPanel.test.tsx
+++ b/ui/src/components/ProjectsPanel.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * v0.29 (E5 S5) — Tests for the Sidebar Projects mini-panel.
+ *
+ * Coverage: empty state, top-N truncation, +N more affordance, aria-label
+ * (design HIGH-1), SVG aria-hidden, SVG dot position formula (design
+ * HIGH-2), subtitle copy.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ProjectsPanel } from "./ProjectsPanel.js";
+
+const LAYOUT_BOUND = 30;
+
+function project(tag: string, count: number, x: number, y: number) {
+  return { tag, count, anchor: { x, y } };
+}
+
+describe("ProjectsPanel", () => {
+  it("returns null when projects is empty", () => {
+    const { container } = render(
+      <ProjectsPanel projects={[]} onSelectProject={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders top-N projects in order", () => {
+    const projects = [
+      project("path:hippo", 173, 18, 0),
+      project("path:quantamental", 247, -9, 16),
+      project("path:phzse", 155, -9, -16),
+    ];
+    const { getAllByRole } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    const buttons = getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+    // Order matches input.
+    expect(buttons[0].textContent).toContain("hippo");
+    expect(buttons[1].textContent).toContain("quantamental");
+    expect(buttons[2].textContent).toContain("phzse");
+  });
+
+  it("renders subtitle '(ordered by first-seen)'", () => {
+    const projects = [project("path:hippo", 1, 0, 0)];
+    const { getByText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    expect(getByText("(ordered by first-seen)")).toBeDefined();
+  });
+
+  it("each button has an aria-label of the form 'Filter to project X, N memories' (design HIGH-1) with grammatical pluralization (review MED)", () => {
+    const projects = [
+      project("path:hippo", 173, 18, 0),
+      project("path:quantamental", 247, -9, 16),
+      project("path:singleton", 1, 0, 0),
+    ];
+    const { getByLabelText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    expect(getByLabelText("Filter to project hippo, 173 memories")).toBeDefined();
+    expect(getByLabelText("Filter to project quantamental, 247 memories")).toBeDefined();
+    // Singular form for count=1 (was '1 memories' in v1 — ungrammatical SR).
+    expect(getByLabelText("Filter to project singleton, 1 memory")).toBeDefined();
+  });
+
+  it("each SVG has aria-hidden='true' (decorative, screen readers skip)", () => {
+    const projects = [project("path:hippo", 1, 0, 0)];
+    const { container } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("SVG dot position computes from MINI_CENTER + (anchor.x/LAYOUT_BOUND)*MINI_INNER_RADIUS (design HIGH-2)", () => {
+    // anchor.x = LAYOUT_BOUND → dotX should be at MINI_CENTER + MINI_INNER_RADIUS = 15.
+    // anchor.y = -LAYOUT_BOUND → dotY at MINI_CENTER - MINI_INNER_RADIUS = 5.
+    const projects = [project("path:edge", 1, LAYOUT_BOUND, -LAYOUT_BOUND)];
+    const { container } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    const circles = container.querySelectorAll("circle");
+    expect(circles.length).toBe(2); // outer ring + dot
+    const dot = circles[1]; // second circle = the filled dot
+    expect(dot.getAttribute("cx")).toBe("15");
+    expect(dot.getAttribute("cy")).toBe("5");
+  });
+
+  it("click fires onSelectProject with the tag string", () => {
+    const onSelectProject = vi.fn();
+    const projects = [project("path:hippo", 1, 0, 0)];
+    const { getByLabelText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={onSelectProject} />,
+    );
+    fireEvent.click(getByLabelText("Filter to project hippo, 1 memory"));
+    expect(onSelectProject).toHaveBeenCalledWith("path:hippo");
+  });
+
+  it("renders '+N more' affordance when projects.length > 10", () => {
+    const projects = Array.from({ length: 17 }, (_, i) =>
+      project(`path:proj${i}`, 1, 0, 0),
+    );
+    const { getByText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    expect(getByText("+7 more")).toBeDefined();
+  });
+
+  it("does NOT render '+N more' when projects.length <= 10", () => {
+    const projects = Array.from({ length: 10 }, (_, i) =>
+      project(`path:proj${i}`, 1, 0, 0),
+    );
+    const { queryByText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    expect(queryByText(/\+\d+ more/)).toBeNull();
+  });
+
+  it("button has type='button' (defensive, avoids accidental form submit)", () => {
+    const projects = [project("path:hippo", 1, 0, 0)];
+    const { getByLabelText } = render(
+      <ProjectsPanel projects={projects} onSelectProject={() => {}} />,
+    );
+    const btn = getByLabelText("Filter to project hippo, 1 memory");
+    expect(btn.getAttribute("type")).toBe("button");
+  });
+});

--- a/ui/src/components/ProjectsPanel.tsx
+++ b/ui/src/components/ProjectsPanel.tsx
@@ -1,0 +1,137 @@
+/**
+ * v0.29 (E5) — Sidebar Projects mini-panel.
+ *
+ * Lists path:* projects in their persistent-anchor-index order (first-seen
+ * across user sessions, via localStorage). Each row shows a tiny SVG dot
+ * at the project's anchor position so users can visually correlate a
+ * Sidebar row to a cluster in the canvas. Click filters memories to that
+ * project (via setQuery).
+ *
+ * Caps display at MAX_VISIBLE; "+N more" surfaces overflow count
+ * (passive — no expand affordance in v1; v0.3.0+).
+ */
+
+import { LAYOUT_BOUND } from "../engine/forceLayout.js";
+
+interface ProjectsPanelProps {
+  /** Projects ordered by their anchor index (first-seen order). */
+  projects: ReadonlyArray<{
+    tag: string;
+    count: number;
+    anchor: { x: number; y: number };
+  }>;
+  /** Click handler: filter memories to that project (sets search query). */
+  onSelectProject: (tag: string) => void;
+}
+
+const MAX_VISIBLE = 10;
+
+// Mini SVG geometry — single source of truth, no duplicate cx/cy.
+const MINI_SIZE = 20;
+const MINI_CENTER = MINI_SIZE / 2;       // 10
+const MINI_INNER_RADIUS = 5;             // dot lives within this
+const MINI_OUTER_RADIUS = MINI_INNER_RADIUS + 2; // ring at 7
+
+export function ProjectsPanel({ projects, onSelectProject }: ProjectsPanelProps) {
+  if (projects.length === 0) return null;
+  const visible = projects.slice(0, MAX_VISIBLE);
+  const hiddenCount = Math.max(0, projects.length - MAX_VISIBLE);
+
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <h3 style={panelTitle}>Projects</h3>
+      <div style={subtitleStyle}>(ordered by first-seen)</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {visible.map(({ tag, count, anchor }) => {
+          // Map anchor.x ∈ [-LAYOUT_BOUND, +LAYOUT_BOUND] → screen-x ∈
+          // [center - MINI_INNER_RADIUS, center + MINI_INNER_RADIUS].
+          // Single coordinate system; v1's dead duplicate cx/cy lines gone.
+          const dotX = MINI_CENTER + (anchor.x / LAYOUT_BOUND) * MINI_INNER_RADIUS;
+          const dotY = MINI_CENTER + (anchor.y / LAYOUT_BOUND) * MINI_INNER_RADIUS;
+          const projectName = tag.replace("path:", "");
+          return (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onSelectProject(tag)}
+              aria-label={`Filter to project ${projectName}, ${count} ${count === 1 ? "memory" : "memories"}`}
+              className="project-row"
+              style={projectRowStyle}
+            >
+              <svg
+                width={MINI_SIZE}
+                height={MINI_SIZE}
+                aria-hidden={true}
+                style={{ flexShrink: 0 }}
+              >
+                <circle
+                  cx={MINI_CENTER}
+                  cy={MINI_CENTER}
+                  r={MINI_OUTER_RADIUS}
+                  fill="none"
+                  stroke="var(--border)"
+                  strokeWidth={1}
+                />
+                <circle cx={dotX} cy={dotY} r={2} fill="var(--accent)" />
+              </svg>
+              <span style={projectNameStyle}>{projectName}</span>
+              <span style={projectCountStyle}>{count}</span>
+            </button>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <div style={hiddenCountStyle}>+{hiddenCount} more</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const panelTitle: React.CSSProperties = {
+  fontSize: 11,
+  fontVariant: "small-caps",
+  letterSpacing: "1px",
+  fontWeight: 400,
+  color: "var(--dim)",
+  marginBottom: 4,
+  paddingBottom: 6,
+  borderBottom: "1px solid var(--glass-border)",
+};
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 9,
+  color: "var(--dim)",
+  marginBottom: 8,
+  fontStyle: "italic",
+};
+const projectRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "4px 6px",
+  background: "transparent",
+  border: "1px solid transparent",
+  borderRadius: 3,
+  cursor: "pointer",
+  transition: "background 150ms ease",
+  width: "100%",
+  textAlign: "left",
+};
+const projectNameStyle: React.CSSProperties = {
+  flex: 1,
+  fontFamily: "var(--font-mono)",
+  fontSize: 11,
+  color: "var(--text)",
+};
+const projectCountStyle: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: 10,
+  color: "var(--dim)",
+};
+const hiddenCountStyle: React.CSSProperties = {
+  fontSize: 9,
+  color: "var(--dim)",
+  textAlign: "center",
+  marginTop: 4,
+  fontStyle: "italic",
+  opacity: 0.7,
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import { StatsPanel } from "./StatsPanel.js";
 import { FilterPanel } from "./FilterPanel.js";
 import { TagCloud } from "./TagCloud.js";
 import { ViewPanel } from "./ViewPanel.js";
+import { ProjectsPanel } from "./ProjectsPanel.js";
 
 interface SidebarProps {
   memories: Memory[];
@@ -28,6 +29,15 @@ interface SidebarProps {
   setColorMode: (mode: ColorMode) => void;
   /** P4: reset all filters back to INITIAL_FILTER_STATE (keeping frozen flag). */
   resetFilters: () => void;
+  /** v0.29 (E5) — per-project list for the Projects mini-panel. Each row
+   *  shows a tag, count, and SVG dot at the project's anchor position.
+   *  Empty array → panel renders nothing (e.g. memories with no path
+   *  tags, or LivingMap before first populate). */
+  projects: ReadonlyArray<{
+    tag: string;
+    count: number;
+    anchor: { x: number; y: number };
+  }>;
 }
 
 export function Sidebar({
@@ -45,6 +55,7 @@ export function Sidebar({
   setFadingOnly,
   setColorMode,
   resetFilters,
+  projects,
 }: SidebarProps) {
   // Code-review-critic HIGH #1 fix: when filter is active and matches zero,
   // totalVisible should be 0, not memories.length.
@@ -100,6 +111,11 @@ export function Sidebar({
           (plan-design-critic R2 must-fix #3: literal "above the Filters
           header"). Renders the "Color by" segmented radio. */}
       <ViewPanel filterState={filterState} setColorMode={setColorMode} />
+
+      {/* v0.29 (E5) — Projects mini-panel between ViewPanel and Filters.
+          Each row = one path:* project with a tiny anchor-position dot
+          + click-to-filter. Renders null when projects is empty. */}
+      <ProjectsPanel projects={projects} onSelectProject={setQuery} />
 
       {/* P4 reset button row */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10, paddingBottom: 6, borderBottom: "1px solid var(--glass-border)" }}>

--- a/ui/src/engine/forceLayout.test.ts
+++ b/ui/src/engine/forceLayout.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 import type { Memory, Conflict } from "../types.js";
-import { buildForceLayout, type ForceNode } from "./forceLayout.js";
+import { buildForceLayout, type ForceNode, LAYOUT_BOUND } from "./forceLayout.js";
 import { buildAdjacency } from "./localNeighborhood.js";
 
 function mem(over: Partial<Memory> & { id: string }): Memory {
@@ -310,5 +310,101 @@ describe("perf budget (AC18 + AC19)", () => {
     handle.runToCompletion();
     const ms = performance.now() - t0;
     expect(ms).toBeLessThan(2000);
+  });
+});
+
+/**
+ * v0.29 (E5) — projectAnchors config branch. Plan v2.1 S7 + AC10/AC11/AC12.
+ *
+ * Locks: forceX/forceY added when projectAnchors set; back-compat without;
+ * anchored memories settle near their anchor; LAYOUT_BOUND export equals 30.
+ */
+describe("buildForceLayout projectAnchors (E5)", () => {
+  it("exports LAYOUT_BOUND === 30 (shared constant for scene + ProjectsPanel)", () => {
+    expect(LAYOUT_BOUND).toBe(30);
+  });
+
+  // Helper: settle a 1-node graph with the given config and return the
+  // final position. Single-node avoids charge repulsion in the comparison.
+  function settleOne(
+    config: Parameters<typeof buildForceLayout>[3],
+  ): { x: number; z: number } {
+    const memories = [mem({ id: "A" })];
+    const seed = new Map([["A", { x: 0, z: 0 }]]);
+    const handle = buildForceLayout(memories, new Map(), seed, {
+      maxTicks: 200,
+      randomSource: mulberry32(7),
+      ...config,
+    });
+    handle.runToCompletion();
+    return handle.position("A")!;
+  }
+
+  it("AC10: projectAnchors config pulls the anchored node MEASURABLY toward the anchor (compared to no-anchor baseline)", () => {
+    const anchor = { x: 10, y: 5 };
+    // Baseline: no projectAnchors → node settles via center+charge alone.
+    const withoutAnchor = settleOne({});
+    // With anchor: node should settle measurably closer to (10, 5).
+    const withAnchor = settleOne({
+      projectAnchors: new Map([["A", { ...anchor, strength: 0.5 }]]),
+    });
+
+    const baselineDist = Math.hypot(withoutAnchor.x - anchor.x, withoutAnchor.z - anchor.y);
+    const withAnchorDist = Math.hypot(withAnchor.x - anchor.x, withAnchor.z - anchor.y);
+
+    // The anchor must noticeably reduce distance to the target. d3-force's
+    // alphaDecay limits how much force is applied across maxTicks (default
+    // ~200 ticks × strength × alpha → finite pull, not infinite). A 1+ unit
+    // reduction proves the force is wired and acting, vs the baseline drift.
+    expect(withAnchorDist).toBeLessThan(baselineDist - 1);
+  });
+
+  it("AC11: without projectAnchors config, no project forces are added (back-compat with E4)", () => {
+    // Two parallel runs with the SAME seed + maxTicks. They MUST produce
+    // identical settle positions when neither has projectAnchors — i.e.
+    // the projectAnchors-absent code path is byte-equivalent to E4.
+    const a = settleOne({});
+    const b = settleOne({});
+    expect(a.x).toBe(b.x);
+    expect(a.z).toBe(b.z);
+    // And the position is NOT near (10, 5) — there's no force pulling there.
+    const distToAnchor = Math.hypot(a.x - 10, a.z - 5);
+    expect(distToAnchor).toBeGreaterThan(5); // anchor would have pulled it to <2
+  });
+
+  it("empty projectAnchors map = same as no anchors (no force registered)", () => {
+    // Edge case: passing an empty Map should skip the force registration
+    // (factory checks `size > 0`).
+    const memories = [mem({ id: "A" })];
+    const handle = buildForceLayout(memories, new Map(), null, {
+      projectAnchors: new Map(),
+    });
+    // No throw; ticks work.
+    handle.tick();
+    expect(handle.ticksRun()).toBe(1);
+  });
+
+  it("memories absent from projectAnchors get strength=0 (no pull)", () => {
+    // A is anchored at (10, 5) with strength 0.5; B is NOT in the map.
+    // After runToCompletion, A drifts toward (10, 5) but B stays near origin
+    // (only center + charge act on it).
+    const memories = [mem({ id: "A" }), mem({ id: "B" })];
+    const projectAnchors = new Map([
+      ["A", { x: 10, y: 5, strength: 0.5 }],
+      // B absent — no entry
+    ]);
+    const seed = new Map([["A", { x: 0, z: 0 }], ["B", { x: 0, z: 0 }]]);
+    const handle = buildForceLayout(memories, new Map(), seed, {
+      maxTicks: 50,
+      projectAnchors,
+      randomSource: mulberry32(7),
+    });
+    handle.runToCompletion();
+    const pA = handle.position("A")!;
+    const pB = handle.position("B")!;
+    // A pulled toward (10, 5).
+    expect(Math.hypot(pA.x - 10, pA.z - 5)).toBeLessThan(Math.hypot(pA.x, pA.z));
+    // B near origin (no anchor pull).
+    expect(Math.hypot(pB.x, pB.z)).toBeLessThan(Math.hypot(pB.x - 10, pB.z - 5));
   });
 });

--- a/ui/src/engine/forceLayout.ts
+++ b/ui/src/engine/forceLayout.ts
@@ -4,7 +4,10 @@
  * Y axis is kept as the layer-stratification offset (LAYER_Y_OFFSET in
  * scene.ts) so the visual layer metaphor is preserved.
  *
- * Per-project anchor forces are deferred to E5 (task #106).
+ * Per-project anchor forces (v0.29 E5): optional `projectAnchors` config
+ * adds forceX/forceY per node, pulling toward the project's anchor point.
+ * See projectAnchors.ts for the golden-angle packing that keeps anchors
+ * stable as new project tags appear.
  *
  * Pure factory. Caller drives tick() from BrainScene.animate. Disposal
  * is just dropping the returned reference (the simulation is .stop()'d
@@ -45,7 +48,22 @@ export interface ForceLayoutConfig {
   collideRadius?: number;
   bound?: number;
   randomSource?: () => number;
+  /**
+   * v0.29 (E5) — per-memory anchor targets. Memory id → {x, y, strength}.
+   * Memories present in this map get forceX/forceY pulls toward (x, y)
+   * with the given strength. Memories absent get strength=0 (no pull).
+   * Absent or empty config → no project forces (back-compat with E4).
+   */
+  projectAnchors?: Map<string, { x: number; y: number; strength: number }>;
 }
+
+/**
+ * v0.29 (E5) — layout coordinate bound. Memories are clamped within
+ * ±LAYOUT_BOUND on each axis by the simulation tick loop. Exported so
+ * consumers (scene.populate, computeProjectAnchors, ProjectsPanel
+ * mini-map) share the same magic number instead of re-hardcoding 30.
+ */
+export const LAYOUT_BOUND = 30;
 
 const DEFAULTS = {
   alphaMin: 0.01,
@@ -55,7 +73,7 @@ const DEFAULTS = {
   chargeStrength: -30,
   centerStrength: 0.05,
   collideRadius: 0.6,
-  bound: 30,
+  bound: LAYOUT_BOUND,
 } as const;
 
 export type SettleSource = "tick" | "reduced-motion";
@@ -163,6 +181,26 @@ export function buildForceLayout(
     .alphaMin(alphaMin)
     .alphaDecay(alphaDecay)
     .stop();
+
+  // v0.29 (E5) — optional per-project anchor forces. forceX/forceY accept
+  // per-node accessors so memories WITHOUT an entry in projectAnchors get
+  // strength=0 (no pull). Composes additively with link/charge/center.
+  const projectAnchors = config.projectAnchors;
+  if (projectAnchors && projectAnchors.size > 0) {
+    simulation
+      .force(
+        "project-x",
+        d3
+          .forceX<ForceNode>((d) => projectAnchors.get(d.id)?.x ?? 0)
+          .strength((d) => projectAnchors.get(d.id)?.strength ?? 0),
+      )
+      .force(
+        "project-y",
+        d3
+          .forceY<ForceNode>((d) => projectAnchors.get(d.id)?.y ?? 0)
+          .strength((d) => projectAnchors.get(d.id)?.strength ?? 0),
+      );
+  }
 
   if (config.randomSource) {
     simulation.randomSource(config.randomSource);

--- a/ui/src/engine/projectAnchors.test.ts
+++ b/ui/src/engine/projectAnchors.test.ts
@@ -1,0 +1,197 @@
+/**
+ * v0.29 (E5 S2 + S8) — Tests for per-project anchor computation.
+ *
+ * Highlights:
+ *   - AC20 byte-identical stability: existing anchors unchanged when a
+ *     new tag is added (the core E4 R2 fix).
+ *   - path:skf_s filtered out.
+ *   - Golden-angle formula: angle = i × GOLDEN_ANGLE per index.
+ *   - orderedTags includes only actually-anchored tags (HIGH-4 fix).
+ *   - Memories pick shortest path tag (alpha tiebreak) via shared helper.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeProjectAnchors,
+  GOLDEN_ANGLE,
+} from "./projectAnchors.js";
+import type { ProjectAnchorOrder } from "../state/projectAnchorOrder.js";
+import type { Memory } from "../types.js";
+
+const LAYOUT_BOUND = 30;
+const RADIUS = LAYOUT_BOUND * 0.6;
+
+function mem(id: string, tags: string[]): Memory {
+  return {
+    id,
+    content: "",
+    layer: "episodic",
+    strength: 0.5,
+    half_life_days: 30,
+    retrieval_count: 1,
+    age_days: 1,
+    schema_fit: 0,
+    emotional_valence: "neutral",
+    confidence: "observed",
+    pinned: false,
+    projected_strength_7d: 0.5,
+    projected_strength_30d: 0.5,
+    created: "2026-01-01T00:00:00Z",
+    last_retrieved: "2026-01-01T00:00:00Z",
+    tags,
+  };
+}
+
+function order(entries: Array<[string, number]>): ProjectAnchorOrder {
+  const indexByTag = new Map(entries);
+  const nextIndex = entries.length === 0 ? 0 : Math.max(...entries.map(([, i]) => i)) + 1;
+  return { indexByTag, nextIndex };
+}
+
+describe("computeProjectAnchors", () => {
+  it("filters path:skf_s (filesystem root, not a project)", () => {
+    const memories = [mem("a", ["path:skf_s"]), mem("b", ["path:hippo"])];
+    const ord = order([["path:skf_s", 0], ["path:hippo", 1]]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    expect(layout.byTag.has("path:skf_s")).toBe(false);
+    expect(layout.byTag.has("path:hippo")).toBe(true);
+    // Memory `a` had ONLY path:skf_s → no anchor.
+    expect(layout.byMemoryId.has("a")).toBe(false);
+    expect(layout.byMemoryId.has("b")).toBe(true);
+  });
+
+  it("places each anchor at (cos(i*GOLDEN_ANGLE)*r, sin(i*GOLDEN_ANGLE)*r)", () => {
+    const memories = [
+      mem("a", ["path:hippo"]),
+      mem("b", ["path:quantamental"]),
+      mem("c", ["path:phzse"]),
+    ];
+    const ord = order([
+      ["path:hippo", 0],
+      ["path:quantamental", 1],
+      ["path:phzse", 2],
+    ]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+
+    const anchor0 = layout.byTag.get("path:hippo")!;
+    expect(anchor0.x).toBeCloseTo(Math.cos(0) * RADIUS, 10);
+    expect(anchor0.y).toBeCloseTo(Math.sin(0) * RADIUS, 10);
+
+    const anchor1 = layout.byTag.get("path:quantamental")!;
+    expect(anchor1.x).toBeCloseTo(Math.cos(GOLDEN_ANGLE) * RADIUS, 10);
+    expect(anchor1.y).toBeCloseTo(Math.sin(GOLDEN_ANGLE) * RADIUS, 10);
+
+    const anchor2 = layout.byTag.get("path:phzse")!;
+    const angle2 = (2 * GOLDEN_ANGLE) % (2 * Math.PI);
+    expect(anchor2.x).toBeCloseTo(Math.cos(angle2) * RADIUS, 10);
+    expect(anchor2.y).toBeCloseTo(Math.sin(angle2) * RADIUS, 10);
+  });
+
+  it("AC20 — byte-identical positions for existing tags after a new tag is added (the core E4 R2 fix)", () => {
+    const memoriesV1 = [
+      mem("a", ["path:hippo"]),
+      mem("b", ["path:quantamental"]),
+      mem("c", ["path:phzse"]),
+    ];
+    const orderV1 = order([
+      ["path:hippo", 0],
+      ["path:quantamental", 1],
+      ["path:phzse", 2],
+    ]);
+    const layoutV1 = computeProjectAnchors(memoriesV1, orderV1, LAYOUT_BOUND);
+    const hippo1 = layoutV1.byTag.get("path:hippo")!;
+    const quant1 = layoutV1.byTag.get("path:quantamental")!;
+    const phzse1 = layoutV1.byTag.get("path:phzse")!;
+
+    // Add a new tag at index 3.
+    const memoriesV2 = [...memoriesV1, mem("d", ["path:resona"])];
+    const orderV2 = order([
+      ["path:hippo", 0],
+      ["path:quantamental", 1],
+      ["path:phzse", 2],
+      ["path:resona", 3],
+    ]);
+    const layoutV2 = computeProjectAnchors(memoriesV2, orderV2, LAYOUT_BOUND);
+    const hippo2 = layoutV2.byTag.get("path:hippo")!;
+    const quant2 = layoutV2.byTag.get("path:quantamental")!;
+    const phzse2 = layoutV2.byTag.get("path:phzse")!;
+
+    // Byte-identical (strict equality, not toBeCloseTo) — golden-angle
+    // makes existing indices' angles independent of total count N.
+    expect(hippo2.x).toBe(hippo1.x);
+    expect(hippo2.y).toBe(hippo1.y);
+    expect(quant2.x).toBe(quant1.x);
+    expect(quant2.y).toBe(quant1.y);
+    expect(phzse2.x).toBe(phzse1.x);
+    expect(phzse2.y).toBe(phzse1.y);
+
+    // And the newcomer is wherever golden-angle puts it.
+    const resona2 = layoutV2.byTag.get("path:resona")!;
+    expect(resona2).toBeDefined();
+  });
+
+  it("memories with no qualifying path tag are not in byMemoryId", () => {
+    const memories = [mem("a", ["topic:foo"])];
+    const ord = order([]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    expect(layout.byMemoryId.has("a")).toBe(false);
+  });
+
+  it("memories with multiple path tags pick the shortest (alpha tiebreak)", () => {
+    const memories = [mem("a", ["path:hippo-tests", "path:hippo"])];
+    const ord = order([
+      ["path:hippo", 0],
+      ["path:hippo-tests", 1],
+    ]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    const anchor = layout.byMemoryId.get("a")!;
+    const hippoAnchor = layout.byTag.get("path:hippo")!;
+    expect(anchor).toBe(hippoAnchor); // reference equality
+  });
+
+  it("orderedTags returns tags in persistent-index order", () => {
+    const memories = [
+      mem("a", ["path:c-late"]),
+      mem("b", ["path:a-early"]),
+      mem("c", ["path:b-mid"]),
+    ];
+    const ord = order([
+      ["path:c-late", 5],
+      ["path:a-early", 0],
+      ["path:b-mid", 2],
+    ]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    expect(layout.orderedTags).toEqual(["path:a-early", "path:b-mid", "path:c-late"]);
+  });
+
+  it("orderedTags includes ONLY tags actually picked as an anchored tag (HIGH-4 fix)", () => {
+    // Memory carries both path:hippo and path:hippo-tests, but
+    // pickShortestPathTag picks path:hippo (shorter). path:hippo-tests
+    // exists in the order but anchors zero memories → should NOT appear
+    // in orderedTags.
+    const memories = [mem("a", ["path:hippo", "path:hippo-tests"])];
+    const ord = order([
+      ["path:hippo", 0],
+      ["path:hippo-tests", 1],
+    ]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    expect(layout.orderedTags).toEqual(["path:hippo"]);
+    // byTag still has both (positions computed for all known indices) —
+    // it's the Sidebar legend that filters.
+    expect(layout.byTag.has("path:hippo-tests")).toBe(true);
+  });
+
+  it("respects anchorStrength override", () => {
+    const memories = [mem("a", ["path:hippo"])];
+    const ord = order([["path:hippo", 0]]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND, 0.04);
+    expect(layout.byTag.get("path:hippo")!.strength).toBe(0.04);
+  });
+
+  it("default anchorStrength is 0.08", () => {
+    const memories = [mem("a", ["path:hippo"])];
+    const ord = order([["path:hippo", 0]]);
+    const layout = computeProjectAnchors(memories, ord, LAYOUT_BOUND);
+    expect(layout.byTag.get("path:hippo")!.strength).toBe(0.08);
+  });
+});

--- a/ui/src/engine/projectAnchors.ts
+++ b/ui/src/engine/projectAnchors.ts
@@ -1,0 +1,128 @@
+/**
+ * v0.29 (E5) — Per-project anchor force computation.
+ *
+ * Each unique path:* tag is assigned a STABLE position on a circle of
+ * radius `LAYOUT_BOUND * 0.6` around origin. Memories carrying that tag
+ * get a gentle pull (default strength 0.08) toward the anchor via
+ * forceX/forceY in the d3-force simulation.
+ *
+ * Stability guarantee (AC20, the core E4 R2 fix):
+ *   Each tag at persistent index i gets angle `(i * GOLDEN_ANGLE) % 2π`.
+ *   The angle depends ONLY on i — not on the total tag count. So adding
+ *   a new tag at index N+1 leaves anchors 0..N byte-identical.
+ *
+ *   GOLDEN_ANGLE = π · (3 − √5) ≈ 137.508°. Vogel sunflower spiral
+ *   packing — dense and collision-free for any N up to ~50.
+ *
+ * Excludes EXCLUDED_PATH_TAGS (currently just path:skf_s, the filesystem
+ * root — 60% of memories. Including it would dominate the layout.)
+ *
+ * Per-memory tag pick uses the shared pickShortestPathTag helper (matches
+ * pickColorTag's path-mode rule from E1 tag palette).
+ */
+
+import type { Memory } from "../types.js";
+import type { ProjectAnchorOrder } from "../state/projectAnchorOrder.js";
+import { pickShortestPathTag } from "./tagPalette.js";
+
+/** Filter: which path:* tags are "real projects". Excludes the root
+ *  filesystem dir which is not a project. */
+const EXCLUDED_PATH_TAGS: ReadonlySet<string> = new Set(["path:skf_s"]);
+
+/**
+ * Vogel sunflower spiral angle. `(i * GOLDEN_ANGLE) % (2π)` is the same
+ * angle every time for the same i — independent of N. This is what makes
+ * AC20 (anchor stability) achievable; v1's slotCount-based angle had to
+ * shift every anchor when N grew, reintroducing the E4 R2 mass-resettle.
+ */
+export const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+export interface AnchorTarget {
+  /** Force-layout X (XZ-plane). */
+  x: number;
+  /** Force-layout Y (maps to scene-Z). */
+  y: number;
+  /** Pull strength toward this anchor. 0.08 is gentle (vs linkStrength
+   *  0.4) so anchors compose with edge-driven clustering without
+   *  overwhelming it. See force-balance note below. */
+  strength: number;
+}
+
+export interface AnchorLayout {
+  /** Anchor positions keyed by path tag. */
+  byTag: Map<string, AnchorTarget>;
+  /** Per-memory anchor lookup (memory.id → anchor target, or undefined
+   *  if memory has no qualifying path tag). */
+  byMemoryId: Map<string, AnchorTarget>;
+  /** The unique path tags considered (in their persistent-index order).
+   *  ONLY includes tags that were actually picked as the anchored tag for
+   *  at least one memory (not just "any path tag carried by a memory").
+   *  Used by the Sidebar Projects panel. */
+  orderedTags: string[];
+}
+
+/**
+ * Default anchor strength. 0.08 chosen so per-node anchor pull (1 per
+ * memory) is less than per-link pull (E4's linkStrength 0.4 × ~3-5 links
+ * per node = effective 1.2-2.0). Worst case: memory with 1 link to a
+ * different-project cluster + 1 anchor pull → 0.4 vs 0.08 = link wins 5×.
+ */
+const DEFAULT_ANCHOR_STRENGTH = 0.08;
+
+/**
+ * Compute per-project anchor positions on a circle of radius `bound × 0.6`
+ * around the origin. Each tag at persistent index `i` is placed at angle
+ * `(i × GOLDEN_ANGLE) mod 2π` — stable per i regardless of total tag count.
+ *
+ * Filters out EXCLUDED_PATH_TAGS.
+ *
+ * Each memory gets the anchor of its shortest qualifying path tag
+ * (alpha tiebreak), via pickShortestPathTag (shared with pickColorTag's
+ * "path" branch).
+ */
+export function computeProjectAnchors(
+  memories: readonly Memory[],
+  order: ProjectAnchorOrder,
+  bound: number,
+  anchorStrength: number = DEFAULT_ANCHOR_STRENGTH,
+): AnchorLayout {
+  const radius = bound * 0.6;
+  const TWO_PI = 2 * Math.PI;
+
+  // Build byTag anchor positions via golden-angle packing.
+  const byTag = new Map<string, AnchorTarget>();
+  for (const [tag, index] of order.indexByTag) {
+    if (EXCLUDED_PATH_TAGS.has(tag)) continue;
+    const angle = (index * GOLDEN_ANGLE) % TWO_PI;
+    byTag.set(tag, {
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      strength: anchorStrength,
+    });
+  }
+
+  // Build per-memory lookup AND collect actually-anchored tags for the
+  // orderedTags output. Single pass via pickShortestPathTag.
+  const byMemoryId = new Map<string, AnchorTarget>();
+  const anchoredTags = new Set<string>();
+  for (const mem of memories) {
+    const tag = pickShortestPathTag(mem.tags, EXCLUDED_PATH_TAGS);
+    if (tag === null) continue;
+    const anchor = byTag.get(tag);
+    if (anchor) {
+      byMemoryId.set(mem.id, anchor);
+      anchoredTags.add(tag);
+    }
+  }
+
+  // Sidebar: only tags that ACTUALLY anchor a memory (not "any path tag
+  // a memory carries"). Memory tagged [path:hippo, path:hippo-tests]
+  // anchors at path:hippo only; Sidebar won't show a ghost
+  // path:hippo-tests row with no visible cluster.
+  const orderedTags = [...order.indexByTag.entries()]
+    .filter(([tag]) => anchoredTags.has(tag))
+    .sort((a, b) => a[1] - b[1])
+    .map(([tag]) => tag);
+
+  return { byTag, byMemoryId, orderedTags };
+}

--- a/ui/src/engine/scene.ts
+++ b/ui/src/engine/scene.ts
@@ -18,7 +18,13 @@ import { isFading, type ColorMode } from "../state/filterState.js";
 import { buildPalette, resolveColor, TAG_PALETTE, PATH_PALETTE } from "./tagPalette.js";
 import { computeSharedTagPairs } from "./sharedTagPairs.js";
 import type { AdjacencyMap } from "./localNeighborhood.js";
-import { buildForceLayout, type ForceLayoutHandle, type SettleSource } from "./forceLayout.js";
+import { buildForceLayout, type ForceLayoutHandle, type SettleSource, LAYOUT_BOUND } from "./forceLayout.js";
+import { computeProjectAnchors, type AnchorLayout } from "./projectAnchors.js";
+import {
+  loadProjectAnchorOrder,
+  reconcileProjectOrder,
+  saveProjectAnchorOrder,
+} from "../state/projectAnchorOrder.js";
 
 // v0.28 (E2 real-edges) — pathological-filter mitigation. Module const so
 // it's referenced as HARD_EDGE_CAP without a class prefix.
@@ -121,6 +127,16 @@ export class BrainScene {
    */
   private settleSubscribers = new Set<(settling: boolean, source: SettleSource) => void>();
   private currentForceUnsubscribe: (() => void) | null = null;
+  /**
+   * v0.29 (E5) — cached AnchorLayout from the most recent populate(). Same
+   * reference returned by getProjectAnchorLayout() until the next populate
+   * runs. This stability lets LivingMap's projectsForSidebar useMemo skip
+   * rebuilds when populate hasn't fired (between populates). The reference
+   * IS replaced on every populate (computeProjectAnchors returns a fresh
+   * object each call) — that's the trigger React state needs to re-render
+   * the Sidebar with up-to-date anchor + count info.
+   */
+  private projectAnchorLayout: AnchorLayout | null = null;
 
   constructor(private container: HTMLDivElement) {
     this.initRenderer();
@@ -396,7 +412,27 @@ export class BrainScene {
         prior ?? { x: node.basePosition.x, z: node.basePosition.z },
       );
     }
-    this.forceLayout = buildForceLayout(memories, adjacency, seedPositions);
+    // v0.29 (E5) — per-project anchor computation. Persisted append-only
+    // ordering (localStorage) + golden-angle packing keep existing anchors
+    // STABLE when new project tags appear (the core E4 R2 fix). Computed
+    // BEFORE buildForceLayout so the result feeds the projectAnchors config.
+    const persistedOrder = loadProjectAnchorOrder();
+    const allPathTags = new Set<string>();
+    for (const m of memories) {
+      for (const t of m.tags) if (t.startsWith("path:")) allPathTags.add(t);
+    }
+    const reconciledOrder = reconcileProjectOrder([...allPathTags], persistedOrder);
+    if (reconciledOrder !== persistedOrder) {
+      // reconcileProjectOrder returns SAME ref when nothing changed — only
+      // touch localStorage when there's actually something new to write.
+      saveProjectAnchorOrder(reconciledOrder);
+    }
+    const projectAnchors = computeProjectAnchors(memories, reconciledOrder, LAYOUT_BOUND);
+    this.projectAnchorLayout = projectAnchors;
+
+    this.forceLayout = buildForceLayout(memories, adjacency, seedPositions, {
+      projectAnchors: projectAnchors.byMemoryId,
+    });
     // Forward forceLayout events to scene-level subscribers + replay current
     // state for any subscriber that attached before this populate.
     this.currentForceUnsubscribe = this.forceLayout.onSettleStateChange((settling, source) => {
@@ -475,6 +511,15 @@ export class BrainScene {
    * silently return stale counts — change the consumer to a callback
    * pattern at the same time.
    */
+  /**
+   * v0.29 (E5) — Returns the latest computed AnchorLayout, or null if
+   * populate has not yet run. Returns the SAME object reference until
+   * the next populate() call — safe to use as a React useMemo dep.
+   */
+  public getProjectAnchorLayout(): AnchorLayout | null {
+    return this.projectAnchorLayout;
+  }
+
   public getEdgeCounts(): EdgeCounts {
     let open = 0;
     let resolved = 0;

--- a/ui/src/engine/tagPalette.test.ts
+++ b/ui/src/engine/tagPalette.test.ts
@@ -20,6 +20,7 @@ import {
   TAG_FALLBACK_COLOR,
   buildPalette,
   pickColorTag,
+  pickShortestPathTag,
   resolveColor,
 } from "./tagPalette.js";
 import { contrastRatio } from "./contrast.js";
@@ -201,5 +202,46 @@ describe("palette contrast (AC10)", () => {
 
   it("TAG_FALLBACK_COLOR has >= 4.5:1 contrast vs COLOR_MAP_BG", () => {
     expect(contrastRatio(TAG_FALLBACK_COLOR, COLOR_MAP_BG)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+/**
+ * v0.29 (E5 HIGH-3) — pickShortestPathTag direct tests. The helper is now
+ * exported (shared with computeProjectAnchors) so its contract is part of
+ * the module surface, not just an internal pickColorTag detail.
+ */
+describe("pickShortestPathTag", () => {
+  it("returns null when tag list is empty", () => {
+    expect(pickShortestPathTag([])).toBeNull();
+  });
+
+  it("returns null when no path:* tag exists", () => {
+    expect(pickShortestPathTag(["topic:foo", "agent:bar"])).toBeNull();
+  });
+
+  it("picks the shortest path tag", () => {
+    expect(
+      pickShortestPathTag(["path:hippo-tests", "path:hippo", "path:longer-name"]),
+    ).toBe("path:hippo");
+  });
+
+  it("alpha tiebreak on equal-length path tags", () => {
+    expect(pickShortestPathTag(["path:zzz", "path:aaa"])).toBe("path:aaa");
+  });
+
+  it("excludeSet filters out matched tags before picking", () => {
+    expect(
+      pickShortestPathTag(["path:skf_s", "path:hippo"], new Set(["path:skf_s"])),
+    ).toBe("path:hippo");
+  });
+
+  it("excludeSet excluding all path tags returns null", () => {
+    expect(
+      pickShortestPathTag(["path:skf_s"], new Set(["path:skf_s"])),
+    ).toBeNull();
+  });
+
+  it("undefined excludeSet behaves like empty (no exclusions)", () => {
+    expect(pickShortestPathTag(["path:hippo"])).toBe("path:hippo");
   });
 });

--- a/ui/src/engine/tagPalette.ts
+++ b/ui/src/engine/tagPalette.ts
@@ -129,15 +129,45 @@ export function buildPalette(
 }
 
 /**
+ * v0.29 (E5 HIGH-3) — Pick the SHORTEST qualifying path:* tag from a tag
+ * list, with alpha tiebreak. **Path-mode only** — does not handle the
+ * non-path tag-mode pick (pickColorTag's "tag" branch keeps its own inline
+ * filter for those, which excludes path:* tags and is structurally
+ * different from a "pick from prefix" rule).
+ *
+ * Used by:
+ *   - pickColorTag's "path" branch (refactored to call this) — no exclusion
+ *   - computeProjectAnchors (projectAnchors.ts) — excludes filesystem-root
+ *     tags via excludeSet
+ */
+export function pickShortestPathTag(
+  tags: readonly string[],
+  excludeSet?: ReadonlySet<string>,
+): string | null {
+  const qualifying = tags.filter(
+    (t) => t.startsWith(PATH_PREFIX) && !(excludeSet?.has(t) ?? false),
+  );
+  if (qualifying.length === 0) return null;
+  qualifying.sort((a, b) => a.length - b.length || a.localeCompare(b));
+  return qualifying[0] ?? null;
+}
+
+/**
  * Pick the color-driving tag for a memory under tag/path mode.
  * Rule: shortest qualifying tag wins; alphabetical tiebreak.
  * Returns null if no qualifying tag exists → caller uses fallback color.
+ *
+ * v0.29: "path" branch now delegates to pickShortestPathTag (shared with
+ * computeProjectAnchors). "tag" branch keeps its inline filter (excludes
+ * path:* tags; structurally inverse of the path-tag rule, not worth a
+ * second shared helper).
  */
 export function pickColorTag(memory: Memory, mode: "tag" | "path"): string | null {
-  const qualifying = memory.tags.filter((tag) => {
-    if (mode === "path") return tag.startsWith(PATH_PREFIX);
-    return !tag.startsWith(PATH_PREFIX);
-  });
+  if (mode === "path") {
+    return pickShortestPathTag(memory.tags);
+  }
+  // "tag" mode: shortest non-path tag, alpha tiebreak.
+  const qualifying = memory.tags.filter((tag) => !tag.startsWith(PATH_PREFIX));
   if (qualifying.length === 0) return null;
   qualifying.sort((a, b) => a.length - b.length || a.localeCompare(b));
   return qualifying[0] ?? null;

--- a/ui/src/state/projectAnchorOrder.test.ts
+++ b/ui/src/state/projectAnchorOrder.test.ts
@@ -1,0 +1,199 @@
+/**
+ * v0.29 (E5 S1) — Tests for the persisted append-only project ordering.
+ *
+ * Coverage: load/save round-trip, append-only semantics, reference-equality
+ * skip-save, shape validation (including the v2.1 inner-tuple corruption
+ * case that golden-angle math is allergic to).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  loadProjectAnchorOrder,
+  saveProjectAnchorOrder,
+  reconcileProjectOrder,
+  clearProjectAnchorOrder,
+} from "./projectAnchorOrder.js";
+
+const STORAGE_KEY = "hippo:projectAnchorOrder:v1";
+
+describe("projectAnchorOrder", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    clearProjectAnchorOrder();
+    vi.restoreAllMocks();
+  });
+
+  describe("loadProjectAnchorOrder", () => {
+    it("returns empty when localStorage is empty", () => {
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+      expect(order.nextIndex).toBe(0);
+    });
+
+    it("returns empty when localStorage value is non-JSON", () => {
+      window.localStorage.setItem(STORAGE_KEY, "not json {{{");
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+      expect(order.nextIndex).toBe(0);
+    });
+
+    it("returns empty when JSON shape lacks tags array", () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ nextIndex: 5 }));
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+      expect(order.nextIndex).toBe(0);
+    });
+
+    it("returns empty when JSON shape lacks nextIndex number", () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ tags: [["path:hippo", 0]] }));
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+    });
+
+    it("returns empty when tags is present but non-iterable", () => {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ tags: "hello", nextIndex: 0 }));
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+    });
+
+    it("returns empty on inner-tuple corruption (v2.1: new Map(['hello']) silent corruption)", () => {
+      // Single-element entries → Map gets {hello: undefined} → NaN downstream.
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ tags: [["hello"], ["world"]], nextIndex: 2 }),
+      );
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+      expect(order.nextIndex).toBe(0);
+    });
+
+    it("returns empty when an inner tuple has non-string key", () => {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ tags: [[42, 0]], nextIndex: 1 }),
+      );
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+    });
+
+    it("returns empty when an inner tuple has non-finite number value", () => {
+      // JSON.stringify({nextIndex: NaN}) → 'null'; we synthesize a value with infinite via raw.
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        '{"tags":[["path:hippo",null]],"nextIndex":1}',
+      );
+      const order = loadProjectAnchorOrder();
+      expect(order.indexByTag.size).toBe(0);
+    });
+  });
+
+  describe("saveProjectAnchorOrder + load round-trip", () => {
+    it("round-trips a populated order", () => {
+      const order = {
+        indexByTag: new Map([
+          ["path:hippo", 0],
+          ["path:quantamental", 1],
+          ["path:phzse", 2],
+        ]),
+        nextIndex: 3,
+      };
+      saveProjectAnchorOrder(order);
+      const loaded = loadProjectAnchorOrder();
+      expect(loaded.nextIndex).toBe(3);
+      expect(loaded.indexByTag.get("path:hippo")).toBe(0);
+      expect(loaded.indexByTag.get("path:quantamental")).toBe(1);
+      expect(loaded.indexByTag.get("path:phzse")).toBe(2);
+    });
+
+    it("silent-skips save when localStorage throws (QuotaExceededError)", () => {
+      // Spy on the prototype — jsdom's Storage proxy doesn't surface
+      // instance-level spies, but prototype methods are reached via lookup.
+      const setItemSpy = vi
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("Quota exceeded", "QuotaExceededError");
+        });
+      expect(() =>
+        saveProjectAnchorOrder({ indexByTag: new Map([["x", 0]]), nextIndex: 1 }),
+      ).not.toThrow();
+      expect(setItemSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("reconcileProjectOrder", () => {
+    it("appends new tags with next-after-max index", () => {
+      const start = {
+        indexByTag: new Map([["path:hippo", 0]]),
+        nextIndex: 1,
+      };
+      const result = reconcileProjectOrder(["path:hippo", "path:resona"], start);
+      expect(result.indexByTag.get("path:hippo")).toBe(0);
+      expect(result.indexByTag.get("path:resona")).toBe(1);
+      expect(result.nextIndex).toBe(2);
+    });
+
+    it("keeps existing tags' indices stable (the core AC)", () => {
+      const start = {
+        indexByTag: new Map([
+          ["path:hippo", 0],
+          ["path:quantamental", 1],
+          ["path:phzse", 2],
+        ]),
+        nextIndex: 3,
+      };
+      const result = reconcileProjectOrder(
+        ["path:hippo", "path:quantamental", "path:phzse", "path:newcomer"],
+        start,
+      );
+      expect(result.indexByTag.get("path:hippo")).toBe(0);
+      expect(result.indexByTag.get("path:quantamental")).toBe(1);
+      expect(result.indexByTag.get("path:phzse")).toBe(2);
+      expect(result.indexByTag.get("path:newcomer")).toBe(3);
+      expect(result.nextIndex).toBe(4);
+    });
+
+    it("returns SAME object reference when nothing changed (skip-save pattern)", () => {
+      const start = {
+        indexByTag: new Map([["path:hippo", 0]]),
+        nextIndex: 1,
+      };
+      const result = reconcileProjectOrder(["path:hippo"], start);
+      expect(result).toBe(start); // reference equality
+    });
+
+    it("returns SAME ref when current tags are a subset (deletions don't compact)", () => {
+      const start = {
+        indexByTag: new Map([["path:hippo", 0], ["path:zoom", 1]]),
+        nextIndex: 2,
+      };
+      const result = reconcileProjectOrder(["path:hippo"], start);
+      expect(result).toBe(start);
+      expect(result.nextIndex).toBe(2); // slot 1 stays unused
+      expect(result.indexByTag.has("path:zoom")).toBe(true);
+    });
+
+    it("assigns new tags alpha-sorted within a single batch", () => {
+      const start = { indexByTag: new Map<string, number>(), nextIndex: 0 };
+      const result = reconcileProjectOrder(
+        ["path:zoom", "path:apple", "path:mango"],
+        start,
+      );
+      expect(result.indexByTag.get("path:apple")).toBe(0);
+      expect(result.indexByTag.get("path:mango")).toBe(1);
+      expect(result.indexByTag.get("path:zoom")).toBe(2);
+      expect(result.nextIndex).toBe(3);
+    });
+  });
+
+  describe("clearProjectAnchorOrder", () => {
+    it("removes the localStorage key", () => {
+      saveProjectAnchorOrder({ indexByTag: new Map([["x", 0]]), nextIndex: 1 });
+      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      clearProjectAnchorOrder();
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/ui/src/state/projectAnchorOrder.ts
+++ b/ui/src/state/projectAnchorOrder.ts
@@ -1,0 +1,129 @@
+/**
+ * v0.29 (E5) — Append-only persisted ordering of project (path:*) tags.
+ *
+ * Stable across sessions: once a project gets an index, that index NEVER
+ * moves. New project tags get the next-after-max index. Deleted tags retain
+ * their slot. Combined with golden-angle anchor packing in projectAnchors.ts,
+ * existing tags' anchor positions are byte-identical pre/post any new-tag
+ * addition — the structural fix for the E4 R2 mass-resettle bug.
+ *
+ * STORAGE_KEY versioning: bump to "...:v2" if the persisted schema
+ * changes; old v1 keys become orphaned (not migrated) — acceptable since
+ * the data is purely UI-state with no canonical value.
+ */
+
+const STORAGE_KEY = "hippo:projectAnchorOrder:v1";
+
+export interface ProjectAnchorOrder {
+  /** Tag → its persistent index (0-based). Stable across sessions. */
+  indexByTag: Map<string, number>;
+  /** Highest index assigned. Next new tag gets nextIndex (= maxIndex + 1). */
+  nextIndex: number;
+}
+
+const EMPTY: ProjectAnchorOrder = { indexByTag: new Map(), nextIndex: 0 };
+
+/**
+ * Load from localStorage. Returns empty on first run, parse error, OR
+ * shape mismatch (legacy / corrupted / hand-edited payload). Two-layer
+ * defense: try/catch for JSON.parse + explicit shape validation before
+ * constructing the Map (which would throw OR silently corrupt on
+ * non-iterable / non-tuple `tags`).
+ */
+export function loadProjectAnchorOrder(): ProjectAnchorOrder {
+  if (typeof window === "undefined") return EMPTY;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      !Array.isArray((parsed as { tags?: unknown }).tags) ||
+      typeof (parsed as { nextIndex?: unknown }).nextIndex !== "number"
+    ) {
+      return EMPTY;
+    }
+    const candidateTags = (parsed as { tags: unknown[] }).tags;
+    // v2.1: tighten inner-tuple shape check. new Map([['hello']]) does NOT
+    // throw — it silently produces {key:'hello', value:undefined} and the
+    // undefined index then NaN-propagates through golden-angle math. Reject
+    // any entry that isn't exactly [string, finite-number].
+    if (
+      !candidateTags.every(
+        (t): t is [string, number] =>
+          Array.isArray(t) &&
+          t.length === 2 &&
+          typeof t[0] === "string" &&
+          typeof t[1] === "number" &&
+          Number.isFinite(t[1]),
+      )
+    ) {
+      return EMPTY;
+    }
+    const valid = parsed as { tags: Array<[string, number]>; nextIndex: number };
+    return {
+      indexByTag: new Map(valid.tags),
+      nextIndex: valid.nextIndex,
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+/**
+ * Persist to localStorage. Silent no-op if window/storage unavailable.
+ * Layout still works without persistence; new tags get re-assigned per
+ * session (locally consistent within the session, just not across them).
+ */
+export function saveProjectAnchorOrder(order: ProjectAnchorOrder): void {
+  if (typeof window === "undefined") return;
+  try {
+    const serialized = JSON.stringify({
+      tags: [...order.indexByTag.entries()],
+      nextIndex: order.nextIndex,
+    });
+    window.localStorage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    // localStorage may be full or disabled — silently skip.
+  }
+}
+
+/**
+ * Reconcile current project tags with the persisted ordering.
+ * - Tags already in ordering: keep their existing index.
+ * - New tags: assigned nextIndex (alpha-sorted batch order), nextIndex++.
+ * - Tags no longer in current set: index retained in ordering but unused.
+ *
+ * Returns SAME order object reference when nothing changed (reference
+ * equality lets caller skip the save call).
+ */
+export function reconcileProjectOrder(
+  currentTags: readonly string[],
+  order: ProjectAnchorOrder,
+): ProjectAnchorOrder {
+  const sortedTags = [...currentTags].sort(); // deterministic add order
+  const indexByTag = new Map(order.indexByTag);
+  let nextIndex = order.nextIndex;
+  let changed = false;
+  for (const tag of sortedTags) {
+    if (!indexByTag.has(tag)) {
+      indexByTag.set(tag, nextIndex);
+      nextIndex++;
+      changed = true;
+    }
+  }
+  return changed ? { indexByTag, nextIndex } : order;
+}
+
+/**
+ * @internal Reset for tests / future "reset layout" affordance. Not wired
+ * into product code in this episode — exported only so tests can isolate
+ * state between runs. v0.3.0 will wire a button.
+ */
+export function clearProjectAnchorOrder(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch { /* ignore */ }
+}

--- a/ui/src/tokens.css
+++ b/ui/src/tokens.css
@@ -70,6 +70,12 @@
   border-radius: var(--radius-sm);
 }
 
+/* v0.29 (E5 ProjectsPanel) — hover affordance for Sidebar project rows.
+   No :focus-visible override here — global *:focus-visible (above, 2px/2px)
+   intentionally wins so all interactive elements share one focus standard.
+   Plan v2.1 design must-fix. */
+.project-row:hover { background: var(--ink-faint); }
+
 /* E5 S3 — sr-only utility for visually-hidden but SR-readable content.
    Standard a11y pattern. */
 .sr-only {

--- a/ui/src/views/LivingMap/LivingMap.tsx
+++ b/ui/src/views/LivingMap/LivingMap.tsx
@@ -314,7 +314,15 @@ export function LivingMap({
     }
   }, [setLocalView]);
 
-  const { containerRef, handleMouseMove, handleClick, handleKeyDown, edgeCounts, forceSettling } = useCanvasEngine({
+  const {
+    containerRef,
+    handleMouseMove,
+    handleClick,
+    handleKeyDown,
+    edgeCounts,
+    forceSettling,
+    projectAnchorLayout,
+  } = useCanvasEngine({
     memories, embeddings, conflicts, width: size.width, height: size.height,
     onHover, onClick: onClickMemory,
     searchQuery: filterState.query,
@@ -325,6 +333,26 @@ export function LivingMap({
     adjacency,
     onSceneReady: setSceneInstance,
   });
+
+  // v0.29 (E5) — Sidebar projects list with counts. Memoized on memories
+  // + the anchor-layout reference (which scene caches per populate, so
+  // this memo only rebuilds when populate fires — exactly what we want).
+  const projectsForSidebar = useMemo(() => {
+    if (!projectAnchorLayout) return [];
+    const counts = new Map<string, number>();
+    for (const m of memories) {
+      for (const t of m.tags) {
+        if (projectAnchorLayout.byTag.has(t)) {
+          counts.set(t, (counts.get(t) ?? 0) + 1);
+        }
+      }
+    }
+    return projectAnchorLayout.orderedTags.map((tag) => ({
+      tag,
+      count: counts.get(tag) ?? 0,
+      anchor: projectAnchorLayout.byTag.get(tag)!,
+    }));
+  }, [memories, projectAnchorLayout]);
 
   // v0.27 — derive the color-driving tag for the currently hovered memory
   // so MemoryTooltip can surface it in tag/path mode (a11y non-color channel
@@ -424,6 +452,7 @@ export function LivingMap({
         setFadingOnly={setFadingOnly}
         setColorMode={setColorMode}
         resetFilters={resetFilters}
+        projects={projectsForSidebar}
       />
 
       {matchCount === 0 && filterState.query.trim().length > 0 && (

--- a/ui/src/views/LivingMap/useCanvasEngine.ts
+++ b/ui/src/views/LivingMap/useCanvasEngine.ts
@@ -3,6 +3,7 @@ import type { Memory, Conflict, EmbeddingIndex } from "../../types.js";
 import { BrainScene, type EdgeCounts } from "../../engine/scene.js";
 import { projectTo3D } from "../../engine/projection.js";
 import type { AdjacencyMap } from "../../engine/localNeighborhood.js";
+import type { AnchorLayout } from "../../engine/projectAnchors.js";
 import type { ColorMode } from "../../state/filterState.js";
 
 const INITIAL_EDGE_COUNTS: EdgeCounts = {
@@ -79,6 +80,12 @@ export function useCanvasEngine({
   // re-renders BottomBar with fresh affordance copy / bail hint.
   // No render-time getter polling = no stale-data race.
   const [edgeCounts, setEdgeCounts] = useState<EdgeCounts>(INITIAL_EDGE_COUNTS);
+  // v0.29 (E5) — project anchor layout in React state. Set in the same
+  // effect as setEdgeCounts (right after scene.populate returns) so the
+  // populate-driven layout change triggers a re-render that propagates
+  // to the Sidebar Projects panel. Ref-read at render time would NOT
+  // trigger re-render — useState is the structural fix (CRIT-2).
+  const [projectAnchorLayout, setProjectAnchorLayout] = useState<AnchorLayout | null>(null);
   // v0.28+ E4 — settling state for BottomBar affordance. settlingKindRef
   // flips from "initial" to "refresh" after first settle stops. Suppressed
   // entirely when fired from reduced-motion path (user doesn't see animation).
@@ -121,6 +128,11 @@ export function useCanvasEngine({
     // counts immediately after returns the freshly-built state. Triggers
     // a React re-render of BottomBar with the new affordance copy.
     setEdgeCounts(scene.getEdgeCounts());
+    // v0.29 (E5) — same idea for the project anchor layout. populate
+    // computes + caches it on the scene; we read + set React state in
+    // the SAME synchronous block so the Sidebar Projects panel sees
+    // it as soon as the canvas does.
+    setProjectAnchorLayout(scene.getProjectAnchorLayout());
   }, [memories, embeddings, conflicts, adjacency]);
 
   // v0.28+ E4 — subscribe once to scene-level settling events. Scene forwards
@@ -219,5 +231,13 @@ export function useCanvasEngine({
     if (e.key === "Escape") sceneRef.current?.deselect();
   }, []);
 
-  return { containerRef, handleMouseMove, handleClick, handleKeyDown, edgeCounts, forceSettling };
+  return {
+    containerRef,
+    handleMouseMove,
+    handleClick,
+    handleKeyDown,
+    edgeCounts,
+    forceSettling,
+    projectAnchorLayout,
+  };
 }


### PR DESCRIPTION
Closes the Obsidian-inspired graph upgrades stack. E5 was spun out of E4 (task #106) when the per-project anchor scope surfaced 3 separate HIGH design issues in E4 R2 critic.

## What ships

Per-project anchor forces on the d3-force layout from E4. Each unique `path:*` tag gets a stable position on a golden-angle-packed circle around origin; memories carrying that tag get a gentle pull toward it (strength 0.08 vs linkStrength 0.4 so edges still dominate clustering). Sidebar Projects mini-panel lets users read which cluster is which project and click to filter.

`localStorage` persists project ordering append-only across sessions, so existing anchors stay byte-identical when new project tags appear (the AC20 stability guarantee, addressing the E4 R2 mass-resettle issue).

## Episode trail

01KSFW6KEPY679H2MF4MSDZQ89 via `/dev-framework-rl` orchestrator. Plan v2.1 across:
- plan-eng-critic: R1 fail (4) -> R2 pass (7)
- plan-design-critic: R1/R2 pass-with-fixes (8)
- code-review-critic: R1 fail (7) -> R2 pass (9)
- independent-review-critic: pass-with-fixes (78); Header sync + aria pluralization folded in-stage
- ship-readiness-critic: pass-with-fixes (78); CHANGELOG + commit folded

All must_fixes addressed. Full record in CHANGELOG v0.2.5 entry.

## Tests

220 / 220 pass across 14 test files in `ui/`. `npx tsc --noEmit` clean. `npm run build` clean.

New tests: 16 (projectAnchorOrder) + 10 (projectAnchors AC20 stability) + 9 (ProjectsPanel aria + SVG) + 5 (forceLayout LAYOUT_BOUND + projectAnchors config) + 7 (pickShortestPathTag direct).

## Release

Bundled into hippo-memory v1.12.10 -> v1.12.11 via `/publish-repo` after merge. v1.12.11 publishes E1-E5 cumulatively (E1-E4 commits landed at 8d6cc47 but were never `npm publish`ed).

## Test plan

- [x] `npm test --run` from `ui/`: 220/220 pass
- [x] `npx tsc --noEmit`: clean
- [x] `npm run build`: clean
- [x] Plan ACs 1-22 covered (see plan doc + CHANGELOG)
- [x] No em-dashes in commit message / CHANGELOG / UI strings
- [x] No secrets, no debug code in production paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)