### PR TITLE
feat: E3.3 criterion-2 CI lint (graph writes funnel through the audited writer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,14 @@
   graph consistent with live consolidated state. This is internal infrastructure (no
   CLI/HTTP/SDK yet); the `hippo sleep` enqueue hook, E3.1 entity extraction, E3.2
   multi-hop recall, and the E3.3 CI lint are deferred follow-ups.
+- E3.3 criterion 2 (CI-level enforcement): `scripts/check-graph-writes.mjs`, wired into
+  `prepublishOnly`, fails the build if any source file other than the sanctioned writer
+  `src/graph.ts` contains a DATA write (`INSERT INTO` / `UPDATE`) to a graph table
+  (`entities`, `relations`, `graph_extraction_queue`). This enforces the
+  single-audited-graph-writer architecture at PR/CI time as defense-in-depth on top of
+  the v37 DB triggers (which remain the airtight runtime backstop). With this, all three
+  E3.3 enforcement layers (DB CHECK + triggers, the consolidated-source queue table, and
+  the CI lint) are in place.
 
 ## 1.15.0 (2026-05-28): E2 decisions first-class object
 

--- a/docs/plans/2026-06-01-e3-graph-write-lint.md
+++ b/docs/plans/2026-06-01-e3-graph-write-lint.md
@@ -1,0 +1,91 @@
+# Plan: E3.3 criterion-2 CI lint (graph writes funnel through the audited writer)
+
+- Date: 2026-06-01
+- Episode: 01KT1WR6GDV9M29TTKC6X091N4 (/dev-framework-rl, project_type=backend)
+- Status: Draft (not yet engineering-reviewed)
+
+## Goal
+
+Complete E3.3's last enforcement layer. The DB-level guard (v37 triggers) + the
+pipeline-level table (graph_extraction_queue) shipped in the prior episode. E3.3's
+success criterion 2 ("lint catches direct-write code paths" / "CI-level: a lint rule
+fails any PR that introduces a code path writing to graph from non-consolidated
+state") is the remaining piece. This ships a lint that enforces the architectural
+invariant: **all writes to the graph tables (`entities`, `relations`,
+`graph_extraction_queue`) funnel through the single audited writer `src/graph.ts`**
+(whose `resolveConsolidatedSource` guard + the DB triggers enforce never-raw). A
+second writer added anywhere else fails the lint at PR/CI time, before the DB guard
+has to catch it at runtime.
+
+## Why a lint when the DB guard is already airtight
+
+Defense-in-depth + fast feedback + architecture. The v37 triggers make a raw-layer
+reference unrepresentable at runtime regardless of code path. The lint adds: (a) PR-
+time feedback (you learn at CI, not at a failing insert), and (b) the
+"single-audited-writer" architectural invariant (every graph write goes through
+`graph.ts`, which applies the helper guard + keeps writes auditable in one place).
+Modest marginal value over the DB guard, but it is the roadmap's stated criterion 2
+and cheap to maintain.
+
+## Design
+
+`scripts/check-graph-writes.mjs` (mirrors `scripts/check-em-dashes-in-release-notes.mjs`):
+
+- Exports `findGraphWriteViolations(srcDir)`: recursively scan `srcDir` for `.ts`
+  files, EXCLUDING the sanctioned writer `src/graph.ts`, and return
+  `[{ file, line, text }]` for every line matching a graph-table DATA write:
+  `/\b(INSERT\s+INTO|UPDATE)\s+(entities|relations|graph_extraction_queue)\b/i`.
+  - Skips comment lines (trimmed line starts with `//`, `*`, or `/*`) to avoid
+    false-matching a comment that mentions the pattern.
+  - Targets DATA writes only: `CREATE TABLE entities`, `BEFORE INSERT ON entities`,
+    `BEFORE UPDATE ON entities`, `SELECT ... FROM entities` do NOT match (the regex
+    needs `INSERT INTO <table>` or `UPDATE <table>`, not `INSERT ON`/`UPDATE ON`/
+    `FROM`), so the v37 migration in `src/db.ts` is naturally clean.
+- A CLI main GUARDED by `if (process.argv[1] && fileURLToPath(import.meta.url) ===
+  process.argv[1])` so importing the module from the test does NOT execute the CLI /
+  `process.exit`. The CLI runs `findGraphWriteViolations('src')`, prints each
+  violation, and `process.exit(1)` if any; else prints OK and exits 0.
+- Wire into `package.json` `prepublishOnly` (after check-em-dashes, before build:all).
+
+## Tests (real, no mocks)
+
+`tests/graph-write-lint.test.ts` (imports the exported fn):
+1. `findGraphWriteViolations('src')` on the REAL src tree returns `[]` (today only
+   `src/graph.ts` writes the graph tables, and it is excluded).
+2. Planted-violation fixture: a temp dir with a clean `.ts` file + a `.ts` file
+   containing `db.prepare('INSERT INTO entities(...)')` and another with `UPDATE
+   relations SET ...` -> the fn flags exactly those lines, not the clean file.
+3. The sanctioned writer is excluded: a fixture `graph.ts` with an `INSERT INTO
+   entities` is NOT flagged.
+4. Comment-skip: a line `// INSERT INTO entities is only allowed in graph.ts` is NOT
+   flagged.
+
+(Plus a manual `node scripts/check-graph-writes.mjs` -> OK at verify.)
+
+## Steps (each verify-checked)
+
+1. scripts/check-graph-writes.mjs (exported fn + guarded CLI main).
+2. package.json prepublishOnly: add `node scripts/check-graph-writes.mjs &&`.
+3. tests/graph-write-lint.test.ts.
+4. CHANGELOG Unreleased entry (em-dash-free).
+5. build + vitest + manual lint run green.
+
+## Risks & mitigations
+
+- False-match in a comment -> skip comment lines (`//`, `*`, `/*`).
+- False-match a different table (e.g. `correlations`) -> word-boundary `\b` +
+  `INSERT INTO`/`UPDATE` prefix make this safe (`correlations` has no `\b` before
+  `relations`).
+- Importing the .mjs in the test must not run the CLI -> guarded main block.
+- Migration data-backfill into a graph table (none today) would be flagged -> correct
+  to flag; allow-list or route through graph.ts if ever needed (noted).
+- NO migration / schema-bump / audit-ops / CLI / HTTP / SDK / Python this slice.
+- codex review cwd-PINNED to hippo; all hippo bash commands cwd-prefixed.
+- Ships via merge; CHANGELOG Unreleased; NO publish.
+
+## Out of scope
+
+- The consolidation enqueue-hook (pairs with E3.1; ships the queue's producer).
+- E3.1 entity extraction, E3.2 multi-hop recall, E3.4 graph-quality-under-supersession.
+- AST-based analysis (a regex lint mirrors the existing check-em-dashes precedent and
+  is sufficient for "no second graph-writer").

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "smoke:openclaw-install": "node scripts/smoke-openclaw-install.mjs",
     "build:ui": "cd ui && npm install && npm run build",
     "build:all": "npm run build && npm run build:ui",
-    "prepublishOnly": "node scripts/check-manifest-versions.mjs && node scripts/check-em-dashes-in-release-notes.mjs && npm run build:all"
+    "prepublishOnly": "node scripts/check-manifest-versions.mjs && node scripts/check-em-dashes-in-release-notes.mjs && node scripts/check-graph-writes.mjs && npm run build:all"
   },
   "keywords": [
     "memory",

--- a/scripts/check-graph-writes.mjs
+++ b/scripts/check-graph-writes.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * E3.3 graph-on-consolidated guard - criterion 2 (CI-level enforcement).
+ *
+ * The graph layer (entities / relations / graph_extraction_queue) must only ever be
+ * written through the single audited writer `src/graph.ts`, whose
+ * `resolveConsolidatedSource` guard + the v37 DB triggers make a raw-layer reference
+ * unrepresentable. This lint enforces the architectural invariant at PR/CI time as
+ * defense-in-depth on top of the runtime DB guard: it fails if any other source file
+ * contains a DATA write (INSERT INTO / UPDATE) to a graph table.
+ *
+ * The DB triggers are the airtight runtime backstop; this is fast PR-time feedback +
+ * the "single graph-writer" rule. Regex-based (mirrors
+ * scripts/check-em-dashes-in-release-notes.mjs); a write split across multiple lines
+ * would slip the line-scan but is still caught at runtime by the DB guard.
+ *
+ * Ticket: ROADMAP-RESEARCH.md E3.3 success criterion 2.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const GRAPH_TABLES = ['entities', 'relations', 'graph_extraction_queue'];
+/** A DATA write to a graph table: `INSERT INTO <table>`, `UPDATE <table>`, or
+ *  `DELETE FROM <table>`. Does NOT match `CREATE TABLE <table>`,
+ *  `BEFORE INSERT ON <table>`, `BEFORE UPDATE ON <table>`, or `SELECT ... FROM <table>`
+ *  (the v37 migration DDL). DELETE is included so the "single graph-writer" rule covers
+ *  all of INSERT/UPDATE/DELETE (code-review 2026-06-01); graph deletes today happen via
+ *  ON DELETE CASCADE, not a direct DELETE, so this flags only a future bypass. */
+// Global + newline-tolerant: `\s+` matches across line breaks, so a write split over
+// multiple lines (`INSERT INTO\n  entities(...)`) is still caught (codex-review
+// 2026-06-01, P2). `g` so we can find every match + its offset for line reporting.
+// Covers SQLite write variants (codex-review 2026-06-01, retry P2): an optional
+// `OR IGNORE|REPLACE|ROLLBACK|ABORT|FAIL` modifier after INSERT, and an optional
+// quoted/bracketed table identifier (`"entities"`, `[entities]`). NOTE: this is a
+// BEST-EFFORT defense-in-depth lint - the v37 DB triggers are the airtight runtime
+// enforcement of the never-raw invariant; a determined bypass (dynamic SQL / string
+// concatenation / schema-qualified `main.entities`) is out of scope for a regex lint
+// and irrelevant to the never-raw guarantee. (Backtick-quoted identifiers cannot occur
+// in this codebase's SQL, which lives inside JS backtick template literals.)
+const WRITE_RE = new RegExp(
+  `\\b(INSERT(\\s+OR\\s+\\w+)?\\s+INTO|UPDATE|DELETE\\s+FROM)\\s+["'\\[]?\\s*(${GRAPH_TABLES.join('|')})\\b`,
+  'gi',
+);
+/** The one sanctioned writer, as a path RELATIVE TO srcDir (exact, not basename): a
+ *  hypothetical `src/sub/graph.ts` is NOT the sanctioned writer and must be linted
+ *  (codex-review 2026-06-01, P2). */
+const SANCTIONED_REL = 'graph.ts';
+
+/**
+ * Blank out comments (block `/* *​/` and line `//`) by replacing their characters with
+ * spaces, PRESERVING newlines + byte offsets, so (a) a comment that merely mentions
+ * the SQL pattern is not a false positive, and (b) match offsets still map to the
+ * original file's line numbers. Naive re: a `//` inside a string literal is also
+ * blanked, but that only matters if such a string also contained a real graph-write
+ * pattern (absurd) - acceptable for a regex lint (mirrors check-em-dashes).
+ */
+function blankComments(text) {
+  let out = text.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+  out = out.replace(/\/\/[^\n]*/g, (m) => ' '.repeat(m.length));
+  return out;
+}
+
+function walk(dir, onFile) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    const s = statSync(p);
+    if (s.isDirectory()) walk(p, onFile);
+    else onFile(p);
+  }
+}
+
+/**
+ * Scan `srcDir` for graph-table DATA writes outside the sanctioned writer
+ * (`<srcDir>/graph.ts`). Catches multi-line writes; ignores comments + DDL.
+ * Returns `[{ file, line, text }]` (empty when clean).
+ */
+export function findGraphWriteViolations(srcDir) {
+  const violations = [];
+  walk(srcDir, (file) => {
+    if (!file.endsWith('.ts')) return;
+    // Allow ONLY the single sanctioned writer at the srcDir root (exact relative path).
+    if (relative(srcDir, file).replace(/\\/g, '/') === SANCTIONED_REL) return;
+    const text = readFileSync(file, 'utf8');
+    const blanked = blankComments(text);
+    const origLines = text.split(/\r?\n/);
+    WRITE_RE.lastIndex = 0;
+    let m;
+    while ((m = WRITE_RE.exec(blanked)) !== null) {
+      // 1-based line of the matched verb (start of the match).
+      const line = blanked.slice(0, m.index).split('\n').length;
+      violations.push({ file, line, text: (origLines[line - 1] ?? m[0]).trim() });
+    }
+  });
+  return violations;
+}
+
+// CLI main. Guarded so importing this module (e.g. from the test) does NOT run the
+// check or process.exit. pathToFileURL(argv[1]) normalises to a file:// URL that
+// matches import.meta.url cross-platform (Windows path separators / drive casing).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const srcDir = process.argv[2] ?? 'src';
+  const violations = findGraphWriteViolations(srcDir);
+  if (violations.length > 0) {
+    console.error('');
+    console.error(`Graph-write violation(s): the graph tables (${GRAPH_TABLES.join(', ')}) may only be`);
+    console.error(`written through the sanctioned writer src/${SANCTIONED_REL}, but found DATA writes elsewhere:`);
+    for (const v of violations) {
+      console.error(`  ${v.file}:${v.line}: ${v.text}`);
+    }
+    console.error('');
+    console.error('Fix: route the write through src/graph.ts (insertEntity / insertRelation /');
+    console.error('enqueueExtraction), which applies the consolidated-source guard. The graph must');
+    console.error('never index the raw layer (ROADMAP-RESEARCH E3.3).');
+    console.error('');
+    process.exit(1);
+  }
+  console.log(`No graph-write violations in ${srcDir}/. All graph writes funnel through src/${SANCTIONED_REL}. OK.`);
+}

--- a/tests/graph-write-lint.test.ts
+++ b/tests/graph-write-lint.test.ts
@@ -1,0 +1,100 @@
+/**
+ * E3.3 criterion-2 CI lint - tests for scripts/check-graph-writes.mjs.
+ * Docs: docs/plans/2026-06-01-e3-graph-write-lint.md
+ *
+ * The lint enforces: graph tables (entities/relations/graph_extraction_queue) may only
+ * be written through the sanctioned src/graph.ts. These tests pin the detection +
+ * the false-positive exclusions (sanctioned writer, comment lines, name substrings).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// Imported from the .mjs lint script; the CLI main is guarded so this import does
+// NOT run the check or process.exit.
+import { findGraphWriteViolations } from '../scripts/check-graph-writes.mjs';
+
+describe('check-graph-writes lint (E3.3 criterion 2)', () => {
+  it('the real src/ tree is clean (only src/graph.ts writes the graph tables, and it is excluded)', () => {
+    expect(findGraphWriteViolations('src')).toEqual([]);
+  });
+
+  describe('fixture behavior', () => {
+    let dir: string;
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'graph-lint-')); });
+    afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+    function file(name: string, body: string): void {
+      const p = join(dir, name);
+      mkdirSync(join(p, '..'), { recursive: true });
+      writeFileSync(p, body, 'utf8');
+    }
+
+    it('flags INSERT INTO / UPDATE of graph tables in a non-sanctioned file', () => {
+      file('clean.ts', `export const x = 1;\nconst q = db.prepare('SELECT * FROM entities WHERE id = ?');\n`);
+      file('bad-insert.ts', `db.prepare(\`INSERT INTO entities(tenant_id, name) VALUES (?, ?)\`).run(t, n);\n`);
+      file('bad-update.ts', `db.prepare('UPDATE relations SET rel_type = ? WHERE id = ?').run(r, id);\n`);
+      const v = findGraphWriteViolations(dir);
+      const files = v.map((x) => x.file.replace(/\\/g, '/'));
+      expect(files.some((f) => f.endsWith('bad-insert.ts'))).toBe(true);
+      expect(files.some((f) => f.endsWith('bad-update.ts'))).toBe(true);
+      expect(files.some((f) => f.endsWith('clean.ts'))).toBe(false); // SELECT FROM is not a write
+      expect(v.length).toBe(2);
+    });
+
+    it('does NOT flag the sanctioned src/graph.ts (exact relative path), but DOES flag subgraph.ts AND a subdir graph.ts', () => {
+      file('graph.ts', `db.prepare('INSERT INTO entities(name) VALUES (?)').run(n);\n`);
+      file('subgraph.ts', `db.prepare('INSERT INTO relations(rel_type) VALUES (?)').run(r);\n`);
+      file('connectors/graph.ts', `db.prepare('INSERT INTO entities(name) VALUES (?)').run(n);\n`); // a DIFFERENT graph.ts, not sanctioned
+      const files = findGraphWriteViolations(dir).map((x) => x.file.replace(/\\/g, '/'));
+      expect(files.some((f) => f.endsWith('/graph.ts') && !f.includes('connectors'))).toBe(false);
+      expect(files.some((f) => f.endsWith('subgraph.ts'))).toBe(true);
+      expect(files.some((f) => f.endsWith('connectors/graph.ts'))).toBe(true); // subdir graph.ts IS linted
+    });
+
+    it('catches a MULTI-LINE write (verb and table on separate lines) - codex P2', () => {
+      file('multiline.ts', `db.prepare(\`\n  INSERT INTO\n  entities(name)\n  VALUES (?)\`).run(n);\n`);
+      const v = findGraphWriteViolations(dir);
+      expect(v.length).toBe(1);
+      expect(v[0].file.replace(/\\/g, '/').endsWith('multiline.ts')).toBe(true);
+    });
+
+    it('catches SQLite write variants: INSERT OR IGNORE/REPLACE + quoted/bracketed identifiers - codex retry P2', () => {
+      file('or-ignore.ts', `db.prepare('INSERT OR IGNORE INTO entities(name) VALUES (?)').run(n);\n`);
+      file('or-replace.ts', `db.prepare('INSERT OR REPLACE INTO relations(rel_type) VALUES (?)').run(r);\n`);
+      file('quoted.ts', `db.prepare('INSERT INTO "entities"(name) VALUES (?)').run(n);\n`);
+      file('bracketed.ts', `db.prepare('UPDATE [graph_extraction_queue] SET status = ?').run(s);\n`);
+      const files = findGraphWriteViolations(dir).map((x) => x.file.replace(/\\/g, '/'));
+      for (const f of ['or-ignore.ts', 'or-replace.ts', 'quoted.ts', 'bracketed.ts']) {
+        expect(files.some((x) => x.endsWith(f)), `expected ${f} flagged`).toBe(true);
+      }
+    });
+
+    it('does NOT flag comments (block /* */ + line //) that merely mention the pattern', () => {
+      file('doc.ts', `/*\n * UPDATE graph_extraction_queue is off-limits here\n * only graph.ts may INSERT INTO entities\n */\n// DELETE FROM relations is also only allowed in graph.ts\nexport const y = 2;\n`);
+      expect(findGraphWriteViolations(dir)).toEqual([]);
+    });
+
+    it('does NOT false-match a table whose name contains a graph-table name (correlations)', () => {
+      file('corr.ts', `db.prepare('INSERT INTO correlations(a, b) VALUES (?, ?)').run(a, b);\nconst u = 'UPDATE correlations SET a = ?';\n`);
+      expect(findGraphWriteViolations(dir)).toEqual([]);
+    });
+
+    it('flags DELETE FROM a graph table (the single-writer rule covers INSERT/UPDATE/DELETE)', () => {
+      file('bad-delete.ts', `db.prepare('DELETE FROM entities WHERE id = ?').run(id);\n`);
+      const v = findGraphWriteViolations(dir);
+      expect(v.length).toBe(1);
+      expect(v[0].file.replace(/\\/g, '/').endsWith('bad-delete.ts')).toBe(true);
+    });
+
+    it('does NOT flag DDL forms (CREATE TABLE / BEFORE INSERT ON / BEFORE UPDATE ON)', () => {
+      file('ddl.ts', [
+        `db.exec('CREATE TABLE entities (id INTEGER PRIMARY KEY)');`,
+        `db.exec('CREATE TRIGGER t BEFORE INSERT ON entities BEGIN SELECT 1; END');`,
+        `db.exec('CREATE TRIGGER u BEFORE UPDATE ON relations BEGIN SELECT 1; END');`,
+      ].join('\n') + '\n');
+      expect(findGraphWriteViolations(dir)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Completes the **E3.3 graph-on-consolidated guard**'s last enforcement layer. The DB-level triggers (v37) + the `graph_extraction_queue` shipped already; this adds the **CI-level single-writer rule**: `scripts/check-graph-writes.mjs` fails the build if any source file other than the sanctioned `src/graph.ts` writes (INSERT/UPDATE/DELETE) to a graph table.

With this, all three E3.3 enforcement layers are in place: **DB** (CHECK + INSERT/UPDATE/reverse triggers), **pipeline** (the consolidated-source queue table), and **CI** (this lint).

## Surface

- **`scripts/check-graph-writes.mjs`**: exports `findGraphWriteViolations(srcDir)` + a guarded CLI main; wired into `package.json` `prepublishOnly` (mirrors `check-em-dashes`). Catches SQLite write variants (`INSERT OR IGNORE/REPLACE`, quoted/bracketed identifiers) and multi-line writes; excludes exactly `src/graph.ts` (not any basename), comments, and DDL.
- **`tests/graph-write-lint.test.ts`**: 9 real-fixture tests (detection incl variants + multi-line; exclusions: sanctioned writer, comments, `correlations`, DDL; a real-`src/`-clean regression guard).

## Best-effort by design

This is **defense-in-depth**: the v37 DB triggers are the airtight never-raw *runtime* enforcement; the lint is the single-writer *architectural* guard-rail. A regex lint can't enumerate every SQL-write form (dynamic SQL / string concat / schema-qualified are out of scope) — documented in the script. It catches the casual/accidental second-writer at PR time.

## Review

Built via /dev-framework-rl. Gates: plan-eng 88, code-review 88, independent-review pass, ship-readiness 96. Cross-model codex review caught 3 P2 regex-completeness edges over 2 rounds (multi-line, basename-vs-exact-path, SQLite variants); all fixed per operator decision at the review cap. The manual CLI run also caught a const-rename bug the tests missed. Ships via merge + CHANGELOG Unreleased. No publish.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run tests/graph-write-lint.test.ts` (9 pass)
- [x] full suite 2377 functional pass (no src/.ts changed)
- [x] `node scripts/check-graph-writes.mjs` -> OK (clean), planted violation -> exit 1

Generated with /dev-framework-rl