### PR TITLE
chore(openclaw): bump plugin manifest 1.12.11 to 1.12.12

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.12.11",
+  "version": "1.12.12",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## What

One-line fix: `openclaw.plugin.json` `1.12.11` -> `1.12.12` to match `package.json`.

## Why

`tests/openclaw-package.test.ts` asserts the two version strings stay in sync. The v1.12.12 release bumped `package.json` but missed `openclaw.plugin.json`, leaving the test red. It has been failing across 3 consecutive PRs (#71 C5, #72 E2, #73 J3); each PR documented it as out-of-scope per surgical-changes, but ship-readiness-critic on PR #73 flagged the recurrence as risk to masking real regressions.

## Test plan

- [x] `npm test -- tests/openclaw-package.test.ts` now 2/2 pass (was 1/2)
- [x] Em-dash check on commit body: 0
- [x] One-file diff, no scope creep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
