### PR TITLE
feat: E3.3 graph-on-consolidated guard (graph substrate + raw-layer guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,18 @@
   deferred (the entities table is unbuilt). With this, all eight E2 first-class objects
   (decision, prediction, incident, process, policy, skill, project_brief,
   customer_note) are shipped.
+- E3.3 graph-on-consolidated guard (first slice of the E3 graph layer). Adds the
+  `entities`, `relations`, and `graph_extraction_queue` tables (schema migration v37)
+  plus a `src/graph.ts` insert/load/enqueue API. The graph sits on top of consolidated
+  state and is guarded so it can only reference CONSOLIDATED memories
+  (`kind IN ('distilled','superseded')`), never `kind='raw'`: each table has a CHECK on
+  its `source_kind`/`kind` plus BEFORE INSERT and BEFORE UPDATE triggers that tie that
+  column to the referenced memory's actual kind and enforce tenant-match (relations also
+  reject cross-tenant edges), so a raw-layer reference is unrepresentable via any code
+  path (insert or update). `memory_id` is NOT NULL with ON DELETE CASCADE, keeping the
+  graph consistent with live consolidated state. This is internal infrastructure (no
+  CLI/HTTP/SDK yet); the `hippo sleep` enqueue hook, E3.1 entity extraction, E3.2
+  multi-hop recall, and the E3.3 CI lint are deferred follow-ups.
 
 ## 1.15.0 (2026-05-28): E2 decisions first-class object
 

--- a/docs/plans/2026-06-01-e3-graph-guard.md
+++ b/docs/plans/2026-06-01-e3-graph-guard.md
@@ -1,0 +1,205 @@
+# Plan: E3.3 graph-on-consolidated guard (DB substrate + DB-level enforcement)
+
+- Date: 2026-06-01
+- Episode: 01KT1N4XC3JFJ5YK7FQ4XXZKCE (/dev-framework-rl, project_type=backend)
+- Status: Shipped. plan-eng-critic retry-1 PASS (round 1 caught an INSERT-only guard ->
+  added BEFORE UPDATE triggers). codex review then caught the reverse direction: a P1
+  (mutating a referenced memory to raw post-insertion) + 2 P2 mutation edges, fixed by
+  adding two reverse-guard triggers (`trg_memories_graph_referenced_guard` on memories;
+  `trg_entities_no_tenant_move_when_referenced` on entities). So the SHIPPED migration v37
+  has **8 guard triggers** (6 graph-table INSERT/UPDATE + 2 reverse guards), superseding
+  the "3 triggers" the draft body below describes. Central invariant ("graph never indexes
+  raw") is DB-enforced unrepresentable on every path: insert, graph-table update, and
+  memory/entity mutation.
+
+## Goal
+
+Ship the first slice of the E3 graph layer: the **graph-on-consolidated guard**
+(ROADMAP-RESEARCH.md E3.3, the only E3 item marked `[next]`). The hard rule the
+graph must obey: **it never indexes the raw layer** - `entities` and `relations`
+reference only consolidated memories (`kind IN ('distilled','superseded')`), never
+`kind='raw'`. This slice delivers the DB substrate + the DB-level enforcement; E3.1
+(entity extraction at sleep, the NLP/precision work) and E3.2 (multi-hop recall) and
+the pipeline enqueue-hook + CI lint are explicit follow-ups.
+
+## Scope (and what is deferred)
+
+IN: migration v37 (`entities`, `relations`, `graph_extraction_queue` tables with FK +
+CHECK + raw-rejection triggers); `src/graph.ts` (a thin insert/load/enqueue API that
+surfaces the guard as throws); real-DB tests incl the E3.3 success criterion
+(`INSERT INTO entities` with a raw-FK fails). NO CLI/HTTP/SDK - the graph is internal
+infrastructure until E3.2 makes it operator-facing. NO new audit ops - graph writes
+are internal (no operator action) and become meaningful when E3.1 wires extraction;
+adding the 3-site lockstep now would be premature.
+
+DEFERRED (follow-ups): E3.1 entity extraction at sleep (NLP; 80%-precision gold-set);
+E3.2 multi-hop recall (`hippo recall --hops`); the consolidation **enqueue hook**
+(pipeline-level: `hippo sleep` enqueues distilled writes); the **CI lint** (E3.3
+success criterion 2: a lint that fails PRs writing to the graph from non-consolidated
+state). This slice delivers E3.3 success **criterion 1** (regression test:
+raw-FK insert fails); criterion 2 (lint) is the fast-follow.
+
+## Schema (migration v37) - NEW tables, so real CHECK constraints (unlike ALTER'd memories)
+
+`CURRENT_SCHEMA_VERSION` 36 -> 37. Three new tables, all carrying the envelope
+(`tenant_id`) + the consolidated-source guard. Reserved-word check (rule 10):
+`entities`, `relations`, `graph_extraction_queue` and every column
+(`entity_type`/`name`/`source_kind`/`rel_type`/`from_entity_id`/`to_entity_id`/
+`memory_id`/`tenant_id`/`status`/`enqueued_at`/`processed_at`/`created_at`) are
+non-reserved; `rel_type` avoids the `REFERENCES` keyword.
+
+```sql
+CREATE TABLE entities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  tenant_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL CHECK (entity_type IN ('person','project','customer','system','policy','decision')),
+  name TEXT NOT NULL,
+  memory_id TEXT NOT NULL,                 -- the consolidated source row
+  source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled','superseded')),
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+CREATE TABLE relations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  tenant_id TEXT NOT NULL,
+  from_entity_id INTEGER NOT NULL,
+  to_entity_id INTEGER NOT NULL,
+  rel_type TEXT NOT NULL CHECK (rel_type IN ('owns','supersedes','depends-on','blocked-by','references')),
+  memory_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled','superseded')),
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY (to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+  FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+CREATE TABLE graph_extraction_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  tenant_id TEXT NOT NULL,
+  memory_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('distilled','superseded')),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','processed','skipped')),
+  enqueued_at TEXT NOT NULL,
+  processed_at TEXT,
+  FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+```
+
+Indexes: `idx_entities_tenant` (tenant_id), `idx_entities_memory` (memory_id),
+`idx_relations_tenant` (tenant_id), `idx_relations_from` (from_entity_id),
+`idx_relations_to` (to_entity_id), `idx_relations_memory` (memory_id),
+`idx_graph_queue_status` (tenant_id, status). All `if (!tableExists(...))` guarded.
+
+### DB-level enforcement triggers (the E3.3 guard) - INSERT *and* UPDATE
+
+Per table, BOTH a BEFORE INSERT and a BEFORE UPDATE trigger (the subquery-capable
+SELECT-CASE pattern used by the sibling memory-FK tables - e.g.
+`trg_predictions_tenant_match_insert`/`_update` at db.ts:1026-1047, NOT the
+literal-only v14 `trg_memories_kind_check_insert` which has no subquery). Both
+INSERT and UPDATE are required: an INSERT-only guard is bypassable via a raw SQL
+`UPDATE entities SET memory_id='<raw_id>'`, which would re-create exactly the
+raw-on-graph state the guard forbids. The invariant must be DB-level unrepresentable
+regardless of code path (plan-eng-critic 2026-06-01, HIGH).
+
+A single combined check per trigger (one `SELECT CASE` with two WHEN arms):
+- **kind/source guard:** ABORT if `NEW.source_kind` != the FK'd memory's actual kind
+  (`(SELECT kind FROM memories WHERE id = NEW.memory_id)`). Combined with the
+  `source_kind IN ('distilled','superseded')` CHECK, this makes a raw FK *or* a lying
+  `source_kind` both ABORT (a raw memory's kind can never equal a CHECK-valid
+  source_kind).
+- **tenant guard:** ABORT if `NEW.tenant_id` != the memory's tenant_id.
+
+- `trg_entities_consolidated_only_insert` (BEFORE INSERT) +
+  `trg_entities_consolidated_only_update` (BEFORE UPDATE, fires `WHEN NEW.memory_id IS
+  NOT OLD.memory_id OR NEW.source_kind IS NOT OLD.source_kind OR NEW.tenant_id IS NOT
+  OLD.tenant_id`).
+- `trg_relations_consolidated_only_insert` + `_update` (same shape).
+- `trg_graph_queue_consolidated_only_insert` + `_update`: guard on `NEW.kind` ==
+  the memory's actual kind (+ tenant-match); UPDATE fires when memory_id/kind/tenant_id
+  change.
+
+CASCADE rationale: `memory_id` is NOT NULL (a graph node MUST have a consolidated
+source). ON DELETE CASCADE keeps the graph strictly consistent with live consolidated
+state - forgetting a consolidated memory removes its entities, and their relations
+cascade. E3.4 (graph quality maintenance: tombstone vs versioned edges, `[research]`)
+will revisit; CASCADE is the correct simple default for this slice. (Note: the A3
+`trg_memories_raw_append_only` already forbids deleting raw memories, so the CASCADE
+only ever fires for distilled/superseded sources.)
+
+## Module `src/graph.ts` (internal infra API; surfaces the guard as throws)
+
+Exports: `EntityType`, `RelationType`, `GraphQueueStatus` + `VALID_*` sets; `Entity`,
+`Relation`, `GraphQueueItem` interfaces; `GRAPH_ENTITY_TYPES` etc.
+
+- `insertEntity(hippoRoot, tenantId, { entityType, name, memoryId })`: reads the
+  source memory (must exist, same tenant, kind != 'raw'); derives `source_kind` from
+  the memory's kind; INSERTs. Throws a clear error on not-found / cross-tenant / raw
+  BEFORE hitting the trigger (the trigger is the DB backstop). Returns the Entity.
+- `insertRelation(hippoRoot, tenantId, { fromEntityId, toEntityId, relType, memoryId })`:
+  validates both entities exist in-tenant + the source memory (non-raw); INSERTs.
+- `loadEntities(hippoRoot, tenantId, { entityType?, limit? })`,
+  `loadRelations(hippoRoot, tenantId, { limit? })`, `loadEntityById`.
+- `enqueueExtraction(hippoRoot, tenantId, memoryId)`: enqueues a consolidated memory
+  for later extraction (kind derived; raw rejected). `loadExtractionQueue(tenantId,
+  { status?, limit? })`. (The producer hook in `hippo sleep` is deferred; this is the
+  API that hook + E3.1 will call.)
+- Input validation: `name` required + capped (`MAX_ENTITY_NAME_LEN = 512`);
+  entityType/relType validated against the VALID sets (defensive, in addition to the
+  DB CHECK).
+
+## Tests (real DB, no mocks)
+
+- `tests/graph-store.test.ts`: insertEntity from a distilled memory (source_kind set);
+  insertRelation links two entities; **E3.3 CRITERION 1 - raw-FK rejection BOTH via
+  the helper (throws) AND via a direct `INSERT INTO entities` raw SQL (INSERT trigger
+  ABORTs)**; **UPDATE-path guard (raw SQL, no helper): `UPDATE entities SET
+  memory_id=<raw_id>` ABORTs, and `UPDATE entities SET source_kind=<mismatch>` ABORTs**
+  (the BEFORE UPDATE trigger - the bypass the plan-eng-critic caught); lying-source_kind
+  on INSERT rejected (trigger); cross-tenant entity->memory rejected on INSERT and
+  UPDATE (trigger); cross-tenant relation->entity rejected; bad entity_type / rel_type
+  / source_kind rejected (CHECK); enqueueExtraction (distilled enqueues; raw rejected;
+  queue kind-mismatch ABORTs on INSERT and UPDATE); ON DELETE CASCADE (delete a
+  distilled memory -> its entities + their relations + queue rows vanish);
+  loadEntities/loadRelations filters; name cap.
+- `tests/graph-schema.test.ts`: schema v37 produces the 3 tables + 7 indexes + 3
+  guard triggers; CHECK constraints present.
+- **Schema-version bump**: 20 assertion sites 36 -> 37 (18x `.toBe(36)` across 8 files
+  + 2x `'36'` string in db-migration-v27-self-heal; binary-mode script; physics
+  `toBe(32)` untouched; dynamic `toBe(getCurrentSchemaVersion())` sites auto-follow).
+
+## Steps (each verify-checked)
+
+1. db.ts: CURRENT_SCHEMA_VERSION 36->37 + v37 migration (3 tables, 7 indexes, 3 guard triggers).
+2. src/graph.ts module (types + insert/load/enqueue API + guard pre-checks).
+3. CHANGELOG Unreleased entry (em-dash-free).
+4. tests/graph-store.test.ts + tests/graph-schema.test.ts.
+5. 20 schema-version assertions 36->37; grep-confirm zero schema `.toBe(36)` remain.
+6. Full build + vitest + pytest green.
+
+## Risks & mitigations
+
+- Reserved word (rule 10): table + column names checked, all safe.
+- Cross-cap (rule 9): N/A (no assembler).
+- CHECK can't subquery: the FK'd-memory-kind match is enforced by a trigger, not a
+  CHECK (the CHECK only constrains the literal `source_kind`); both together guarantee
+  non-raw. Mirror of the v14 memories kind-check trigger.
+- CASCADE aggressiveness: NOT NULL memory_id + ON DELETE CASCADE keeps the graph
+  consistent with live consolidated state; E3.4 (`[research]`) revisits. Tested.
+- Scope discipline: NO CLI/HTTP/SDK/audit-ops/Python this slice (graph is internal
+  until E3.2). Enqueue hook + CI lint deferred (criterion 2).
+- Schema-version drift: 20 sites; grep-confirm post-bump.
+- Line endings: targeted Edits (repo uniformly LF).
+- codex review cwd-PINNED to hippo (`cd hippo && codex review --uncommitted`; verify
+  the `workdir:` line) + ALL feature-repo bash commands cwd-prefixed (the generalized
+  cwd-drift lesson).
+- Ships via merge; CHANGELOG Unreleased; NO publish.
+
+## Out of scope (noted)
+
+- E3.1 entity extraction at sleep (the NLP; 80%-precision gold set): follow-up.
+- E3.2 multi-hop graph recall (`hippo recall --hops`): follow-up.
+- The consolidation **enqueue hook** (`hippo sleep` feeds the queue): follow-up
+  (this episode ships the queue table + API the hook will call).
+- The **CI lint** (E3.3 criterion 2): fast-follow.
+- E3.4 graph quality maintenance (tombstone / versioned edges on supersession):
+  `[research]`.
+- Operator surface (CLI/HTTP/SDK): lands with E3.2 recall.

--- a/src/db.ts
+++ b/src/db.ts
@@ -23,7 +23,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 36;
+const CURRENT_SCHEMA_VERSION = 37;
 
 type Migration = {
   version: number;
@@ -1651,6 +1651,216 @@ const MIGRATIONS: Migration[] = [
               WHEN NEW.tenant_id != (SELECT tenant_id FROM customer_notes WHERE id = NEW.superseded_by)
               THEN RAISE(ABORT, 'customer_notes.superseded_by must reference a customer_note in the same tenant')
             END;
+          END
+        `);
+      }
+    },
+  },
+  {
+    version: 37,
+    up: (db) => {
+      // E3.3 graph-on-consolidated guard (docs/plans/2026-06-01-e3-graph-guard.md).
+      // The graph layer (entities + relations) sits ON TOP OF consolidated state and
+      // must NEVER index the raw layer. The substrate: entities + relations +
+      // graph_extraction_queue, each FK-ing to memories and guarded so they can only
+      // reference CONSOLIDATED memories (kind IN ('distilled','superseded')), never
+      // kind='raw'. New tables -> real CHECK constraints (unlike the ALTER'd memories,
+      // whose kind CHECK lives in triggers). The kind/source MATCH (source_kind ==
+      // the FK'd memory's actual kind) cannot be a CHECK (CHECK can't subquery), so it
+      // is a BEFORE INSERT *and* BEFORE UPDATE trigger (the subquery-capable pattern
+      // from the v30 decisions / predictions tenant-match triggers). Both INSERT and
+      // UPDATE are guarded: an INSERT-only guard is bypassable via a raw SQL UPDATE
+      // that moves a row onto a raw memory (plan-eng-critic 2026-06-01). All column
+      // names checked vs SQL reserved words (rule 10): rel_type avoids REFERENCES.
+      if (!tableExists(db, 'entities')) {
+        db.exec(`
+          CREATE TABLE entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id TEXT NOT NULL,
+            entity_type TEXT NOT NULL
+              CHECK (entity_type IN ('person', 'project', 'customer', 'system', 'policy', 'decision')),
+            name TEXT NOT NULL,
+            memory_id TEXT NOT NULL,
+            source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled', 'superseded')),
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+          )
+        `);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_tenant ON entities(tenant_id)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_memory ON entities(memory_id)`);
+        db.exec(`
+          CREATE TABLE relations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id TEXT NOT NULL,
+            from_entity_id INTEGER NOT NULL,
+            to_entity_id INTEGER NOT NULL,
+            rel_type TEXT NOT NULL
+              CHECK (rel_type IN ('owns', 'supersedes', 'depends-on', 'blocked-by', 'references')),
+            memory_id TEXT NOT NULL,
+            source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled', 'superseded')),
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+            FOREIGN KEY (to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+            FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+          )
+        `);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_tenant ON relations(tenant_id)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_from ON relations(from_entity_id)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_to ON relations(to_entity_id)`);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_memory ON relations(memory_id)`);
+        db.exec(`
+          CREATE TABLE graph_extraction_queue (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id TEXT NOT NULL,
+            memory_id TEXT NOT NULL,
+            kind TEXT NOT NULL CHECK (kind IN ('distilled', 'superseded')),
+            status TEXT NOT NULL DEFAULT 'pending'
+              CHECK (status IN ('pending', 'processed', 'skipped')),
+            enqueued_at TEXT NOT NULL,
+            processed_at TEXT,
+            FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+          )
+        `);
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_graph_queue_status ON graph_extraction_queue(tenant_id, status)`);
+
+        // entities guard: source_kind must equal the FK'd memory's actual kind (so a
+        // raw memory or a lying source_kind both ABORT), and tenant must match. Both
+        // INSERT and UPDATE (UPDATE fires when memory_id/source_kind/tenant_id change).
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_entities_consolidated_only_insert
+          BEFORE INSERT ON entities
+          BEGIN
+            SELECT CASE
+              WHEN NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'entities.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'entities.tenant_id must match memories.tenant_id for the referenced memory')
+            END;
+          END
+        `);
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_entities_consolidated_only_update
+          BEFORE UPDATE ON entities
+          WHEN NEW.memory_id IS NOT OLD.memory_id
+            OR NEW.source_kind IS NOT OLD.source_kind
+            OR NEW.tenant_id IS NOT OLD.tenant_id
+          BEGIN
+            SELECT CASE
+              WHEN NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'entities.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'entities.tenant_id must match memories.tenant_id for the referenced memory')
+            END;
+          END
+        `);
+
+        // relations guard: source_kind must equal the FK'd memory's kind; tenant must
+        // match the memory AND both endpoint entities (no cross-tenant edges).
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_relations_consolidated_only_insert
+          BEFORE INSERT ON relations
+          BEGIN
+            SELECT CASE
+              WHEN NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'relations.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match memories.tenant_id for the referenced memory')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.from_entity_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match the from_entity tenant (no cross-tenant edges)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.to_entity_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match the to_entity tenant (no cross-tenant edges)')
+            END;
+          END
+        `);
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_relations_consolidated_only_update
+          BEFORE UPDATE ON relations
+          WHEN NEW.memory_id IS NOT OLD.memory_id
+            OR NEW.source_kind IS NOT OLD.source_kind
+            OR NEW.tenant_id IS NOT OLD.tenant_id
+            OR NEW.from_entity_id IS NOT OLD.from_entity_id
+            OR NEW.to_entity_id IS NOT OLD.to_entity_id
+          BEGIN
+            SELECT CASE
+              WHEN NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'relations.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match memories.tenant_id for the referenced memory')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.from_entity_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match the from_entity tenant (no cross-tenant edges)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.to_entity_id)
+              THEN RAISE(ABORT, 'relations.tenant_id must match the to_entity tenant (no cross-tenant edges)')
+            END;
+          END
+        `);
+
+        // graph_extraction_queue guard: kind must equal the FK'd memory's actual kind
+        // (so a raw memory ABORTs), and tenant must match. INSERT and UPDATE.
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_graph_queue_consolidated_only_insert
+          BEFORE INSERT ON graph_extraction_queue
+          BEGIN
+            SELECT CASE
+              WHEN NEW.kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'graph_extraction_queue.kind must equal the referenced memory kind; only consolidated memories are queued (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'graph_extraction_queue.tenant_id must match memories.tenant_id for the referenced memory')
+            END;
+          END
+        `);
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_graph_queue_consolidated_only_update
+          BEFORE UPDATE ON graph_extraction_queue
+          WHEN NEW.memory_id IS NOT OLD.memory_id
+            OR NEW.kind IS NOT OLD.kind
+            OR NEW.tenant_id IS NOT OLD.tenant_id
+          BEGIN
+            SELECT CASE
+              WHEN NEW.kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'graph_extraction_queue.kind must equal the referenced memory kind; only consolidated memories are queued (no raw)')
+              WHEN NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+              THEN RAISE(ABORT, 'graph_extraction_queue.tenant_id must match memories.tenant_id for the referenced memory')
+            END;
+          END
+        `);
+
+        // Reverse guard (codex-review-critic 2026-06-01, P1): the graph-table triggers
+        // only fire on writes to the GRAPH tables. They do NOT fire when an
+        // already-indexed memory is later mutated. So 'UPDATE memories SET kind=raw'
+        // (or a tenant change) on a memory the graph references would silently leave
+        // entity/relation/queue rows pointing at a raw / cross-tenant memory while
+        // their source_kind stays 'distilled' - bypassing the central 'graph never
+        // indexes raw' invariant after insertion. This trigger closes that direction:
+        // a memory cannot be reclassified to raw, nor moved cross-tenant, WHILE the
+        // graph references it (rebuild/remove the graph rows first). Cheap: the EXISTS
+        // checks are only evaluated when kind actually becomes raw or tenant changes.
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_memories_graph_referenced_guard
+          BEFORE UPDATE ON memories
+          WHEN (NEW.kind IS NOT OLD.kind OR NEW.tenant_id IS NOT OLD.tenant_id)
+            AND (
+              EXISTS (SELECT 1 FROM entities WHERE memory_id = OLD.id)
+              OR EXISTS (SELECT 1 FROM relations WHERE memory_id = OLD.id)
+              OR EXISTS (SELECT 1 FROM graph_extraction_queue WHERE memory_id = OLD.id)
+            )
+          BEGIN
+            SELECT RAISE(ABORT, 'cannot change the kind or tenant of a memory while the graph references it (E3.3 graph-on-consolidated guard); a graph-referenced memory is immutable in kind/tenant - rebuild/remove the graph rows first, or rebuild them after supersession');
+          END
+        `);
+        // Reverse guard #2 (codex-review-critic 2026-06-01 retry, P2): an entity that is
+        // a relation endpoint cannot be moved cross-tenant. The entity UPDATE trigger
+        // validates the entity against its source memory, but an existing relation
+        // pointing at the entity is NOT re-validated, so a raw 'UPDATE entities SET
+        // tenant_id=?, memory_id=?' to another tenant would leave a tenant-A relation
+        // pointing at a tenant-B entity. Block the tenant move while the entity is
+        // referenced by any relation (rebuild the relations first).
+        db.exec(`
+          CREATE TRIGGER IF NOT EXISTS trg_entities_no_tenant_move_when_referenced
+          BEFORE UPDATE ON entities
+          WHEN NEW.tenant_id IS NOT OLD.tenant_id
+            AND EXISTS (SELECT 1 FROM relations WHERE from_entity_id = OLD.id OR to_entity_id = OLD.id)
+          BEGIN
+            SELECT RAISE(ABORT, 'cannot move an entity cross-tenant while a relation references it as an endpoint (E3.3 graph-on-consolidated guard); rebuild/remove the relations first');
           END
         `);
       }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,442 @@
+/**
+ * E3.3 graph layer over consolidated state - the graph-on-consolidated guard.
+ * (docs/plans/2026-06-01-e3-graph-guard.md).
+ *
+ * A graph of canonical `entities` (person/project/customer/system/policy/decision) and
+ * `relations` (owns/supersedes/depends-on/blocked-by/references) sits ON TOP OF
+ * consolidated memories. The hard rule: the graph NEVER indexes the raw layer - every
+ * entity and relation references a memory whose `kind IN ('distilled','superseded')`,
+ * never `kind='raw'`. Enforced at the DB level (CHECK on source_kind/kind + BEFORE
+ * INSERT and BEFORE UPDATE triggers that tie source_kind/kind to the FK'd memory's
+ * actual kind and enforce tenant-match - relations also reject cross-tenant edges), so
+ * the forbidden state is unrepresentable regardless of code path. These helpers
+ * surface the same guard as clear throws BEFORE hitting the trigger backstop.
+ *
+ * Scope (E3.3 first slice): the substrate + the guard + a thin insert/load/enqueue
+ * API. The `graph_extraction_queue` is the interface the deferred `hippo sleep`
+ * enqueue-hook + E3.1 entity extraction will call. No operator surface (CLI/HTTP/SDK)
+ * until E3.2 multi-hop recall.
+ */
+
+import { openHippoDb, closeHippoDb } from './db.js';
+import { assertTenantId } from './store.js';
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type EntityType = 'person' | 'project' | 'customer' | 'system' | 'policy' | 'decision';
+export type RelationType = 'owns' | 'supersedes' | 'depends-on' | 'blocked-by' | 'references';
+export type GraphQueueStatus = 'pending' | 'processed' | 'skipped';
+/** The consolidated source kinds the graph is permitted to index (never 'raw'). */
+export type SourceKind = 'distilled' | 'superseded';
+
+export const GRAPH_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+  'person', 'project', 'customer', 'system', 'policy', 'decision',
+]);
+export const GRAPH_RELATION_TYPES: ReadonlySet<RelationType> = new Set<RelationType>([
+  'owns', 'supersedes', 'depends-on', 'blocked-by', 'references',
+]);
+export const VALID_QUEUE_STATES: ReadonlySet<GraphQueueStatus> = new Set<GraphQueueStatus>([
+  'pending', 'processed', 'skipped',
+]);
+
+export const MAX_ENTITY_NAME_LEN = 512;
+
+export interface Entity {
+  id: number;
+  tenantId: string;
+  entityType: EntityType;
+  name: string;
+  /** The consolidated source memory this entity was extracted from. */
+  memoryId: string;
+  sourceKind: SourceKind;
+  createdAt: string;
+}
+
+export interface Relation {
+  id: number;
+  tenantId: string;
+  fromEntityId: number;
+  toEntityId: number;
+  relType: RelationType;
+  memoryId: string;
+  sourceKind: SourceKind;
+  createdAt: string;
+}
+
+export interface GraphQueueItem {
+  id: number;
+  tenantId: string;
+  memoryId: string;
+  kind: SourceKind;
+  status: GraphQueueStatus;
+  enqueuedAt: string;
+  processedAt: string | null;
+}
+
+export interface InsertEntityOpts {
+  entityType: EntityType;
+  name: string;
+  /** A consolidated (distilled/superseded) memory; raw is rejected. */
+  memoryId: string;
+}
+
+export interface InsertRelationOpts {
+  fromEntityId: number;
+  toEntityId: number;
+  relType: RelationType;
+  /** A consolidated (distilled/superseded) memory; raw is rejected. */
+  memoryId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row <-> domain mapping
+// ---------------------------------------------------------------------------
+
+interface EntityRow {
+  id: number;
+  tenant_id: string;
+  entity_type: string;
+  name: string;
+  memory_id: string;
+  source_kind: string;
+  created_at: string;
+}
+interface RelationRow {
+  id: number;
+  tenant_id: string;
+  from_entity_id: number;
+  to_entity_id: number;
+  rel_type: string;
+  memory_id: string;
+  source_kind: string;
+  created_at: string;
+}
+interface QueueRow {
+  id: number;
+  tenant_id: string;
+  memory_id: string;
+  kind: string;
+  status: string;
+  enqueued_at: string;
+  processed_at: string | null;
+}
+
+function rowToEntity(row: EntityRow): Entity {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    entityType: row.entity_type as EntityType,
+    name: row.name,
+    memoryId: row.memory_id,
+    sourceKind: row.source_kind as SourceKind,
+    createdAt: row.created_at,
+  };
+}
+function rowToRelation(row: RelationRow): Relation {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    fromEntityId: row.from_entity_id,
+    toEntityId: row.to_entity_id,
+    relType: row.rel_type as RelationType,
+    memoryId: row.memory_id,
+    sourceKind: row.source_kind as SourceKind,
+    createdAt: row.created_at,
+  };
+}
+function rowToQueueItem(row: QueueRow): GraphQueueItem {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    memoryId: row.memory_id,
+    kind: row.kind as SourceKind,
+    status: row.status as GraphQueueStatus,
+    enqueuedAt: row.enqueued_at,
+    processedAt: row.processed_at,
+  };
+}
+
+const ENTITY_COLS = `id, tenant_id, entity_type, name, memory_id, source_kind, created_at`;
+const RELATION_COLS = `id, tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at`;
+const QUEUE_COLS = `id, tenant_id, memory_id, kind, status, enqueued_at, processed_at`;
+
+// ---------------------------------------------------------------------------
+// Guard helper: resolve a consolidated source memory or throw
+// ---------------------------------------------------------------------------
+
+interface DbLike {
+  prepare(sql: string): { get(...params: unknown[]): unknown };
+}
+
+/**
+ * Look up a memory and assert it is a valid CONSOLIDATED source for the graph: it
+ * exists, belongs to `tenantId`, and is not raw. Returns its kind (the source_kind to
+ * store). Throws a clear error otherwise. This is the code-level mirror of the DB
+ * trigger guard (which is the unbypassable backstop).
+ */
+function resolveConsolidatedSource(db: DbLike, tenantId: string, memoryId: string, label: string): SourceKind {
+  const row = db.prepare(`SELECT kind, tenant_id FROM memories WHERE id = ?`).get(memoryId) as
+    | { kind: string; tenant_id: string }
+    | undefined;
+  if (!row) {
+    throw new Error(`${label}: source memory ${memoryId} not found`);
+  }
+  if (row.tenant_id !== tenantId) {
+    throw new Error(`${label}: source memory ${memoryId} belongs to another tenant`);
+  }
+  if (row.kind === 'raw') {
+    throw new Error(`${label}: source memory ${memoryId} is raw; the graph indexes consolidated state only`);
+  }
+  if (row.kind !== 'distilled' && row.kind !== 'superseded') {
+    throw new Error(`${label}: source memory ${memoryId} has unsupported kind '${row.kind}'`);
+  }
+  return row.kind;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a graph entity extracted from a consolidated memory. Throws if the source
+ * memory is missing / cross-tenant / raw (the DB trigger is the backstop).
+ */
+export function insertEntity(
+  hippoRoot: string,
+  tenantId: string,
+  opts: InsertEntityOpts,
+): Entity {
+  assertTenantId('insertEntity', tenantId);
+  if (!GRAPH_ENTITY_TYPES.has(opts.entityType)) {
+    throw new Error(`insertEntity: entityType must be one of ${Array.from(GRAPH_ENTITY_TYPES).join('|')}; got ${opts.entityType}`);
+  }
+  const name = (opts.name ?? '').trim();
+  if (name.length === 0) throw new Error('insertEntity: name is required');
+  if (name.length > MAX_ENTITY_NAME_LEN) {
+    throw new Error(`insertEntity: name exceeds the ${MAX_ENTITY_NAME_LEN}-char cap`);
+  }
+  const now = new Date().toISOString();
+  const db = openHippoDb(hippoRoot);
+  try {
+    const sourceKind = resolveConsolidatedSource(db, tenantId, opts.memoryId, 'insertEntity');
+    const result = db.prepare(`
+      INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(tenantId, opts.entityType, name, opts.memoryId, sourceKind, now);
+    const id = Number(result.lastInsertRowid ?? 0);
+    const row = db.prepare(`SELECT ${ENTITY_COLS} FROM entities WHERE id = ?`).get(id) as EntityRow | undefined;
+    if (!row) throw new Error('insertEntity: failed to reload inserted entity');
+    return rowToEntity(row);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Insert a graph relation between two entities, sourced from a consolidated memory.
+ * Both entities must exist in the same tenant; the source memory must be consolidated.
+ */
+export function insertRelation(
+  hippoRoot: string,
+  tenantId: string,
+  opts: InsertRelationOpts,
+): Relation {
+  assertTenantId('insertRelation', tenantId);
+  if (!GRAPH_RELATION_TYPES.has(opts.relType)) {
+    throw new Error(`insertRelation: relType must be one of ${Array.from(GRAPH_RELATION_TYPES).join('|')}; got ${opts.relType}`);
+  }
+  const now = new Date().toISOString();
+  const db = openHippoDb(hippoRoot);
+  try {
+    for (const [eid, role] of [[opts.fromEntityId, 'from'], [opts.toEntityId, 'to']] as const) {
+      const ent = db.prepare(`SELECT tenant_id FROM entities WHERE id = ?`).get(eid) as { tenant_id: string } | undefined;
+      if (!ent) throw new Error(`insertRelation: ${role}_entity ${eid} not found`);
+      if (ent.tenant_id !== tenantId) {
+        throw new Error(`insertRelation: ${role}_entity ${eid} belongs to another tenant (no cross-tenant edges)`);
+      }
+    }
+    const sourceKind = resolveConsolidatedSource(db, tenantId, opts.memoryId, 'insertRelation');
+    const result = db.prepare(`
+      INSERT INTO relations(tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(tenantId, opts.fromEntityId, opts.toEntityId, opts.relType, opts.memoryId, sourceKind, now);
+    const id = Number(result.lastInsertRowid ?? 0);
+    const row = db.prepare(`SELECT ${RELATION_COLS} FROM relations WHERE id = ?`).get(id) as RelationRow | undefined;
+    if (!row) throw new Error('insertRelation: failed to reload inserted relation');
+    return rowToRelation(row);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export function loadEntityById(hippoRoot: string, tenantId: string, id: number): Entity | null {
+  assertTenantId('loadEntityById', tenantId);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const row = db.prepare(`SELECT ${ENTITY_COLS} FROM entities WHERE id = ? AND tenant_id = ?`)
+      .get(id, tenantId) as EntityRow | undefined;
+    return row ? rowToEntity(row) : null;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export function loadEntities(
+  hippoRoot: string,
+  tenantId: string,
+  opts: { entityType?: EntityType; limit?: number } = {},
+): Entity[] {
+  assertTenantId('loadEntities', tenantId);
+  const limit = opts.limit ?? 100;
+  if (opts.entityType && !GRAPH_ENTITY_TYPES.has(opts.entityType)) {
+    throw new Error(`loadEntities: entityType must be one of ${Array.from(GRAPH_ENTITY_TYPES).join('|')}; got ${opts.entityType}`);
+  }
+  const db = openHippoDb(hippoRoot);
+  try {
+    const clauses = ['tenant_id = ?'];
+    const params: unknown[] = [tenantId];
+    if (opts.entityType) {
+      clauses.push('entity_type = ?');
+      params.push(opts.entityType);
+    }
+    params.push(limit);
+    const rows = db.prepare(`
+      SELECT ${ENTITY_COLS} FROM entities
+      WHERE ${clauses.join(' AND ')}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(...params) as EntityRow[];
+    return rows.map(rowToEntity);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export function loadRelations(
+  hippoRoot: string,
+  tenantId: string,
+  opts: { fromEntityId?: number; limit?: number } = {},
+): Relation[] {
+  assertTenantId('loadRelations', tenantId);
+  const limit = opts.limit ?? 100;
+  const db = openHippoDb(hippoRoot);
+  try {
+    const clauses = ['tenant_id = ?'];
+    const params: unknown[] = [tenantId];
+    if (opts.fromEntityId !== undefined) {
+      clauses.push('from_entity_id = ?');
+      params.push(opts.fromEntityId);
+    }
+    params.push(limit);
+    const rows = db.prepare(`
+      SELECT ${RELATION_COLS} FROM relations
+      WHERE ${clauses.join(' AND ')}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(...params) as RelationRow[];
+    return rows.map(rowToRelation);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extraction queue (the interface the deferred sleep enqueue-hook + E3.1 will use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue a consolidated memory for later graph extraction. Rejects a raw / missing /
+ * cross-tenant memory (the DB trigger is the backstop). The producer hook in
+ * `hippo sleep` is deferred (E3.1); this is the API it will call.
+ */
+export function enqueueExtraction(
+  hippoRoot: string,
+  tenantId: string,
+  memoryId: string,
+): GraphQueueItem {
+  assertTenantId('enqueueExtraction', tenantId);
+  const now = new Date().toISOString();
+  const db = openHippoDb(hippoRoot);
+  try {
+    const kind = resolveConsolidatedSource(db, tenantId, memoryId, 'enqueueExtraction');
+    const result = db.prepare(`
+      INSERT INTO graph_extraction_queue(tenant_id, memory_id, kind, status, enqueued_at, processed_at)
+      VALUES (?, ?, ?, 'pending', ?, NULL)
+    `).run(tenantId, memoryId, kind, now);
+    const id = Number(result.lastInsertRowid ?? 0);
+    const row = db.prepare(`SELECT ${QUEUE_COLS} FROM graph_extraction_queue WHERE id = ?`).get(id) as QueueRow | undefined;
+    if (!row) throw new Error('enqueueExtraction: failed to reload queue item');
+    return rowToQueueItem(row);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export function loadExtractionQueue(
+  hippoRoot: string,
+  tenantId: string,
+  opts: { status?: GraphQueueStatus; limit?: number } = {},
+): GraphQueueItem[] {
+  assertTenantId('loadExtractionQueue', tenantId);
+  const limit = opts.limit ?? 100;
+  if (opts.status && !VALID_QUEUE_STATES.has(opts.status)) {
+    throw new Error(`loadExtractionQueue: status must be one of ${Array.from(VALID_QUEUE_STATES).join('|')}; got ${opts.status}`);
+  }
+  const db = openHippoDb(hippoRoot);
+  try {
+    const clauses = ['tenant_id = ?'];
+    const params: unknown[] = [tenantId];
+    if (opts.status) {
+      clauses.push('status = ?');
+      params.push(opts.status);
+    }
+    params.push(limit);
+    const rows = db.prepare(`
+      SELECT ${QUEUE_COLS} FROM graph_extraction_queue
+      WHERE ${clauses.join(' AND ')}
+      ORDER BY enqueued_at ASC, id ASC
+      LIMIT ?
+    `).all(...params) as QueueRow[];
+    return rows.map(rowToQueueItem);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Mark a queue item terminal (processed | skipped). Only `status`/`processed_at`
+ * change, so the consolidated-source guard trigger (which fires on
+ * memory_id/kind/tenant_id changes) is not involved. CAS on the current status to a
+ * non-terminal 'pending'.
+ */
+export function markExtractionProcessed(
+  hippoRoot: string,
+  tenantId: string,
+  id: number,
+  status: 'processed' | 'skipped' = 'processed',
+): GraphQueueItem {
+  assertTenantId('markExtractionProcessed', tenantId);
+  const now = new Date().toISOString();
+  const db = openHippoDb(hippoRoot);
+  try {
+    const updated = db.prepare(`
+      UPDATE graph_extraction_queue
+      SET status = ?, processed_at = ?
+      WHERE id = ? AND tenant_id = ? AND status = 'pending'
+    `).run(status, now, id, tenantId);
+    if (updated.changes === 0) {
+      const existing = db.prepare(`SELECT status FROM graph_extraction_queue WHERE id = ? AND tenant_id = ?`)
+        .get(id, tenantId) as { status: string } | undefined;
+      if (!existing) throw new Error(`markExtractionProcessed: queue item ${id} not found for tenant ${tenantId}`);
+      throw new Error(`markExtractionProcessed: queue item ${id} is not pending (status='${existing.status}')`);
+    }
+    const row = db.prepare(`SELECT ${QUEUE_COLS} FROM graph_extraction_queue WHERE id = ? AND tenant_id = ?`)
+      .get(id, tenantId) as QueueRow | undefined;
+    if (!row) throw new Error(`markExtractionProcessed: queue item ${id} not found after UPDATE`);
+    return rowToQueueItem(row);
+  } finally {
+    closeHippoDb(db);
+  }
+}

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(36);
+    expect(getCurrentSchemaVersion()).toBe(37);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(36);
+    expect(getSchemaVersion(db)).toBe(37);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
-      expect(getCurrentSchemaVersion()).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
+      expect(getCurrentSchemaVersion()).toBe(37);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(36);
+    expect(getCurrentSchemaVersion()).toBe(37);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
-      expect(getCurrentSchemaVersion()).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
+      expect(getCurrentSchemaVersion()).toBe(37);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(36);
+    expect(getCurrentSchemaVersion()).toBe(37);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -74,7 +74,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db, 'schema_version')).toBe('36');
+      expect(getMeta(db, 'schema_version')).toBe('37');
     } finally {
       closeHippoDb(db);
     }
@@ -134,7 +134,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db2);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db2, 'schema_version')).toBe('36');
+      expect(getMeta(db2, 'schema_version')).toBe('37');
     } finally {
       closeHippoDb(db2);
     }

--- a/tests/graph-schema.test.ts
+++ b/tests/graph-schema.test.ts
@@ -1,0 +1,77 @@
+/**
+ * E3.3 graph-on-consolidated guard - schema v37 shape.
+ * Docs: docs/plans/2026-06-01-e3-graph-guard.md
+ *
+ * Pins the 3 tables + 7 indexes + 6 guard triggers (INSERT and UPDATE per table).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb, getCurrentSchemaVersion } from '../src/db.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graph-schema-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+describe('graph schema v37 (E3.3)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('CURRENT_SCHEMA_VERSION is 37', () => {
+    expect(getCurrentSchemaVersion()).toBe(37);
+  });
+
+  it('creates entities + relations + graph_extraction_queue tables', () => {
+    const db = openHippoDb(home);
+    try {
+      for (const t of ['entities', 'relations', 'graph_extraction_queue']) {
+        expect(db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`).get(t), `missing table ${t}`).toBeDefined();
+      }
+    } finally { closeHippoDb(db); }
+  });
+
+  it('creates the 7 graph indexes', () => {
+    const db = openHippoDb(home);
+    try {
+      const names = (db.prepare(`SELECT name FROM sqlite_master WHERE type='index' AND (name LIKE 'idx_entities_%' OR name LIKE 'idx_relations_%' OR name LIKE 'idx_graph_%')`)
+        .all() as Array<{ name: string }>).map((r) => r.name);
+      for (const idx of [
+        'idx_entities_tenant', 'idx_entities_memory',
+        'idx_relations_tenant', 'idx_relations_from', 'idx_relations_to', 'idx_relations_memory',
+        'idx_graph_queue_status',
+      ]) {
+        expect(names, `missing index ${idx}`).toContain(idx);
+      }
+    } finally { closeHippoDb(db); }
+  });
+
+  it('creates the 6 graph-table guard triggers (INSERT + UPDATE per table)', () => {
+    const db = openHippoDb(home);
+    try {
+      const names = (db.prepare(`SELECT name FROM sqlite_master WHERE type='trigger' AND (name LIKE 'trg_entities_%' OR name LIKE 'trg_relations_%' OR name LIKE 'trg_graph_queue_%')`)
+        .all() as Array<{ name: string }>).map((r) => r.name);
+      for (const trg of [
+        'trg_entities_consolidated_only_insert', 'trg_entities_consolidated_only_update',
+        'trg_relations_consolidated_only_insert', 'trg_relations_consolidated_only_update',
+        'trg_graph_queue_consolidated_only_insert', 'trg_graph_queue_consolidated_only_update',
+      ]) {
+        expect(names, `missing trigger ${trg}`).toContain(trg);
+      }
+    } finally { closeHippoDb(db); }
+  });
+
+  it('creates the reverse-guard triggers (codex P1 + P2): memories + entities', () => {
+    const db = openHippoDb(home);
+    try {
+      expect(db.prepare(`SELECT name FROM sqlite_master WHERE type='trigger' AND name='trg_memories_graph_referenced_guard'`).get()).toBeDefined();
+      expect(db.prepare(`SELECT name FROM sqlite_master WHERE type='trigger' AND name='trg_entities_no_tenant_move_when_referenced'`).get()).toBeDefined();
+    } finally { closeHippoDb(db); }
+  });
+});

--- a/tests/graph-store.test.ts
+++ b/tests/graph-store.test.ts
@@ -1,0 +1,270 @@
+/**
+ * E3.3 graph-on-consolidated guard - store-layer tests.
+ * Docs: docs/plans/2026-06-01-e3-graph-guard.md
+ *
+ * The graph must NEVER index the raw layer. These tests pin the DB-level guard
+ * (CHECK + BEFORE INSERT/UPDATE triggers) as the unbypassable invariant, plus the
+ * src/graph.ts helper API.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, deleteEntry, writeEntry } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import {
+  insertEntity,
+  insertRelation,
+  loadEntityById,
+  loadEntities,
+  loadRelations,
+  enqueueExtraction,
+  loadExtractionQueue,
+  markExtractionProcessed,
+  MAX_ENTITY_NAME_LEN,
+} from '../src/graph.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graph-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+/** Write a memory and force its kind (default writes are 'distilled'). Setting kind
+ *  to 'raw' is allowed (the append-only trigger is BEFORE DELETE, not UPDATE). */
+function addMemory(home: string, tenant: string, kind: 'distilled' | 'superseded' | 'raw'): string {
+  const mem = createMemory('graph source memory for guard tests', { tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: tenant });
+  writeEntry(home, mem, { actor: 'test' });
+  if (kind !== 'distilled') {
+    const db = openHippoDb(home);
+    try { db.prepare(`UPDATE memories SET kind = ? WHERE id = ?`).run(kind, mem.id); }
+    finally { closeHippoDb(db); }
+  }
+  return mem.id;
+}
+function countRows(home: string, table: string): number {
+  const db = openHippoDb(home);
+  try { return (db.prepare(`SELECT COUNT(*) as c FROM ${table}`).get() as { c: number }).c; }
+  finally { closeHippoDb(db); }
+}
+
+describe('graph store (E3.3 graph-on-consolidated guard)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('insertEntity from a distilled / superseded memory sets source_kind; insertRelation links them', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const ms = addMemory(home, 'default', 'superseded');
+    const a = insertEntity(home, 'default', { entityType: 'customer', name: 'Acme', memoryId: md });
+    const b = insertEntity(home, 'default', { entityType: 'person', name: 'Jordan', memoryId: ms });
+    expect(a.sourceKind).toBe('distilled');
+    expect(b.sourceKind).toBe('superseded');
+    const rel = insertRelation(home, 'default', { fromEntityId: a.id, toEntityId: b.id, relType: 'owns', memoryId: md });
+    expect(rel.relType).toBe('owns');
+    expect(rel.sourceKind).toBe('distilled');
+    expect(loadEntityById(home, 'default', a.id)!.name).toBe('Acme');
+  });
+
+  it('CRITERION 1: a raw-FK entity is rejected via the helper AND via a direct raw SQL INSERT (trigger ABORTs)', () => {
+    const raw = addMemory(home, 'default', 'raw');
+    // helper rejects
+    expect(() => insertEntity(home, 'default', { entityType: 'system', name: 'x', memoryId: raw }))
+      .toThrow(/raw|consolidated/i);
+    // direct raw SQL INSERT (claiming source_kind='distilled') is rejected by the trigger
+    const db = openHippoDb(home);
+    try {
+      expect(() => {
+        db.prepare(`INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+          VALUES ('default', 'system', 'x', ?, 'distilled', ?)`).run(raw, new Date().toISOString());
+      }).toThrow(/source_kind must equal the referenced memory kind/);
+    } finally { closeHippoDb(db); }
+    expect(countRows(home, 'entities')).toBe(0);
+  });
+
+  it('UPDATE-path guard: cannot move a graph row onto a raw memory or fake source_kind via raw SQL UPDATE', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const raw = addMemory(home, 'default', 'raw');
+    const e = insertEntity(home, 'default', { entityType: 'project', name: 'p', memoryId: md });
+    const db = openHippoDb(home);
+    try {
+      // move memory_id to a raw memory -> ABORT (BEFORE UPDATE trigger)
+      expect(() => db.prepare(`UPDATE entities SET memory_id = ? WHERE id = ?`).run(raw, e.id))
+        .toThrow(/source_kind must equal the referenced memory kind/);
+      // change source_kind to disagree with the (distilled) memory -> ABORT
+      expect(() => db.prepare(`UPDATE entities SET source_kind = 'superseded' WHERE id = ?`).run(e.id))
+        .toThrow(/source_kind must equal the referenced memory kind/);
+      // the row is unchanged
+      const row = db.prepare(`SELECT memory_id, source_kind FROM entities WHERE id = ?`).get(e.id) as { memory_id: string; source_kind: string };
+      expect(row.memory_id).toBe(md);
+      expect(row.source_kind).toBe('distilled');
+    } finally { closeHippoDb(db); }
+  });
+
+  it('lying source_kind on INSERT is rejected (raw SQL: distilled memory but source_kind=superseded)', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const db = openHippoDb(home);
+    try {
+      expect(() => {
+        db.prepare(`INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+          VALUES ('default', 'system', 'x', ?, 'superseded', ?)`).run(md, new Date().toISOString());
+      }).toThrow(/source_kind must equal the referenced memory kind/);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('cross-tenant entity->memory rejected (helper + raw SQL trigger)', () => {
+    const mb = addMemory(home, 'tenant-b', 'distilled');
+    expect(() => insertEntity(home, 'tenant-a', { entityType: 'customer', name: 'x', memoryId: mb }))
+      .toThrow(/another tenant/);
+    const db = openHippoDb(home);
+    try {
+      expect(() => {
+        db.prepare(`INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+          VALUES ('tenant-a', 'customer', 'x', ?, 'distilled', ?)`).run(mb, new Date().toISOString());
+      }).toThrow(/tenant_id must match memories\.tenant_id/);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('cross-tenant relation->entity rejected (helper + raw SQL trigger)', () => {
+    const ma = addMemory(home, 'tenant-a', 'distilled');
+    const mb = addMemory(home, 'tenant-b', 'distilled');
+    const ea = insertEntity(home, 'tenant-a', { entityType: 'system', name: 'a', memoryId: ma });
+    const eb = insertEntity(home, 'tenant-b', { entityType: 'system', name: 'b', memoryId: mb });
+    expect(() => insertRelation(home, 'tenant-a', { fromEntityId: ea.id, toEntityId: eb.id, relType: 'depends-on', memoryId: ma }))
+      .toThrow(/another tenant/);
+    const db = openHippoDb(home);
+    try {
+      // raw SQL: relation in tenant-a referencing tenant-b's entity -> trigger ABORTs
+      expect(() => {
+        db.prepare(`INSERT INTO relations(tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at)
+          VALUES ('tenant-a', ?, ?, 'depends-on', ?, 'distilled', ?)`).run(ea.id, eb.id, ma, new Date().toISOString());
+      }).toThrow(/to_entity tenant|from_entity tenant/);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('CHECK constraints reject bad entity_type / rel_type / source_kind (raw SQL)', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(`INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+        VALUES ('default', 'alien', 'x', ?, 'distilled', ?)`).run(md, 't')).toThrow(/CHECK|constraint/i);
+      // source_kind='raw' is doubly-invalid (CHECK + trigger); the BEFORE INSERT
+      // trigger fires before the CHECK in SQLite, so it raises the trigger message.
+      expect(() => db.prepare(`INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+        VALUES ('default', 'system', 'x', ?, 'raw', ?)`).run(md, 't')).toThrow(/source_kind must equal|CHECK|constraint/i);
+      const e = insertEntity(home, 'default', { entityType: 'system', name: 'a', memoryId: md });
+      expect(() => db.prepare(`INSERT INTO relations(tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at)
+        VALUES ('default', ?, ?, 'frobnicates', ?, 'distilled', ?)`).run(e.id, e.id, md, 't')).toThrow(/CHECK|constraint/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('helper rejects bad entityType/relType and over-cap name before touching the DB', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    // @ts-expect-error runtime validation
+    expect(() => insertEntity(home, 'default', { entityType: 'alien', name: 'x', memoryId: md })).toThrow(/entityType must be one of/);
+    expect(() => insertEntity(home, 'default', { entityType: 'system', name: '  ', memoryId: md })).toThrow(/name is required/);
+    expect(() => insertEntity(home, 'default', { entityType: 'system', name: 'z'.repeat(MAX_ENTITY_NAME_LEN + 1), memoryId: md })).toThrow(/name exceeds/);
+  });
+
+  it('enqueueExtraction: distilled enqueues; raw rejected; queue kind-mismatch UPDATE ABORTs; markProcessed', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const raw = addMemory(home, 'default', 'raw');
+    const q = enqueueExtraction(home, 'default', md);
+    expect(q.status).toBe('pending');
+    expect(q.kind).toBe('distilled');
+    expect(() => enqueueExtraction(home, 'default', raw)).toThrow(/raw|consolidated/i);
+    // queue UPDATE that re-points to raw / fakes kind ABORTs
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(`UPDATE graph_extraction_queue SET memory_id = ? WHERE id = ?`).run(raw, q.id))
+        .toThrow(/kind must equal the referenced memory kind/);
+    } finally { closeHippoDb(db); }
+    // status-only update (markProcessed) is allowed (guard fires only on memory_id/kind/tenant change)
+    const done = markExtractionProcessed(home, 'default', q.id);
+    expect(done.status).toBe('processed');
+    expect(done.processedAt).not.toBeNull();
+    expect(() => markExtractionProcessed(home, 'default', q.id)).toThrow(/not pending/);
+    expect(loadExtractionQueue(home, 'default', { status: 'pending' }).length).toBe(0);
+    expect(loadExtractionQueue(home, 'default', { status: 'processed' }).length).toBe(1);
+  });
+
+  it('ON DELETE CASCADE: forgetting a consolidated memory removes its entities + relations + queue rows', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const a = insertEntity(home, 'default', { entityType: 'system', name: 'a', memoryId: md });
+    const b = insertEntity(home, 'default', { entityType: 'system', name: 'b', memoryId: md });
+    insertRelation(home, 'default', { fromEntityId: a.id, toEntityId: b.id, relType: 'depends-on', memoryId: md });
+    enqueueExtraction(home, 'default', md);
+    expect(countRows(home, 'entities')).toBe(2);
+    expect(countRows(home, 'relations')).toBe(1);
+    expect(countRows(home, 'graph_extraction_queue')).toBe(1);
+    deleteEntry(home, md); // distilled deletes are allowed (raw is append-only); cascades to graph rows
+    expect(countRows(home, 'entities')).toBe(0);
+    expect(countRows(home, 'relations')).toBe(0);
+    expect(countRows(home, 'graph_extraction_queue')).toBe(0);
+  });
+
+  it('REVERSE guard (codex P1+P2): a graph-referenced memory is immutable in kind/tenant (raw, superseded, or tenant move all ABORT)', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    insertEntity(home, 'default', { entityType: 'system', name: 'a', memoryId: md });
+    const db = openHippoDb(home);
+    try {
+      // P1: reclassify the referenced memory to raw -> ABORT
+      expect(() => db.prepare(`UPDATE memories SET kind = 'raw' WHERE id = ?`).run(md))
+        .toThrow(/while the graph references it/);
+      // P2: ANY kind change (e.g. distilled->superseded) -> ABORT (avoids stale source_kind)
+      expect(() => db.prepare(`UPDATE memories SET kind = 'superseded' WHERE id = ?`).run(md))
+        .toThrow(/while the graph references it/);
+      // move the referenced memory cross-tenant -> ABORT
+      expect(() => db.prepare(`UPDATE memories SET tenant_id = 'tenant-x' WHERE id = ?`).run(md))
+        .toThrow(/while the graph references it/);
+      const row = db.prepare(`SELECT kind, tenant_id FROM memories WHERE id = ?`).get(md) as { kind: string; tenant_id: string };
+      expect(row.kind).toBe('distilled');
+      expect(row.tenant_id).toBe('default');
+    } finally { closeHippoDb(db); }
+    // an UNreferenced consolidated memory can still change kind freely (guard fires only when referenced)
+    const free = addMemory(home, 'default', 'distilled');
+    const db2 = openHippoDb(home);
+    try {
+      expect(() => db2.prepare(`UPDATE memories SET kind = 'superseded' WHERE id = ?`).run(free)).not.toThrow();
+    } finally { closeHippoDb(db2); }
+  });
+
+  it('REVERSE guard (codex P2): a relation-endpoint entity cannot be moved cross-tenant via raw UPDATE', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const mb = addMemory(home, 'tenant-b', 'distilled');
+    const a = insertEntity(home, 'default', { entityType: 'system', name: 'a', memoryId: md });
+    const b = insertEntity(home, 'default', { entityType: 'system', name: 'b', memoryId: md });
+    insertRelation(home, 'default', { fromEntityId: a.id, toEntityId: b.id, relType: 'depends-on', memoryId: md });
+    const db = openHippoDb(home);
+    try {
+      // moving endpoint 'a' to tenant-b (with a tenant-b memory, so the entity<->memory
+      // check would pass) must ABORT because a relation references it as an endpoint
+      expect(() => db.prepare(`UPDATE entities SET tenant_id = 'tenant-b', memory_id = ?, source_kind = 'distilled' WHERE id = ?`).run(mb, a.id))
+        .toThrow(/while a relation references it/);
+      expect(db.prepare(`SELECT tenant_id FROM entities WHERE id = ?`).get(a.id)).toEqual({ tenant_id: 'default' });
+    } finally { closeHippoDb(db); }
+    // an entity NOT referenced by any relation can still move tenant (with a matching memory)
+    const cmem = addMemory(home, 'default', 'distilled');
+    const c = insertEntity(home, 'default', { entityType: 'system', name: 'c', memoryId: cmem });
+    const db2 = openHippoDb(home);
+    try {
+      expect(() => db2.prepare(`UPDATE entities SET tenant_id = 'tenant-b', memory_id = ?, source_kind = 'distilled' WHERE id = ?`).run(mb, c.id)).not.toThrow();
+    } finally { closeHippoDb(db2); }
+  });
+
+  it('loadEntities / loadRelations filters + tenant isolation', () => {
+    const md = addMemory(home, 'default', 'distilled');
+    const a = insertEntity(home, 'default', { entityType: 'customer', name: 'Acme', memoryId: md });
+    insertEntity(home, 'default', { entityType: 'person', name: 'Jo', memoryId: md });
+    expect(loadEntities(home, 'default').length).toBe(2);
+    expect(loadEntities(home, 'default', { entityType: 'customer' }).map((e) => e.id)).toEqual([a.id]);
+    expect(loadEntities(home, 'other-tenant').length).toBe(0);
+    insertRelation(home, 'default', { fromEntityId: a.id, toEntityId: a.id, relType: 'references', memoryId: md });
+    expect(loadRelations(home, 'default', { fromEntityId: a.id }).length).toBe(1);
+  });
+});

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
-      expect(getCurrentSchemaVersion()).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
+      expect(getCurrentSchemaVersion()).toBe(37);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(36);
+    expect(getCurrentSchemaVersion()).toBe(37);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(36);
+      expect(getSchemaVersion(db2)).toBe(37);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(36);
+      expect(getSchemaVersion(db2)).toBe(37);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(36);
+    expect(getCurrentSchemaVersion()).toBe(37);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(36);
+      expect(getSchemaVersion(db)).toBe(37);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
## What

First slice of the **E3 graph layer** (ROADMAP-RESEARCH E3.3, the only E3 item marked `[next]`). A graph of `entities` + `relations` sits on top of consolidated state and must **never index the raw layer**. This ships the substrate + the DB-level guard that makes a raw-layer reference **unrepresentable on every code path**.

## Surface

- **Migration v37**: `entities`, `relations`, `graph_extraction_queue` tables (FK to `memories`, `CHECK source_kind/kind IN ('distilled','superseded')`), 7 indexes, **8 guard triggers**:
  - **6 forward guards** (BEFORE INSERT + BEFORE UPDATE per table) tying `source_kind`/`kind` to the FK'd memory's actual kind + tenant-match; relations also reject cross-tenant edges.
  - **2 reverse guards** (added in response to codex review): `trg_memories_graph_referenced_guard` blocks any kind/tenant change on a graph-referenced memory; `trg_entities_no_tenant_move_when_referenced` blocks moving a relation-endpoint entity cross-tenant.
- **`src/graph.ts`**: `insertEntity`/`insertRelation`/loaders/`enqueueExtraction`/`loadExtractionQueue`/`markExtractionProcessed`, surfacing the guard as throws. `memory_id` NOT NULL + ON DELETE CASCADE keeps the graph consistent with live state.
- Internal infra — **no CLI/HTTP/SDK** yet (lands with E3.2 recall).

## Why it's unrepresentable (the invariant)

A raw-layer graph reference cannot exist via: graph-table INSERT (trigger + CHECK), graph-table UPDATE (trigger), OR post-insertion mutation of the referenced memory/entity (reverse guards). codex caught the reverse direction that 3 Claude gates (incl an empirical probe) missed.

## Tests

18 new real-DB tests (raw-FK rejection via helper + raw INSERT + raw UPDATE; both reverse guards; CASCADE; cross-tenant; CHECK; name cap). Schema bump 36 -> 37 across 20 sites. Full suite 2372 functional pass (1 flaky `server-concurrency` passes in isolation) + 114 pytest.

## Review

Built via /dev-framework-rl. Gates: plan-eng 90 (retry-1 — caught an INSERT-only guard), code-review 92, independent-review 95 (empirical probe), ship-readiness 96. Cross-model codex review caught a P1 (reverse-mutation bypass) + 2 P2 mutation edges; all fixed at the DB level per operator decision. Ships via merge + CHANGELOG Unreleased. No publish.

## Deferred follow-ups

E3.1 entity extraction (NLP), E3.2 multi-hop recall, the `hippo sleep` enqueue hook, the E3.3 CI lint, and E3.4 graph-quality-under-supersession.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` (2372 functional pass; 1 flaky passes in isolation)
- [x] `pytest` (114 pass)
- [x] schema-version grep-confirmed (zero `.toBe(36)` remain)

Generated with /dev-framework-rl