### PR TITLE
feat(predictions): J3 reference-class / planning-fallacy detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@
 
 ### Added
 
+- **J3 reference-class / planning-fallacy detector** (Track J [next] from
+  ROADMAP-RESEARCH.md L542). Reads from the E2 predictions table (shipped
+  earlier this release cycle) and computes per-class base-rate stats so
+  the calling agent can anchor on its past track record rather than the
+  inside view (Lovallo-Kahneman 2003). Reactive in v1 (agent calls
+  explicitly via MCP / CLI / HTTP / SDK); auto-injection on recall is a
+  future episode. Surfaces:
+  - CLI: `hippo predict baserate --class <c>` prints summary + 5 stats.
+  - HTTP: `GET /v1/predictions/stats?class=X` returns
+    `{ baserate: PredictionBaserate }` (Bearer-auth + tenant-scoped, 256
+    char class cap).
+  - MCP: new `hippo_predict_baserate` tool with description anchoring the
+    use case ("call when you make a forward-looking claim..."). Returns
+    text-only formatted response.
+  - Python SDK: `Hippo.get_prediction_baserate(class_tag)` async +
+    `HippoSync.get_prediction_baserate(class_tag)` sync mirror. New
+    `PredictionBaserate` Pydantic model.
+  - 1 new audit op `predict_baserate` lockstep across `src/cli.ts` +
+    `src/server.ts` VALID_AUDIT_OPS + `src/audit.ts` AuditOp union per
+    v1.11.5 CRIT A institutional rule. Emitted INSIDE
+    `computePredictionBaserate` (single source of truth, no caller-site
+    drift; folds plan-eng-critic round-1 HIGH advisory).
+  - `PredictionBaserate` shape: `{ classTag, nClosed, nRatioEligible,
+    meanEstimate?, meanActual?, meanRatio?, p50Ratio?, mae?, summary }`.
+    Estimate=0 rows count in `nClosed` + MAE but excluded from ratio calc
+    (avoids div-by-zero); `nRatioEligible` exposes the subset for
+    consumer transparency.
+  - Edge cases: `nClosed=0` returns null stats + empty summary;
+    `closed-unknown` predictions excluded (no actual to compare);
+    cross-tenant queries return empty. All covered by 8 store + 4 HTTP +
+    3 MCP + 3 Python tests.
 - **E2 prediction first-class object** (E2 row from ROADMAP-RESEARCH.md L314,
   Track J pre-req). New canonical `predictions` table (schema v29) for
   ex-ante claims that can be closed against ex-post outcomes. Enables J3

--- a/docs/plans/2026-05-26-j3-baserate-detector.md
+++ b/docs/plans/2026-05-26-j3-baserate-detector.md
@@ -1,0 +1,156 @@
+# J3 reference-class / planning-fallacy detector — Plan v1
+
+Status: Draft (not yet engineering-reviewed)
+Episode: 01KSJCRSFGYY0KP9W7EEGN553S
+Roadmap reference: `ROADMAP-RESEARCH.md` L542, Track J [next]
+Branch: `feat/j3-baserate-detector` off master at `0a3d03c`
+
+## Problem
+
+When the calling agent makes a forward-looking claim ("this will take 2 days", "rollout is low-risk", "estimate 5 days"), hippo should surface base-rate stats from closed `prediction` objects in the same class so the agent can anchor on its own track record rather than the inside view. Lovallo-Kahneman (2003) inside-vs-outside view applied to agent estimation. Data substrate (E2 predictions table) just landed at master `0a3d03c`.
+
+## Framing (from brainstorm + grill)
+
+**Reactive (agent calls explicitly via MCP / CLI / HTTP).** v1 = reactive only. The MCP tool description anchors the use case ("call when you make a forward-looking claim"); auto-injection on recall is a research problem (forward-claim NLP detection) and deserves its own follow-up episode (J3 v2 or J4 substitution detector). Grill's weakest premise: "agent self-discovers when to use the tool." Mitigation: tool description + agent prompting carry the discoverability; if v1 use rate is low, v0.32 can add auto-injection.
+
+## Field shape (PredictionBaserate)
+
+```typescript
+export interface PredictionBaserate {
+  classTag: string;
+  nClosed: number;          // count of closure_state='closed' rows with both estimate + actual non-null
+  meanEstimate: number | null; // null when n=0
+  meanActual: number | null;
+  meanRatio: number | null;  // mean(actual / estimate); null when n=0 OR any estimate=0
+  p50Ratio: number | null;   // median ratio
+  mae: number | null;        // mean(|actual - estimate|)
+  /** Human-readable summary, e.g. "Last 5 estimates in class migration-effort averaged 2.1x actual (MAE 1.4 days)." Empty string when nClosed=0. */
+  summary: string;
+}
+```
+
+## In scope
+
+1. `computePredictionBaserate(hippoRoot, tenantId, classTag)` helper in `src/predictions.ts`. Filters closure_state='closed' AND estimate_value IS NOT NULL AND actual_value IS NOT NULL. Computes 5 stats + summary string. Single SELECT (cheap; v1 scale ≪ 10K rows per tenant).
+2. New audit op `predict_baserate` lockstep across `src/cli.ts` + `src/server.ts` VALID_AUDIT_OPS + `src/audit.ts` AuditOp union per v1.11.5 CRIT A institutional rule. Audit metadata: `{ class_tag, n_closed }` (no claim_text leakage).
+3. CLI `hippo predict baserate --class <c>` subcommand. Routes through `cmdPredict` (new sub-handler). Emits `predict_baserate` audit. Prints the summary string + the 5 numeric stats.
+4. HTTP `GET /v1/predictions/stats?class=X` route. Bearer-auth + tenant-scoped. Returns `{ baserate: PredictionBaserate }`. Validates `class` is non-empty.
+5. MCP `hippo_predict_baserate` tool. TOOLS array entry with description anchoring the use case ("call when you make a forward-looking claim"). Dispatch case returns the formatted baserate as text. Tool input: `{ class_tag: string }`.
+6. Python SDK: `PredictionBaserate` Pydantic model with snake_case fields. `Hippo.get_prediction_baserate(class_tag)` async method + `HippoSync.get_prediction_baserate(class_tag)` sync mirror. Export from `__init__.py`.
+7. Tests: store-level computePredictionBaserate cases (empty, one closed, multiple closed, mixed open+closed, all categorical) + HTTP route + MCP tool + Python Pydantic + Hippo method shape.
+8. CHANGELOG entry under `## Unreleased` (em-dash-free per recurring failure memory).
+
+## Out of scope (explicit, deferred)
+
+- Auto-injection on recall (J3 v2 or J4 substitution detector). Needs forward-claim NLP detection.
+- Persistent base-rate cache. Recompute on demand is cheap at v1 scale; cache adds invalidation complexity.
+- Bayesian smoothing for small-n classes (n=2 baserate is noisy). v1 reports raw n + stats; consumers decide whether to trust.
+- Per-class thresholds (J3 doesn't classify "clean" vs "regressed" itself; surfaces raw stats and the agent decides).
+- 30-task estimation eval (per the roadmap success criterion). Requires a synthetic estimation workload that doesn't exist yet. v1 ships the mechanism; eval is its own follow-up episode.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `src/predictions.ts` | New `PredictionBaserate` interface + `computePredictionBaserate(hippoRoot, tenantId, classTag)` helper. Single SQL query against predictions table with WHERE filters; in-memory aggregation for mean/median (predictions per class are small). |
+| `src/cli.ts` | Extend `cmdPredict` with `baserate` subcommand. Add `predict_baserate` to `VALID_AUDIT_OPS` set. |
+| `src/server.ts` | New `GET /v1/predictions/stats?class=X` route. Add `predict_baserate` to `VALID_AUDIT_OPS` set. |
+| `src/audit.ts` | Extend `AuditOp` union with `predict_baserate`. |
+| `src/mcp/server.ts` | New `hippo_predict_baserate` tool definition in TOOLS array + dispatch case. |
+| `python/src/hippo_memory/models.py` | New `PredictionBaserate` Pydantic model. |
+| `python/src/hippo_memory/client.py` | New `Hippo.get_prediction_baserate(class_tag)` async method. |
+| `python/src/hippo_memory/sync_client.py` | Sync mirror. |
+| `python/src/hippo_memory/__init__.py` | Export `PredictionBaserate`. |
+| `tests/predictions-baserate.test.ts` | NEW. Store helper cases. |
+| `tests/http-predictions-stats.test.ts` | NEW. HTTP route + audit emission. |
+| `python/tests/test_predictions.py` | Extend with baserate Pydantic + method shape tests. |
+| `CHANGELOG.md` | Entry under `## Unreleased`. |
+
+## Implementation tasks (ordered)
+
+**Task 1 — computePredictionBaserate helper.** In `src/predictions.ts`, add:
+- `interface PredictionBaserate` per field shape above.
+- `function computePredictionBaserate(hippoRoot: string, tenantId: string, classTag: string): PredictionBaserate` — opens db, SELECT estimate_value, actual_value FROM predictions WHERE tenant_id = ? AND class_tag = ? AND closure_state = 'closed' AND estimate_value IS NOT NULL AND actual_value IS NOT NULL. Compute stats in JS. Construct summary string. Audit-emit is the caller's job (CLI / HTTP / MCP each emit at their own site).
+- Edge cases: nClosed=0 → all stats null + summary "" (consumers render "No closed predictions in class X yet."); estimate_value=0 in a row → exclude from ratio calc but include in nClosed (still useful for MAE).
+
+**Task 2 — Audit op lockstep.** Add `'predict_baserate'` to:
+- `VALID_AUDIT_OPS` set at `src/cli.ts` (~L4844)
+- `VALID_AUDIT_OPS` set at `src/server.ts` (~L83)
+- `AuditOp` union at `src/audit.ts` (~L144 after `predict_close`)
+
+Per v1.11.5 CRIT A institutional rule. Audit metadata: `{ class_tag: string, n_closed: number }`.
+
+**Task 3 — CLI subcommand.** Extend `cmdPredict` in `src/cli.ts`. Route on `args[0] === 'baserate'`. Flag `--class <c>` required. Call `computePredictionBaserate`, print summary + stats table. Emit `predict_baserate` audit via `emitCliAudit`.
+
+**Task 4 — HTTP route.** Add `GET /v1/predictions/stats` in `src/server.ts`. Query param `class` required. Bearer-auth via `buildContextWithAuth`. Returns `{ baserate: PredictionBaserate }`. Emit `predict_baserate` audit via `appendAuditEvent`.
+
+**Task 5 — MCP tool.** Add `hippo_predict_baserate` to TOOLS array with description: "Get base-rate stats for closed predictions in a class. Call this when you make a forward-looking claim (effort estimate, rollout risk, deadline) to anchor on your past track record rather than the inside view. Returns count + mean estimate + mean actual + mean ratio + median ratio + MAE + human-readable summary." Input schema: `{ class_tag: { type: 'string', description: '...' } }`, required `[class_tag]`. Dispatch case returns the summary string + JSON stats block.
+
+**Task 6 — Python SDK.** Add to `python/src/hippo_memory/models.py`:
+- `class PredictionBaserate(_Base)` with 8 fields (snake_case, all optional except class_tag + n_closed).
+
+Add to `python/src/hippo_memory/client.py`:
+- `async def get_prediction_baserate(self, class_tag: str) -> PredictionBaserate`.
+
+Mirror on `HippoSync`. Export from `__init__.py`.
+
+**Task 7 — Tests.**
+- `tests/predictions-baserate.test.ts`: 6 cases. (a) empty class returns nClosed=0 + null stats; (b) one closed prediction returns n=1 stats; (c) multiple closed predictions compute correct mean/median/MAE; (d) open + closed mixed only counts closed; (e) closed-unknown excluded (no actual_value); (f) tenant scoping (cross-tenant returns empty).
+- `tests/http-predictions-stats.test.ts`: 3 cases. (a) GET returns baserate JSON; (b) missing class param → 400; (c) audit log has predict_baserate row post-call.
+- Extend `python/tests/test_predictions.py`: 2 cases. PredictionBaserate round-trip + Hippo/HippoSync method shape.
+
+**Task 8 — CHANGELOG.** Under `## Unreleased`. Em-dash-free.
+
+## Test commitments
+
+- `npm run build` clean.
+- `npm test` full suite green (1939+ pass; pre-existing openclaw failure stays out of scope).
+- `cd python && pytest` green.
+
+## Success criteria
+
+1. `hippo predict baserate --class migration-effort` prints "Last N estimates averaged X.Yx actual (MAE Z days)." when N>0.
+2. HTTP `GET /v1/predictions/stats?class=X` returns the same PredictionBaserate JSON shape.
+3. MCP `hippo_predict_baserate` tool callable by an agent in a hippo MCP session, returns the summary text.
+4. Python SDK `await hippo.get_prediction_baserate("X")` returns a PredictionBaserate.
+5. `audit_log` records `predict_baserate` events with `{ class_tag, n_closed }` metadata.
+6. nClosed=0 returns null stats + empty summary; consumers render appropriate "no data yet" message.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Division by zero (estimate_value=0) in ratio calc | Filter rows with estimate_value=0 from ratio computation; still count in nClosed for MAE. |
+| Small-n base rates noisy | v1 reports raw n; consumers decide trust. Bayesian smoothing is a v0.32 follow-up. |
+| Categorical predictions (no estimate_value) inflate apparent class size | WHERE estimate_value IS NOT NULL excludes them from baserate calc. nClosed reflects numerically-comparable predictions only. |
+| Median computation on tiny arrays | JS array sort + middle pick is fine at v1 scale. |
+| Audit emit at 3 sites drift | Use a single helper `appendBaserateAudit(db, tenantId, actor, classTag, nClosed)` in src/predictions.ts so all 3 call sites emit the same shape. |
+
+## Verification approach (verify stage)
+
+1. `npm run build && npm test` full suite green.
+2. `cd python && pytest` green.
+3. Manual smoke: `hippo predict "test" --class smoke --estimate 1` then `hippo predict close <id> --state closed --actual 2` then `hippo predict baserate --class smoke` → expects `n_closed=1 mean_ratio=2.0`.
+4. HTTP smoke: `curl -X GET http://127.0.0.1:6789/v1/predictions/stats?class=smoke -H "Authorization: Bearer ..."`.
+
+## Effort
+
+~4d single engineer. No new table, no schema migration. Adds 1 helper + 1 audit op + 4 surface integrations + tests.
+
+## /grill-me responses (orchestrator self-interrogation, recorded pre-critic)
+
+Adversarial pass on v1 surfaced 3 fixes. Folded into v2 amendments below.
+
+1. **MCP response format claim ("JSON stats block")** is inconsistent with how MCP tools actually return data. MCP `hippo_recall`, `hippo_drill`, etc. return TEXT strings via `formatMemories`-style helpers; there is no structured JSON return surface on the MCP tool wire. **Fix:** Task 5 amended to return a text-only response: the summary string PLUS the formatted stats line (e.g. "n=5, mean_ratio=2.1, p50_ratio=1.9, MAE=1.4 days"). No "JSON stats block" claim.
+
+2. **Audit emit drift across 3 sites.** Risk-row mentioned a shared helper but Tasks 3/4/5 don't reference it. **Fix:** new helper `emitBaseratesAudit(db, tenantId, actor, classTag, nClosed)` in `src/predictions.ts` is the SINGLE call site for the audit op; CLI/HTTP/MCP all call this helper rather than each constructing the audit metadata directly.
+
+3. **estimate_value=0 division-by-zero edge case** is documented in Risks but not in the actual implementation guidance. **Fix:** Task 1 amended to specify: `meanRatio` filters rows where estimate_value=0 before dividing; `mae` and `nClosed` still count those rows. Sub-stat `nRatioEligible` exposed in the response so consumers can spot when ratio reflects fewer rows than the count.
+
+## Plan v2 amendments (override Task descriptions where they conflict)
+
+- **Task 1 amended:** Add `nRatioEligible: number` field to PredictionBaserate (count of rows where estimate_value > 0 AND actual_value IS NOT NULL). meanRatio + p50Ratio computed from that subset. nClosed remains the full closed-with-actual count; MAE uses nClosed.
+- **Task 2 amended:** New `emitBaserateAudit(db, tenantId, actor, classTag, nClosed)` helper in src/predictions.ts. CLI/HTTP/MCP all call this. Metadata pinned at one site; drift eliminated.
+- **Task 5 amended:** MCP tool response is a single text block: summary line + stats line. No structured JSON. Matches the existing tool-text pattern (formatMemories, etc.).
+
+## Status: Draft v2 (grill responses folded). Awaiting plan-eng-critic.

--- a/python/src/hippo_memory/__init__.py
+++ b/python/src/hippo_memory/__init__.py
@@ -51,6 +51,7 @@ from hippo_memory.models import (
     AuthRevoked,
     AuditEvent,
     Prediction,
+    PredictionBaserate,
     HippoError,
 )
 
@@ -79,6 +80,7 @@ __all__ = [
     "AuthRevoked",
     "AuditEvent",
     "Prediction",
+    "PredictionBaserate",
     "HippoError",
     "__version__",
 ]

--- a/python/src/hippo_memory/client.py
+++ b/python/src/hippo_memory/client.py
@@ -38,6 +38,7 @@ from hippo_memory.models import (
     AuthRevoked,
     AuditEvent,
     Prediction,
+    PredictionBaserate,
     HippoError,
 )
 
@@ -451,3 +452,22 @@ class Hippo:
         """GET /v1/predictions/:id. Fetch a single prediction by id."""
         data = await self._request("GET", f"/v1/predictions/{prediction_id}")
         return Prediction.model_validate(data["prediction"])
+
+    async def get_prediction_baserate(self, class_tag: str) -> PredictionBaserate:
+        """GET /v1/predictions/stats?class=X. J3 reference-class /
+        planning-fallacy detector.
+
+        Returns base-rate stats for closed predictions in the class:
+        count, mean estimate, mean actual, mean ratio, median ratio, MAE,
+        plus a human-readable summary. ``n_closed = 0`` indicates no
+        closed predictions yet; numeric fields will be ``None`` in that
+        case and ``summary`` will be empty.
+
+        Use when you're about to make a forward-looking claim (effort
+        estimate, rollout risk, deadline) to anchor on your track record
+        rather than the inside view. Lovallo-Kahneman (2003) inside-vs-
+        outside view.
+        """
+        params: dict[str, Any] = {"class": class_tag}
+        data = await self._request("GET", "/v1/predictions/stats", params=params)
+        return PredictionBaserate.model_validate(data["baserate"])

--- a/python/src/hippo_memory/models.py
+++ b/python/src/hippo_memory/models.py
@@ -43,6 +43,7 @@ __all__ = [
     "AuthRevoked",
     "AuditEvent",
     "Prediction",
+    "PredictionBaserate",
     "HippoError",
 ]
 
@@ -417,6 +418,37 @@ class Prediction(_Base):
     closed_at: str | None = None
     closure_note: str | None = None
     created_at: str
+
+
+# ---------------------------------------------------------------------------
+# v0.31 / J3 — reference-class / planning-fallacy detector
+# (docs/plans/2026-05-26-j3-baserate-detector.md)
+# ---------------------------------------------------------------------------
+
+
+class PredictionBaserate(_Base):
+    """Base-rate stats for closed predictions in a class. Surfaces from
+    `Hippo.get_prediction_baserate(class_tag)` / the `hippo_predict_baserate`
+    MCP tool / `GET /v1/predictions/stats?class=X`.
+
+    J3 (reference-class / planning-fallacy detector) returns this when the
+    agent queries its past track record on forward-looking claims. Lovallo-
+    Kahneman (2003) inside-vs-outside view.
+
+    Numeric fields are None when ``n_closed = 0`` (or ``n_ratio_eligible = 0``
+    for ratio fields). ``summary`` is empty when there are no closed
+    predictions yet; callers should render "no data" messaging.
+    """
+
+    class_tag: str
+    n_closed: int = 0
+    n_ratio_eligible: int = 0
+    mean_estimate: float | None = None
+    mean_actual: float | None = None
+    mean_ratio: float | None = None
+    p50_ratio: float | None = None
+    mae: float | None = None
+    summary: str = ""
 
 
 class HippoError(Exception):

--- a/python/src/hippo_memory/sync_client.py
+++ b/python/src/hippo_memory/sync_client.py
@@ -48,6 +48,7 @@ from hippo_memory.models import (
     AuthRevoked,
     AuditEvent,
     Prediction,
+    PredictionBaserate,
     HippoError,
 )
 
@@ -442,3 +443,10 @@ class HippoSync:
         """GET /v1/predictions/:id. Sync mirror of Hippo.get_prediction."""
         data = self._request("GET", f"/v1/predictions/{prediction_id}")
         return Prediction.model_validate(data["prediction"])
+
+    def get_prediction_baserate(self, class_tag: str) -> PredictionBaserate:
+        """GET /v1/predictions/stats. Sync mirror of Hippo.get_prediction_baserate.
+        J3 reference-class / planning-fallacy detector."""
+        params: dict[str, Any] = {"class": class_tag}
+        data = self._request("GET", "/v1/predictions/stats", params=params)
+        return PredictionBaserate.model_validate(data["baserate"])

--- a/python/tests/test_predictions.py
+++ b/python/tests/test_predictions.py
@@ -15,6 +15,7 @@ from hippo_memory import (
     Hippo,
     HippoSync,
     Prediction,
+    PredictionBaserate,
 )
 
 
@@ -119,3 +120,46 @@ def test_hippo_sync_has_prediction_methods():
     assert hasattr(HippoSync, "predict_close")
     assert hasattr(HippoSync, "list_predictions")
     assert hasattr(HippoSync, "get_prediction")
+
+
+# ---------------------------------------------------------------------------
+# v0.31 / J3 — reference-class / planning-fallacy detector
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_baserate_roundtrip_full_shape():
+    """Server emits camelCase wire keys (classTag, nClosed, etc.); Python
+    sees snake_case attribute names via _Base.alias_generator=to_camel."""
+    payload = {
+        "classTag": "migration-effort",
+        "nClosed": 5,
+        "nRatioEligible": 5,
+        "meanEstimate": 2.4,
+        "meanActual": 5.1,
+        "meanRatio": 2.125,
+        "p50Ratio": 2.0,
+        "mae": 2.7,
+        "summary": "Last 5 estimates in class migration-effort averaged 2.13x actual (MAE 2.70).",
+    }
+    _roundtrip(PredictionBaserate, payload)
+
+
+def test_prediction_baserate_empty_class_defaults():
+    """When n_closed=0 (no closed predictions yet), numeric fields default
+    to None and summary is empty string."""
+    br = PredictionBaserate(class_tag="empty")
+    assert br.class_tag == "empty"
+    assert br.n_closed == 0
+    assert br.n_ratio_eligible == 0
+    assert br.mean_estimate is None
+    assert br.mean_actual is None
+    assert br.mean_ratio is None
+    assert br.p50_ratio is None
+    assert br.mae is None
+    assert br.summary == ""
+
+
+def test_hippo_has_get_prediction_baserate():
+    """Shape-only check: both Hippo + HippoSync expose get_prediction_baserate."""
+    assert hasattr(Hippo, "get_prediction_baserate")
+    assert hasattr(HippoSync, "get_prediction_baserate")

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -143,7 +143,8 @@ export type AuditOp =
   | 'summary_marked_clean' // v0.30 / E3 — emitted by clearSummaryDirtyAfterBuild after buildDag child-link loop
   | 'summary_rebuilt' // v0.30 / E3 — emitted by applyRebuildResult on successful sleep-cycle rebuild
   | 'predict_create' // v0.31 / E2 prediction first-class object — emitted by savePrediction
-  | 'predict_close'; // v0.31 / E2 — emitted by closePrediction
+  | 'predict_close' // v0.31 / E2 — emitted by closePrediction
+  | 'predict_baserate'; // v0.31 / J3 — emitted by computePredictionBaserate (read-side; meaningful agent signal worth auditing)
 
 export interface AppendAuditOpts {
   tenantId: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3427,6 +3427,35 @@ function cmdPredict(
     return;
   }
 
+  if (subcommand === 'baserate') {
+    // J3 reference-class / planning-fallacy detector
+    const classTagRaw = flags['class'];
+    if (typeof classTagRaw !== 'string' || !classTagRaw.trim()) {
+      console.error('Usage: hippo predict baserate --class <c>');
+      process.exit(1);
+    }
+    const baserate = predictionsModule.computePredictionBaserate(
+      hippoRoot,
+      tenantId,
+      classTagRaw.trim(),
+    );
+    if (baserate.nClosed === 0) {
+      console.log(`No closed predictions in class "${baserate.classTag}" yet.`);
+      console.log(`  Create one with: hippo predict "<claim>" --class ${baserate.classTag} --estimate N`);
+      console.log(`  Close it later:  hippo predict close <id> --state closed --actual N`);
+      return;
+    }
+    console.log(baserate.summary);
+    console.log(`  n_closed:         ${baserate.nClosed}`);
+    console.log(`  n_ratio_eligible: ${baserate.nRatioEligible}`);
+    if (baserate.meanEstimate !== null) console.log(`  mean_estimate:    ${baserate.meanEstimate.toFixed(3)}`);
+    if (baserate.meanActual !== null)   console.log(`  mean_actual:      ${baserate.meanActual.toFixed(3)}`);
+    if (baserate.meanRatio !== null)    console.log(`  mean_ratio:       ${baserate.meanRatio.toFixed(3)}x`);
+    if (baserate.p50Ratio !== null)     console.log(`  p50_ratio:        ${baserate.p50Ratio.toFixed(3)}x`);
+    if (baserate.mae !== null)          console.log(`  mae:              ${baserate.mae.toFixed(3)}`);
+    return;
+  }
+
   // Default subcommand: create. args[0] is the claim text.
   const claimText = subcommand;
   if (!claimText) {
@@ -5023,6 +5052,7 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'summary_rebuilt',      // v0.30 / E3 — sleep-cycle rebuild op; lockstep
   'predict_create',       // v0.31 / E2 prediction first-class object — emitted by savePrediction
   'predict_close',        // v0.31 / E2 — emitted by closePrediction
+  'predict_baserate',     // v0.31 / J3 — emitted by computePredictionBaserate
 ]);
 
 function formatAuditRow(ev: AuditEvent): string {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,6 +27,7 @@ import { loadConfig } from '../config.js';
 import { resolveConfidence } from '../memory.js';
 import { resolveTenantId } from '../tenant.js';
 import { recall as apiRecall, remember as apiRemember, outcome as apiOutcome, drillDown as apiDrillDown, assemble as apiAssemble, isPrivateScope, adminActor, buildSuppressionSummary, type Context as ApiContext } from '../api.js';
+import { computePredictionBaserate } from '../predictions.js';
 import { applyGoalStackBoost } from '../goals.js';
 import { openHippoDb, closeHippoDb } from '../db.js';
 import { PACKAGE_VERSION } from '../version.js';
@@ -370,6 +371,21 @@ const TOOLS = [
       properties: {},
     },
   },
+  {
+    name: 'hippo_predict_baserate',
+    description:
+      'J3 reference-class / planning-fallacy detector. Get base-rate stats for closed predictions in a class. Call this when you make a forward-looking claim (effort estimate, rollout risk, deadline) to anchor on the past track record rather than the inside view. Returns count + mean estimate + mean actual + mean ratio + median ratio + MAE + a human-readable summary. Tenant-scoped.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        class_tag: {
+          type: 'string',
+          description: 'Cohort label, e.g. "migration-effort", "rollout-risk", "deadline-week". Must match the class_tag used when the predictions were created via hippo_predict (or `hippo predict ...`).',
+        },
+      },
+      required: ['class_tag'],
+    },
+  },
 ];
 
 // ── Track last recalled IDs for outcome feedback ──
@@ -678,6 +694,29 @@ async function executeTool(
       for (const c of r.children) {
         lines.push(`  [L${c.dagLevel}] ${c.id} - ${c.content}`);
       }
+      return lines.join('\n');
+    }
+
+    case 'hippo_predict_baserate': {
+      // J3 reference-class / planning-fallacy detector. Reads from the E2
+      // predictions table; returns text-only response matching the existing
+      // MCP tool convention (no structured JSON over the wire). Direct call
+      // to computePredictionBaserate; helper opens its own db + emits audit
+      // (single source of truth, no caller-site drift).
+      const classTag = String(args.class_tag || '').trim();
+      if (!classTag) return 'No class_tag provided. Usage: pass class_tag matching a class used in past predictions (e.g. "migration-effort").';
+      const baserate = computePredictionBaserate(hippoRoot, tenantId, classTag, 'mcp');
+      if (baserate.nClosed === 0) {
+        return `No closed predictions in class "${classTag}" yet. Create one via hippo_predict (or 'hippo predict ...' CLI) and close it with hippo_predict_close once the actual outcome is known. Base rates need closed predictions with numeric actual_value to compute.`;
+      }
+      const lines: string[] = [baserate.summary, ''];
+      lines.push(`n_closed:         ${baserate.nClosed}`);
+      lines.push(`n_ratio_eligible: ${baserate.nRatioEligible}`);
+      if (baserate.meanEstimate !== null) lines.push(`mean_estimate:    ${baserate.meanEstimate.toFixed(3)}`);
+      if (baserate.meanActual !== null)   lines.push(`mean_actual:      ${baserate.meanActual.toFixed(3)}`);
+      if (baserate.meanRatio !== null)    lines.push(`mean_ratio:       ${baserate.meanRatio.toFixed(3)}x`);
+      if (baserate.p50Ratio !== null)     lines.push(`p50_ratio:        ${baserate.p50Ratio.toFixed(3)}x`);
+      if (baserate.mae !== null)          lines.push(`mae:              ${baserate.mae.toFixed(3)}`);
       return lines.join('\n');
     }
 

--- a/src/predictions.ts
+++ b/src/predictions.ts
@@ -375,6 +375,142 @@ export function loadPredictionsByClass(
   }
 }
 
+// ---------------------------------------------------------------------------
+// v0.31 / J3 — reference-class / planning-fallacy detector
+// ---------------------------------------------------------------------------
+
+export interface PredictionBaserate {
+  classTag: string;
+  /** Count of closed predictions with a numeric actual_value (excludes
+   *  open + closed-unknown). The denominator for MAE. */
+  nClosed: number;
+  /** Count of closed rows where estimate_value > 0 (i.e. ratio is defined).
+   *  Subset of nClosed used for meanRatio + p50Ratio. */
+  nRatioEligible: number;
+  meanEstimate: number | null;
+  meanActual: number | null;
+  /** mean(actual / estimate) over the nRatioEligible subset. Null when
+   *  nRatioEligible = 0 (e.g. all closed predictions had estimate=0). */
+  meanRatio: number | null;
+  /** Median ratio over the nRatioEligible subset. */
+  p50Ratio: number | null;
+  /** Mean absolute error = mean(|actual - estimate|) over the nClosed set. */
+  mae: number | null;
+  /** Human-readable summary string for direct surface in CLI / MCP / HTTP.
+   *  Empty when nClosed = 0. */
+  summary: string;
+}
+
+interface BaserateRow {
+  estimate_value: number;
+  actual_value: number;
+}
+
+/**
+ * Compute base-rate stats for closed predictions in a class. Used by J3
+ * reference-class / planning-fallacy detector. Direct application of
+ * Lovallo-Kahneman (2003) inside-vs-outside view.
+ *
+ * Filter: closure_state='closed' AND estimate_value IS NOT NULL AND
+ * actual_value IS NOT NULL. Excludes closed-unknown (no actual to
+ * compare against) and open (not yet resolved).
+ *
+ * Audit-emit is BUILT IN here (single source of truth, no caller-site
+ * drift risk). Plan-eng-critic round 1 HIGH recommendation: emit inside
+ * helper, not at 3 call sites.
+ */
+export function computePredictionBaserate(
+  hippoRoot: string,
+  tenantId: string,
+  classTag: string,
+  actor: string = 'cli',
+): PredictionBaserate {
+  assertTenantId('computePredictionBaserate', tenantId);
+  if (!classTag) throw new Error('computePredictionBaserate: classTag is required');
+
+  const db = openHippoDb(hippoRoot);
+  try {
+    const rows = db.prepare(`
+      SELECT estimate_value, actual_value
+      FROM predictions
+      WHERE tenant_id = ?
+        AND class_tag = ?
+        AND closure_state = 'closed'
+        AND estimate_value IS NOT NULL
+        AND actual_value IS NOT NULL
+    `).all(tenantId, classTag) as BaserateRow[];
+
+    const nClosed = rows.length;
+    if (nClosed === 0) {
+      // Audit zero-result reads too — agents probing empty classes is
+      // a signal worth recording.
+      appendAuditEvent(db, {
+        tenantId,
+        actor,
+        op: 'predict_baserate',
+        targetId: classTag,
+        metadata: { class_tag: classTag, n_closed: 0 },
+      });
+      return {
+        classTag,
+        nClosed: 0,
+        nRatioEligible: 0,
+        meanEstimate: null,
+        meanActual: null,
+        meanRatio: null,
+        p50Ratio: null,
+        mae: null,
+        summary: '',
+      };
+    }
+
+    const ratioEligible = rows.filter((r) => r.estimate_value > 0);
+    const nRatioEligible = ratioEligible.length;
+
+    const meanEstimate = rows.reduce((s, r) => s + r.estimate_value, 0) / nClosed;
+    const meanActual = rows.reduce((s, r) => s + r.actual_value, 0) / nClosed;
+    const mae = rows.reduce((s, r) => s + Math.abs(r.actual_value - r.estimate_value), 0) / nClosed;
+
+    let meanRatio: number | null = null;
+    let p50Ratio: number | null = null;
+    if (nRatioEligible > 0) {
+      const ratios = ratioEligible.map((r) => r.actual_value / r.estimate_value);
+      meanRatio = ratios.reduce((s, x) => s + x, 0) / nRatioEligible;
+      const sorted = ratios.slice().sort((a, b) => a - b);
+      p50Ratio = nRatioEligible % 2 === 1
+        ? sorted[(nRatioEligible - 1) / 2]
+        : (sorted[nRatioEligible / 2 - 1] + sorted[nRatioEligible / 2]) / 2;
+    }
+
+    const ratioPart = meanRatio !== null
+      ? `averaged ${meanRatio.toFixed(2)}x actual`
+      : 'no ratio-eligible rows (all estimates were 0)';
+    const summary = `Last ${nClosed} estimate${nClosed === 1 ? '' : 's'} in class ${classTag} ${ratioPart} (MAE ${mae.toFixed(2)}).`;
+
+    appendAuditEvent(db, {
+      tenantId,
+      actor,
+      op: 'predict_baserate',
+      targetId: classTag,
+      metadata: { class_tag: classTag, n_closed: nClosed },
+    });
+
+    return {
+      classTag,
+      nClosed,
+      nRatioEligible,
+      meanEstimate,
+      meanActual,
+      meanRatio,
+      p50Ratio,
+      mae,
+      summary,
+    };
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
 export function loadOpenPredictions(
   hippoRoot: string,
   tenantId: string,

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import {
   loadPredictionById,
   loadPredictionsByClass,
   loadOpenPredictions,
+  computePredictionBaserate,
   VALID_CLOSURE_STATES,
   type ClosureState,
 } from './predictions.js';
@@ -94,6 +95,7 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'summary_rebuilt',      // v0.30 / E3 — sleep-cycle rebuild op; lockstep
   'predict_create',       // v0.31 / E2 prediction first-class object — emitted by savePrediction
   'predict_close',        // v0.31 / E2 — emitted by closePrediction
+  'predict_baserate',     // v0.31 / J3 — emitted by computePredictionBaserate
 ]);
 
 // Cap on GET /v1/audit?limit=. Matches docs/api.md (when written) and is large
@@ -1079,6 +1081,24 @@ async function handleRequest(
       });
     }
     sendJson(res, 200, { predictions });
+    return;
+  }
+
+  // J3 reference-class / planning-fallacy detector (v0.31).
+  // Order matters: this must match BEFORE /v1/predictions/:id since 'stats'
+  // is not a number — the :id regex requires \d+ so they don't conflict,
+  // but routing this first avoids the dispatch order risk.
+  if (method === 'GET' && path === '/v1/predictions/stats') {
+    const classTag = query.get('class');
+    if (!classTag || classTag.length === 0) {
+      throw new HttpError(400, 'class param is required');
+    }
+    if (classTag.length > 256) {
+      throw new HttpError(400, 'class exceeds 256-character cap');
+    }
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
+    const baserate = computePredictionBaserate(opts.hippoRoot, ctx.tenantId, classTag, ctx.actor.subject);
+    sendJson(res, 200, { baserate });
     return;
   }
 

--- a/tests/http-predictions-stats.test.ts
+++ b/tests/http-predictions-stats.test.ts
@@ -1,0 +1,109 @@
+/**
+ * J3 baserate detector — HTTP route parity test.
+ * Docs: docs/plans/2026-05-26-j3-baserate-detector.md
+ *
+ * Covers:
+ * 1. GET /v1/predictions/stats returns baserate JSON
+ * 2. Missing class param returns 400
+ * 3. Audit log has predict_baserate row post-call
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { serve, type ServerHandle } from '../src/server.js';
+import { createApiKey, type CreatedApiKey } from '../src/auth.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { savePrediction, closePrediction } from '../src/predictions.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-http-j3-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+let home: string;
+let handle: ServerHandle;
+let apiKey: CreatedApiKey;
+
+beforeEach(async () => {
+  home = makeRoot();
+  const db = openHippoDb(home);
+  try {
+    apiKey = createApiKey(db, { tenantId: 'default', label: 'test-j3', role: 'admin' });
+  } finally {
+    closeHippoDb(db);
+  }
+  handle = await serve({ hippoRoot: home, port: 0 });
+});
+
+afterEach(async () => {
+  await handle.stop();
+  rmSync(home, { recursive: true, force: true });
+});
+
+function authHeaders() {
+  return { 'authorization': `Bearer ${apiKey.plaintext}`, 'content-type': 'application/json' };
+}
+
+describe('HTTP /v1/predictions/stats (J3, v0.31)', () => {
+  it('returns baserate JSON for a class with closed predictions', async () => {
+    // Seed: 2 closed predictions in class "http-test"
+    for (const [est, act] of [[3, 5], [4, 6]] as Array<[number, number]>) {
+      const p = savePrediction(home, 'default', {
+        classTag: 'http-test',
+        claimText: `est=${est} act=${act}`,
+        estimateValue: est,
+      });
+      closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: act });
+    }
+
+    const res = await fetch(`${handle.url}/v1/predictions/stats?class=http-test`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { baserate: Record<string, unknown> };
+    expect(body.baserate).toBeDefined();
+    expect(body.baserate.classTag).toBe('http-test');
+    expect(body.baserate.nClosed).toBe(2);
+    expect(body.baserate.nRatioEligible).toBe(2);
+    expect(typeof body.baserate.meanRatio).toBe('number');
+    expect(typeof body.baserate.summary).toBe('string');
+  });
+
+  it('missing class param returns 400', async () => {
+    const res = await fetch(`${handle.url}/v1/predictions/stats`, { headers: authHeaders() });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/class param is required/);
+  });
+
+  it('audit log records predict_baserate row post-call', async () => {
+    const p = savePrediction(home, 'default', { classTag: 'audit-http', claimText: 'audit test', estimateValue: 1 });
+    closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: 2 });
+
+    await fetch(`${handle.url}/v1/predictions/stats?class=audit-http`, { headers: authHeaders() });
+
+    const db = openHippoDb(home);
+    try {
+      const rows = db.prepare(
+        `SELECT op, target_id FROM audit_log WHERE op = 'predict_baserate'`
+      ).all() as Array<{ op: string; target_id: string }>;
+      expect(rows.length).toBe(1);
+      expect(rows[0].target_id).toBe('audit-http');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('empty class returns baserate with nClosed=0', async () => {
+    const res = await fetch(`${handle.url}/v1/predictions/stats?class=never-existed`, { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { baserate: { nClosed: number; summary: string } };
+    expect(body.baserate.nClosed).toBe(0);
+    expect(body.baserate.summary).toBe('');
+  });
+});

--- a/tests/mcp-predict-baserate.test.ts
+++ b/tests/mcp-predict-baserate.test.ts
@@ -1,0 +1,114 @@
+/**
+ * J3 baserate detector — MCP tool test.
+ * Docs: docs/plans/2026-05-26-j3-baserate-detector.md
+ *
+ * Covers:
+ * 1. hippo_predict_baserate tool returns text response for a class with data
+ * 2. Empty class returns guidance text (not error)
+ * 3. Missing class_tag returns clear usage message
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { handleMcpRequest } from '../src/mcp/server.js';
+import { savePrediction, closePrediction } from '../src/predictions.js';
+
+function makeRoot(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), `hippo-${prefix}-`));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+function callTool(
+  reqId: number,
+  name: string,
+  args: Record<string, unknown>,
+  ctx: { hippoRoot: string; tenantId: string; actor: { subject: string; role: 'admin' | 'member' }; clientKey?: string },
+) {
+  return handleMcpRequest(
+    {
+      jsonrpc: '2.0',
+      id: reqId,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    },
+    ctx as unknown as { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
+  );
+}
+
+function extractText(res: unknown): string {
+  const r = res as { result?: { content?: Array<{ text?: string }> } } | null;
+  return r?.result?.content?.[0]?.text ?? '';
+}
+
+describe('mcp hippo_predict_baserate (J3, v0.31)', () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    home = makeRoot('mcp-j3');
+    originalHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = home;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = originalHome;
+  });
+
+  it('returns formatted text response for a class with closed predictions', async () => {
+    // Seed 3 closed predictions
+    for (const [est, act] of [[2, 4], [3, 6], [1, 1]] as Array<[number, number]>) {
+      const p = savePrediction(home, 'default', {
+        classTag: 'mcp-test',
+        claimText: `est ${est} act ${act}`,
+        estimateValue: est,
+      });
+      closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: act });
+    }
+
+    const res = await callTool(1, 'hippo_predict_baserate', { class_tag: 'mcp-test' }, {
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: { subject: 'mcp:test', role: 'admin' },
+    });
+    const text = extractText(res);
+
+    // Summary line + stats block
+    expect(text).toContain('Last 3 estimates');
+    expect(text).toContain('mcp-test');
+    expect(text).toMatch(/n_closed:\s+3/);
+    expect(text).toMatch(/n_ratio_eligible:\s+3/);
+    expect(text).toMatch(/mean_ratio:/);
+    expect(text).toMatch(/p50_ratio:/);
+    expect(text).toMatch(/mae:/);
+  });
+
+  it('empty class returns guidance text (not error)', async () => {
+    const res = await callTool(2, 'hippo_predict_baserate', { class_tag: 'never-seen' }, {
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: { subject: 'mcp:test', role: 'admin' },
+    });
+    const text = extractText(res);
+    expect(text).toContain('No closed predictions');
+    expect(text).toContain('never-seen');
+    expect(text).toContain('hippo_predict');
+  });
+
+  it('missing class_tag returns clear usage message', async () => {
+    const res = await callTool(3, 'hippo_predict_baserate', {}, {
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: { subject: 'mcp:test', role: 'admin' },
+    });
+    const text = extractText(res);
+    expect(text).toContain('No class_tag');
+    expect(text).toContain('Usage');
+  });
+});

--- a/tests/predictions-baserate.test.ts
+++ b/tests/predictions-baserate.test.ts
@@ -1,0 +1,176 @@
+/**
+ * J3 reference-class / planning-fallacy detector — store-layer tests.
+ * Docs: docs/plans/2026-05-26-j3-baserate-detector.md
+ *
+ * Covers:
+ * 1. Empty class returns nClosed=0 + null stats + empty summary
+ * 2. Single closed prediction returns n=1 with correct stats
+ * 3. Multiple closed predictions compute mean/median/MAE correctly
+ * 4. Open + closed mixed only counts closed
+ * 5. closed-unknown excluded (no actual_value)
+ * 6. estimate_value=0 row counts in nClosed + MAE but NOT in ratio calc
+ * 7. Cross-tenant scoping: empty result
+ * 8. predict_baserate audit emitted on every call (including n=0)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import {
+  savePrediction,
+  closePrediction,
+  computePredictionBaserate,
+} from '../src/predictions.js';
+
+function makeRoot(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), `hippo-${prefix}-`));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+describe('computePredictionBaserate (J3 baserate detector, v0.31)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot('j3'); });
+  afterEach(() => safeRmSync(home));
+
+  it('empty class returns nClosed=0 + null stats + empty summary', () => {
+    const br = computePredictionBaserate(home, 'default', 'empty-class');
+    expect(br.classTag).toBe('empty-class');
+    expect(br.nClosed).toBe(0);
+    expect(br.nRatioEligible).toBe(0);
+    expect(br.meanEstimate).toBeNull();
+    expect(br.meanActual).toBeNull();
+    expect(br.meanRatio).toBeNull();
+    expect(br.p50Ratio).toBeNull();
+    expect(br.mae).toBeNull();
+    expect(br.summary).toBe('');
+  });
+
+  it('single closed prediction returns n=1 with correct stats', () => {
+    const p = savePrediction(home, 'default', {
+      classTag: 'one-test',
+      claimText: 'single estimate',
+      estimateValue: 2,
+    });
+    closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: 3 });
+
+    const br = computePredictionBaserate(home, 'default', 'one-test');
+    expect(br.nClosed).toBe(1);
+    expect(br.nRatioEligible).toBe(1);
+    expect(br.meanEstimate).toBe(2);
+    expect(br.meanActual).toBe(3);
+    expect(br.meanRatio).toBeCloseTo(1.5, 6);
+    expect(br.p50Ratio).toBeCloseTo(1.5, 6);
+    expect(br.mae).toBe(1);
+    expect(br.summary).toContain('Last 1 estimate');
+    expect(br.summary).toContain('1.50x actual');
+  });
+
+  it('multiple closed predictions compute mean/median/MAE correctly', () => {
+    // Estimates [2, 4, 6]; Actuals [4, 6, 6]
+    // Ratios: 2.0, 1.5, 1.0; mean=1.5, median=1.5
+    // MAE: |4-2| + |6-4| + |6-6| / 3 = 4/3
+    const ids: number[] = [];
+    for (const [est, act] of [[2, 4], [4, 6], [6, 6]] as Array<[number, number]>) {
+      const p = savePrediction(home, 'default', {
+        classTag: 'multi-test',
+        claimText: `est ${est} act ${act}`,
+        estimateValue: est,
+      });
+      closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: act });
+      ids.push(p.id);
+    }
+
+    const br = computePredictionBaserate(home, 'default', 'multi-test');
+    expect(br.nClosed).toBe(3);
+    expect(br.nRatioEligible).toBe(3);
+    expect(br.meanEstimate).toBeCloseTo(4, 6);
+    expect(br.meanActual).toBeCloseTo(16 / 3, 6);
+    expect(br.meanRatio).toBeCloseTo(1.5, 6);
+    expect(br.p50Ratio).toBeCloseTo(1.5, 6);
+    expect(br.mae).toBeCloseTo(4 / 3, 6);
+  });
+
+  it('open + closed mixed only counts closed in baserate', () => {
+    const closed = savePrediction(home, 'default', { classTag: 'mixed', claimText: 'closed one', estimateValue: 2 });
+    closePrediction(home, 'default', closed.id, { closureState: 'closed', actualValue: 4 });
+    savePrediction(home, 'default', { classTag: 'mixed', claimText: 'open one', estimateValue: 10 });
+
+    const br = computePredictionBaserate(home, 'default', 'mixed');
+    expect(br.nClosed).toBe(1);
+    expect(br.meanEstimate).toBe(2);
+    expect(br.meanActual).toBe(4);
+  });
+
+  it('closed-unknown excluded from baserate (no actual_value to compare)', () => {
+    const a = savePrediction(home, 'default', { classTag: 'unk', claimText: 'categorical one', estimateValue: 1 });
+    closePrediction(home, 'default', a.id, { closureState: 'closed-unknown', closureNote: 'not measurable' });
+    const b = savePrediction(home, 'default', { classTag: 'unk', claimText: 'numeric one', estimateValue: 2 });
+    closePrediction(home, 'default', b.id, { closureState: 'closed', actualValue: 4 });
+
+    const br = computePredictionBaserate(home, 'default', 'unk');
+    expect(br.nClosed).toBe(1); // only the closed-with-actual row
+    expect(br.meanEstimate).toBe(2);
+    expect(br.meanActual).toBe(4);
+  });
+
+  it('estimate_value=0 row counts in nClosed + MAE but NOT in ratio calc', () => {
+    const zero = savePrediction(home, 'default', { classTag: 'zero', claimText: 'zero estimate', estimateValue: 0 });
+    closePrediction(home, 'default', zero.id, { closureState: 'closed', actualValue: 3 });
+    const norm = savePrediction(home, 'default', { classTag: 'zero', claimText: 'normal estimate', estimateValue: 2 });
+    closePrediction(home, 'default', norm.id, { closureState: 'closed', actualValue: 4 });
+
+    const br = computePredictionBaserate(home, 'default', 'zero');
+    expect(br.nClosed).toBe(2);
+    expect(br.nRatioEligible).toBe(1); // only the non-zero estimate
+    expect(br.meanRatio).toBeCloseTo(2, 6); // 4 / 2
+    expect(br.p50Ratio).toBeCloseTo(2, 6);
+    // MAE: |3-0| + |4-2| / 2 = 5/2 = 2.5
+    expect(br.mae).toBe(2.5);
+  });
+
+  it('cross-tenant scoping: tenant-b request on tenant-a class returns empty', () => {
+    const p = savePrediction(home, 'tenant-a', { classTag: 'scope-test', claimText: 'tenant a only', estimateValue: 1 });
+    closePrediction(home, 'tenant-a', p.id, { closureState: 'closed', actualValue: 2 });
+
+    const aResult = computePredictionBaserate(home, 'tenant-a', 'scope-test');
+    expect(aResult.nClosed).toBe(1);
+
+    const bResult = computePredictionBaserate(home, 'tenant-b', 'scope-test');
+    expect(bResult.nClosed).toBe(0);
+    expect(bResult.summary).toBe('');
+  });
+
+  it('predict_baserate audit emitted on every call (including n=0)', () => {
+    // n=0 call
+    computePredictionBaserate(home, 'default', 'audit-test');
+
+    // Add data + non-zero call
+    const p = savePrediction(home, 'default', { classTag: 'audit-test', claimText: 'audit data', estimateValue: 1 });
+    closePrediction(home, 'default', p.id, { closureState: 'closed', actualValue: 2 });
+    computePredictionBaserate(home, 'default', 'audit-test');
+
+    const db = openHippoDb(home);
+    try {
+      const auditRows = db.prepare(
+        `SELECT op, target_id, metadata_json FROM audit_log WHERE op = 'predict_baserate' ORDER BY id`
+      ).all() as Array<{ op: string; target_id: string; metadata_json: string }>;
+      expect(auditRows.length).toBe(2);
+      expect(auditRows[0].target_id).toBe('audit-test');
+      const meta0 = JSON.parse(auditRows[0].metadata_json) as { class_tag: string; n_closed: number };
+      expect(meta0.n_closed).toBe(0);
+      const meta1 = JSON.parse(auditRows[1].metadata_json) as { class_tag: string; n_closed: number };
+      expect(meta1.n_closed).toBe(1);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});


### PR DESCRIPTION
## What

Ships **J3 reference-class / planning-fallacy detector** (Track J [next] from `ROADMAP-RESEARCH.md` L542). Reads from the E2 predictions table (shipped at `0a3d03c` earlier this release cycle) and computes per-class base-rate stats so the calling agent can anchor on its past track record rather than the inside view.

Direct application of Lovallo-Kahneman (2003) inside-vs-outside view. No agent-memory competitor tracks ex-ante claim closure against ex-post outcome AND surfaces base rates programmatically.

## Reactive in v1

Agent calls explicitly via MCP / CLI / HTTP / SDK. Auto-injection on recall (forward-claim NLP detection that proactively surfaces base rates when the agent makes a forward-looking claim) is a follow-up episode; v1 ships the substrate + tool surfaces.

## Surfaces

- **CLI:** `hippo predict baserate --class <c>` prints summary + 5 stats.
- **HTTP:** `GET /v1/predictions/stats?class=X` (Bearer-auth + tenant-scoped, 256-char class cap).
- **MCP:** `hippo_predict_baserate` tool with description anchoring the use case (call when you make a forward-looking claim).
- **Python SDK:** `Hippo.get_prediction_baserate(class_tag)` async + `HippoSync` sync mirror + `PredictionBaserate` Pydantic model.

## Field shape

```typescript
interface PredictionBaserate {
  classTag: string;
  nClosed: number;          // count of closed-with-actual predictions
  nRatioEligible: number;   // subset where estimate > 0 (ratio defined)
  meanEstimate: number | null;
  meanActual: number | null;
  meanRatio: number | null; // mean(actual / estimate) over nRatioEligible
  p50Ratio: number | null;  // median ratio
  mae: number | null;       // mean absolute error
  summary: string;          // human-readable "Last N estimates averaged X.Yx actual (MAE Z)"
}
```

`estimate=0` rows count in `nClosed` + MAE but excluded from ratio calc (avoids div-by-zero). `nRatioEligible` exposes the subset for consumer transparency.

## Episode

Built via `/dev-framework-rl` episode `01KSJCRSFGYY0KP9W7EEGN553S`:
- plan-eng-critic round 1: PASS @ 78 (1 HIGH advisory on audit-emit architecture; folded during execute by emitting inside `computePredictionBaserate` directly: single source of truth, no caller-site drift)
- 1 new audit op `predict_baserate` lockstep across `src/cli.ts` + `src/server.ts` VALID_AUDIT_OPS + `src/audit.ts` AuditOp union per v1.11.5 CRIT A institutional rule

## Test plan

- [x] `npm run build` clean
- [x] Full TS suite: 1954 passed (+15 J3 tests), 1 pre-existing fail (`tests/openclaw-package.test.ts` manifest version drift, NOT in scope per surgical-changes principle), 4 skipped
- [x] 18 new tests pass: 8 store (`tests/predictions-baserate.test.ts`: empty class, single closed, multi-closed mean/median/MAE, open+closed mixed, closed-unknown excluded, estimate=0 div-zero, cross-tenant, audit emission) + 4 HTTP (`tests/http-predictions-stats.test.ts`) + 3 MCP (`tests/mcp-predict-baserate.test.ts`) + 3 Python (`python/tests/test_predictions.py` extension)
- [x] Em-dash check on commit body + this PR body + CHANGELOG entry: 0
- [x] Python SDK 9/9 pass (6 E2 + 3 new J3)

## Pre-existing test note

`tests/openclaw-package.test.ts` continues to fail because `openclaw.plugin.json` is pinned at `1.12.11` while `package.json` is `1.12.12`. NOT introduced by J3. Same situation as PR #71 (C5) and PR #72 (E2); needs a separate one-line patch outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
