### PR TITLE
feat: E3.1 deterministic entity extraction (hippo graph extract)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,17 @@
   the v37 DB triggers (which remain the airtight runtime backstop). With this, all three
   E3.3 enforcement layers (DB CHECK + triggers, the consolidated-source queue table, and
   the CI lint) are in place.
+- E3.1 deterministic entity extraction (first slice): `hippo graph extract` populates the
+  graph from the already-structured consolidated E2 objects, with NO LLM/NLP. It is an
+  idempotent rebuild (`extractGraph` in `src/graph-extract.ts`, backed by a new
+  `clearGraph` in `src/graph.ts`): it clears the tenant's graph and re-derives one entity
+  per active-or-superseded decision (`decision`), policy (`policy`), customer_note
+  (`customer`), and project_brief (`project`) - the four E2 types matching the
+  `entity_type` enum - plus a `supersedes` relation along each supersede chain. All writes
+  go through the consolidated-source guard. Closed objects and objects whose source memory
+  was forgotten (NULL `memory_id`) are excluded. The NLP prose-extraction path (the
+  gold-set/precision work), `skill`/`incident`/`process` entities, the `hippo sleep`
+  enqueue hook, and E3.2 multi-hop recall are deferred follow-ups.
 
 ## 1.15.0 (2026-05-28): E2 decisions first-class object
 

--- a/docs/plans/2026-06-01-e3-deterministic-extraction.md
+++ b/docs/plans/2026-06-01-e3-deterministic-extraction.md
@@ -1,0 +1,126 @@
+# Plan: E3.1 deterministic entity extraction (first slice)
+
+- Date: 2026-06-01
+- Episode: 01KT2023EGD1F7J52FKAJ4D40D (/dev-framework-rl, project_type=backend)
+- Status: Draft (not yet engineering-reviewed)
+
+## Goal
+
+Populate the E3 graph (built + guarded in the E3.3 episodes) from the already-
+structured consolidated E2 objects, DETERMINISTICALLY (no NLP, no 80%-precision gate).
+This is the first slice of E3.1 ("entity extraction at sleep") - the structured-object
+path. The NLP prose-extraction (extracting entities from raw/distilled prose memories,
+the 12d gold-set part) is the deferred follow-up. This slice makes the graph real +
+queryable so E3.2 multi-hop recall has something to traverse.
+
+## Design
+
+### `src/graph.ts`: add `clearGraph(hippoRoot, tenantId): number`
+
+DELETE FROM entities WHERE tenant_id = ? (relations cascade via the FK). Returns the
+deleted entity count. Lives in graph.ts (the sanctioned graph writer), so the E3.3
+CI lint allows its `DELETE FROM entities`. This is the rebuild primitive.
+
+### `src/graph-extract.ts` (NEW): `extractGraph(hippoRoot, tenantId): ExtractResult`
+
+Idempotent REBUILD: the graph is a pure derived function of the current E2 state.
+1. `clearGraph(tenantId)` - wipe the tenant's deterministic graph.
+2. For each of the 4 E2-object types whose type matches the `entity_type` enum, load
+   ACTIVE + SUPERSEDED rows (exclude `closed` = retired), up to
+   `MAX_EXTRACT_PER_TYPE = 10000` each (documented bound; the default loader limit is
+   100). Skip rows with a NULL `memory_id` (forgotten source - cannot reference).
+   For each, `insertEntity({ entityType, name, memoryId })` (the guard enforces the
+   consolidated source). Record `entityIdByKey[(type, e2Id)] = entity.id`.
+
+   | E2 table        | entity_type | name field      |
+   |-----------------|-------------|-----------------|
+   | decisions       | `decision`  | `decisionText`  |
+   | policies        | `policy`    | `policyName`    |
+   | customer_notes  | `customer`  | `customer`      |
+   | project_briefs  | `project`   | `repo`          |
+
+   (`skill` / `incident` / `process` are NOT in the entity_type enum, so they are out
+   of this slice - adding them needs an enum expansion, deferred.)
+3. `supersedes` relations: for each loaded object X with `supersededBy = Y` (Y is the
+   SUCCESSOR), if BOTH X and Y were extracted to entities, `insertRelation({
+   fromEntityId: entityOf(Y), toEntityId: entityOf(X), relType: 'supersedes',
+   memoryId: Y.memoryId })` - Y supersedes X. Skip if either entity is missing (e.g.
+   Y is `closed`). The entity name is TRUNCATED to MAX_ENTITY_NAME_LEN (512) in the
+   extractor before insertEntity (the E2 name fields are uncapped at source and
+   insertEntity REJECTS, not truncates, an over-cap name - which after clearGraph would
+   brick the rebuild; codex + independent-review 2026-06-01).
+4. Return `{ entities, relations, byType: { decision, policy, customer, project } }`.
+
+`graph-extract.ts` calls only the `graph.ts` helpers (insertEntity / insertRelation /
+clearGraph) + the E2 loaders - NO raw SQL - so the E3.3 lint stays clean.
+
+### `src/cli.ts`: `hippo graph extract`
+
+`cmdGraph` (keyword `graph`, confirmed free): subcommand `extract` -> `extractGraph`,
+print the counts (`Extracted N entities (decision a, policy b, customer c, project d)
++ M supersedes relations.`). Operator-invoked; idempotent (safe to re-run).
+
+## Idempotency + atomicity (grill-acknowledged)
+
+- Rebuild => `extractGraph` output is a pure function of current E2 state; re-running
+  yields the same graph (tested). Because this is the SOLE graph producer today, a
+  full clear-and-rebuild is correct. NOTE: when a second producer (NLP E3.1) lands,
+  extraction will need a `source`/`origin` marker so the rebuild scopes to only the
+  deterministically-extracted rows; flagged, not built now.
+- The clear + inserts run across graph.ts's per-call DB connections (not one txn). A
+  mid-extract crash leaves a partial graph; a re-run rebuilds it cleanly (idempotent).
+  Acceptable for a derived, operator-rebuilt graph; a transactional batch API is a
+  future optimisation, not needed for correctness here.
+
+## Tests (real DB, no mocks) - `tests/graph-extract.test.ts`
+
+- Seed via the real save APIs: decisions (incl a v1->v2 supersede chain), a policy, a
+  customer_note, a project_brief. `extractGraph` -> assert per-type entity counts +
+  the entity_type/name mapping + a `supersedes` relation for the chain (from v2 to v1).
+- Idempotency: run `extractGraph` twice -> identical counts, no duplicate entities.
+- Excludes `closed`: a closed decision -> no entity.
+- Skips NULL memory_id: a decision whose memory was deleted (ON DELETE SET NULL) -> no
+  entity (and no crash).
+- `supersedes` skipped when the successor is not an entity (e.g. closed).
+- `clearGraph`: returns the count + cascades relations (entities + relations both 0
+  after).
+- Entities reference consolidated (non-raw) memories (inherited from the guard; the
+  E2 mirrors are `distilled`).
+
+## Steps (each verify-checked)
+
+1. src/graph.ts: add `clearGraph`.
+2. src/graph-extract.ts: `extractGraph` + `MAX_EXTRACT_PER_TYPE` + `ExtractResult`.
+3. src/cli.ts: `cmdGraph` + dispatch (`graph`) + help + example.
+4. tests/graph-extract.test.ts.
+5. CHANGELOG Unreleased entry (em-dash-free).
+6. build + vitest (+ the E3.3 lint still passes: graph-extract.ts uses helpers, no raw SQL).
+
+## Risks & mitigations
+
+- Rebuild wipes all graph rows: correct as sole producer; `source` marker noted for the
+  NLP follow-up.
+- Non-atomic clear+insert: idempotent re-run fixes a partial graph; acceptable.
+- Loader default limit 100: extractor passes `MAX_EXTRACT_PER_TYPE = 10000`; documented
+  bound (a tenant with >10k of one E2 type would under-extract - log/note, not a
+  realistic case now).
+- id collision across E2 tables: the entity map is keyed by `(entityType, e2Id)`, not
+  bare id, so a decision #1 and a policy #1 don't collide.
+- NULL memory_id (forgotten source): skipped (entities.memory_id is NOT NULL).
+- E3.3 lint: graph-extract.ts uses graph.ts helpers (no raw SQL); clearGraph's DELETE
+  lives in the sanctioned graph.ts. Lint stays green.
+- NO schema/migration/audit-ops change. Reuses the v37 guard.
+- codex review cwd-PINNED; all hippo bash commands cwd-prefixed.
+- Ships via merge; CHANGELOG Unreleased; NO publish.
+
+## Out of scope
+
+- NLP prose-extraction from raw/distilled memories (the 80%-precision gold-set): the
+  big E3.1 follow-up. This slice is the deterministic structured-object path.
+- `skill` / `incident` / `process` entities (need an entity_type enum expansion).
+- Cross-object relations beyond `supersedes` (e.g. customer_note -> customer
+  `references`, incident -> linked_memory_ids): future.
+- The `hippo sleep` enqueue-hook + auto-extract-on-sleep (this is operator-invoked
+  `hippo graph extract` for now).
+- E3.2 multi-hop recall (the operator query surface): next, enabled by this.
+- `hippo graph stats`/`list` view commands: not needed (extract prints its counts).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -166,6 +166,7 @@ import * as policiesModule from './policies.js';
 import * as skillsModule from './skills.js';
 import * as briefsModule from './project-briefs.js';
 import * as customerNotesModule from './customer-notes.js';
+import { extractGraph } from './graph-extract.js';
 import { createHash } from 'node:crypto';
 import {
   detectAnchoring,
@@ -4794,6 +4795,31 @@ function noteUsage(): void {
   console.error('       hippo note close <id>');
 }
 
+function cmdGraph(
+  hippoRoot: string,
+  args: string[],
+  _flags: Record<string, string | boolean | string[]>
+): void {
+  requireInit(hippoRoot);
+  const tenantId = resolveTenantId({});
+  const subcommand = args[0] ?? '';
+
+  if (subcommand === 'extract') {
+    const result = extractGraph(hippoRoot, tenantId);
+    const byType = Object.entries(result.byType)
+      .map(([t, n]) => `${t} ${n}`)
+      .join(', ');
+    console.log(`Graph extracted: ${result.entities} entities (${byType}) + ${result.relations} supersedes relations.`);
+    if (result.truncated.length > 0) {
+      console.error(`WARNING: under-extracted (hit the per-type cap): ${result.truncated.join(', ')}. The graph is incomplete for those types.`);
+    }
+    return;
+  }
+
+  console.error('Usage: hippo graph extract   (rebuild the entity/relation graph from consolidated decisions/policies/customer-notes/project-briefs)');
+  process.exit(1);
+}
+
 function cmdCustomerNote(
   hippoRoot: string,
   args: string[],
@@ -7436,6 +7462,8 @@ Commands:
     --text "<note>"        The new note body (required)
     --change "<summary>"   What changed in this version (the delta note)
   note close <id>          Retire (close) an active customer note by its table id
+  graph extract            Rebuild the entity/relation graph from consolidated objects
+                           (decisions/policies/customer-notes/project-briefs); idempotent
   invalidate "<pattern>"   Actively weaken memories matching an old pattern
     --reason "<why>"       Optional: what replaced it
   wm <sub>                 Working memory — bounded buffer for current state
@@ -7527,6 +7555,7 @@ Examples:
   hippo brief refresh "hippo"
   hippo note new "Acme Corp" --text "Renewal call: wants SSO before Q3; champion is the VP Eng"
   hippo note list --customer "Acme Corp" --status active
+  hippo graph extract
   hippo invalidate "REST API" --reason "migrated to GraphQL"
   hippo export memories.json
   hippo export --format markdown memories.md
@@ -8187,6 +8216,10 @@ async function main(): Promise<void> {
     case 'note':
     case 'customer-note':
       cmdCustomerNote(hippoRoot, args, flags);
+      break;
+
+    case 'graph':
+      cmdGraph(hippoRoot, args, flags);
       break;
 
     case 'help':

--- a/src/graph-extract.ts
+++ b/src/graph-extract.ts
@@ -1,0 +1,176 @@
+/**
+ * E3.1 deterministic entity extraction (first slice)
+ * (docs/plans/2026-06-01-e3-deterministic-extraction.md).
+ *
+ * Populates the E3 graph from the already-structured consolidated E2-object tables -
+ * NO NLP, no precision gate. The graph is a pure derived function of the current E2
+ * state, so `extractGraph` is an idempotent REBUILD: clear the tenant's graph, then
+ * re-derive entities + `supersedes` relations from decisions / policies /
+ * customer_notes / project_briefs (the four E2 types whose kind maps to the
+ * `entity_type` enum). All writes go through the src/graph.ts consolidated-source
+ * guard (insertEntity / insertRelation / clearGraph); this module issues no raw SQL.
+ *
+ * Deferred (follow-ups): NLP prose-extraction from raw/distilled memories (the
+ * 80%-precision gold-set part); skill/incident/process entities (not in the
+ * entity_type enum); cross-object relations beyond supersedes; the `hippo sleep`
+ * enqueue-hook; E3.2 multi-hop recall. When a SECOND producer (NLP) lands, extraction
+ * will need a `source` marker so the rebuild scopes to only the deterministically-
+ * extracted rows.
+ */
+
+import { clearGraph, insertEntity, insertRelation, MAX_ENTITY_NAME_LEN, type EntityType } from './graph.js';
+import { loadDecisions } from './decisions.js';
+import { loadPolicies } from './policies.js';
+import { loadCustomerNotes } from './customer-notes.js';
+import { loadProjectBriefs } from './project-briefs.js';
+import { assertTenantId } from './store.js';
+
+/** Per-type load cap (the loaders default to 100). A type whose active or superseded
+ *  set exceeds this is truncated; `ExtractResult.truncated` records it so the
+ *  incompleteness is observable rather than silent. */
+export const MAX_EXTRACT_PER_TYPE = 10000;
+
+export interface ExtractResult {
+  entities: number;
+  relations: number;
+  /** Entity count per extracted type. */
+  byType: Record<string, number>;
+  /** Entity types whose active or superseded load hit MAX_EXTRACT_PER_TYPE (the graph
+   *  is under-extracted for those). */
+  truncated: string[];
+}
+
+/** A consolidated E2 row normalised to the fields extraction needs. */
+interface ExtractRow {
+  entityType: EntityType;
+  /** The E2 table id (unique only WITHIN its table, hence keyed with entityType). */
+  e2Id: number;
+  name: string;
+  memoryId: string | null;
+  /** The successor's E2 id (Y) when this row (X) is superseded; null otherwise. */
+  supersededBy: number | null;
+}
+
+/** Stable map key: entity types share an id space across tables, so key by both. */
+function keyOf(entityType: EntityType, e2Id: number): string {
+  return `${entityType}:${e2Id}`;
+}
+
+/**
+ * Load a type's ACTIVE + SUPERSEDED rows (excluding `closed` = retired), normalised.
+ * Calls the loader once per status so MAX_EXTRACT_PER_TYPE is a per-status budget
+ * (closed rows never consume it). Sets `hitCap` when either status load is full.
+ */
+function loadType(
+  hippoRoot: string,
+  tenantId: string,
+  entityType: EntityType,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  loadFn: (root: string, tenant: string, opts: any) => any[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nameOf: (row: any) => string,
+): { rows: ExtractRow[]; hitCap: boolean } {
+  const rows: ExtractRow[] = [];
+  let hitCap = false;
+  for (const status of ['active', 'superseded'] as const) {
+    const loaded = loadFn(hippoRoot, tenantId, { status, limit: MAX_EXTRACT_PER_TYPE });
+    if (loaded.length === MAX_EXTRACT_PER_TYPE) hitCap = true;
+    for (const r of loaded) {
+      rows.push({
+        entityType,
+        e2Id: r.id as number,
+        name: nameOf(r),
+        memoryId: (r.memoryId ?? null) as string | null,
+        supersededBy: (r.supersededBy ?? null) as number | null,
+      });
+    }
+  }
+  return { rows, hitCap };
+}
+
+/**
+ * Idempotent rebuild of the tenant's deterministic graph from its consolidated E2
+ * objects. Returns the entity/relation counts (+ which types were truncated at the
+ * per-type cap). Safe to re-run: output is a pure function of the current E2 state.
+ */
+export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult {
+  assertTenantId('extractGraph', tenantId);
+
+  const sources: Array<{
+    entityType: EntityType;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    loadFn: (root: string, tenant: string, opts: any) => any[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    nameOf: (row: any) => string;
+  }> = [
+    { entityType: 'decision', loadFn: loadDecisions, nameOf: (r) => r.decisionText },
+    { entityType: 'policy', loadFn: loadPolicies, nameOf: (r) => r.policyName },
+    { entityType: 'customer', loadFn: loadCustomerNotes, nameOf: (r) => r.customer },
+    { entityType: 'project', loadFn: loadProjectBriefs, nameOf: (r) => r.repo },
+  ];
+
+  // Rebuild from scratch: the graph is derived, so clear then re-derive.
+  clearGraph(hippoRoot, tenantId);
+
+  const byType: Record<string, number> = {};
+  const truncated: string[] = [];
+  const allRows: ExtractRow[] = [];
+  const entityIdByKey = new Map<string, number>();
+  const memoryIdByKey = new Map<string, string>();
+
+  // Pass 1: entities. Skip rows whose source memory was forgotten (NULL memory_id) -
+  // an entity must reference a consolidated memory (entities.memory_id is NOT NULL).
+  for (const src of sources) {
+    const { rows, hitCap } = loadType(hippoRoot, tenantId, src.entityType, src.loadFn, src.nameOf);
+    if (hitCap) truncated.push(src.entityType);
+    byType[src.entityType] = 0;
+    for (const row of rows) {
+      allRows.push(row);
+      if (row.memoryId === null) continue;
+      // Normalise the label so a long/odd-but-valid E2 name can never throw in
+      // insertEntity and (because clearGraph already ran) brick the rebuild
+      // unrebuildably. E2 name fields (decisionText / policyName) are UNCAPPED at
+      // source, and insertEntity REJECTS (not truncates) both an over-cap name AND an
+      // empty one. So: TRIM FIRST (codex 2026-06-01: >512 leading-whitespace chars
+      // would otherwise slice to a whitespace-only string -> trimmed to '' ->
+      // 'name is required' throw), THEN cap to MAX_ENTITY_NAME_LEN; if the normalised
+      // label is empty (the E2 save APIs forbid this, but be defensive) skip the row
+      // rather than throw. This closes the entire name-brick class.
+      const name = (row.name ?? '').trim().slice(0, MAX_ENTITY_NAME_LEN);
+      if (name.length === 0) continue;
+      const entity = insertEntity(hippoRoot, tenantId, {
+        entityType: row.entityType,
+        name,
+        memoryId: row.memoryId,
+      });
+      const k = keyOf(row.entityType, row.e2Id);
+      entityIdByKey.set(k, entity.id);
+      memoryIdByKey.set(k, row.memoryId);
+      byType[src.entityType] += 1;
+    }
+  }
+
+  // Pass 2: `supersedes` relations. For X superseded by Y (Y is the successor), emit
+  // "Y supersedes X" - but only when BOTH X and Y were extracted (e.g. Y may be closed
+  // and absent). The relation is sourced from Y's consolidated memory.
+  let relations = 0;
+  for (const row of allRows) {
+    if (row.supersededBy === null) continue;
+    const xKey = keyOf(row.entityType, row.e2Id);
+    const yKey = keyOf(row.entityType, row.supersededBy);
+    const fromId = entityIdByKey.get(yKey); // successor Y
+    const toId = entityIdByKey.get(xKey); // superseded X
+    const yMemoryId = memoryIdByKey.get(yKey);
+    if (fromId === undefined || toId === undefined || yMemoryId === undefined) continue;
+    insertRelation(hippoRoot, tenantId, {
+      fromEntityId: fromId,
+      toEntityId: toId,
+      relType: 'supersedes',
+      memoryId: yMemoryId,
+    });
+    relations += 1;
+  }
+
+  const entities = Array.from(entityIdByKey.keys()).length;
+  return { entities, relations, byType, truncated };
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -440,3 +440,22 @@ export function markExtractionProcessed(
     closeHippoDb(db);
   }
 }
+
+/**
+ * Delete ALL entities for a tenant (relations cascade via the from/to FKs). Returns
+ * the number of entities deleted. The rebuild primitive for graph extraction: the
+ * deterministic graph is a pure derived function of the consolidated objects, so an
+ * extract clears then re-derives. Lives in graph.ts (the sole sanctioned graph
+ * writer), so the E3.3 CI lint permits this `DELETE FROM entities`. Does NOT touch
+ * graph_extraction_queue (the enqueue-hook's domain).
+ */
+export function clearGraph(hippoRoot: string, tenantId: string): number {
+  assertTenantId('clearGraph', tenantId);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const res = db.prepare(`DELETE FROM entities WHERE tenant_id = ?`).run(tenantId);
+    return Number(res.changes ?? 0);
+  } finally {
+    closeHippoDb(db);
+  }
+}

--- a/tests/graph-extract.test.ts
+++ b/tests/graph-extract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * E3.1 deterministic entity extraction - tests.
+ * Docs: docs/plans/2026-06-01-e3-deterministic-extraction.md
+ *
+ * extractGraph rebuilds the graph from the consolidated E2 objects (decision/policy/
+ * customer_note/project_brief -> entities + supersedes relations). Real DB, no mocks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, deleteEntry } from '../src/store.js';
+import { saveDecision, closeDecision } from '../src/decisions.js';
+import { savePolicy } from '../src/policies.js';
+import { saveCustomerNote } from '../src/customer-notes.js';
+import { saveProjectBrief } from '../src/project-briefs.js';
+import { loadEntities, loadRelations } from '../src/graph.js';
+import { extractGraph } from '../src/graph-extract.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graph-extract-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+function entityCount(home: string): number {
+  const db = openHippoDb(home);
+  try { return (db.prepare(`SELECT COUNT(*) c FROM entities`).get() as { c: number }).c; }
+  finally { closeHippoDb(db); }
+}
+
+describe('graph extraction (E3.1 deterministic, from consolidated E2 objects)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('extracts entities (4 types) + a supersedes relation; excludes closed; idempotent', () => {
+    // decision v1 -> superseded by v2 (active)
+    const d1 = saveDecision(home, 'default', { decisionText: 'Adopt Postgres' });
+    const d2 = saveDecision(home, 'default', { decisionText: 'Adopt Postgres (managed)', supersedesDecisionId: d1.id });
+    // a closed decision (must be excluded)
+    const dc = saveDecision(home, 'default', { decisionText: 'Retired idea' });
+    closeDecision(home, 'default', dc.id);
+    // one of each other type
+    savePolicy(home, 'default', { policyName: 'Data retention', policyText: 'Delete logs after 90 days' });
+    saveCustomerNote(home, 'default', { customer: 'Acme Corp', note: 'renewal in Q3' });
+    saveProjectBrief(home, 'default', { repo: 'hippo', summary: 'agent-memory lib' });
+
+    const r = extractGraph(home, 'default');
+    expect(r.byType).toEqual({ decision: 2, policy: 1, customer: 1, project: 1 }); // dc excluded
+    expect(r.entities).toBe(5);
+    expect(r.relations).toBe(1);
+    expect(r.truncated).toEqual([]);
+
+    const ents = loadEntities(home, 'default', { limit: 100 });
+    expect(ents.length).toBe(5);
+    expect(ents.filter((e) => e.entityType === 'decision').length).toBe(2);
+    expect(ents.some((e) => e.entityType === 'policy' && e.name === 'Data retention')).toBe(true);
+    expect(ents.some((e) => e.entityType === 'customer' && e.name === 'Acme Corp')).toBe(true);
+    expect(ents.some((e) => e.entityType === 'project' && e.name === 'hippo')).toBe(true);
+    expect(ents.some((e) => e.name === 'Retired idea')).toBe(false); // closed excluded
+
+    // the supersedes relation: v2 supersedes v1
+    const e1 = ents.find((e) => e.name === 'Adopt Postgres')!;
+    const e2 = ents.find((e) => e.name === 'Adopt Postgres (managed)')!;
+    const rels = loadRelations(home, 'default', { limit: 100 });
+    expect(rels.length).toBe(1);
+    expect(rels[0].relType).toBe('supersedes');
+    expect(rels[0].fromEntityId).toBe(e2.id); // successor
+    expect(rels[0].toEntityId).toBe(e1.id);   // superseded
+
+    // idempotent: re-running rebuilds to the same graph (no duplication)
+    const r2 = extractGraph(home, 'default');
+    expect(r2.entities).toBe(5);
+    expect(r2.relations).toBe(1);
+    expect(loadEntities(home, 'default', { limit: 100 }).length).toBe(5);
+    expect(loadRelations(home, 'default', { limit: 100 }).length).toBe(1);
+  });
+
+  it('skips an E2 object whose source memory was forgotten (NULL memory_id)', () => {
+    const dn = saveDecision(home, 'default', { decisionText: 'Will lose its memory' });
+    deleteEntry(home, dn.memoryId!); // distilled delete is allowed; decisions.memory_id -> NULL
+    saveDecision(home, 'default', { decisionText: 'Keeps its memory' });
+    const r = extractGraph(home, 'default');
+    expect(r.byType.decision).toBe(1); // only the one with a live memory
+    const names = loadEntities(home, 'default', { limit: 100 }).map((e) => e.name);
+    expect(names).toContain('Keeps its memory');
+    expect(names).not.toContain('Will lose its memory');
+  });
+
+  it('skips a supersedes relation when the successor is not extracted (closed)', () => {
+    // d1 superseded by d2, then d2 closed -> d1 superseded (extracted), d2 closed (not)
+    const d1 = saveDecision(home, 'default', { decisionText: 'orig' });
+    const d2 = saveDecision(home, 'default', { decisionText: 'replacement', supersedesDecisionId: d1.id });
+    closeDecision(home, 'default', d2.id);
+    const r = extractGraph(home, 'default');
+    // d1 (superseded) extracted; d2 (closed) excluded -> no relation (successor missing)
+    expect(r.byType.decision).toBe(1);
+    expect(r.relations).toBe(0);
+  });
+
+  it('rebuild reflects current state: a brand-new object appears, a closed one disappears, on re-extract', () => {
+    const d = saveDecision(home, 'default', { decisionText: 'first' });
+    extractGraph(home, 'default');
+    expect(entityCount(home)).toBe(1);
+    saveDecision(home, 'default', { decisionText: 'second' });
+    closeDecision(home, 'default', d.id);
+    const r = extractGraph(home, 'default');
+    expect(r.byType.decision).toBe(1); // 'second' present, 'first' (now closed) gone
+    expect(loadEntities(home, 'default', { limit: 100 }).map((e) => e.name)).toEqual(['second']);
+  });
+
+  it('truncates an over-cap E2 name instead of throwing + bricking the rebuild (codex/independent-review)', () => {
+    // decisionText is uncapped at source; a >512-char one must NOT throw in insertEntity
+    // (which would leave the cleared graph empty + unrebuildable). It is truncated.
+    const longText = 'D' + 'x'.repeat(700);
+    saveDecision(home, 'default', { decisionText: longText });
+    saveDecision(home, 'default', { decisionText: 'short one' });
+    const r = extractGraph(home, 'default'); // must not throw
+    expect(r.byType.decision).toBe(2);
+    const ents = loadEntities(home, 'default', { limit: 100 });
+    const longEnt = ents.find((e) => e.name.startsWith('Dxxx'))!;
+    expect(longEnt).toBeDefined();
+    expect(longEnt.name.length).toBeLessThanOrEqual(512);
+    // re-run still works (not bricked)
+    expect(() => extractGraph(home, 'default')).not.toThrow();
+    expect(loadEntities(home, 'default', { limit: 100 }).length).toBe(2);
+  });
+
+  it('trims leading whitespace before capping (codex R2: a long whitespace-prefix name must not brick)', () => {
+    const d = saveDecision(home, 'default', { decisionText: 'placeholder' });
+    // Inject a name whose first 512 chars are whitespace (slice-without-trim would
+    // yield a whitespace-only label -> insertEntity trims to '' -> throws -> brick).
+    const db = openHippoDb(home);
+    try {
+      db.prepare(`UPDATE decisions SET decision_text = ? WHERE id = ?`).run(' '.repeat(600) + 'real decision', d.id);
+    } finally { closeHippoDb(db); }
+    const r = extractGraph(home, 'default'); // must not throw
+    expect(r.byType.decision).toBe(1);
+    const ent = loadEntities(home, 'default', { limit: 100 })[0];
+    expect(ent.name).toBe('real decision'); // trimmed, non-empty
+    expect(() => extractGraph(home, 'default')).not.toThrow(); // not bricked
+  });
+
+  it('empty store extracts to an empty graph (no crash)', () => {
+    const r = extractGraph(home, 'default');
+    expect(r).toEqual({ entities: 0, relations: 0, byType: { decision: 0, policy: 0, customer: 0, project: 0 }, truncated: [] });
+  });
+});


### PR DESCRIPTION
## What

Populates the E3 graph from the already-structured consolidated E2 objects, **with no NLP**. `hippo graph extract` is an idempotent rebuild: clear the tenant graph, then re-derive one entity per active-or-superseded decision/policy/customer_note/project_brief (→ `decision`/`policy`/`customer`/`project` entity types) + a `supersedes` relation along each chain — all through the `src/graph.ts` consolidated-source guard. This is the first thing to **populate** the graph, enabling E3.2 multi-hop recall next.

## Surface

- **`src/graph.ts`**: `clearGraph` (tenant-scoped `DELETE`; relations cascade; lives in the sanctioned writer so the E3.3 lint allows it).
- **`src/graph-extract.ts`**: `extractGraph` — per-status active+superseded loads, the `(entityType, e2Id)` entity map (collision-safe), `supersedes` relations, `MAX_EXTRACT_PER_TYPE` cap with `truncated[]`. Entity names are **trimmed-then-capped + empty-skipped**, so an uncapped/odd E2 name cannot throw mid-rebuild and brick the (already-cleared) graph.
- **`src/cli.ts`**: `hippo graph extract` (prints counts; warns on truncation).
- 7 real-DB tests; excludes closed objects + NULL-`memory_id` rows; idempotent (rebuild = pure function of current E2 state).

**No schema change** (reuses the v37 guard). NLP prose-extraction, `skill`/`incident`/`process` entities, the `hippo sleep` enqueue-hook, and E3.2 recall are deferred.

## Review

Built via /dev-framework-rl. Gates: plan-eng 88, code-review 92, independent-review 84, ship-readiness 94. **codex + the independent fresh-eyes review both converged on a brick-the-rebuild bug** — an over-cap or whitespace-only entity name threw *after* `clearGraph` had run, leaving the graph cleared-but-unrebuildable. Fixed at root (trim-then-slice + skip-empty, which provably closes the class). Ships via merge + CHANGELOG Unreleased. No publish.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` (2387 functional pass; 1 flaky `server-concurrency` passes in isolation)
- [x] `pytest` 114 unchanged (no Python)
- [x] `node scripts/check-graph-writes.mjs` green (extract uses helpers; clearGraph DELETE in sanctioned graph.ts)

Generated with /dev-framework-rl