### PR TITLE
chore(release): v1.15.0 (decisions first-class object) + SDK 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.15.0 (2026-05-28): E2 decisions first-class object
 
 ### Added
 
@@ -30,6 +30,22 @@
 - **Tests:** store-layer (real DB: dual-write SAVEPOINT atomicity, supersede
   CAS, close guard, cross-tenant triggers, ON DELETE SET NULL), HTTP route
   parity, and Python SDK Pydantic round-trip.
+
+### Fixed
+
+- **`PACKAGE_VERSION` version drift.** The binary self-reported version
+  (`src/version.ts`, surfaced via MCP `serverInfo`, the HTTP `/health` endpoint,
+  and the DB rollback-safety compatibility gate) had drifted to 1.12.10 while the
+  published package was 1.14.0. It is now bumped in lockstep and guarded by
+  `scripts/check-manifest-versions.mjs`, which previously validated only the four
+  JSON manifests and not the version.ts constant.
+
+### Packaging
+
+- **Python SDK `hippo-memory-sdk` 0.3.0** carries the new `Decision` API (model
+  plus async and sync `decide`, `supersede_decision`, `close_decision`,
+  `list_decisions`, `get_decision`) alongside the earlier J2 `AvailabilityHint`
+  model.
 
 ## 1.14.0 (2026-05-28): J2 availability-bias detector (Track J)
 

--- a/docs/plans/2026-05-28-v1.15.0-release.md
+++ b/docs/plans/2026-05-28-v1.15.0-release.md
@@ -1,0 +1,148 @@
+# Plan: hippo-memory v1.15.0 release (E2 decisions first-class object)
+
+- Date: 2026-05-28
+- Episode: 01KSR5424D5845DMXSAQQBEBRX (/dev-framework-rl, project_type=library)
+- Status: Draft (not yet engineering-reviewed)
+
+## Goal
+
+Cut the v1.15.0 minor release of the decisions first-class object merged in
+PR #78 (commit 9a1a46d), currently staged under `CHANGELOG.md` `## Unreleased`
+with no version bump. Ship a version-consistent release across all carrying
+manifests, run the mandatory release chain, and stop at the human deploy gate
+before any npm / PyPI publish or tag push.
+
+## Why a minor bump
+
+The decisions surface adds new public API (CLI subcommands `decide list|get|close`,
+HTTP `/v1/decisions` routes, Python SDK `Decision` + 5 methods, schema migration
+v30). New backward-compatible API = minor under semver. Current TS `1.14.0` ->
+`1.15.0`; Python SDK `0.2.2` -> `0.3.0` (0.x minor for new API).
+
+## Three independent version lines (audited)
+
+Enumerated via literal-version grep across the repo plus the authoritative
+`scripts/check-manifest-versions.mjs` lockstep allowlist.
+
+### 1. TS core `hippo-memory` 1.14.0 -> 1.15.0
+
+Lockstep manifests (the 4 the checker enforces; v1.14.0 commit 09dc4a3 bumped
+exactly these):
+
+- `package.json`
+- `openclaw.plugin.json`
+- `extensions/openclaw-plugin/package.json`
+- `extensions/openclaw-plugin/openclaw.plugin.json`
+
+Plus `package-lock.json` root `version` (lines 3 + 9 only; the other `1.14.0`
+hits are coincidental `onnxruntime` deps). The checker excludes the lockfile by
+design, but a clean publish needs it synced. Use `npm install --package-lock-only`
+to sync the lockfile to package.json with minimal churn (a hand-edit of the two
+lines risks desyncing other lock fields and failing `npm ci` in CI).
+
+### 2. Python SDK `hippo-memory-sdk` 0.2.2 -> 0.3.0
+
+- `python/pyproject.toml` (`version`)
+- `python/src/hippo_memory/__init__.py` (`__version__`)
+
+These two must agree. Note: commit f97bad8 bumped the SDK to 0.2.2 for
+AvailabilityHint but its message says "PyPI upload pending twine auth", so 0.2.2
+may never have published. 0.3.0 supersedes it regardless (carries AvailabilityHint
++ the new Decision API).
+
+### 3. Drift fix: `src/version.ts` PACKAGE_VERSION 1.12.10 -> 1.15.0
+
+This is the one scope addition beyond the pure release bump. Root-cause framing:
+
+- Problem: the binary self-reports `1.12.10` via MCP `serverInfo.version`, HTTP
+  `/health`, and the DB rollback-safety compat gate (`db.ts:1207`,
+  `compareSemver(minRequired, PACKAGE_VERSION)`), while the published package is
+  `1.14.0`. A DB stamped `min_compatible_binary` between 1.12.11 and 1.14.0 would
+  falsely refuse to open on a valid binary.
+- Root cause: `PACKAGE_VERSION` is documented in version.ts's own header as one
+  of "five manifests in total carrying the version field", bumped manually every
+  release. But `check-manifest-versions.mjs` validates only the 4 JSON manifests,
+  not the .ts constant. So the last 2 releases (1.13.x, 1.14.0) silently forgot it
+  and nothing caught the drift.
+- Structural fix: (a) bump `PACKAGE_VERSION` to 1.15.0; (b) extend
+  `check-manifest-versions.mjs` to assert the version.ts constant against
+  package.json (regex-extract `PACKAGE_VERSION = '...'`), closing the gap so the
+  manual step can never be silently skipped again. This reconciles the checker
+  with version.ts's documented "five manifests" contract.
+
+### Excluded (independent cadence, decisions did not touch them)
+
+Confirmed via `git show 9a1a46d`: `ui/` (0.2.5) and
+`extensions/claude-code-plugin/` (0.4.0) are excluded by the checker and were not
+modified this cycle. Leave both.
+
+## Changelog promotion
+
+Promote `## Unreleased` -> `## 1.15.0 (2026-05-28): E2 decisions first-class object`.
+The existing Added entries stay (already em-dash-free per the prepublish guard).
+Add:
+
+- under Added: the Python SDK `hippo-memory-sdk` 0.3.0 line if not already implied.
+- a `### Fixed` subsection: "Binary self-reported version (`PACKAGE_VERSION`) was
+  stale at 1.12.10; now tracked by the manifest-version guard so it stays in
+  lockstep with the package."
+
+No new empty `## Unreleased` heading is added (next episode re-creates it).
+
+## Steps (each with a verify check)
+
+1. Bump TS lockstep (4 manifests) + lockfile to 1.15.0.
+   verify: `node scripts/check-manifest-versions.mjs` prints "All 4 ... OK"; no
+   stray `1.14.0` in the lockstep set.
+2. Bump `src/version.ts` PACKAGE_VERSION to 1.15.0; extend
+   `check-manifest-versions.mjs` to validate it.
+   verify: temporarily set version.ts to a wrong value -> checker exits non-zero;
+   restore -> checker passes. (Self-test the new guard.)
+3. Bump Python SDK to 0.3.0 (pyproject + __init__).
+   verify: `grep` both files show 0.3.0 and agree.
+4. Promote CHANGELOG section.
+   verify: `node scripts/check-em-dashes-in-release-notes.mjs` passes.
+5. Build everything: `npm run build:all` (tsc + UI).
+   verify: clean exit; `dist/` and `dist-ui/` produced.
+6. Full test suites: `npm test` (vitest) + Python tests.
+   verify: all green, including the schema-version + decisions + version tests.
+7. /self-review (execute tail) -> code-review-critic gate.
+8. /review -> independent-review-critic + codex-review-critic gates.
+9. /ship-check + /quiz-me -> ship-readiness-critic; open PR; require green CI.
+10. STOP at human deploy gate. On approval only: `npm publish` (runs
+    prepublishOnly guards), `python -m twine upload --non-interactive` for the
+    SDK, `git tag v1.15.0`, push tag.
+
+## Risks & mitigations
+
+- Line endings: FIXED via `.gitattributes` (27f5ae6); repo is uniformly LF. No
+  CRLF-flip diffs expected. (ROADMAP.md shows a pending LF-renormalize warning;
+  unrelated, leave it.)
+- PyPI twine auth hangs interactively: use
+  `TWINE_USERNAME=__token__ TWINE_PASSWORD='pypi-...' python -m twine upload
+  --non-interactive python/dist/*` with a project-scoped token (per 2026-05-27
+  lesson). At the publish gate, verify whether 0.2.2 is on PyPI first.
+- prepublishOnly auto-guards: check-manifest-versions + check-em-dashes +
+  build:all all run on `npm publish`; the new version.ts guard joins them.
+- Uncommitted `ROADMAP.md` speculative line is unrelated; scope `git add` to
+  release files only, do not sweep it in.
+- Git identity: hippo uses local `kit@clawd.ai` (not the global skfsk27 address);
+  recent commits confirm this. Do not change it.
+
+## Success criteria
+
+- `check-manifest-versions.mjs` reports all 5 carrying manifests (4 JSON +
+  version.ts) at 1.15.0.
+- Python SDK at 0.3.0, pyproject == __init__.
+- All TS + Python tests green; clean build:all.
+- CHANGELOG `## 1.15.0` dated, em-dash-free.
+- PR opened, required CI checks green.
+- (deploy, human-gated) npm `hippo-memory@1.15.0` + PyPI `hippo-memory-sdk 0.3.0`
+  published; tag `v1.15.0` pushed.
+
+## Out of scope (noted, not done)
+
+- Python-side version consistency guard (pyproject vs __init__): no observed drift
+  this release; both at 0.2.2. A future hygiene follow-up, not this episode.
+- Backfilling existing `decision`-tagged memories into the new table: explicitly
+  non-goal per the v30 migration (additive, no backfill).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.14.0",
+  "version": "1.15.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hippo-memory-sdk"
-version = "0.2.2"
+version = "0.3.0"
 description = "Python SDK (async + sync) for hippo-memory (biologically-inspired memory for AI agents). Wraps the HTTP API of the hippo-memory npm package."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/hippo_memory/__init__.py
+++ b/python/src/hippo_memory/__init__.py
@@ -60,7 +60,7 @@ from hippo_memory.models import (
     HippoError,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 __all__ = [
     "Hippo",

--- a/scripts/check-manifest-versions.mjs
+++ b/scripts/check-manifest-versions.mjs
@@ -55,6 +55,25 @@ for (const path of LOCKSTEP_MANIFESTS) {
   }
 }
 
+// src/version.ts carries PACKAGE_VERSION as a TS constant (not JSON). Its own
+// header names it the "fifth manifest" bumped manually every release, but it was
+// historically excluded from this guard, so it silently drifted (1.12.10 vs
+// published 1.14.0) across two releases while feeding MCP serverInfo, the HTTP
+// /health endpoint, and the DB rollback-compat gate. Assert it here so the
+// documented manual bump can never be silently skipped again.
+const VERSION_TS = 'src/version.ts';
+if (!existsSync(VERSION_TS)) {
+  drifts.push({ path: VERSION_TS, found: '(missing)', expected: expectedVersion });
+} else {
+  const src = readFileSync(VERSION_TS, 'utf8');
+  const m = src.match(/export const PACKAGE_VERSION = '([^']+)'/);
+  if (!m) {
+    drifts.push({ path: VERSION_TS, found: '(PACKAGE_VERSION not found)', expected: expectedVersion });
+  } else if (m[1] !== expectedVersion) {
+    drifts.push({ path: VERSION_TS, found: m[1], expected: expectedVersion });
+  }
+}
+
 if (drifts.length > 0) {
   console.error('');
   console.error('VERSION DRIFT detected. The following manifests do not match package.json:');
@@ -68,4 +87,4 @@ if (drifts.length > 0) {
   process.exit(1);
 }
 
-console.log(`All ${LOCKSTEP_MANIFESTS.length} lockstep manifests at version ${expectedVersion}. OK.`);
+console.log(`All ${LOCKSTEP_MANIFESTS.length} lockstep manifests + src/version.ts at version ${expectedVersion}. OK.`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.12.10';
+export const PACKAGE_VERSION = '1.15.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/openclaw-package.test.ts
+++ b/tests/openclaw-package.test.ts
@@ -40,4 +40,17 @@ describe('openclaw package metadata', () => {
     expect(nestedPkg.version).toBe(pkg.version);
     expect(nestedPlugin.version).toBe(pkg.version);
   });
+
+  // v1.15.0: src/version.ts PACKAGE_VERSION is the "fifth manifest" named in its
+  // own header but was excluded from check-manifest-versions.mjs, so it drifted
+  // to 1.12.10 while the package shipped 1.14.0 (user-facing via MCP serverInfo,
+  // HTTP /health, and the DB rollback-compat gate). Assert parity here too so a
+  // future refactor of the prepublish script cannot reintroduce the drift.
+  it('keeps src/version.ts PACKAGE_VERSION aligned with the package version', () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+    const versionTs = readFileSync(join(repoRoot, 'src/version.ts'), 'utf8');
+    const match = versionTs.match(/export const PACKAGE_VERSION = '([^']+)'/);
+    expect(match, 'PACKAGE_VERSION constant should be present in src/version.ts').not.toBeNull();
+    expect(match?.[1]).toBe(pkg.version);
+  });
 });


### PR DESCRIPTION
## hippo-memory v1.15.0 (decisions first-class object) + SDK 0.3.0

Promotes the E2 decisions first-class object (#78) from CHANGELOG `Unreleased` to a versioned release, and fixes a real version-misreporting bug found during the release audit.

### What's in it
- **TS core 1.14.0 -> 1.15.0** across the 4 lockstep manifests + lockfile.
- **Python SDK `hippo-memory-sdk` 0.2.2 -> 0.3.0** for the new `Decision` API.
- **`src/version.ts` PACKAGE_VERSION drift fix.** The binary self-reported version had silently drifted to 1.12.10 while the package shipped 1.14.0 (surfaced via MCP `serverInfo`, HTTP `/health`, and the DB rollback-compat gate). Bumped to 1.15.0 AND `scripts/check-manifest-versions.mjs` extended to guard the constant, so the documented manual bump can never be silently skipped again. Backed by a committed parity regression test.
- **CHANGELOG** `Unreleased` promoted to dated `1.15.0` with Fixed + Packaging sections.

### Why the version.ts fix is in this release
version.ts's own header declares it the "fifth manifest" bumped every release, but the prepublish checker validated only the 4 JSON manifests, so it drifted across two releases. This is release-pipeline hygiene (TODOS #496), fixed at root.

### Test plan
- [x] `npm run build` clean (tsc + benchmarks)
- [x] `npm test` green: 2158 passed, 4 skipped, 1 flaky (server-concurrency ECONNRESET, passes isolated)
- [x] Python `pytest` green: 74 passed
- [x] `check-manifest-versions.mjs` OK (4 manifests + version.ts at 1.15.0)
- [x] `check-em-dashes-in-release-notes.mjs` OK (1.15.0 section em-dash-free)
- [x] New version.ts guard proven to fire on drift (mutate -> exit 1; restore -> pass)

### Gates (dev-framework-rl)
plan-eng 88, code-review 92, independent-review 94, codex cross-model pass, ship-readiness 90.

### Not in this PR (post-merge, separate go)
npm publish + PyPI `hippo-memory-sdk` 0.3.0 + `git tag v1.15.0`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
