### PR TITLE
feat(dag): E5 level-3 entity profiles + drillDown depth

### DIFF
--- a/docs/plans/2026-05-25-dag-e5-entity-profiles.md
+++ b/docs/plans/2026-05-25-dag-e5-entity-profiles.md
@@ -1,0 +1,517 @@
+# 2026-05-25 / DAG live-coupling E5: level-3 entity profiles + drillDown depth
+
+**Status:** Draft v3 (R2 PASS score 8 / 4 must_fix folded: S5 eligible.length code-bug, SELECT-before-UPDATE perf via RETURNING clause, audit metadata line anchors, cmdDrillDown rename + client-side depth clamps)
+**Episode:** 01KSGH3FFBEN9WGV19CNJJZQTV
+**Branch:** feat-dag-e5-entity-profiles (off feat-dag-e4-recall; stacked PR, do NOT --delete-branch E4 on merge)
+**Owner:** Claude (Keith review)
+
+## Discover refinement (hoisted per "Discover IS a scope-decision stage" memory)
+
+Brainstorm framing: "level-3 entity profiles + drillDown --depth N".
+
+E3+E4 retro lessons applied during discover (pre-verified before plan-write):
+
+1. **All 5 SQL guards filtering `dag_level = 2` enumerated**: store.ts:2524 (markSummaryDirtyInTx), :2561 (markSummaryDirty), :2690 + :2700 (applyRebuildResult bumpRebuildCount true/false branches), :2799 (clearSummaryDirtyAfterBuild). E5 widens all 5 to `IN (2, 3)`. The E1/E2 comments explicitly anticipated this: store.ts:2541 says "E5 will widen the dag_level guard to IN (2, 3) when level-3 build path lands".
+
+2. **3 api.ts sites pin to dag_level=2 in the overflow substitution path** (R1 LOW L4 enumeration): api.ts:542 (`if ((e.dag_level ?? 0) > 1) continue;` filters L1+L0 candidates), api.ts:553 (`(p) => (p.dag_level ?? 0) === 2` filters eligible parents to L2 only), api.ts:883 (recall-time scope filter that also pins L2). **All three explicitly OUT OF SCOPE for E5** — L3 substitution in api.recall overflow is a separate refactor. Do NOT widen these.
+
+3. **dag_level_3_built_at column already exists in schema v28** (db.ts:968-971, MemoryEntry.dag_level_3_built_at at memory.ts:94, MEMORY_SELECT_COLUMNS at store.ts:199). No schema migration needed. Populated at L3 creation time; NOT bumped on rebuild.
+
+4. **drillDown signature** at api.ts:1018, DrillDownOpts has `limit` + `budget`. E5 adds `depth?: number` (default 1, preserves backward compat).
+
+5. **drillDown call sites traced**: cli.ts:4537 (`cmdDrill`), server.ts:643 (HTTP /v1/drill), mcp/server.ts (via apiDrillDown import). Each needs `--depth` / `depth` pass-through.
+
+6. **AuditOp lockstep verified**: `summary_marked_dirty` + `summary_rebuilt` + `summary_marked_clean` already in union (audit.ts:142-144) + cli.ts VALID_AUDIT_OPS (4738-4740) + server.ts VALID_AUDIT_OPS (83-85). **No new ops for E5**; E5 only widens existing emitters' WHERE clauses + extends metadata semantics.
+
+7. **rebuildDirtySummaries already generic over level**: loadChildrenOfSummary at store.ts:2620 walks by `dag_parent_id`, level-agnostic. applyRebuildResult's UPDATE filters `dag_level = 2`, which becomes IN (2, 3). generateDagSummary takes `(label, factContents, opts)` — for L3, the "facts" are L2 summary contents. Reusable as-is.
+
+8. **buildEntityProfiles mirrors buildDag**: cluster L2 by shared entity tag (speaker:X, topic:X) using same `clusterFacts` helper from dag.ts:10, threshold 2+ L2s per entity, generate via generateDagSummary, set dag_level=3 + dag_parent_id=null + dag_level_3_built_at=now + descendant_count + earliest/latest_at. Then link the L2 children with dag_parent_id pointing to new L3, then `clearSummaryDirtyAfterBuild` on the new L3 (born-dirty cancellation, E3 retro lesson).
+
+9. **E4 deboost: extend isDagSummary to L3** — current `isDagSummary(entry)` returns `dag_level === 2`. E5 widens to `dag_level === 2 || dag_level === 3`. Same 0.85 deboost applies. Differentiated deboost (e.g. 0.7 for L3) flagged as follow-up, not E5 scope.
+
+10. **H1 FOLD: existing tests that hardcode `dag_level: 2` in audit metadata assertions**: `tests/dag-dirty-flag-schema.test.ts:165` does `expect(events[0]!.metadata).toMatchObject({ dag_level: 2, source: 'E1' });`. With the widened predicate, the L2 case still emits `dag_level: 2` (the actual level read at audit time, NOT a hardcoded constant), so this test continues to pass unchanged. The L3 case emits `dag_level: 3` — exercised by new E5 tests. Plan v2 reads the actual level pre-UPDATE (via SELECT or caller pass-through) so audit metadata stays accurate. Existing tests:
+   - `dag-dirty-flag-schema.test.ts:165` — unchanged (L2 → 2 still correct)
+   - `dag-dirty-flag-schema.test.ts:102` test name "markSummaryDirty no-ops on non-summary rows (dag_level !== 2)" — RENAME to "(dag_level NOT IN (2, 3))" since the predicate widens
+   - `dag-recall-first-class.test.ts:315` `isDagSummary({dag_level: 1}) === false` — unchanged (L1 still false); add `isDagSummary({dag_level: 3}) === true` as a new case in this test or a new E5 test
+   - No other tests pin `dag_level: 2` in metadata.
+
+11. **H2 FOLD: phase 1.9 data source**: `survivors` (consolidate.ts:139) is built from the decay-pass output. buildDag (phase 1.7) writes new L2 summaries directly via `writeEntry` without pushing them back into `survivors`. So `survivors` does NOT contain the just-created L2s at phase 1.9 time. R1 H2 must-fix: phase 1.9 MUST re-load from disk. Two options:
+    - (a) `loadAllEntries(hippoRoot)` second-call (already done at L121 for main pass). Memory cost: full table re-load. On large stores this is real.
+    - (b) Add `loadAllL2Summaries(hippoRoot)` tenant-host-wide helper that filters at SQL (`WHERE dag_level = 2 AND dag_parent_id IS NULL AND kind != 'archived'`).
+    
+    **Plan v2 picks (b)** — aligns with the loadAllDirtySummaries pattern (E3), cheaper, single-purpose. Adds ~25 lines to store.ts.
+
+Carry-forward concerns (each addressed):
+
+1. **Phase ordering**: consolidate runs 1.7 buildDag → 1.8 rebuildDirtySummaries → **1.9 buildEntityProfiles** (NEW). L3 build reads fresh L2 content via `loadAllL2Summaries` (NOT `survivors`).
+
+2. **Born-dirty cancellation on L3**: same dance as buildDag at L161 (E3). `buildEntityProfiles` calls `clearSummaryDirtyAfterBuild` on each newly-created L3 after its L2 children link loop. M3 FOLD: `clearSummaryDirtyAfterBuild` gains a `source?: string` param (default 'buildDag-clean'). buildEntityProfiles passes `source='buildEntityProfiles-clean'` for distinguishability.
+
+3. **drillDown depth>1 budget semantics**: GLOBAL cumulative budget across all levels (NOT per-level). Same `Math.ceil(content.length / 4)` cost per child. Truncation flag set on first level that hits the cap.
+
+4. **Cycle prevention + dedup in drillDown depth walk** (M1 FOLD): DAG is acyclic by construction (no back-edges), BUT `dag_parent_id` has no uniqueness constraint, so two L2s sharing an L1 child (data anomaly) would double-emit at depth>1. BFS gets `visited: Set<string>` to dedup. Test #8 asserts "all returned ids unique".
+
+5. **Audit ops**: no new ops. `summary_rebuilt` source='E3-rebuild' fires for L2 + L3 rebuilds uniformly. `summary_marked_dirty` source='E2' fires for L2 + L3 dirty marks. `summary_marked_clean` source='buildDag-clean' or 'buildEntityProfiles-clean' via new source param.
+
+6. **Multi-tenant isolation**: existing isolation pattern preserved. `loadAllDirtySummaries` and new `loadAllL2Summaries` are host-wide loaders that return entries with tenantId attached; per-summary children query stays tenant-scoped via summary.tenantId. drillDown depth-walk uses ctx.tenantId at each level (loadChildrenOf is tenant-scoped).
+
+7. **totalChildren vs descendantCount semantics** (M5 FOLD): with depth>1, returned `totalChildren = collected.length` (sum across all visited levels), while `summary.descendantCount` stays as the summary's stored direct-child count. Plan documents this explicitly + test #8 asserts both numbers separately so the contract is unambiguous.
+
+8. **Phase 1.9 vs 1.7 asymmetry** (M4 FOLD): phase 1.9 runs even when phase 1.7 was skipped (no extracted facts that cycle). Intentional — E5 should re-cluster existing L2s into L3s on every sleep regardless of new extraction. The phase 1.9 guard `if (l2Summaries.length >= 2)` handles the empty-store case.
+
+9. **cmdDag tree view extension** (L1 FOLD, promoted to MED): cli.ts:4479 (cmdDag tree mode) currently filters `entries.filter((e) => e.dag_level === 2)`. After E5, L3 entity profiles would render nowhere in `hippo dag` tree. R1 LOW L1 promoted to MED. Plan v2 S9 (NEW) extends cmdDag to render a two-level tree: L3 → L2 → (optional L1 leaves). UX gap closed.
+
+## Why this exists
+
+Final episode of 5-episode DAG live-coupling arc. E1-E4 built the L2 layer with live-coupled rebuild + first-class scoring. E5 lifts to L3: entity-aware aggregation across multiple L2 topic summaries for the same person/entity. Use case: "all the things I know about Alice" becomes a single L3 profile node that recall can surface OR drill into for full detail.
+
+Without E5: each speaker:Alice topic summary stands alone in recall results, even when 10 of them all describe the same person.
+
+## Goal
+
+Four changes, all additive backward-compatible:
+
+1. **buildEntityProfiles** new phase in dag.ts: clusters L2 summaries by entity tag, generates L3 profiles via existing generateDagSummary, links L2 children, clears born-dirty.
+
+2. **Widen 5 SQL guards** in store.ts from `dag_level = 2` to `dag_level IN (2, 3)`. Rebuild path automatically handles dirty L3 via the same applyRebuildResult. Audit metadata reads actual level (NOT hardcoded constant) so L2 stays `dag_level: 2` and L3 emits `dag_level: 3`.
+
+3. **drillDown depth** parameter in api.ts (+ MCP + HTTP + CLI pass-through). Default 1 preserves backward compat. Higher values walk N levels with visited-Set dedup.
+
+4. **isDagSummary widening + cmdDag tree extension**: scoring deboost applies to both L2+L3; `hippo dag` tree view renders L3 nodes with their L2 children.
+
+## Scope
+
+### S1 — buildEntityProfiles in `src/dag.ts`
+
+```typescript
+export interface EntityProfilesBuildResult {
+  candidateClusters: number;
+  profilesCreated: number;
+  l2sLinked: number;
+}
+
+/**
+ * v0.30 / E5 — build L3 entity profiles by clustering L2 summaries by
+ * shared entity tag. Threshold 2+ L2s per entity. Mirrors buildDag L1->L2
+ * pattern, one level up. Same born-dirty cancellation via
+ * clearSummaryDirtyAfterBuild with source='buildEntityProfiles-clean'.
+ */
+export async function buildEntityProfiles(
+  hippoRoot: string,
+  l2Summaries: MemoryEntry[],
+  opts: DagSummaryOptions,
+): Promise<EntityProfilesBuildResult> {
+  const result: EntityProfilesBuildResult = {
+    candidateClusters: 0,
+    profilesCreated: 0,
+    l2sLinked: 0,
+  };
+
+  // Only L2 with no L3 parent yet (avoid re-clustering already-profiled L2s).
+  const unparented = l2Summaries.filter(
+    (s) => s.dag_level === 2 && !s.dag_parent_id,
+  );
+
+  // Reuse existing clusterFacts; jaccard on entity tags.
+  const clusters = clusterFacts(unparented);
+  const eligible = clusters.filter((c) => c.members.length >= 2);
+  result.candidateClusters = eligible.length;
+
+  for (const cluster of eligible) {
+    const summary = await generateDagSummary(
+      cluster.label,
+      cluster.members.map((m) => m.content),
+      opts,
+    );
+    if (!summary) continue;
+
+    const memberCreatedAts = cluster.members.map((m) => m.created).sort();
+    const nowIso = new Date().toISOString();
+    const profileEntry = createMemory(summary, {
+      layer: Layer.Semantic,
+      tags: [...cluster.entityTags, 'dag-entity-profile'],
+      confidence: 'inferred',
+      dag_level: 3,
+    });
+    profileEntry.descendant_count = cluster.members.length;
+    profileEntry.earliest_at = memberCreatedAts[0];
+    profileEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
+    profileEntry.dag_level_3_built_at = nowIso;
+    writeEntry(hippoRoot, profileEntry);
+    result.profilesCreated++;
+
+    for (const member of cluster.members) {
+      const updated: MemoryEntry = { ...member, dag_parent_id: profileEntry.id };
+      writeEntry(hippoRoot, updated);
+      result.l2sLinked++;
+    }
+    // E3 born-dirty cancellation, same pattern as buildDag L161.
+    // M3 FOLD: pass source='buildEntityProfiles-clean' via new source param.
+    clearSummaryDirtyAfterBuild(
+      hippoRoot,
+      profileEntry.id,
+      profileEntry.tenantId,
+      'buildEntityProfiles',
+      'buildEntityProfiles-clean',
+    );
+  }
+
+  return result;
+}
+```
+
+### S2 — Widen 5 SQL guards in `src/store.ts`
+
+Change `AND dag_level = 2` to `AND dag_level IN (2, 3)` at:
+- L2524: markSummaryDirtyInTx
+- L2561: markSummaryDirty
+- L2690: applyRebuildResult bumpRebuildCount=true branch
+- L2700: applyRebuildResult bumpRebuildCount=false branch
+- L2799: clearSummaryDirtyAfterBuild
+
+**H1 FOLD — audit metadata strategy: use SQLite `RETURNING` clause (R2 must_fix perf fix)**:
+
+R2 flagged that SELECT-before-UPDATE on every markSummaryDirtyInTx call doubles per-row DB ops in the hot path (5 caller sites: writeEntry, bulk writeMany, batch path, raw-archive, api.supersede). Solution: use `RETURNING dag_level` on the UPDATE — single round trip, captures actual level + change confirmation in one query.
+
+For **markSummaryDirtyInTx** (store.ts:2513, R2 line anchor):
+```typescript
+const result = db.prepare(`
+  UPDATE memories SET summary_dirty = 1
+  WHERE id = ? AND tenant_id = ?
+    AND dag_level IN (2, 3)
+    AND summary_dirty = 0
+    AND kind != 'archived'
+  RETURNING dag_level
+`).get(summaryId, tenantId) as { dag_level: number } | undefined;
+if (result) {
+  audit(db, 'summary_marked_dirty', summaryId, { dag_level: result.dag_level, source: 'E2' }, actor, tenantId);
+}
+```
+
+For **markSummaryDirty** (store.ts:2546, R2 line anchor): same RETURNING shape.
+
+For **applyRebuildResult** (store.ts:2748 audit call, R2 line anchor): caller already has full `summary: MemoryEntry` in scope. Pass `summary.dag_level` directly into audit metadata. No SELECT needed.
+
+For **clearSummaryDirtyAfterBuild** (store.ts:2804 audit call, R2 line anchor): same RETURNING pattern as markSummaryDirty (caller may not have level — buildDag passes L2 entries, buildEntityProfiles passes L3 entries, but the helper stays level-agnostic).
+
+**Performance note**: RETURNING is one round trip per call (same as the current UPDATE). Available in SQLite ≥3.35 (2021). node:sqlite ships with a much newer version. No regression vs current; better than the originally-proposed SELECT-before-UPDATE.
+
+### S3 — Add `loadAllL2Summaries(hippoRoot)` to `src/store.ts` (H2 FOLD)
+
+Tenant-host-wide helper mirroring `loadAllDirtySummaries`:
+
+```typescript
+/**
+ * v0.30 / E5 — host-wide loader for L2 topic summaries without an L3 parent.
+ * Used by consolidate phase 1.9 (buildEntityProfiles) to cluster L2s into
+ * L3 entity profiles. Cheaper than re-running loadAllEntries; SQL filters
+ * at index level. Returns entries with tenantId attached so per-cluster
+ * writes stay tenant-scoped.
+ */
+export function loadAllL2Summaries(hippoRoot: string): MemoryEntry[] {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const rows = db.prepare(`
+      SELECT ${MEMORY_SELECT_COLUMNS}
+        FROM memories
+       WHERE dag_level = 2
+         AND dag_parent_id IS NULL
+         AND kind != 'archived'
+       ORDER BY created ASC, id ASC
+    `).all() as MemoryRow[];
+    return rows.map(rowToEntry);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+```
+
+### S4 — Extend `isDagSummary` in `src/search.ts`
+
+```typescript
+// E5 widens predicate to L2 + L3 (single deboost factor for both).
+// Differentiated deboost (e.g. 0.7 for L3) is follow-up scope.
+export function isDagSummary(entry: MemoryEntry): boolean {
+  return entry.dag_level === 2 || entry.dag_level === 3;
+}
+```
+
+ScoreBreakdown `dagLevel` field automatically reflects 3 for L3 entries (already populated when dag_level !== undefined per E4 S3).
+
+### S5 — Add `depth` to `drillDown` in `src/api.ts` (M1 + M5 FOLDS)
+
+Extend DrillDownOpts:
+
+```typescript
+export interface DrillDownOpts {
+  limit?: number;
+  budget?: number;
+  /** v0.30 / E5 — walk N levels down (default 1 = direct children only).
+   *  Higher values include children of children, etc. Token budget remains
+   *  GLOBAL (cumulative across levels), not per-level. BFS uses visited Set
+   *  to dedup if data anomaly results in two parents sharing a child. */
+  depth?: number;
+}
+```
+
+Modify drillDown to walk with visited-Set dedup:
+
+```typescript
+export function drillDown(
+  ctx: Context,
+  summaryId: string,
+  opts: DrillDownOpts = {},
+): DrillDownOutcome {
+  const limit = opts.limit ?? 50;
+  const depth = Math.max(1, Math.min(opts.depth ?? 1, 10)); // hard cap 10 levels (R3 mitigation)
+  // ... existing summary lookup + failure checks unchanged ...
+
+  // BFS walk levels 1..depth with visited-Set dedup (M1 FOLD).
+  const collected: MemoryEntry[] = [];
+  const visited = new Set<string>([summaryId]); // include root so it can't reappear
+  let frontier = [summaryId];
+  for (let level = 0; level < depth; level++) {
+    const nextFrontier: string[] = [];
+    for (const parentId of frontier) {
+      const kids = loadChildrenOf(ctx.hippoRoot, parentId, ctx.tenantId);
+      const eligible = kids.filter((c) => passesScopeFilterForRecall(c.scope ?? null, undefined));
+      for (const k of eligible) {
+        if (visited.has(k.id)) continue; // dedup
+        visited.add(k.id);
+        collected.push(k);
+        nextFrontier.push(k.id);
+      }
+    }
+    if (nextFrontier.length === 0) break;
+    frontier = nextFrontier;
+  }
+
+  // Apply global cumulative token budget + limit cap on collected.
+  let children = collected;
+  let truncated = false;
+  if (opts.budget !== undefined) {
+    const out: MemoryEntry[] = [];
+    let used = 0;
+    for (const c of collected) {
+      const t = Math.ceil(c.content.length / 4);
+      if (out.length > 0 && used + t > opts.budget) {
+        truncated = true;
+        break;
+      }
+      out.push(c);
+      used += t;
+    }
+    children = out;
+  }
+  if (children.length > limit) {
+    children = children.slice(0, limit);
+    truncated = true;
+  }
+
+  return {
+    summary: {
+      id: summary.id,
+      content: summary.content,
+      // M5 FOLD: descendantCount stays at summary's STORED value (direct
+      // children at L2/L3 creation time). totalChildren below reflects the
+      // depth-walk collection (may be much larger).
+      // R2 must-fix: `eligible` no longer exists in depth-walk rewrite;
+      // fallback is `collected.length` (BFS-collected count).
+      descendantCount: summary.descendant_count ?? collected.length,
+      earliestAt: summary.earliest_at ?? null,
+      latestAt: summary.latest_at ?? null,
+    },
+    children: children.map((c) => ({
+      id: c.id,
+      content: c.content,
+      layer: c.layer,
+      dagLevel: c.dag_level ?? 0,
+      created: c.created,
+    })),
+    // M5 FOLD: totalChildren = collected.length after dedup, BEFORE
+    // limit/budget cap. For depth=1 backward compat, this equals
+    // eligible.length (same as pre-E5). For depth>1, this is the full
+    // BFS-collected count.
+    totalChildren: collected.length,
+    truncated,
+  };
+}
+```
+
+### S6 — consolidate.ts wiring
+
+Add phase 1.9 after 1.8 rebuild:
+
+```typescript
+// 1.9. DAG entity profiles — build L3 from clustered L2 summaries.
+// Runs even when phase 1.7 was skipped (no extracted facts) — re-clusters
+// existing L2s on every sleep regardless of new extraction.
+if (apiKey && !dryRun) {
+  try {
+    const { buildEntityProfiles } = await import('./dag.js');
+    const { loadAllL2Summaries } = await import('./store.js');
+    const l2Summaries = loadAllL2Summaries(hippoRoot);
+    if (l2Summaries.length >= 2) {
+      const profileResult = await buildEntityProfiles(hippoRoot, l2Summaries, {
+        apiKey,
+        model: config.extraction.model,
+      });
+      result.entityProfilesCreated = profileResult.profilesCreated;
+      if (profileResult.profilesCreated > 0) {
+        result.details.push(`  🌲 DAG L3: ${profileResult.profilesCreated} entity profiles, ${profileResult.l2sLinked} L2s linked`);
+      }
+    }
+  } catch {
+    // Best-effort.
+  }
+}
+```
+
+Add `entityProfilesCreated: number` field to `ConsolidationResult` interface + init.
+
+### S7 — CLI + HTTP + MCP pass-through for `--depth` (R2 cmdDrillDown rename + client-side clamps)
+
+`cli.ts:4528` `cmdDrillDown` (R2 must-fix: function name corrected from cmdDrill): add `--depth N` argv parsing with client-side clamp `Math.max(1, Math.min(parsedDepth, 10))` so misuse is rejected at the CLI layer (defense-in-depth before reaching api.drillDown's internal clamp).
+
+`server.ts:643` (HTTP /v1/drill): accept `depth` query param, clamp to `[1, 10]` at HTTP layer before calling api.drillDown.
+
+`mcp/server.ts` (hippo_drill): add `depth?: number` to tool input schema with `minimum: 1, maximum: 10` so JSON schema validation enforces the cap before the call.
+
+Default 1 everywhere, preserves backward compat. Triple-clamp (CLI/HTTP/MCP + internal) so any misconfigured caller surfaces the constraint at their layer rather than silent-clamping inside drillDown.
+
+### S8 — cmdDag tree view extension (R1 L1 MED-promoted)
+
+cli.ts:4479 currently:
+
+```typescript
+const summaries = entries.filter((e) => e.dag_level === 2);
+```
+
+E5 extends to render TWO-LEVEL tree: L3 → L2 → (optional L1 leaves). Pseudo-code:
+
+```typescript
+const profiles = entries.filter((e) => e.dag_level === 3);
+const l2Map = new Map<string, MemoryEntry[]>(); // L3.id -> L2 children
+const orphanL2 = []; // L2 with no L3 parent
+for (const l2 of entries.filter((e) => e.dag_level === 2)) {
+  if (l2.dag_parent_id) {
+    const list = l2Map.get(l2.dag_parent_id) ?? [];
+    list.push(l2);
+    l2Map.set(l2.dag_parent_id, list);
+  } else {
+    orphanL2.push(l2);
+  }
+}
+
+// Print L3 profiles as roots, with their L2 children indented.
+for (const profile of profiles) {
+  console.log(`🌲 ${profile.id} ${profile.content.slice(0, 60)}...`);
+  const l2s = l2Map.get(profile.id) ?? [];
+  for (const l2 of l2s) {
+    console.log(`  └─ 🌳 ${l2.id} ${l2.content.slice(0, 60)}...`);
+  }
+}
+// Then print orphan L2 (no L3 parent) at top level.
+for (const l2 of orphanL2) {
+  console.log(`🌳 ${l2.id} ${l2.content.slice(0, 60)}... (no L3 parent)`);
+}
+```
+
+### S9 — Tests in `tests/dag-e5-entity-profiles.test.ts`
+
+13 cases, all real-DB:
+
+1. **buildEntityProfiles happy path**: 3 L2 summaries sharing speaker:Alice tag (no L3 parent), mocked fetcher returns synthetic profile. Verify 1 L3 created with dag_level=3, dag_level_3_built_at populated, descendant_count=3, all 3 L2s now have dag_parent_id pointing to L3.
+
+2. **No clustering below threshold**: 1 L2 summary alone with speaker:Alice tag, buildEntityProfiles returns profilesCreated=0.
+
+3. **Skips L2s with existing L3 parent**: 2 L2s with speaker:Alice (one already has dag_parent_id set to an existing L3) → only the unparented ones are eligible.
+
+4. **L3 born-dirty cancellation** (M3 lock): After buildEntityProfiles, the new L3's summary_dirty must be 0. Audit row `summary_marked_clean` source='buildEntityProfiles-clean' exists. Audit metadata includes `dag_level: 3` (NOT hardcoded 2).
+
+5. **markSummaryDirtyInTx widened to L3** (S2 lock): write an L2 with dag_parent_id pointing to an L3 → the L3's summary_dirty becomes 1 (was 0 before). Audit row `summary_marked_dirty` with target_id = L3.id AND `dag_level: 3` in metadata (H1 lock).
+
+6. **rebuildDirtySummaries handles dirty L3** (M2 FOLD: with label-derivation + dag_level_3_built_at preservation assertions): pre-set summary_dirty=1 on an L3, mocked fetcher returns new L3 content. Verify: (a) fetcher was called with the L3's speaker:X tag as label (locks dag.ts:236-241 label path for L3), (b) content updated, (c) rebuild_count bumped, (d) last_rebuilt_at set to nowIso, (e) **dag_level_3_built_at UNCHANGED** (set once at create, not bumped on rebuild — locks S8 contract), (f) summary_dirty cleared, (g) audit row `summary_rebuilt` source='E3-rebuild' with `dag_level: 3`.
+
+7. **drillDown depth=1 backward compat**: existing dag-drill-down tests still pass (depth=1 default = current behavior).
+
+8. **drillDown depth=2 from L3 with dedup + totalChildren lock** (M1+M5 FOLDS): L3 has 2 L2 children, each L2 has 3 L1 children. drillDown(L3.id, {depth: 2}) returns 8 entries (2 L2s + 6 L1s). Assert: (a) all returned ids unique (Set size = collected.length), (b) `totalChildren === 8` (post-BFS collect), (c) `summary.descendantCount === 2` (L3's stored value — UNCHANGED by depth walk).
+
+9. **drillDown depth=3 from L3**: same setup, depth=3 (BFS exhausts at depth=2 since L1s have no children). Returns same 8 entries (no over-walk).
+
+10. **drillDown depth global budget**: depth=2, budget cap forces truncation mid-walk → truncated=true.
+
+11. **drillDown depth tenant isolation** (R1 L2 FOLD — strengthened setup): L3 + L2-A both in tenant-a (L2-A.dag_parent_id = L3.id). L1-Bs in tenant-b with L1-B.dag_parent_id = L2-A.id (data anomaly via direct SQL). drillDown(L3, depth=2) from tenant-a context should return [L2-A] but EXCLUDE L1-Bs (loadChildrenOf at level 2 is tenant-scoped on tenant-a; L1-Bs in tenant-b don't appear).
+
+12. **isDagSummary extension** (S4 lock): assert isDagSummary({dag_level: 2}) === true, isDagSummary({dag_level: 3}) === true, isDagSummary({dag_level: 1}) === false, isDagSummary({dag_level: 0}) === false.
+
+13. **E4 deboost applies to L3 in hybridSearch** (S4 integration lock): write L3 entity profile, query, verify breakdown.summaryDeboost = 0.85 and breakdown.dagLevel = 3.
+
+### S10 — Scope boundary
+
+NOT in E5:
+- Differentiated deboost (L2: 0.85, L3: 0.7) — follow-up if benchmark shows L3 dominates
+- **L3 substitution in api.recall overflow path** — pinned at api.ts:542, :553, :883 (THREE sites, R1 L4 enumeration). Out of scope; separate refactor.
+- L4 hierarchy (not anticipated)
+- CLI `hippo entity-profiles` standalone command (consolidate runs it automatically)
+- HTTP /v1/entity-profiles endpoint (drillDown depth gives equivalent access)
+- Recomputing dag_level_3_built_at on rebuild (set once at create; rebuild bumps last_rebuilt_at instead)
+- buildEntityProfiles freshness re-clustering (existing L3s with stale L2 membership)
+
+## Acceptance criteria
+
+1. AC1: `buildEntityProfiles(hippoRoot, l2Summaries, opts)` creates L3 profiles from clusters of unparented L2s. Threshold 2+ members per cluster.
+2. AC2: New L3 entries have dag_level=3, dag_parent_id=null, dag_level_3_built_at populated, descendant_count + earliest/latest_at populated.
+3. AC3: All cluster members get dag_parent_id pointing to new L3 (linked).
+4. AC4: clearSummaryDirtyAfterBuild fires on new L3 (born-dirty cancellation). Audit `summary_marked_clean` source='buildEntityProfiles-clean' with `dag_level: 3` metadata.
+5. AC5: All 5 SQL guards in store.ts widened from `dag_level = 2` to `IN (2, 3)`. Audit metadata reads actual level (NOT hardcoded). Tests 4+5+6 lock the behavior.
+6. AC6: rebuildDirtySummaries handles dirty L3 via same applyRebuildResult path. dag_level_3_built_at UNCHANGED on rebuild (only last_rebuilt_at + rebuild_count). Test 6 locks.
+7. AC7: drillDown gains `depth?:number` opt (default 1, backward compat, hard cap 10). Tests 7+8+9 lock behavior. Visited-Set dedup prevents double-emit.
+8. AC8: drillDown depth budget is global cumulative. Test 10 locks.
+9. AC9: drillDown depth respects tenant isolation at each level. Test 11 locks (strengthened setup).
+10. AC10: isDagSummary extended to L2 + L3 (single deboost factor). Test 12 locks; test 13 locks E4 deboost integration.
+11. AC11: consolidate runs phase 1.9 (buildEntityProfiles) after 1.8 (rebuild) via NEW `loadAllL2Summaries` helper (NOT `survivors` which lacks newly-created L2s). ConsolidationResult.entityProfilesCreated populated.
+12. AC12: CLI `hippo drill --depth N` + HTTP /v1/drill?depth=N + MCP hippo_drill `depth` arg pass through. Hard cap 10.
+13. AC13: cmdDag tree view renders L3 profiles as roots with L2 children indented (S8 NEW).
+14. AC14: drillDown.totalChildren reflects BFS-collected count (depth-aware); summary.descendantCount reflects L3's stored direct-child count (unchanged by depth). Test 8 locks both.
+15. AC15: All 13 new tests pass.
+16. AC16: No regression — full test suite green. dag-dirty-flag-schema.test.ts:165 still passes (L2 → dag_level: 2). Rename test :102 wording to "(dag_level NOT IN (2, 3))" — non-functional rename.
+
+## Risks (R1 updates folded)
+
+1. **R1 (RESOLVED in v2)**: audit metadata "drop hardcoded" decision reverted to "read actual level". No test breakage.
+2. **R2 (RESOLVED in v2)**: phase 1.9 data source: `loadAllL2Summaries` helper, NOT `survivors`.
+3. **R3 (LOW)**: drillDown BFS could collect a large set before truncation. Hard cap depth=10 + visited-Set dedup + token budget + limit cap. Acceptable.
+4. **R4 (LOW)**: Snapshot tests on `hippo sleep` output may diff for the new "🌲 DAG L3" details line. Scan in execute stage.
+5. **R5 (MED, promoted from LOW)**: cmdDag tree view extended (S8 NEW) to render L3.
+6. **R6 (LOW)**: rebuildDirtySummaries' generateDagSummary for L3 uses L2 contents as "facts". L2 content is already summary-shaped; LLM may produce odd meta-summary. Acceptable for E5; quality tuning is follow-up.
+7. **R7 (LOW, NEW)**: dag-recall-first-class.test.ts:315 should add `isDagSummary({dag_level: 3}) === true` case (or covered by E5 test #12).
+
+## Out of scope (deferred)
+
+- Differentiated L2 vs L3 deboost factors in search.ts
+- L3 substitution in api.recall overflow path (3 sites at api.ts:542/553/883)
+- L4 hierarchy
+- Standalone CLI / HTTP endpoints for entity profiles
+- buildEntityProfiles freshness re-clustering (existing L3s with stale L2 membership)
+
+## Ship pattern (E4 retro lessons applied)
+
+Stacked PR off `feat-dag-e4-recall`. PR #70 expected. Per gh-cascade memory: plain `gh pr merge 69 --rebase` on E4 merge (NO --delete-branch).
+
+Title (E3+E4 retro, ≤70 chars, no em dash, drop arc suffix): `feat(dag): E5 level-3 entity profiles + drillDown depth` (54 chars).
+
+**Pre-commit em-dash grep ritual (R1 L3 specified explicitly per E4 retro feedback memory)**:
+
+```bash
+# Before git commit:
+git diff --cached -- src/ tests/ docs/ | grep -nP '\xe2\x80\x94' && echo "EM DASH DETECTED — fix before commit" && exit 1
+# Or simpler for the commit message itself: write commit message to a temp file first, then:
+grep -nP '\xe2\x80\x94' /tmp/commit-msg.txt && echo "EM DASH IN COMMIT MSG" && exit 1
+# Same for PR body before gh pr create.
+```
+
+Plan body uses em dashes freely (internal doc, NOT restricted per Stop Slop). Commit message + PR body must be em-dash-free.
+
+After E5 ship-ready: bundled merge sequence (E1 → E2 → E3 → E4 → E5) + `npm publish` v1.12.12 per Keith's "one bundled release" pick.

--- a/src/api.ts
+++ b/src/api.ts
@@ -966,8 +966,18 @@ export interface DrillDownOpts {
    * Optional token budget. When set, children are appended in chronological
    * order (created ASC) until adding the next child would exceed the budget.
    * Token cost = ceil(content.length / 4) per child.
+   *
+   * For depth > 1, the budget is GLOBAL cumulative (NOT per-level).
    */
   budget?: number;
+  /**
+   * v0.30 / E5 — walk N levels down (default 1 = direct children only).
+   * Higher values include children of children, etc. Internal hard cap 10
+   * to prevent pathological depth walks. BFS uses visited Set for dedup
+   * (defensive against shared-child data anomalies; DAG is acyclic by
+   * construction).
+   */
+  depth?: number;
 }
 
 export interface DrillDownResult {
@@ -1021,6 +1031,9 @@ export function drillDown(
   opts: DrillDownOpts = {},
 ): DrillDownOutcome {
   const limit = opts.limit ?? 50;
+  // v0.30 / E5: depth defaults 1 (backward compat); hard cap 10 levels
+  // prevents pathological deep trees. CLI/HTTP/MCP layers also clamp.
+  const depth = Math.max(1, Math.min(opts.depth ?? 1, 10));
   const summary = readEntry(ctx.hippoRoot, summaryId, ctx.tenantId);
   // No unscoped cross-tenant probe here — readEntry's null return covers
   // both "doesn't exist" and "exists in another tenant" by design.
@@ -1036,14 +1049,41 @@ export function drillDown(
     return { failure: 'not_found' };
   }
 
-  const allChildren = loadChildrenOf(ctx.hippoRoot, summaryId, ctx.tenantId);
-  const eligible = allChildren.filter((c) => passesScopeFilterForRecall(c.scope ?? null, undefined));
-  let children = eligible;
+  // v0.30 / E5: BFS walk levels 1..depth with visited-Set dedup. Defensive
+  // against shared-child data anomalies (dag_parent_id has no uniqueness
+  // constraint, so a misconfigured tree could double-emit at depth > 1).
+  // Each level uses loadChildrenOf which is tenant-scoped via ctx.tenantId.
+  const collected: MemoryEntry[] = [];
+  const visited = new Set<string>([summaryId]);
+  let frontier: string[] = [summaryId];
+  // independent-review MED #4 fold: track level-0 direct-children count
+  // separately so the descendantCount fallback (for legacy summaries with
+  // null descendant_count) reflects DIRECT children, not BFS-collected total.
+  let level0DirectCount = 0;
+  for (let level = 0; level < depth; level++) {
+    const nextFrontier: string[] = [];
+    for (const parentId of frontier) {
+      const kids = loadChildrenOf(ctx.hippoRoot, parentId, ctx.tenantId);
+      const eligibleKids = kids.filter((c) => passesScopeFilterForRecall(c.scope ?? null, undefined));
+      for (const k of eligibleKids) {
+        if (visited.has(k.id)) continue;
+        visited.add(k.id);
+        collected.push(k);
+        nextFrontier.push(k.id);
+        if (level === 0) level0DirectCount++;
+      }
+    }
+    if (nextFrontier.length === 0) break;
+    frontier = nextFrontier;
+  }
+
+  // Apply global cumulative token budget + limit cap on collected.
+  let children = collected;
   let truncated = false;
   if (opts.budget !== undefined) {
-    const out: typeof eligible = [];
+    const out: MemoryEntry[] = [];
     let used = 0;
-    for (const c of eligible) {
+    for (const c of collected) {
       const t = Math.ceil(c.content.length / 4);
       if (out.length > 0 && used + t > opts.budget) {
         truncated = true;
@@ -1063,7 +1103,12 @@ export function drillDown(
     summary: {
       id: summary.id,
       content: summary.content,
-      descendantCount: summary.descendant_count ?? eligible.length,
+      // v0.30 / E5: descendant_count stays the summary's STORED value
+      // (direct children at creation time). totalChildren below reflects
+      // the full BFS collection at the requested depth.
+      // independent-review MED #4 fold: legacy fallback uses level-0 direct
+      // count (NOT collected.length which is BFS-depth-N total).
+      descendantCount: summary.descendant_count ?? level0DirectCount,
       earliestAt: summary.earliest_at ?? null,
       latestAt: summary.latest_at ?? null,
     },
@@ -1074,7 +1119,10 @@ export function drillDown(
       dagLevel: c.dag_level ?? 0,
       created: c.created,
     })),
-    totalChildren: eligible.length,
+    // v0.30 / E5: totalChildren = BFS-collected count (depth-aware). For
+    // depth=1 this equals the eligible direct-children count (backward
+    // compat). For depth>1 it is the cumulative count across levels.
+    totalChildren: collected.length,
     truncated,
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4475,18 +4475,47 @@ function cmdDag(hippoRoot: string, flags: Record<string, string | boolean | stri
     return;
   }
 
-  // Tree view: show summaries and their children
-  const summaries = entries.filter((e) => e.dag_level === 2);
-  if (summaries.length === 0) {
+  // Tree view: v0.30 / E5 renders L3 entity profiles as roots (with L2
+  // children indented), then orphan L2 summaries (no L3 parent) at top
+  // level. Pre-E5 behavior was L2-only roots; rendering now covers L3.
+  const profiles = entries.filter((e) => e.dag_level === 3);
+  const l2List = entries.filter((e) => e.dag_level === 2);
+  const orphanL2 = l2List.filter((e) => !e.dag_parent_id);
+  const childL2ByProfile = new Map<string, typeof l2List>();
+  for (const l2 of l2List) {
+    if (!l2.dag_parent_id) continue;
+    const list = childL2ByProfile.get(l2.dag_parent_id) ?? [];
+    list.push(l2);
+    childL2ByProfile.set(l2.dag_parent_id, list);
+  }
+
+  if (profiles.length === 0 && orphanL2.length === 0) {
     console.log('No DAG summaries yet. Run `hippo sleep` with ANTHROPIC_API_KEY set.');
     return;
   }
 
-  for (const summary of summaries) {
+  // L3 entity profiles as tree roots with their L2 children.
+  for (const profile of profiles) {
+    const profileTags = profile.tags.filter((t) => t !== 'dag-entity-profile').join(', ');
+    console.log(`\n🌲 ${profile.content.slice(0, 80)}`);
+    if (profileTags) console.log(`   [${profileTags}]`);
+    const l2Children = childL2ByProfile.get(profile.id) ?? [];
+    for (const l2 of l2Children) {
+      const l2Tags = l2.tags.filter((t) => t !== 'dag-summary').join(', ');
+      console.log(`   └─ 📌 ${l2.content.slice(0, 70)}`);
+      if (l2Tags) console.log(`      [${l2Tags}]`);
+      const facts = entries.filter((e) => e.dag_parent_id === l2.id);
+      for (const f of facts) {
+        console.log(`      └─ ${f.content.slice(0, 60)}`);
+      }
+    }
+  }
+
+  // Orphan L2 summaries (no L3 parent) at top level — pre-E5 default shape.
+  for (const summary of orphanL2) {
     const summaryTags = summary.tags.filter((t) => t !== 'dag-summary').join(', ');
     console.log(`\n📌 ${summary.content.slice(0, 80)}`);
     if (summaryTags) console.log(`   [${summaryTags}]`);
-
     const children = entries.filter((e) => e.dag_parent_id === summary.id);
     for (const child of children) {
       console.log(`   └─ ${child.content.slice(0, 70)}`);
@@ -4529,6 +4558,17 @@ function cmdDrillDown(hippoRoot: string, summaryId: string, flags: Record<string
   requireInit(hippoRoot);
   const limit = typeof flags['limit'] === 'string' ? Number(flags['limit']) : undefined;
   const budget = typeof flags['budget'] === 'string' ? Number(flags['budget']) : undefined;
+  // v0.30 / E5: --depth N walks N levels down (default 1, hard cap 10).
+  // L4 fold: reject out-of-range explicitly (no silent clamp).
+  const rawDepth = typeof flags['depth'] === 'string' ? Number(flags['depth']) : undefined;
+  let depth: number | undefined;
+  if (rawDepth !== undefined) {
+    if (!Number.isFinite(rawDepth) || rawDepth < 1 || rawDepth > 10) {
+      console.error(`--depth must be an integer between 1 and 10 (got ${flags['depth']})`);
+      process.exit(2);
+    }
+    depth = rawDepth;
+  }
   const ctx: api.Context = {
     hippoRoot,
     tenantId: resolveTenantId({}),
@@ -4537,6 +4577,7 @@ function cmdDrillDown(hippoRoot: string, summaryId: string, flags: Record<string
   const r = api.drillDown(ctx, summaryId, {
     ...(Number.isFinite(limit) && limit! > 0 ? { limit } : {}),
     ...(Number.isFinite(budget) && budget! > 0 ? { budget } : {}),
+    ...(depth !== undefined ? { depth } : {}),
   });
   if ('failure' in r) {
     // v1.6.4: only `not_drillable` is caller-actionable. `not_found`

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -77,6 +77,8 @@ export interface ConsolidationResult {
   summariesRebuildFailed: number;
   summariesZeroChildSkipped: number;
   summariesRebuildCapped: boolean;
+  // v0.30 / E5 — L3 entity-profile build count
+  entityProfilesCreated: number;
   dryRun: boolean;
   details: string[];
   physicsSimulated: number;
@@ -109,6 +111,7 @@ export async function consolidate(
     summariesRebuildFailed: 0,
     summariesZeroChildSkipped: 0,
     summariesRebuildCapped: false,
+    entityProfilesCreated: 0,
     dryRun,
     details: [],
     physicsSimulated: 0,
@@ -358,6 +361,35 @@ export async function consolidate(
       }
     } catch {
       // Best-effort — same posture as buildDag block above.
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 1.9. DAG entity profiles — cluster L2 topic summaries into L3 profiles
+  // -------------------------------------------------------------------------
+  // E5 phase: aggregate per-entity L2 summaries (e.g. all the speaker:Alice
+  // topic summaries) into a single L3 entity profile. Runs even when phase
+  // 1.7 buildDag was skipped (re-clusters existing L2s every sleep).
+  //
+  // Uses loadAllL2Summaries (not `survivors`) because phase 1.7 wrote new
+  // L2s directly via writeEntry without pushing back into survivors.
+  if (apiKey && !dryRun) {
+    try {
+      const { buildEntityProfiles } = await import('./dag.js');
+      const { loadAllL2Summaries } = await import('./store.js');
+      const l2Summaries = loadAllL2Summaries(hippoRoot);
+      if (l2Summaries.length >= 2) {
+        const profileResult = await buildEntityProfiles(hippoRoot, l2Summaries, {
+          apiKey,
+          model: config.extraction.model,
+        });
+        result.entityProfilesCreated = profileResult.profilesCreated;
+        if (profileResult.profilesCreated > 0) {
+          result.details.push(`  🌲 DAG L3: ${profileResult.profilesCreated} entity profiles, ${profileResult.l2sLinked} L2s linked`);
+        }
+      }
+    } catch {
+      // Best-effort.
     }
   }
 

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -281,3 +281,111 @@ export async function rebuildDirtySummaries(
 
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// v0.30 / E5 of DAG live-coupling — L3 entity profile build path
+// ---------------------------------------------------------------------------
+
+export interface EntityProfilesBuildResult {
+  candidateClusters: number;
+  profilesCreated: number;
+  l2sLinked: number;
+  // independent-review MED #3 fold: surface failure counter so operators
+  // see LLM null / rate-limit / 401 signal (parity with DagRebuildResult.failed).
+  failed: number;
+}
+
+/**
+ * v0.30 / E5 — build L3 entity profiles by clustering L2 summaries with
+ * shared entity tags. Threshold 2+ L2s per entity. Mirrors buildDag L1->L2
+ * pattern, one level up.
+ *
+ * Born-dirty cancellation (E3 lesson): after linking L2 children to the new
+ * L3 (each link write fires E2 hook on L3 via widened markSummaryDirtyInTx),
+ * call clearSummaryDirtyAfterBuild with source='buildEntityProfiles-clean'
+ * so E3 sleep-cycle rebuild doesn't re-rebuild the freshly-built L3 this
+ * same cycle.
+ */
+export async function buildEntityProfiles(
+  hippoRoot: string,
+  l2Summaries: MemoryEntry[],
+  opts: DagSummaryOptions,
+): Promise<EntityProfilesBuildResult> {
+  const result: EntityProfilesBuildResult = {
+    candidateClusters: 0,
+    profilesCreated: 0,
+    l2sLinked: 0,
+    failed: 0,
+  };
+
+  // Only L2 with no L3 parent yet (avoid re-clustering already-profiled L2s).
+  const unparented = l2Summaries.filter(
+    (s) => s.dag_level === 2 && !s.dag_parent_id,
+  );
+
+  // independent-review HIGH #1 fold: cluster ONLY within-tenant.
+  // clusterFacts has no tenant awareness; without this partition step a
+  // multi-tenant host could form a cluster spanning tenants and produce
+  // a single L3 with tenantId='default' that doesn't belong to either
+  // child tenant. Fix: bucket by tenantId, run clusterFacts per-tenant,
+  // pass tenantId to createMemory.
+  const byTenant = new Map<string, MemoryEntry[]>();
+  for (const l2 of unparented) {
+    const tid = l2.tenantId ?? 'default';
+    const list = byTenant.get(tid) ?? [];
+    list.push(l2);
+    byTenant.set(tid, list);
+  }
+
+  for (const [tenantId, tenantL2s] of byTenant) {
+    const clusters = clusterFacts(tenantL2s);
+    const eligible = clusters.filter((c) => c.members.length >= 2);
+    result.candidateClusters += eligible.length;
+
+    for (const cluster of eligible) {
+      const summary = await generateDagSummary(
+        cluster.label,
+        cluster.members.map((m) => m.content),
+        opts,
+      );
+      if (!summary) {
+        result.failed++;
+        continue;
+      }
+
+      const memberCreatedAts = cluster.members.map((m) => m.created).sort();
+      const nowIso = new Date().toISOString();
+      const profileEntry = createMemory(summary, {
+        layer: Layer.Semantic,
+        tags: [...cluster.entityTags, 'dag-entity-profile'],
+        confidence: 'inferred',
+        dag_level: 3,
+        tenantId, // HIGH #1 fold: thread tenant explicitly
+      });
+      profileEntry.descendant_count = cluster.members.length;
+      profileEntry.earliest_at = memberCreatedAts[0];
+      profileEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
+      profileEntry.dag_level_3_built_at = nowIso;
+      writeEntry(hippoRoot, profileEntry);
+      result.profilesCreated++;
+
+      for (const member of cluster.members) {
+        const updated: MemoryEntry = { ...member, dag_parent_id: profileEntry.id };
+        writeEntry(hippoRoot, updated);
+        result.l2sLinked++;
+      }
+      // E3 born-dirty cancellation, same dance as buildDag L161-168 but for
+      // L3. Pass source='buildEntityProfiles-clean' to distinguish in audit.
+      // Args: (root, id, tenantId, actor, source).
+      clearSummaryDirtyAfterBuild(
+        hippoRoot,
+        profileEntry.id,
+        tenantId,
+        'buildEntityProfiles',
+        'buildEntityProfiles-clean',
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -245,7 +245,13 @@ const TOOLS = [
         },
         budget: {
           type: 'number',
-          description: 'Max total token cost (≈ chars/4) of returned children. Truncates chronologically.',
+          description: 'Max total token cost (~ chars/4) of returned children. Truncates chronologically.',
+        },
+        depth: {
+          type: 'number',
+          minimum: 1,
+          maximum: 10,
+          description: 'v0.30 / E5: walk N levels down (default 1 = direct children only). Higher values include children of children. Token budget remains GLOBAL across levels. Hard cap 10.',
         },
       },
       required: ['summary_id'],
@@ -575,6 +581,17 @@ async function executeTool(
       if (!summaryId) return 'No summary_id provided.';
       const limit = Number(args.limit);
       const budget = Number(args.budget);
+      // v0.30 / E5: depth walks N levels (default 1, hard cap 10).
+      // independent-review MED #5 fold: reject out-of-range explicitly
+      // (no silent clamp) so MCP callers see the constraint at their layer.
+      let depth: number | undefined;
+      if (args.depth !== undefined) {
+        const depthRaw = Number(args.depth);
+        if (!Number.isFinite(depthRaw) || depthRaw < 1 || depthRaw > 10) {
+          return `depth must be an integer between 1 and 10 (got ${args.depth})`;
+        }
+        depth = depthRaw;
+      }
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
@@ -583,6 +600,7 @@ async function executeTool(
       const r = apiDrillDown(apiCtx, summaryId, {
         ...(Number.isFinite(limit) && limit > 0 ? { limit } : {}),
         ...(Number.isFinite(budget) && budget > 0 ? { budget } : {}),
+        ...(depth !== undefined ? { depth } : {}),
       });
       if ('failure' in r) {
         // v1.6.4: only not_drillable is caller-actionable. not_found

--- a/src/search.ts
+++ b/src/search.ts
@@ -251,13 +251,17 @@ const DEFAULT_FRESHNESS_BOOST = 1.05;
 const FRESHNESS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * v0.30 / E4 — single source of truth for "is this a DAG L2 summary".
+ * v0.30 / E4-E5 — single source of truth for "is this a DAG summary".
+ * E4 originally checked dag_level === 2; E5 widens to L2 + L3 since L3
+ * entity profiles also get the same deboost factor. Differentiated
+ * deboost (e.g. 0.7 for L3) is flagged as follow-up.
+ *
  * Existing drill-down at search.ts:506-529/923-946 uses tag check
- * ('dag-summary'); structural truth is dag_level === 2. New E4 code uses
- * this helper. Existing drill-down NOT modified (separate refactor flagged).
+ * ('dag-summary'); structural truth is dag_level === 2 || === 3. New
+ * E4/E5 code uses this helper; existing drill-down NOT modified.
  */
 export function isDagSummary(entry: MemoryEntry): boolean {
-  return entry.dag_level === 2;
+  return entry.dag_level === 2 || entry.dag_level === 3;
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -639,10 +639,22 @@ async function handleRequest(
     if (budget !== undefined && (!Number.isFinite(budget) || budget <= 0)) {
       throw new HttpError(400, 'budget must be a positive number');
     }
+    // v0.30 / E5: depth query param walks N levels (default 1, hard cap 10).
+    const depthRaw = query.get('depth');
+    let depth: number | undefined;
+    if (depthRaw !== null) {
+      const parsed = Number(depthRaw);
+      // L4 fold: reject out-of-range explicitly (no silent clamp).
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 10) {
+        throw new HttpError(400, 'depth must be a positive integer between 1 and 10');
+      }
+      depth = parsed;
+    }
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = drillDown(ctx, drillMatch.id!, {
       ...(limit !== undefined ? { limit } : {}),
       ...(budget !== undefined ? { budget } : {}),
+      ...(depth !== undefined ? { depth } : {}),
     });
     if ('failure' in result) {
       // v1.6.4: leaf id maps to 422 (caller-actionable). Other cases stay

--- a/src/store.ts
+++ b/src/store.ts
@@ -931,8 +931,9 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
       kind, scope, owner, artifact_ref,
       tenant_id,
       descendant_count, earliest_at, latest_at,
+      dag_level_3_built_at,
       updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT(id) DO UPDATE SET
       created = excluded.created,
       last_retrieved = excluded.last_retrieved,
@@ -968,6 +969,7 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
       descendant_count = excluded.descendant_count,
       earliest_at = excluded.earliest_at,
       latest_at = excluded.latest_at,
+      dag_level_3_built_at = excluded.dag_level_3_built_at,
       updated_at = datetime('now')
   `).run(
     entry.id,
@@ -1005,6 +1007,7 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
     entry.descendant_count ?? 0,
     entry.earliest_at ?? null,
     entry.latest_at ?? null,
+    entry.dag_level_3_built_at ?? null,
   );
 
   syncFtsRow(db, entry);
@@ -2516,17 +2519,21 @@ export function markSummaryDirtyInTx(
   tenantId: string,
   actor: string,
 ): void {
+  // v0.30 / E5: widened dag_level=2 -> IN (2, 3). RETURNING dag_level reads
+  // actual level in same round trip so audit metadata stays accurate without
+  // a SELECT-before-UPDATE extra DB op on this hot path (5 caller sites).
   const result = db.prepare(`
     UPDATE memories
        SET summary_dirty = 1
      WHERE id = ?
        AND tenant_id = ?
-       AND dag_level = 2
+       AND dag_level IN (2, 3)
        AND summary_dirty = 0
        AND kind != 'archived'
-  `).run(summaryId, tenantId);
-  if ((result.changes ?? 0) > 0) {
-    audit(db, 'summary_marked_dirty', summaryId, { dag_level: 2, source: 'E2' }, actor, tenantId);
+    RETURNING dag_level
+  `).get(summaryId, tenantId) as { dag_level: number } | undefined;
+  if (result) {
+    audit(db, 'summary_marked_dirty', summaryId, { dag_level: result.dag_level, source: 'E2' }, actor, tenantId);
   }
 }
 
@@ -2553,21 +2560,23 @@ export function markSummaryDirty(
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
+    // v0.30 / E5: widened dag_level=2 -> IN (2, 3). RETURNING dag_level reads
+    // actual level in same round trip.
     const result = db.prepare(`
       UPDATE memories
          SET summary_dirty = 1
        WHERE id = ?
          AND tenant_id = ?
-         AND dag_level = 2
+         AND dag_level IN (2, 3)
          AND summary_dirty = 0
          AND kind != 'archived'
-    `).run(summaryId, tenantId);
-    if ((result.changes ?? 0) > 0) {
-      // audit() wraps appendAuditEvent in try/catch — defends against the
-      // v16-partial-state where audit_log is missing (fixed by v27 heal).
+      RETURNING dag_level
+    `).get(summaryId, tenantId) as { dag_level: number } | undefined;
+    if (result) {
+      // audit() wraps appendAuditEvent in try/catch (v27 heal scenario).
       // metadata.source=E1 leaves a breadcrumb so E2-E5 debugging can
       // distinguish dirty-marks across the arc's wiring layers.
-      audit(db, 'summary_marked_dirty', summaryId, { dag_level: 2, source: 'E1' }, actor, tenantId);
+      audit(db, 'summary_marked_dirty', summaryId, { dag_level: result.dag_level, source: 'E1' }, actor, tenantId);
     }
   } finally {
     closeHippoDb(db);
@@ -2583,6 +2592,34 @@ export function markSummaryDirty(
 // syncFtsRow, assertTenantId. dag.ts owns only the thin orchestrator
 // rebuildDirtySummaries() that calls into these.
 // ---------------------------------------------------------------------------
+
+/**
+ * v0.30 / E5 — host-wide loader for L2 topic summaries without an L3 parent.
+ * Used by consolidate phase 1.9 (buildEntityProfiles) to cluster L2s into
+ * L3 entity profiles. Mirrors loadAllDirtySummaries pattern (E3): SQL-level
+ * filter is cheaper than reusing in-memory `survivors` (which doesn't
+ * contain L2s freshly created by phase 1.7 buildDag).
+ *
+ * Returns entries with tenantId attached so per-cluster writes stay
+ * tenant-scoped via summary.tenantId.
+ */
+export function loadAllL2Summaries(hippoRoot: string): MemoryEntry[] {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const rows = db.prepare(`
+      SELECT ${MEMORY_SELECT_COLUMNS}
+        FROM memories
+       WHERE dag_level = 2
+         AND dag_parent_id IS NULL
+         AND kind != 'archived'
+       ORDER BY created ASC, id ASC
+    `).all() as MemoryRow[];
+    return rows.map(rowToEntry);
+  } finally {
+    closeHippoDb(db);
+  }
+}
 
 /**
  * v0.30 / E3 — host-wide variant of loadDirtySummaries. Iterates all tenants
@@ -2676,6 +2713,7 @@ export function applyRebuildResult(
     try {
       const nowIso = new Date().toISOString();
       // ONE prepared UPDATE per branch. Test #8 inspects the SQL string.
+      // v0.30 / E5: widened dag_level=2 -> IN (2, 3) on both branches.
       const sql = patch.bumpRebuildCount
         ? `UPDATE memories
               SET content = ?,
@@ -2687,7 +2725,7 @@ export function applyRebuildResult(
                   summary_dirty = 0
             WHERE id = ?
               AND tenant_id = ?
-              AND dag_level = 2
+              AND dag_level IN (2, 3)
               AND summary_dirty = 1
               AND kind != 'archived'`
         : `UPDATE memories
@@ -2697,7 +2735,7 @@ export function applyRebuildResult(
                   summary_dirty = 0
             WHERE id = ?
               AND tenant_id = ?
-              AND dag_level = 2
+              AND dag_level IN (2, 3)
               AND summary_dirty = 1
               AND kind != 'archived'`;
 
@@ -2745,7 +2783,9 @@ export function applyRebuildResult(
           'summary_rebuilt',
           summary.id,
           {
-            dag_level: 2,
+            // v0.30 / E5: read actual level from the summary in scope
+            // (NOT hardcoded 2). L2 -> 2, L3 -> 3.
+            dag_level: summary.dag_level,
             source: 'E3-rebuild',
             zero_children: patch.zeroChildren,
             descendant_count: patch.descendant_count,
@@ -2786,22 +2826,28 @@ export function clearSummaryDirtyAfterBuild(
   summaryId: string,
   tenantId: string,
   actor: string = 'cli',
+  source: string = 'buildDag-clean',
 ): void {
   assertTenantId('clearSummaryDirtyAfterBuild', tenantId);
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
+    // v0.30 / E5: widened dag_level=2 -> IN (2, 3). RETURNING dag_level reads
+    // actual level so audit metadata stays accurate without an extra SELECT.
     const result = db.prepare(`
       UPDATE memories
          SET summary_dirty = 0
        WHERE id = ?
          AND tenant_id = ?
-         AND dag_level = 2
+         AND dag_level IN (2, 3)
          AND summary_dirty = 1
          AND kind != 'archived'
-    `).run(summaryId, tenantId);
-    if ((result.changes ?? 0) > 0) {
-      audit(db, 'summary_marked_clean', summaryId, { dag_level: 2, source: 'buildDag-clean' }, actor, tenantId);
+      RETURNING dag_level
+    `).get(summaryId, tenantId) as { dag_level: number } | undefined;
+    if (result) {
+      // v0.30 / E5: source param distinguishes buildDag-clean (L2) from
+      // buildEntityProfiles-clean (L3) and any future build path.
+      audit(db, 'summary_marked_clean', summaryId, { dag_level: result.dag_level, source }, actor, tenantId);
     }
   } finally {
     closeHippoDb(db);

--- a/tests/dag-e5-entity-profiles.test.ts
+++ b/tests/dag-e5-entity-profiles.test.ts
@@ -1,0 +1,439 @@
+/**
+ * v0.30 / E5 of DAG live-coupling — level-3 entity profiles + drillDown depth.
+ *
+ * Locks: buildEntityProfiles L2->L3 aggregation, born-dirty cancellation on
+ * L3, widened dag_level guards (markSummaryDirtyInTx + applyRebuildResult +
+ * clearSummaryDirtyAfterBuild all handle L2+L3 uniformly), audit metadata
+ * reads actual level (NOT hardcoded), drillDown depth N + visited Set dedup
+ * + totalChildren semantics + tenant isolation per level, isDagSummary
+ * widened to L2+L3 with E4 deboost still firing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initStore, writeEntry, loadAllL2Summaries } from '../src/store.js';
+import { openHippoDb } from '../src/db.js';
+import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
+import {
+  buildEntityProfiles,
+  rebuildDirtySummaries,
+} from '../src/dag.js';
+import { drillDown, type Context, type DrillDownResult } from '../src/api.js';
+import { hybridSearch, isDagSummary } from '../src/search.js';
+
+function makeOkFetcher(content: string = 'synthetic-entity-profile-content-xyz') {
+  return vi.fn(async () => {
+    return new Response(
+      JSON.stringify({ content: [{ text: content }] }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function makeL2Summary(
+  content: string,
+  speaker: string = 'alice',
+  parentId?: string | null,
+): MemoryEntry {
+  const s = createMemory(content, {
+    layer: Layer.Semantic,
+    tags: [`speaker:${speaker}`, 'dag-summary'],
+    confidence: 'inferred',
+    dag_level: 2,
+  });
+  if (parentId !== undefined) s.dag_parent_id = parentId ?? undefined;
+  return s;
+}
+
+function makeL3Profile(content: string, speaker: string = 'alice'): MemoryEntry {
+  const s = createMemory(content, {
+    layer: Layer.Semantic,
+    tags: [`speaker:${speaker}`, 'dag-entity-profile'],
+    confidence: 'inferred',
+    dag_level: 3,
+  });
+  return s;
+}
+
+function makeL1Fact(parentId: string, content: string): MemoryEntry {
+  const c = createMemory(content, {
+    layer: Layer.Episodic,
+    tags: ['extracted'],
+    dag_level: 1,
+    dag_parent_id: parentId,
+  });
+  return c;
+}
+
+function forceMarkDirty(hippoRoot: string, summaryId: string): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    db.prepare(`UPDATE memories SET summary_dirty = 1 WHERE id = ?`).run(summaryId);
+  } finally {
+    db.close();
+  }
+}
+
+function defaultCtx(hippoRoot: string, tenantId: string = 'default'): Context {
+  return {
+    hippoRoot,
+    tenantId,
+    actor: { subject: 'test:e5', role: 'admin' },
+  };
+}
+
+describe('v0.30 / E5 — level-3 entity profiles + drillDown depth', () => {
+  let hippoRoot: string;
+
+  beforeEach(() => {
+    hippoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-dag-e5-'));
+    initStore(hippoRoot);
+  });
+
+  afterEach(() => {
+    fs.rmSync(hippoRoot, { recursive: true, force: true });
+  });
+
+  it('test #1: buildEntityProfiles happy path — 3 L2 summaries -> 1 L3 profile', async () => {
+    const l2a = makeL2Summary('alice prefers python type hints', 'alice');
+    const l2b = makeL2Summary('alice ships features in 2-week cycles', 'alice');
+    const l2c = makeL2Summary('alice owns the API layer', 'alice');
+    [l2a, l2b, l2c].forEach((e) => writeEntry(hippoRoot, e));
+
+    const fetcher = makeOkFetcher('synthetic-alice-entity-profile-content-zzz');
+    const result = await buildEntityProfiles(hippoRoot, [l2a, l2b, l2c], {
+      apiKey: 'test-key',
+      fetcher,
+    });
+
+    expect(result.profilesCreated).toBe(1);
+    expect(result.l2sLinked).toBe(3);
+    expect(result.candidateClusters).toBe(1);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const profile = db.prepare(`
+        SELECT id, content, dag_level, dag_level_3_built_at, descendant_count, earliest_at, latest_at
+          FROM memories WHERE dag_level = 3
+      `).get() as any;
+      expect(profile).toBeTruthy();
+      expect(profile.dag_level).toBe(3);
+      expect(profile.dag_level_3_built_at).toBeTruthy();
+      expect(profile.descendant_count).toBe(3);
+      expect(profile.earliest_at).toBeTruthy();
+      expect(profile.latest_at).toBeTruthy();
+
+      // All 3 L2s now have dag_parent_id pointing to profile
+      const linkedRows = db.prepare(`SELECT id FROM memories WHERE dag_parent_id = ?`).all(profile.id) as any[];
+      expect(linkedRows.length).toBe(3);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #2: no clustering below threshold — 1 L2 summary -> 0 profiles', async () => {
+    const l2 = makeL2Summary('alone fact content', 'alice');
+    writeEntry(hippoRoot, l2);
+    const result = await buildEntityProfiles(hippoRoot, [l2], {
+      apiKey: 'k',
+      fetcher: makeOkFetcher(),
+    });
+    expect(result.profilesCreated).toBe(0);
+    expect(result.candidateClusters).toBe(0);
+  });
+
+  it('test #3: skips L2s with existing L3 parent', async () => {
+    const existing = makeL3Profile('existing alice profile content', 'alice');
+    writeEntry(hippoRoot, existing);
+    const parented = makeL2Summary('already linked alice topic', 'alice', existing.id);
+    const unparented1 = makeL2Summary('unlinked alice topic one', 'alice');
+    const unparented2 = makeL2Summary('unlinked alice topic two', 'alice');
+    [parented, unparented1, unparented2].forEach((e) => writeEntry(hippoRoot, e));
+
+    const result = await buildEntityProfiles(hippoRoot, [parented, unparented1, unparented2], {
+      apiKey: 'k',
+      fetcher: makeOkFetcher(),
+    });
+    // Only the 2 unparented ones cluster
+    expect(result.l2sLinked).toBe(2);
+    // M2 fold: confirm the parented L2 STILL points at `existing`, not the new L3.
+    const db = openHippoDb(hippoRoot);
+    try {
+      const row = db.prepare(`SELECT dag_parent_id FROM memories WHERE id = ?`).get(parented.id) as any;
+      expect(row.dag_parent_id).toBe(existing.id);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #4: L3 born-dirty cancellation — summary_dirty=0 after build + audit source=buildEntityProfiles-clean', async () => {
+    const l2a = makeL2Summary('alice topic one for clean test', 'alice');
+    const l2b = makeL2Summary('alice topic two for clean test', 'alice');
+    writeEntry(hippoRoot, l2a);
+    writeEntry(hippoRoot, l2b);
+
+    await buildEntityProfiles(hippoRoot, [l2a, l2b], {
+      apiKey: 'k',
+      fetcher: makeOkFetcher('alice-clean-profile-content-zzz'),
+    });
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const profile = db.prepare(`SELECT id, summary_dirty FROM memories WHERE dag_level = 3`).get() as any;
+      expect(profile.summary_dirty).toBe(0);
+
+      const cleanRows = db.prepare(`
+        SELECT metadata_json FROM audit_log WHERE op = 'summary_marked_clean' AND target_id = ?
+      `).all(profile.id) as Array<{ metadata_json: string }>;
+      expect(cleanRows.length).toBeGreaterThan(0);
+      const meta = JSON.parse(cleanRows[0].metadata_json);
+      expect(meta.source).toBe('buildEntityProfiles-clean');
+      expect(meta.dag_level).toBe(3); // H1 fold: read actual level, NOT hardcoded 2
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #5: markSummaryDirtyInTx widened to L3 — write L2 with dag_parent_id=L3 marks L3 dirty', () => {
+    const l3 = makeL3Profile('alice existing profile content', 'alice');
+    writeEntry(hippoRoot, l3);
+    const db1 = openHippoDb(hippoRoot);
+    db1.prepare(`UPDATE memories SET summary_dirty = 0 WHERE id = ?`).run(l3.id);
+    db1.close();
+
+    // Write a NEW L2 with dag_parent_id pointing to the L3 -> E2 hook fires.
+    const newL2 = makeL2Summary('new alice topic', 'alice', l3.id);
+    writeEntry(hippoRoot, newL2);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const row = db.prepare(`SELECT summary_dirty FROM memories WHERE id = ?`).get(l3.id) as any;
+      expect(row.summary_dirty).toBe(1);
+
+      const auditRows = db.prepare(`
+        SELECT metadata_json FROM audit_log WHERE op = 'summary_marked_dirty' AND target_id = ?
+      `).all(l3.id) as Array<{ metadata_json: string }>;
+      expect(auditRows.length).toBeGreaterThan(0);
+      const meta = JSON.parse(auditRows[0].metadata_json);
+      expect(meta.dag_level).toBe(3); // H1 fold: actual level
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #6: rebuildDirtySummaries handles dirty L3 (label derivation + dag_level_3_built_at preserved)', async () => {
+    const l3 = makeL3Profile('old alice profile content xxx', 'alice');
+    const builtAtIso = '2026-01-01T00:00:00.000Z';
+    l3.dag_level_3_built_at = builtAtIso;
+    writeEntry(hippoRoot, l3);
+    // Add a child L2 so rebuild has children to read
+    const childL2 = makeL2Summary('alice topic for rebuild test', 'alice', l3.id);
+    writeEntry(hippoRoot, childL2);
+    forceMarkDirty(hippoRoot, l3.id);
+
+    let capturedPrompt: string | undefined;
+    const fetcher = vi.fn(async (_url: any, init?: any) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedPrompt = body?.messages?.[0]?.content ?? '';
+      return new Response(
+        JSON.stringify({ content: [{ text: 'rebuilt-alice-profile-content-yyy' }] }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await rebuildDirtySummaries(hippoRoot, {
+      apiKey: 'k',
+      fetcher,
+      cap: 20,
+    });
+    expect(result.rebuilt).toBe(1);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const row = db.prepare(`
+        SELECT content, rebuild_count, last_rebuilt_at, summary_dirty, dag_level_3_built_at
+          FROM memories WHERE id = ?
+      `).get(l3.id) as any;
+      expect(row.content).toBe('rebuilt-alice-profile-content-yyy');
+      expect(row.rebuild_count).toBe(1);
+      expect(row.last_rebuilt_at).toBeTruthy();
+      expect(row.summary_dirty).toBe(0);
+      // dag_level_3_built_at UNCHANGED (set once at create, not bumped on rebuild)
+      expect(row.dag_level_3_built_at).toBe(builtAtIso);
+
+      // Audit row has dag_level: 3 in metadata (NOT hardcoded 2)
+      const auditRow = db.prepare(`
+        SELECT metadata_json FROM audit_log WHERE op = 'summary_rebuilt' AND target_id = ?
+      `).get(l3.id) as any;
+      expect(auditRow).toBeTruthy();
+      const meta = JSON.parse(auditRow.metadata_json);
+      expect(meta.dag_level).toBe(3);
+      expect(meta.source).toBe('E3-rebuild');
+    } finally {
+      db.close();
+    }
+    // Label derivation: prompt contains the speaker:alice tag's value 'alice'
+    expect(capturedPrompt).toContain('alice');
+  });
+
+  it('test #7: drillDown depth=1 backward compat — returns immediate children', () => {
+    const summary = makeL2Summary('compat test summary content', 'alice');
+    writeEntry(hippoRoot, summary);
+    writeEntry(hippoRoot, makeL1Fact(summary.id, 'fact one for compat test'));
+    writeEntry(hippoRoot, makeL1Fact(summary.id, 'fact two for compat test'));
+
+    const r = drillDown(defaultCtx(hippoRoot), summary.id) as DrillDownResult;
+    expect('failure' in r).toBe(false);
+    expect(r.children.length).toBe(2);
+    expect(r.totalChildren).toBe(2);
+  });
+
+  it('test #8: drillDown depth=2 from L3 returns L2s + L1s with dedup + totalChildren=8', () => {
+    const l3 = makeL3Profile('alice profile for depth test', 'alice');
+    l3.descendant_count = 2; // stored direct-child count (2 L2 kids)
+    writeEntry(hippoRoot, l3);
+    const l2a = makeL2Summary('alice topic A for depth', 'alice', l3.id);
+    const l2b = makeL2Summary('alice topic B for depth', 'alice', l3.id);
+    writeEntry(hippoRoot, l2a);
+    writeEntry(hippoRoot, l2b);
+    for (let i = 0; i < 3; i++) {
+      writeEntry(hippoRoot, makeL1Fact(l2a.id, `A-fact-${i} content here`));
+      writeEntry(hippoRoot, makeL1Fact(l2b.id, `B-fact-${i} content here`));
+    }
+
+    const r = drillDown(defaultCtx(hippoRoot), l3.id, { depth: 2 }) as DrillDownResult;
+    expect('failure' in r).toBe(false);
+    // 2 L2s + 6 L1s = 8 entries
+    expect(r.children.length).toBe(8);
+    expect(r.totalChildren).toBe(8);
+    // descendantCount stays at the L3's stored value (2 L2 direct children)
+    expect(r.summary.descendantCount).toBe(2);
+    // All returned ids unique (visited Set dedup lock)
+    const ids = new Set(r.children.map((c) => c.id));
+    expect(ids.size).toBe(8);
+  });
+
+  it('test #9: drillDown depth=3 over-walks safely — BFS exhausts at depth=2 since L1s have no children', () => {
+    const l3 = makeL3Profile('alice profile depth3 test', 'alice');
+    writeEntry(hippoRoot, l3);
+    const l2 = makeL2Summary('alice topic for depth3', 'alice', l3.id);
+    writeEntry(hippoRoot, l2);
+    writeEntry(hippoRoot, makeL1Fact(l2.id, 'fact one for depth3 test'));
+    writeEntry(hippoRoot, makeL1Fact(l2.id, 'fact two for depth3 test'));
+
+    const r = drillDown(defaultCtx(hippoRoot), l3.id, { depth: 3 }) as DrillDownResult;
+    expect('failure' in r).toBe(false);
+    // 1 L2 + 2 L1s = 3 entries; depth=3 doesn't over-walk into nothing
+    expect(r.children.length).toBe(3);
+    expect(r.totalChildren).toBe(3);
+  });
+
+  it('test #10: drillDown depth=2 global budget truncates mid-walk', () => {
+    const l3 = makeL3Profile('alice profile budget test', 'alice');
+    writeEntry(hippoRoot, l3);
+    const l2 = makeL2Summary('alice topic for budget test xxxxx', 'alice', l3.id);
+    writeEntry(hippoRoot, l2);
+    for (let i = 0; i < 5; i++) {
+      writeEntry(hippoRoot, makeL1Fact(l2.id, `fact-${i} with substantial content here for budget test xxxxx yyyy zzzz`));
+    }
+
+    // Very tight budget — should truncate
+    const r = drillDown(defaultCtx(hippoRoot), l3.id, { depth: 2, budget: 30 }) as DrillDownResult;
+    expect('failure' in r).toBe(false);
+    expect(r.truncated).toBe(true);
+    expect(r.children.length).toBeLessThan(6);
+  });
+
+  it('test #11: drillDown depth tenant isolation — L1s in different tenant are excluded at level 2', () => {
+    const l3 = makeL3Profile('alice profile tenant test', 'alice');
+    writeEntry(hippoRoot, l3);
+    const l2a = makeL2Summary('alice topic A in tenant-a', 'alice', l3.id);
+    writeEntry(hippoRoot, l2a);
+
+    // Anomaly: L1s in tenant-b with dag_parent_id pointing to tenant-a's L2-A
+    const db = openHippoDb(hippoRoot);
+    try {
+      for (let i = 0; i < 3; i++) {
+        const l1 = makeL1Fact(l2a.id, `cross-tenant-fact-${i} content here`);
+        // Direct SQL to simulate cross-tenant data anomaly
+        db.prepare(`
+          INSERT INTO memories (id, content, layer, tags_json, dag_level, dag_parent_id, tenant_id, created, last_retrieved, retrieval_count, strength, half_life_days, emotional_valence, schema_fit, source, outcome_score, outcome_positive, outcome_negative, conflicts_with_json, pinned, confidence, parents_json, starred, kind, valid_from, summary_dirty)
+          VALUES (?, ?, 'episodic', '["extracted"]', 1, ?, 'tenant-b', ?, ?, 0, 1.0, 7, 0, 1, 'extraction', 0, 0, 0, '[]', 0, 'inferred', '[]', 0, 'distilled', ?, 0)
+        `).run(l1.id, l1.content, l2a.id, l1.created, l1.created, l1.created);
+      }
+    } finally {
+      db.close();
+    }
+
+    const r = drillDown(defaultCtx(hippoRoot, 'default'), l3.id, { depth: 2 }) as DrillDownResult;
+    expect('failure' in r).toBe(false);
+    // Should return only L2-A (tenant-a), NOT the L1s in tenant-b
+    expect(r.children.length).toBe(1);
+    expect(r.children[0]!.id).toBe(l2a.id);
+  });
+
+  it('test #12: isDagSummary extended to L2 + L3', () => {
+    const l3 = makeL3Profile('test profile content for isDagSummary', 'alice');
+    const l2 = makeL2Summary('test summary content for isDagSummary', 'alice');
+    const l1 = makeL1Fact('placeholder-parent-id-here-fake', 'l1 fact content for test');
+    expect(isDagSummary(l3)).toBe(true);
+    expect(isDagSummary(l2)).toBe(true);
+    expect(isDagSummary(l1)).toBe(false);
+  });
+
+  it('test #14: buildEntityProfiles partitions clusters by tenantId (independent-review HIGH #1 lock)', async () => {
+    // 3 alice L2s in tenant-A, 3 alice L2s in tenant-B with similar content
+    const tenantAL2s = [
+      'alice does python in tenant A repo one',
+      'alice prefers type hints in tenant A repo one',
+      'alice owns the API layer in tenant A repo one',
+    ].map((c, _i) => {
+      const m = makeL2Summary(c, 'alice');
+      m.tenantId = 'tenant-a';
+      return m;
+    });
+    const tenantBL2s = [
+      'alice writes typescript in tenant B repo two',
+      'alice prefers strict mode in tenant B repo two',
+      'alice owns the frontend in tenant B repo two',
+    ].map((c, _i) => {
+      const m = makeL2Summary(c, 'alice');
+      m.tenantId = 'tenant-b';
+      return m;
+    });
+    [...tenantAL2s, ...tenantBL2s].forEach((e) => writeEntry(hippoRoot, e));
+
+    const result = await buildEntityProfiles(
+      hippoRoot,
+      [...tenantAL2s, ...tenantBL2s],
+      { apiKey: 'k', fetcher: makeOkFetcher('synthetic-multi-tenant-profile-content-xyz') },
+    );
+    // 2 L3s expected — one per tenant cluster (NOT one merged L3 in 'default')
+    expect(result.profilesCreated).toBe(2);
+    expect(result.l2sLinked).toBe(6);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const profiles = db.prepare(`SELECT id, tenant_id FROM memories WHERE dag_level = 3`).all() as any[];
+      expect(profiles.length).toBe(2);
+      const tenants = new Set(profiles.map((p) => p.tenant_id));
+      expect(tenants.has('tenant-a')).toBe(true);
+      expect(tenants.has('tenant-b')).toBe(true);
+      expect(tenants.has('default')).toBe(false); // would indicate cross-tenant conflation
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #13: E4 deboost applies to L3 in hybridSearch — breakdown.summaryDeboost=0.85, breakdown.dagLevel=3', async () => {
+    const l3 = makeL3Profile('alice entity profile xyz searchable content', 'alice');
+    writeEntry(hippoRoot, l3);
+    const results = await hybridSearch('searchable xyz', [l3], { explain: true });
+    expect(results.length).toBeGreaterThan(0);
+    const br = results[0]!.breakdown;
+    expect(br?.dagLevel).toBe(3);
+    expect(br?.summaryDeboost).toBeCloseTo(0.85);
+  });
+});


### PR DESCRIPTION
**Episode:** [01KSGH3FFBEN9WGV19CNJJZQTV](trajectories/01KSGH3FFBEN9WGV19CNJJZQTV/)
**Plan:** docs/plans/2026-05-25-dag-e5-entity-profiles.md (v3.1)
**Stacked on:** #69 (DAG E4). On E4 merge use plain `gh pr merge 69 --rebase` (NO --delete-branch).

## What this ships

Final episode of 5-arc. Aggregates per-entity L2 topic summaries into L3 entity profiles via `buildEntityProfiles` (mirrors `buildDag` L1 -> L2 pattern, one level up). Widens 5 SQL guards in store.ts from `dag_level=2` to `IN (2, 3)` so `rebuildDirtySummaries` handles dirty L3 via the same `applyRebuildResult` path. Adds `drillDown depth?:number` opt (default 1, backward compat, hard cap 10) with BFS visited-Set dedup. Extends `cmdDag` tree view to render L3 roots with L2 children indented.

Plus consumes E3 contracts: `clearSummaryDirtyAfterBuild` gets a `source?` param so L3 born-dirty cancellation distinguishes from L2 in audit metadata (`buildDag-clean` vs `buildEntityProfiles-clean`). `RETURNING dag_level` on widened UPDATE statements preserves audit metadata accuracy without SELECT-before-UPDATE perf cost.

## Surface

- `src/dag.ts`: `buildEntityProfiles` + `EntityProfilesBuildResult` (with per-tenant cluster partition per independent-review HIGH #1 fold)
- `src/store.ts`: 5 SQL guards widened via `RETURNING dag_level`, `clearSummaryDirtyAfterBuild` source param, `loadAllL2Summaries` helper, `upsertEntryRow` persists `dag_level_3_built_at`
- `src/api.ts`: `drillDown depth` + BFS + visited Set
- `src/consolidate.ts`: phase 1.9 wiring + `entityProfilesCreated` field
- `src/cli.ts`: `cmdDrillDown --depth` flag with reject-not-clamp + `cmdDag` tree extension
- `src/server.ts` + `src/mcp/server.ts`: depth pass-through with explicit reject on out-of-range
- `src/search.ts`: `isDagSummary` widened to L2 + L3

## Critic gates (full /dev-framework-rl)

| Stage | Round | Verdict | Score |
|---|---|---|---|
| plan-eng | R1 | fail | 7 |
| plan-eng | R2 | PASS | 8 |
| code-review | R1 | PASS | 88 |
| independent-review | R1 | PASS | 7 |

**Round counts**: 2 plan rounds (R1 fail, R2 pass), single code-review pass, single independent-review pass. Faster than E4 (which needed 3 plan rounds). E3+E4 retro lessons applied: pre-verified call graphs + helper exports before plan write, RETURNING-clause pattern avoids SELECT-before-UPDATE perf concern, pre-commit em-dash grep ritual executed.

## Tests

14 new (`tests/dag-e5-entity-profiles.test.ts`), all real-DB:

| # | Locks |
|---|-------|
| 1-3 | buildEntityProfiles happy path, threshold gate, skip-existing-parent |
| 4 | L3 born-dirty cancellation + audit `summary_marked_clean` source=buildEntityProfiles-clean |
| 5 | E2 hook widening to L3 (markSummaryDirtyInTx fires on dag_level=3) |
| 6 | rebuildDirtySummaries handles dirty L3, dag_level_3_built_at preserved |
| 7-9 | drillDown depth 1/2/3 backward compat + dedup + over-walk safety |
| 10 | drillDown depth global budget truncates mid-walk |
| 11 | drillDown depth tenant isolation (BFS level boundary lock) |
| 12 | isDagSummary widened to L2 + L3 |
| 13 | E4 deboost applies to L3 (`breakdown.summaryDeboost=0.85`, `breakdown.dagLevel=3`) |
| 14 | buildEntityProfiles partitions clusters by tenantId (HIGH #1 fold lock) |

**Full suite:** 1905 passed, 4 skipped, 0 failed.

## Known follow-ups (deferred, not blocking)

1. **E4.5**: thread `hybridSearch` through `api.recall` for SDK callers (MCP + cmdContext already inherit via separate paths)
2. **Sleep-cycle mutex**: pre-existing infrastructure debt in `buildDag` and now `buildEntityProfiles`. Two parallel sleep cycles can produce duplicate L3 profiles. Independent-review flagged as HIGH but pre-E5; needs dedicated mutex refactor.
3. Differentiated L2 vs L3 deboost in search.ts (currently both 0.85)
4. L3 substitution in `api.recall` overflow path (3 sites at api.ts:542/553/883)
5. `buildEntityProfiles` re-clustering of late-arriving L2s once an L3 already exists for the entity

## Ship pattern

After this PR merges, bundled merge sequence (E1 -> E2 -> E3 -> E4 -> E5) + `npm publish` v1.12.12 per Keith's "one bundled release" pick.

Generated with [Claude Code](https://claude.com/claude-code)
