### PR TITLE
feat: E3.2 multi-hop graph recall (recall --hops N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,28 @@
 
 ## Unreleased
 
+## 1.16.0 (2026-06-02): E3 graph layer (extract + guard + multi-hop recall) + E2 first-class objects
+
 ### Added
 
+- E3.2 multi-hop graph recall. `hippo recall "<query>" --hops N` augments lexical
+  recall with memories reached by walking the E3 entities/relations graph N hops
+  (0..3, default off) out from the seed results; `--max-neighbors M` caps per-hop
+  fanout (1..200, default 25). Graph hits are loaded directly by id (not via the
+  lexical candidate set, so lexically-orthogonal neighbours surface), inherit their
+  origin seed's relevance, and are placed adjacent to it; output tags them
+  `[graph: Nhop <rel>]` (text) / `graphVia` (JSON). Relation-type-agnostic, so the
+  cross-object edges E3.1 will add light up the same traversal with no rework. The
+  recall hard filters are re-applied to graph-reached rows: the full bi-temporal
+  `--as-of` rule, the default superseded-drop (a `supersedes` `to`-endpoint is the
+  older version, surfaced only under `--include-superseded`; the newer `from`-endpoint
+  shows by default), tenant scoping, and the `--min-results` floor (top rows protected
+  from budget eviction). Local AND global stores are expanded. New module
+  `src/graph-recall.ts` (SELECT-only, so the E3.3 graph-write lint permits it outside
+  `graph.ts`) + three read helpers in `src/graph.ts` (`loadEntitiesByMemoryId`,
+  `loadEntitiesByIds`, bidirectional `loadNeighborRelations`); `graphExpandRecall`
+  exported from the SDK. No migration (read-only). 19 real-DB tests +
+  `benchmarks/e3.2/multihop_benchmark.mjs` (predecessor recall 3/5 to 5/5).
 - E2 incident first-class object. `hippo incident` records an operational event
   as a canonical `incidents` table row (source of truth, survives memory decay)
   plus a memory mirror for recall; forget / consolidate / archive gracefully

--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ hippo watch "npm run build"
 | `hippo recall "<query>" --budget <n>` | Recall within token limit (default: 4000) |
 | `hippo recall "<query>" --limit <n>` | Cap result count |
 | `hippo recall "<query>" --why` | Show match reasons and source buckets |
+| `hippo recall "<query>" --hops <n>` | Also surface memories N hops away in the entity/relation graph (0..3, default off) |
 | `hippo recall "<query>" --json` | Output as JSON |
 | `hippo context --auto` | Smart context injection (auto-detects task from git) |
 | `hippo context "<query>" --budget <n>` | Context injection with explicit query (default: 1500) |

--- a/benchmarks/e3.2/multihop_benchmark.mjs
+++ b/benchmarks/e3.2/multihop_benchmark.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * E3.2 multi-hop graph recall benchmark (roadmap success criterion — DESCRIPTIVE, not a
+ * ship gate). Measures whether `recall --hops 1` surfaces a supersession-linked
+ * predecessor decision that the flat baseline (same `--include-superseded`, same budget)
+ * ranks below the result cut because the predecessor's wording is lexically distinct
+ * from the successor query.
+ *
+ * HONEST framing baked into the design (per the plan's grill fix):
+ *  - On today's supersedes-only graph the predecessor is a SUPERSEDED memory, so it is
+ *    only a candidate at all under --include-superseded; --hops then surfaces it via the
+ *    graph edge regardless of lexical score. Cross-object edges (future E3.1) link ACTIVE
+ *    memories and remove that coupling.
+ *  - Wording is realistic "we changed our mind and describe it differently now" prose,
+ *    NOT artificially orthogonal tokens engineered to manufacture a win.
+ *
+ * Run: node benchmarks/e3.2/multihop_benchmark.mjs   (after `npm run build`)
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI = join(process.cwd(), 'dist', 'cli.js');
+const home = mkdtempSync(join(tmpdir(), 'hippo-e3.2-bench-'));
+// Isolate from the user's real global store ($HIPPO_HOME / ~/.hippo): point HIPPO_HOME at
+// an empty temp dir so recall cannot pull in the operator's actual global memories (codex P2).
+const globalHome = mkdtempSync(join(tmpdir(), 'hippo-e3.2-bench-global-'));
+const env = { ...process.env, HIPPO_HOME: globalHome };
+function hippo(args) {
+  return execFileSync('node', [CLI, ...args], { cwd: home, encoding: 'utf8', env });
+}
+function memIdFrom(out) {
+  const m = out.match(/memory:\s+(\S+)/);
+  if (!m) throw new Error('no memory id in decide output: ' + out);
+  return m[1];
+}
+function rankOf(results, memId) {
+  const i = results.findIndex((r) => r.id === memId);
+  return i < 0 ? null : i + 1; // 1-based, null = absent
+}
+
+// 5 decision lineages: predecessor superseded by successor, lexically distinct wording
+// for the same underlying decision.
+const chains = [
+  { pred: 'Adopt Redis as the primary session cache for the web tier',
+    succ: 'Move ephemeral login state into Postgres unlogged tables instead' },
+  { pred: 'Bill customers monthly in arrears with Stripe metered subscriptions',
+    succ: 'Capture revenue through prepaid credit packs that roll over each cycle' },
+  { pred: 'Run a nightly batch pipeline into a Snowflake analytics warehouse',
+    succ: 'Stream change-data-capture events into an embedded DuckDB at the edge' },
+  { pred: 'Authenticate service to service traffic with long lived API keys',
+    succ: 'Issue short lived workload identity tokens for machine callers' },
+  { pred: 'Deploy the monolith to one region behind a single load balancer',
+    succ: 'Spread the application across three availability zones with anycast routing' },
+];
+
+hippo(['init', '--no-hooks', '--no-schedule', '--no-learn']);
+// distractor noise so the budget cut is meaningful
+for (let i = 0; i < 30; i++) {
+  hippo(['remember', `routine operations note ${i}: dashboards, oncall rotations, log retention windows`]);
+}
+for (const c of chains) {
+  c.predMem = memIdFrom(hippo(['decide', c.pred]));
+  hippo(['decide', c.succ, '--supersedes', c.predMem]);
+}
+const extract = hippo(['graph', 'extract']);
+
+const BUDGET = process.argv[2] ?? '300'; // tokens; tight enough that the cut bites
+let baseHits = 0, hopHits = 0;
+const rows = [];
+for (const c of chains) {
+  const base = JSON.parse(hippo(['recall', c.succ, '--include-superseded', '--budget', BUDGET, '--json']));
+  const hop = JSON.parse(hippo(['recall', c.succ, '--include-superseded', '--hops', '1', '--budget', BUDGET, '--json']));
+  const baseRank = rankOf(base.results, c.predMem);
+  const hopRank = rankOf(hop.results, c.predMem);
+  const hopRow = hop.results.find((r) => r.id === c.predMem);
+  if (baseRank !== null) baseHits++;
+  if (hopRank !== null) hopHits++;
+  rows.push({
+    query: c.succ.slice(0, 38),
+    predInBase: baseRank !== null ? `rank ${baseRank}` : 'MISS',
+    predInHops: hopRank !== null ? `rank ${hopRank}` : 'MISS',
+    viaGraph: hopRow?.graphVia ?? null,
+  });
+}
+console.log('graph extract:', extract.trim().split('\n').pop());
+console.log(JSON.stringify({
+  budget: BUDGET, n: chains.length,
+  predecessor_recall_baseline: `${baseHits}/${chains.length}`,
+  predecessor_recall_hops1: `${hopHits}/${chains.length}`,
+  rows,
+}, null, 2));
+rmSync(home, { recursive: true, force: true });
+rmSync(globalHome, { recursive: true, force: true });

--- a/docs/evals/2026-06-02-e3.2-multihop-result.md
+++ b/docs/evals/2026-06-02-e3.2-multihop-result.md
@@ -1,0 +1,105 @@
+# E3.2 multi-hop graph recall — verify-stage result (DESCRIPTIVE)
+
+- Date: 2026-06-02
+- Episode: 01KT40DPYPFYFHEK2WX1VA70BE (/dev-framework-rl, backend)
+- Feature: `hippo recall --hops N` — augment lexical recall with memories reached by
+  walking the E3 `entities`/`relations` graph N hops from the seed results.
+- Benchmark harness: `benchmarks/e3.2/multihop_benchmark.mjs` (end-to-end via the built
+  CLI; real store, real `hippo decide`/`graph extract`/`recall`).
+
+This is verify-stage evidence that the traversal is correct and useful, **not a pass/fail
+ship gate** (per the plan's grill discipline). Results are reported as-is.
+
+## Methodology
+
+5 decision lineages, each a predecessor decision **superseded** by a successor, written in
+**lexically distinct prose** for the same underlying decision (a realistic "we changed our
+mind and describe it differently now" case — NOT artificially orthogonal tokens). 30
+unrelated distractor memories add noise. For each lineage we query the **successor's**
+wording and check whether the **predecessor** is recalled, baseline vs `--hops 1`, both
+with `--include-superseded`, at a given token budget.
+
+`graph extract` built **10 entities + 5 supersedes relations** as expected.
+
+## Results
+
+Run with `--include-superseded` (the supersedes-only graph links to superseded rows; see
+characteristic #1) and an isolated `HIPPO_HOME`:
+
+| Budget (tokens) | predecessor recall, baseline | predecessor recall, `--hops 1` |
+|---|---|---|
+| 300 (tight)  | 3 / 5 | **5 / 5** (the 2 it adds at ranks 2 / 4) |
+| 4000 (loose) | 3 / 5 | **5 / 5** |
+
+**Headline:** flat recall surfaces 3/5 predecessors (the lexically-similar ones);
+`--hops 1` surfaces **all 5**, adding the 2 **lexically-orthogonal** predecessors that no
+query-token search would rank — at ranks 2-8, adjacent to the successor they are linked
+to. The lift is stable across budgets (3/5 → 5/5), and `--hops` never drops a baseline
+result: the top `--min-results` rows are protected from budget eviction.
+
+(An earlier, pre-fix run showed a 0/5 baseline — that was partly an artifact of the
+benchmark not isolating `HIPPO_HOME` from the operator's real global store, which codex
+flagged and we fixed; the isolated numbers above are the honest ones.)
+
+## Defects caught during verify + review (all fixed)
+
+The end-to-end benchmark and the two-round codex review caught **8 real issues** that the
+unit tests and the two Claude review gates did not — found only because the benchmark
+exercised the full pipeline and codex brought a cross-model second read.
+
+**Benchmark (verify stage) — 2:**
+1. **Lexical gating.** The engine intersected graph-reached memories with the recall
+   handler's candidate set, which is **lexically prefiltered** by query tokens, so the
+   lexically-orthogonal neighbours the feature exists to surface were dropped. **Fix:** load
+   graph-reached memories DIRECTLY by id (`loadEntriesByIds`), bypassing the lexical gate.
+2. **Dead-last ranking.** Graph hits scored `minBaseScore − hops` ranked below every
+   zero-score distractor and were budget-cut. **Fix:** a hit inherits its origin seed's
+   relevance (`× (1 − 0.01·hops)`), placed adjacent to the seed; budget selection by score.
+
+**Codex review round 1 — 3:**
+3. **asOf incompleteness.** asOf + `--hops` only checked `valid_from`, surfacing a
+   superseded neighbour whose successor was already valid at the date. **Fix:** the full
+   bi-temporal rule (load successors, require `successor.valid_from > asOf`).
+4. **500-id cap.** `--hops 3 --max-neighbors 200` reaches up to 600 ids but
+   `loadEntriesByIds` slices to 500. **Fix:** chunk the by-id loads at 500.
+5. **Global store ignored.** Expansion only ran against the local root. **Fix:** expand
+   against the local AND global roots (a global seed's graph lives under the global root).
+
+**Codex review round 2 — 3:**
+6. **Superseded-by-default.** The supersedes-edge predecessor (the `to` endpoint) was
+   surfaced by default because `hippo decide` doesn't set the memory's `superseded_by`.
+   **Fix:** use the **graph edge** as the authoritative superseded signal — drop a node
+   reached as the `to` endpoint of a `supersedes` edge unless `--include-superseded`.
+7. **`--min-results` violated.** Budget eviction could drop base rows below the recall
+   floor. **Fix:** the top `--min-results` base rows are protected from eviction.
+8. **Benchmark not hermetic.** It didn't isolate `HIPPO_HOME`, so recall could pull the
+   operator's real global memories. **Fix:** point `HIPPO_HOME` at a temp dir.
+
+The unit tests passed throughout — they proved traversal correctness but not pipeline-level
+visibility, contracts (`--min-results`), or multi-store behaviour. Codex caught what both
+Claude review gates missed, consistent with its track record on prior episodes.
+
+## Honest characteristics (known + documented)
+
+1. **Supersedes/`--include-superseded` coupling.** Today the only edges are `supersedes`,
+   which link to **superseded** rows. `--hops` from an OLD seed surfaces the NEWER successor
+   by default (current truth); to also see the older superseded predecessors you pass
+   `--include-superseded`. When E3.1 emits cross-object edges (`references`/`depends-on`/…)
+   that link active memories, `--hops` surfaces them by default with zero rework.
+2. **Tight-budget displacement (bounded).** Beyond the protected `--min-results` floor,
+   budget selection is by score, so a high-value graph hit can displace a weakly-scored
+   base distractor. Aggregate recall stays ≥ baseline; the displaced item is the
+   lowest-value one. A base row that is itself graph-linked but only weakly lexical (a
+   *seed*, not a *reached* node) is not separately boosted — seed-to-seed boosting was
+   scoped out as complexity not worth it while the aggregate is a net win.
+3. **asOf + `--hops`** now applies the full bi-temporal rule (matching cmdRecall).
+
+## Runtime evidence (verify + review gates)
+
+- `tests/graph-recall.test.ts`: **19/19 pass** (real SQLite) — seed mapping, N-hop BFS,
+  bidirectional, cycle-safety, fanout cap, by-id load, graph-edge superseded semantics,
+  full bi-temporal asOf, global-store expansion, budget bound + min-results, no-op gate,
+  empty graph, tenant isolation, dedup; + the 4 read-helper tests.
+- Full suite: 2405 pass (1 pre-existing `server-concurrency` network flake, unrelated).
+- `scripts/check-graph-writes.mjs`: green (graph-recall.ts is SELECT-only).
+- CLI smoke: `--hops 1.5 / -1 / 99 / bare` all rejected (exit 1); `--hops 2` runs clean.

--- a/docs/plans/2026-06-02-e3.2-multihop-recall.md
+++ b/docs/plans/2026-06-02-e3.2-multihop-recall.md
@@ -1,0 +1,224 @@
+# Plan: E3.2 multi-hop graph recall (`hippo recall --hops N`)
+
+- Date: 2026-06-02
+- Episode: 01KT40DPYPFYFHEK2WX1VA70BE (/dev-framework-rl, project_type=backend)
+- Status: plan-eng-critic PASS (score 82, round 1, no must_fix). 4 findings folded in
+  pre-execute: (med) reconstruct `visible=[...localEntries,...globalEntries]` at the
+  wiring point (no pre-existing `allEntries` outside the multihop branch); (med) batch
+  `loadNeighborRelations` to ONE IN-list query per hop (kill the per-node N+1); (low) run
+  graph expansion BEFORE the opt-in re-rankers; (low) state the `entry.id ===
+  entities.memory_id` join key.
+
+## Goal
+
+Ship the **consumer** of the E3 graph substrate: a relation-type-agnostic multi-hop
+traversal that augments `hippo recall` with memories reached by walking the
+`entities`/`relations` graph N hops out from the lexically-matched seed results.
+CLI surface: `hippo recall "<query>" --hops N`.
+
+E3.1 (entity extraction → builds the graph) and E3.3 (the graph-on-consolidated
+guard) already shipped. E3.2 is the read-side that makes the graph operator-facing.
+
+## The reframe (carried from brainstorm — READ THIS FIRST)
+
+The roadmap's E3.2 headline query — *"incidents linked to decisions about retry-policy"*,
+traversing decision→policy→incident→owner — is **NOT buildable on today's graph**, and
+this plan does not claim to build it. Two producer-side gaps, both tracked as E3.1
+follow-ups, gate it:
+
+1. `relations` contains only **`supersedes`** edges today (graph-extract.ts Pass 2).
+   The other four rel-types (`owns`/`depends-on`/`blocked-by`/`references`) and ALL
+   cross-object edges are deferred.
+2. `entities` is populated only for **decision/policy/customer/project**;
+   incident/process/skill/person/system are not extracted yet.
+
+So the headline cross-entity walk has no edges to walk. What IS buildable now, and what
+this episode ships, is the **traversal engine itself**: relation-type-agnostic, correct
+on the `supersedes`-only graph that exists (where it surfaces a supersession-linked
+predecessor/successor that lexical search misses), and forward-compatible so that the
+moment E3.1 emits cross-object edges, multi-hop cross-entity recall works with **zero
+traversal rework**. Building the consumer before the producer is fully rich is not a
+patch (the sparse graph is a tracked producer limitation, not something we bypass);
+the relation rows are already flowing through the audited writer.
+
+## Scope (and what is deferred)
+
+IN:
+- `src/graph-recall.ts` — new module (READ-ONLY; SELECTs only, so the E3.3
+  `check-graph-writes.mjs` lint, which flags writes only, permits it outside graph.ts).
+- Two read helpers added to `src/graph.ts` (the graph module, mirrors its existing
+  `loadEntities`/`loadRelations`): bidirectional neighbour lookup + memory-id→entity
+  mapping.
+- CLI wiring of `--hops N` in the `recall` handler in `src/cli.ts`.
+- `index.ts` export of the new public function (mirrors `multihopSearch`).
+- Real-DB vitest coverage + a 5-question multi-hop micro-benchmark (the roadmap
+  success criterion) recorded under `docs/evals/2026-06-02-e3.2-multihop-result.md`.
+
+DEFERRED (follow-ups, named so they stay visible):
+- Cross-object relation extraction + incident/process/skill/person entities (E3.1
+  follow-ups) — the unlock for the headline cross-entity query.
+- `--hops` over HTTP/SDK (operator-facing API parity) — CLI first, like other recall flags.
+- Any graph write / new edge type / migration — **this episode adds no schema change.**
+
+## Design
+
+### CLI contract
+
+```
+hippo recall "<query>" --hops N [--max-neighbors M]
+```
+
+- `--hops N`: hops to expand. `0` (or absent) = **off**, recall is byte-identical to
+  today (the no-op gate). `1` = direct neighbours, `2` = neighbours-of-neighbours.
+  Validate: `Number.isInteger(N) && 0 <= N <= MAX_HOPS (3)` — reject `--hops 1.5`,
+  `--hops -1`, `--hops 99` with a clear error. (Audit rule 8: graph readers use raw
+  `LIMIT ?`; a fractional value reaches SQLite and 500s, so the integer guard is in
+  the CLI handler BEFORE any query.)
+- `--max-neighbors M` (optional, default `25`): per-hop fanout cap to bound blow-up
+  on a future dense graph. Same integer guard. Bounded `1..200`.
+- Default OFF. No config key (Simplicity First — pure flag, mirrors `--evc-adaptive`
+  rather than `--multihop`'s config.enabled). If a config default is wanted later it
+  can be added without touching the engine.
+
+### Differentiation from existing recall features (audit rule 2 — functional-duplicate)
+
+- vs **`--multihop`** (`src/multihop.ts`): that is *lexical* `speaker:`/`topic:` tag
+  re-query, no graph involved. `--hops` walks the actual `relations` edges. They are
+  independent mechanisms and **coexist**; `--hops` does not modify or deprecate
+  `--multihop` in this episode.
+- vs **`--include-superseded`**: that pulls a *queried* entity's OWN superseded
+  versions into the candidate pool. `--hops` walks edges from a *matched* entity to
+  pull a *linked* entity's memory — on today's supersedes graph that is the
+  predecessor/successor entity, which may be lexically dissimilar and which flat
+  recall would not rank. The benchmark (verify stage) must demonstrate this distinct
+  lift, or the feature has not earned its place.
+
+### Engine (`src/graph-recall.ts`)
+
+`graphExpandRecall(baseResults, opts) → SearchResult[]`
+
+1. Take `baseResults` (the SearchResult[] the existing recall branch already produced).
+2. Map seed `memory_id`s → seed entities via `loadEntitiesByMemoryId` (new graph.ts
+   helper). Memories with no entity contribute nothing (graceful).
+3. BFS up to `hops`, both directions, over `relations`:
+   - frontier starts = seed entity ids; `visited` set prevents re-expansion (cycle/
+     diamond-safe even though supersedes is a DAG today).
+   - each hop runs **ONE** `loadNeighborRelations(frontierIds[])` query for the whole
+     frontier (plan-eng N+1 fix — NOT one query/connection per node: worst case was
+     ~`maxNeighbors^hops` open/close cycles). The helper takes the frontier id LIST and
+     issues a single `WHERE tenant_id=? AND (from_entity_id IN (...) OR to_entity_id IN
+     (...))` over both existing indexes; the neighbour is the *other* endpoint; cap the
+     new frontier at `maxNeighbors`.
+   - record, per reached entity, the min hop-distance + the rel_type/direction used
+     (for `--why` provenance).
+4. Collect reached entities' `memory_id`s, EXCLUDING memory_ids already in
+   `baseResults` (no duplicates). **Join key (plan-eng low fix — stated explicitly):**
+   `SearchResult.entry.id` is the string memory id (`memory.ts`), and `entities.memory_id`
+   FKs `memories.id` — the SAME id space. The intersection/exclusion keys on
+   `entry.id === entities.memory_id`.
+5. **asOf/scope reuse by intersection, not re-filtering** (grill fix — the earlier
+   "route back through the recall path" was vague and risked duplicating filter logic).
+   The recall handler has already loaded `localEntries` + `globalEntries` with the HARD
+   filters `asOf` + the `includeSuperseded` drop ALREADY applied upstream (scope is a soft
+   relevance boost in recall, not an exclusion, so there is nothing scope-related to
+   reuse). **Plan-eng med fix:** there is
+   NO pre-existing `allEntries` binding at the wiring point on the default/physics/hybrid
+   paths (it only exists inside the `useMultihop` branch, cli.ts ~962), so the wiring
+   constructs the filtered candidate set itself: `const visible = [...localEntries,
+   ...globalEntries]`. `graphExpandRecall` receives `visible` and only promotes a reached
+   entity whose `memory_id` is present in it. A reached memory excluded upstream (future
+   as-of, wrong scope, superseded-while-excluded) is simply absent and dropped for free —
+   no second filter pass, no bypass, single source of truth for what's visible.
+6. Merge: append graph-reached results AFTER the lexical seeds, ranked among themselves
+   by (lower hop-distance first, then base relevance). Budget-bounded by the same
+   `--budget` token cap (audit rule 9 — bounded, stores nothing).
+7. Annotate each graph-reached result with `via: { hops, relType, direction }` so
+   `recall --why` can explain "surfaced via graph: 1 hop along supersedes".
+
+### New graph.ts read helpers (lint-safe — SELECT only)
+
+- `loadEntitiesByMemoryId(root, tenant, memoryIds: string[]) → Entity[]`
+  (`WHERE memory_id IN (...) AND tenant_id = ?`; chunk the IN-list to stay under the
+  SQLite variable cap; integer-safe).
+- `loadNeighborRelations(root, tenant, entityIds: number[], opts:{limit}) → Relation[]`
+  (**batched — one query per hop, not per node** per plan-eng N+1 fix:
+  `WHERE tenant_id = ? AND (from_entity_id IN (...) OR to_entity_id IN (...))`; chunk the
+  IN-list under the SQLite variable cap; opens ONE connection for the call; uses both
+  existing indexes; mirrors `loadRelations`; **closes the audit "from-only" gap**;
+  `Number.isInteger(limit)`).
+
+### cli.ts wiring
+
+In the `recall` handler, after the existing branch computes `results`: if `--hops`
+present, parse+validate, and when `hops > 0` call `graphExpandRecall(results, {...,
+hops, maxNeighbors, hippoRoot, tenantId, asOf, includeSuperseded, visible, budget})`,
+replacing `results` with the augmented set. **Ordering (plan-eng low fix):** run
+`graphExpandRecall` immediately after the base-branch `results` is produced and
+**BEFORE** the opt-in re-rankers that reassign `results` (`--evc-adaptive`,
+`--filter-conflicts`, value-aware, `--rerank-utility`, reranker; cli.ts ~999-1118), so
+graph-reached entries are first-class candidates that participate in the same downstream
+re-ranking and `--why`/formatting rather than being appended after it. `hops === 0` /
+absent leaves `results` untouched (no-op gate). Tenant id comes from the same
+`ctx.tenantId` the recall path already resolves (audit: tenant isolation — BFS only
+ever reads the caller's tenant rows; a cross-tenant entity is unreachable).
+
+## Tests (real DB, vitest — `always use real DB for tests`)
+
+`tests/graph-recall.test.ts`:
+1. seed memory_id → entity mapping (hit + miss).
+2. `--hops 1` surfaces a `supersedes`-linked predecessor memory NOT in the seed set.
+3. `--hops 2` reaches two edges out; `--hops 1` does not reach the 2-hop node.
+4. **bidirectional**: traversal finds a neighbour linked via `to_entity_id` as well as
+   `from_entity_id`.
+5. `visited` dedup: a diamond/back-edge does not double-count or loop.
+6. `maxNeighbors` fanout cap respected.
+7. `asOf` filter applied to graph-reached memories (a reached-but-future memory dropped).
+8. `includeSuperseded=false` interaction is consistent with plain recall.
+9. budget bound respected (augmented set never exceeds token budget).
+10. `--hops 0` / absent ⇒ result identical to plain recall (no-op gate).
+11. empty graph ⇒ no-op, no throw.
+12. tenant isolation: another tenant's entity is never reached.
+
+`tests/graph-recall.test.ts` (graph.ts helpers): `loadNeighborRelations` bidirectional
++ limit guard; `loadEntitiesByMemoryId` IN-list + chunking.
+
+CLI integration: `recall --hops 1` end-to-end surfaces the predecessor; `--hops 1.5`
+and `--hops -1` rejected with a clear message (not a 500).
+
+## Verify-stage benchmark (roadmap success criterion)
+
+5-question multi-hop micro-benchmark: seed a graph with decision supersession chains
+(V1←V2←V3) + distinct wording per version, query a successor, assert `--hops 1`
+retrieves the lexically-dissimilar predecessor that flat recall ranks outside budget;
+report hit-rate `--hops` vs flat baseline. Recorded in
+`docs/evals/2026-06-02-e3.2-multihop-result.md`.
+
+**Benchmark honesty (grill fix — DESCRIPTIVE, not a gate).** The `--hops` win only
+materialises when the linked memory is *lexically dissimilar* from the query; on
+realistic supersession chains where a revision reuses most of the predecessor's wording,
+`--hops` may add little over `--include-superseded`, which already surfaces own-version
+history. The benchmark must report the lift **honestly even if modest or null** — it
+must NOT be rigged with artificially dissimilar wording to manufacture a win. The
+feature's justification is the **forward-compatible traversal engine** (it lights up on
+cross-object edges the moment E3.1 emits them), not a day-1 recall lift. Per the
+project's retraction discipline, a null/modest result is recorded as-is and the engine
+still ships as infrastructure with the caveat documented. The benchmark is verify-stage
+evidence the traversal is correct, not a pass/fail ship gate.
+
+## Ship checklist (audit rule 4 — version targets)
+
+Minor bump 1.15.0 → **1.16.0** (new feature): `package.json`, `src/version.ts`
+(`PACKAGE_VERSION`), `openclaw.plugin.json`, `extensions/openclaw-plugin/openclaw.plugin.json`,
+`extensions/openclaw-plugin/package.json`. Confirm `ui/` + `website/` are independent
+(NOT lockstep). Grep `PACKAGE_VERSION` test assertions. CHANGELOG entry under Unreleased.
+README recall-flags section gets `--hops`.
+
+## Risks / open questions for plan-eng-critic
+
+- Is appending graph-reached results below the lexical seeds the right merge, or should
+  hop-distance compete in the main ranking? (Plan: append-below for v1 — predictable,
+  lexical relevance stays primary; revisit if benchmark shows value buried.)
+- `maxNeighbors=25` default — guess; benchmark on the real graph may retune.
+- Should `--hops` imply pulling the seed entity's own superseded versions too, or stay
+  strictly edge-walk? (Plan: strict edge-walk; `--include-superseded` owns the
+  own-version axis. Keep the axes orthogonal.)

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.15.0",
+  "version": "1.16.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,6 +211,7 @@ import { runFeatureEval, formatResult, resultToBaseline, detectRegressions, type
 import { refineStore } from './refine-llm.js';
 import { wmPush, wmRead, wmClear, wmFlush, WorkingMemoryItem } from './working-memory.js';
 import { multihopSearch } from './multihop.js';
+import { graphExpandRecall, MAX_HOPS, DEFAULT_MAX_NEIGHBORS } from './graph-recall.js';
 import { getReranker } from './rerankers/index.js';
 import { computeSalience } from './salience.js';
 import { computeAmbientState, renderAmbientSummary } from './ambient.js';
@@ -990,6 +991,52 @@ async function cmdRecall(
     });
   }
 
+  // E3.2 multi-hop graph recall. After the base branch produces `results`, optionally
+  // augment with memories reached by walking the entities/relations graph `--hops N` out
+  // from the lexical seeds. Runs BEFORE the opt-in re-rankers below so graph-reached
+  // results are first-class candidates in any downstream re-ranking / --why. Default OFF
+  // (absent or 0 = no-op). Reached memories are loaded directly by id (NOT via the
+  // lexical candidate set, which would exclude the orthogonal neighbours graph recall
+  // exists to surface); the engine re-applies the same superseded/asOf hard filters.
+  if (flags['hops'] !== undefined) {
+    // Reject a value-less `--hops` (parseArgs stores boolean true): Number(true) === 1
+    // would otherwise silently run a 1-hop expansion when the user fat-fingered the value.
+    if (typeof flags['hops'] === 'boolean') {
+      console.error(`--hops requires an integer value 0..${MAX_HOPS} (e.g. --hops 1).`);
+      process.exit(1);
+    }
+    const hops = Number(flags['hops']);
+    if (!Number.isInteger(hops) || hops < 0 || hops > MAX_HOPS) {
+      console.error(`Invalid --hops: "${String(flags['hops'])}". Must be an integer 0..${MAX_HOPS}.`);
+      process.exit(1);
+    }
+    let maxNeighbors = DEFAULT_MAX_NEIGHBORS;
+    if (flags['max-neighbors'] !== undefined) {
+      if (typeof flags['max-neighbors'] === 'boolean') {
+        console.error(`--max-neighbors requires an integer value 1..200.`);
+        process.exit(1);
+      }
+      maxNeighbors = Number(flags['max-neighbors']);
+      if (!Number.isInteger(maxNeighbors) || maxNeighbors < 1 || maxNeighbors > 200) {
+        console.error(`Invalid --max-neighbors: "${String(flags['max-neighbors'])}". Must be an integer 1..200.`);
+        process.exit(1);
+      }
+    }
+    if (hops > 0) {
+      results = graphExpandRecall(results, {
+        hops,
+        maxNeighbors,
+        hippoRoot,
+        globalRoot: isInitialized(globalRoot) && globalRoot !== hippoRoot ? globalRoot : undefined,
+        tenantId,
+        includeSuperseded,
+        asOf,
+        budget,
+        minResults: minResults ?? 1,
+      });
+    }
+  }
+
   // ACC EVC-adaptive recall (RESEARCH.md §PFC.ACC). When the initial top-K is
   // dominated by lexically similar but distinct memories (high pairwise token
   // overlap = same topic, different facts = conflict), allocate extra retrieval
@@ -1537,6 +1584,9 @@ async function cmdRecall(
         base.superseded = true;
         base.superseded_by = r.entry.superseded_by;
       }
+      if (r.graphVia) {
+        base.graphVia = r.graphVia;
+      }
       if (showWhy) {
         const explanation = explainMatch(query, r);
         base.confidence = resolveConfidence(r.entry);
@@ -1651,8 +1701,9 @@ async function cmdRecall(
     const isGlobal = isInitialized(globalRoot) && !localIndex.entries[e.id];
     const globalMark = isGlobal ? ' [global]' : '';
     const supersededMark = e.superseded_by ? ' [superseded]' : '';
+    const graphMark = r.graphVia ? ` [graph: ${r.graphVia.hops}hop ${r.graphVia.relType}]` : '';
     const sourceMark = isGlobal ? ' [global]' : ' [local]';
-    console.log(`--- ${e.id} [${e.layer}] ${confLabel}${globalMark}${supersededMark} score=${fmt(r.score, 3)} strength=${fmt(e.strength)}`);
+    console.log(`--- ${e.id} [${e.layer}] ${confLabel}${globalMark}${supersededMark}${graphMark} score=${fmt(r.score, 3)} strength=${fmt(e.strength)}`);
     console.log(`    [${strengthBar}] tags: ${e.tags.join(', ') || 'none'} | retrieved: ${e.retrieval_count}x`);
     if (showWhy) {
       const explanation = explainMatch(query, r);
@@ -7161,6 +7212,13 @@ Commands:
     --min-results <n>      Minimum results regardless of budget (default: 1)
     --json                 Output as JSON
     --why                  Show match reasons and source annotations
+    --hops <n>             E3.2 multi-hop graph recall: also surface memories
+                           reached by walking the entities/relations graph <n>
+                           hops (0..3, default off) out from the lexical seeds.
+                           Graph hits are tagged [graph: Nhop <rel>]. Today the
+                           graph holds supersedes edges (E3.1); cross-object edges
+                           light up the same traversal once extracted.
+    --max-neighbors <n>    Per-hop fanout cap for --hops (1..200, default 25).
     --no-mmr               Disable MMR diversity re-ranking
     --mmr-lambda <f>       MMR balance 0..1 (default: 0.7, 1.0 = pure relevance)
     --evc-adaptive         ACC-style: when top-K shows high inter-item overlap

--- a/src/graph-recall.ts
+++ b/src/graph-recall.ts
@@ -1,0 +1,273 @@
+/**
+ * E3.2 multi-hop graph recall (docs/plans/2026-06-02-e3.2-multihop-recall.md).
+ *
+ * READ-ONLY consumer of the E3 graph substrate (entities/relations built by E3.1,
+ * guarded by E3.3). Given the lexical recall seeds, walk the relations graph up to N
+ * hops and surface the memories of reached entities that the lexical search did not
+ * already return.
+ *
+ * Relation-type-AGNOSTIC: it walks whatever edges exist. Today the graph holds only
+ * `supersedes` edges (so a 1-hop walk surfaces a supersession-linked predecessor/
+ * successor a lexical search may miss); the moment E3.1 emits cross-object edges
+ * (owns/depends-on/blocked-by/references) the SAME traversal lights up cross-entity
+ * multi-hop with zero rework here.
+ *
+ * Design points (the first two were forced by the verify-stage benchmark, the rest by
+ * codex review — all root-cause, not patches):
+ *  1. Graph-reached memories are loaded DIRECTLY by id (tenant-scoped PK fetch), NOT
+ *     intersected with the recall handler's candidate set — that set is lexically
+ *     prefiltered (loadSearchRows filters by query tokens), so intersecting would exclude
+ *     exactly the lexically-orthogonal neighbours graph recall exists to surface. We
+ *     re-apply the recall HARD filters to the directly-loaded rows: the FULL bi-temporal
+ *     as-of rule (valid_from <= asOf AND, for a superseded row, successor.valid_from >
+ *     asOf — same as cmdRecall) and the default superseded-drop. SCOPE is intentionally
+ *     NOT re-applied: the CLI caller (cmdRecall) does not hard-filter scope either (it
+ *     only soft-boosts it). Rows are tenant-scoped + archived-excluded (loadEntriesByIds).
+ *  2. A graph hit inherits its origin seed's relevance (minus a per-hop discount) and is
+ *     placed adjacent to that seed; budget selection is by score so a high-value hit wins
+ *     a token slot over a noise distractor. Dead-last appending made the feature do
+ *     nothing at realistic budgets.
+ *  3. BOTH the local and global stores are expanded — a global seed's entities/relations
+ *     live under the global root, so graph recall must traverse each seed in the store its
+ *     graph lives in (codex review).
+ *  4. By-id loads are chunked at 500 (loadEntriesByIds caps at 500/call), so a high-fanout
+ *     traversal (--hops 3 --max-neighbors 200 -> up to 600 ids) loses none (codex review).
+ *
+ * No graph writes (only SELECTs via graph.ts read helpers + store reads), so the E3.3
+ * check-graph-writes lint permits this module living outside graph.ts.
+ */
+import { loadEntriesByIds } from './store.js';
+import type { MemoryEntry } from './memory.js';
+import { type SearchResult, estimateTokens } from './search.js';
+import {
+  loadEntitiesByMemoryId,
+  loadEntitiesByIds,
+  loadNeighborRelations,
+} from './graph.js';
+
+/** Hard cap on `--hops` (a higher value just walks more of a finite graph; this bounds
+ *  worst-case work and keeps the flag honest). */
+export const MAX_HOPS = 3;
+/** Default per-hop fanout cap (bounds blow-up on a future dense graph). */
+export const DEFAULT_MAX_NEIGHBORS = 25;
+/** Per-hop relevance discount: a graph hit inherits its origin seed's score, scaled down
+ *  1% per hop, so it ranks just below its seed and orders by hop-distance. */
+const HOP_DISCOUNT = 0.01;
+/** loadEntriesByIds caps each call at 500 ids; chunk to lose none on high fanout. */
+const LOAD_CHUNK = 500;
+
+type GraphVia = { hops: number; relType: string; direction: 'from' | 'to' };
+type GraphHit = SearchResult & { graphVia: GraphVia };
+
+export interface GraphExpandOpts {
+  /** Hops to expand. <= 0 is a no-op (caller should not invoke, but guarded anyway). */
+  hops: number;
+  /** Per-hop fanout cap. Defaults to DEFAULT_MAX_NEIGHBORS. */
+  maxNeighbors?: number;
+  /** The local store root (where local seeds' graph lives). */
+  hippoRoot: string;
+  /** The global store root, when distinct + initialized (where global seeds' graph lives).
+   *  A global seed is only expanded if this is provided. */
+  globalRoot?: string;
+  tenantId: string;
+  /** Mirror the recall handler's hard filters when re-loading graph-reached rows. */
+  includeSuperseded?: boolean;
+  /** ISO date; bi-temporal as-of filter applied to graph-reached rows (full rule, matching
+   *  cmdRecall: a row is visible if valid_from <= asOf AND, when superseded, its successor
+   *  was not yet valid at asOf). */
+  asOf?: string;
+  /** Token budget for the augmented set (defaults to 4000, matching recall's default). */
+  budget?: number;
+  /** The recall --min-results floor: this many top base rows are kept regardless of
+   *  budget, so graph expansion never violates the floor. Defaults to 1. */
+  minResults?: number;
+}
+
+/** Load memories by id in <=500-id chunks (loadEntriesByIds caps each call at 500). */
+function loadByIdsChunked(root: string, tenantId: string, ids: string[]): MemoryEntry[] {
+  if (ids.length === 0) return [];
+  const out: MemoryEntry[] = [];
+  for (let i = 0; i < ids.length; i += LOAD_CHUNK) {
+    out.push(...loadEntriesByIds(root, ids.slice(i, i + LOAD_CHUNK), tenantId));
+  }
+  return out;
+}
+
+/**
+ * Traverse one store's graph from the seeds present in it and accumulate new graph hits
+ * into `hitsByOrigin`. Mutates `seenMemoryIds` so a memory is surfaced at most once across
+ * stores. Pure reads.
+ */
+function produceHitsForRoot(
+  root: string,
+  baseResults: SearchResult[],
+  baseScoreByMemId: Map<string, number>,
+  seenMemoryIds: Set<string>,
+  hitsByOrigin: Map<string, GraphHit[]>,
+  opts: Required<Pick<GraphExpandOpts, 'hops' | 'maxNeighbors' | 'tenantId' | 'includeSuperseded'>> & { asOfDate: Date | null },
+): void {
+  const { hops, maxNeighbors, tenantId, includeSuperseded, asOfDate } = opts;
+
+  // Seeds = graph entities (in THIS store) whose source memory is a base result.
+  const seedEntities = loadEntitiesByMemoryId(root, tenantId, baseResults.map((r) => r.entry.id));
+  if (seedEntities.length === 0) return;
+
+  // BFS, both directions, up to `hops`. `visited` prevents re-expansion (cycle-safe).
+  // `originMemByEntityId` propagates the base-result memory id each reached node descends
+  // from (for adjacency placement + score inheritance).
+  const visitedEntityIds = new Set<number>(seedEntities.map((e) => e.id));
+  const reached = new Map<number, GraphVia>();
+  const originMemByEntityId = new Map<number, string>();
+  for (const se of seedEntities) originMemByEntityId.set(se.id, se.memoryId);
+  let frontier: number[] = seedEntities.map((e) => e.id);
+
+  for (let depth = 1; depth <= hops && frontier.length > 0; depth++) {
+    const frontierSet = new Set(frontier);
+    const rels = loadNeighborRelations(root, tenantId, frontier, {
+      limit: Math.max(maxNeighbors, maxNeighbors * frontier.length),
+    });
+    const nextFrontier: number[] = [];
+    for (const rel of rels) {
+      const fromIn = frontierSet.has(rel.fromEntityId);
+      const toIn = frontierSet.has(rel.toEntityId);
+      let neighborId: number;
+      let reacherId: number;
+      let direction: 'from' | 'to';
+      if (fromIn && !toIn) { neighborId = rel.toEntityId; reacherId = rel.fromEntityId; direction = 'to'; }
+      else if (toIn && !fromIn) { neighborId = rel.fromEntityId; reacherId = rel.toEntityId; direction = 'from'; }
+      else continue;
+      if (visitedEntityIds.has(neighborId)) continue;
+      visitedEntityIds.add(neighborId);
+      reached.set(neighborId, { hops: depth, relType: rel.relType, direction });
+      const origin = originMemByEntityId.get(reacherId);
+      if (origin !== undefined) originMemByEntityId.set(neighborId, origin);
+      nextFrontier.push(neighborId);
+      if (nextFrontier.length >= maxNeighbors) break; // per-hop fanout cap
+    }
+    frontier = nextFrontier;
+  }
+  if (reached.size === 0) return;
+
+  // Reached entities -> source memory ids -> load DIRECTLY by id (chunked), not lexical.
+  const reachedEntities = loadEntitiesByIds(root, tenantId, [...reached.keys()]);
+  const needLoad = [...new Set(reachedEntities.map((e) => e.memoryId).filter((id) => !seenMemoryIds.has(id)))];
+  const loadedById = new Map(loadByIdsChunked(root, tenantId, needLoad).map((m) => [m.id, m]));
+
+  // For the bi-temporal as-of rule on a superseded reached row we need its successor's
+  // valid_from. Batch-load the successors referenced by the loaded rows.
+  let successorValidFrom = new Map<string, string>();
+  if (asOfDate) {
+    const succIds = [...new Set([...loadedById.values()].map((m) => m.superseded_by).filter((id): id is string => !!id))];
+    successorValidFrom = new Map(loadByIdsChunked(root, tenantId, succIds).map((m) => [m.id, m.valid_from]));
+  }
+
+  for (const ent of reachedEntities) {
+    const mem = loadedById.get(ent.memoryId);
+    if (!mem) continue;                       // not found / wrong tenant / already in base
+    if (seenMemoryIds.has(mem.id)) continue;  // another reached entity already added it
+    const via = reached.get(ent.id)!;
+    // A node reached as the `to` endpoint of a `supersedes` edge IS the superseded
+    // (older) version — the graph is the authoritative signal (the memory mirror's
+    // `superseded_by` is NOT set by `hippo decide`, only the decisions table is). By
+    // default recall shows current truth, so drop it unless --include-superseded; the
+    // `from` endpoint (the newer successor) is always kept.
+    const isSupersededEndpoint = via.relType === 'supersedes' && via.direction === 'to';
+    if (asOfDate) {
+      if (new Date(mem.valid_from) > asOfDate) continue;        // not yet valid at asOf
+      if (mem.superseded_by) {
+        const succVf = successorValidFrom.get(mem.superseded_by);
+        // Visible only while its successor was NOT yet valid at asOf (matches cmdRecall).
+        if (succVf && new Date(succVf) <= asOfDate) continue;
+      }
+    } else if (!includeSuperseded && (mem.superseded_by || isSupersededEndpoint)) {
+      continue;                                                 // default recall drops superseded
+    }
+    const origin = originMemByEntityId.get(ent.id) ?? baseResults[0].entry.id;
+    const originScore = baseScoreByMemId.get(origin) ?? baseResults[baseResults.length - 1].score;
+    seenMemoryIds.add(mem.id);
+    const hit: GraphHit = {
+      entry: mem,
+      score: originScore * (1 - HOP_DISCOUNT * via.hops),
+      bm25: 0, cosine: 0,
+      tokens: estimateTokens(mem.content),
+      graphVia: via,
+    };
+    if (!hitsByOrigin.has(origin)) hitsByOrigin.set(origin, []);
+    hitsByOrigin.get(origin)!.push(hit);
+  }
+}
+
+/**
+ * Augment `baseResults` with memories reached by walking the graph `hops` edges out from
+ * the seed results' entities (across the local AND global stores). Each graph hit is
+ * inserted directly after the base result it descends from, scored just below that seed;
+ * the base list's own order is preserved. Token-budget-bounded; deduped against the base
+ * set and across stores.
+ *
+ * No-op (returns `baseResults` unchanged) when `hops <= 0`, there are no base results, the
+ * graph is empty, no seed maps to an entity, or nothing new survives the filters/budget.
+ */
+export function graphExpandRecall(
+  baseResults: SearchResult[],
+  opts: GraphExpandOpts,
+): SearchResult[] {
+  const { hops, hippoRoot, globalRoot, tenantId } = opts;
+  if (hops <= 0 || baseResults.length === 0) return baseResults;
+  const maxNeighbors = opts.maxNeighbors ?? DEFAULT_MAX_NEIGHBORS;
+  const budget = opts.budget ?? 4000;
+  const includeSuperseded = opts.includeSuperseded ?? false;
+  const asOfDate = opts.asOf ? new Date(opts.asOf) : null;
+  const minResults = opts.minResults ?? 1;
+
+  const baseScoreByMemId = new Map(baseResults.map((r) => [r.entry.id, r.score]));
+  const seenMemoryIds = new Set<string>(baseResults.map((r) => r.entry.id));
+  const hitsByOrigin = new Map<string, GraphHit[]>();
+
+  // Expand against each distinct store the seeds may live in (local + global).
+  const roots = globalRoot && globalRoot !== hippoRoot ? [hippoRoot, globalRoot] : [hippoRoot];
+  for (const root of roots) {
+    produceHitsForRoot(root, baseResults, baseScoreByMemId, seenMemoryIds, hitsByOrigin, {
+      hops, maxNeighbors, tenantId, includeSuperseded, asOfDate,
+    });
+  }
+
+  if (hitsByOrigin.size === 0) return baseResults;
+  // Closer hops first within each origin group, then by inherited score.
+  for (const hits of hitsByOrigin.values()) {
+    hits.sort((a, b) => a.graphVia.hops - b.graphVia.hops || b.score - a.score);
+  }
+  const allHits = [...hitsByOrigin.values()].flat();
+
+  // Budget SELECTION by score (not by position): a high-value graph hit (it inherits its
+  // origin seed's relevance) must be able to win a token slot over a low-score lexical
+  // distractor — otherwise a tight --budget keeps the noise and drops the memory --hops
+  // surfaced. The greedy pack uses `continue` (not `break`), so a hit's origin seed is
+  // NOT guaranteed kept just because the hit is; the DISPLAY loop guards that (a hit is
+  // emitted ONLY under a kept seed, never orphaned). At least one result is always kept.
+  // (NOTE: at a tight budget a new graph hit can displace a weakly-scored base result;
+  // aggregate recall stays >= baseline, the displaced item is the lowest-value one.)
+  // Protect the top --min-results base rows from eviction (graph expansion must not
+  // violate the recall min-results floor; codex P2). They are kept regardless of budget;
+  // baseResults is score-ordered, so slice(0, N) is the top N.
+  const protectedCount = Math.min(Math.max(minResults, 1), baseResults.length);
+  const keep = new Set<SearchResult>(baseResults.slice(0, protectedCount));
+  let usedTokens = [...keep].reduce((s, r) => s + r.tokens, 0);
+  for (const r of [...baseResults.slice(protectedCount), ...allHits].sort((a, b) => b.score - a.score)) {
+    if (usedTokens + r.tokens > budget) continue;
+    usedTokens += r.tokens;
+    keep.add(r);
+  }
+
+  // DISPLAY order: base order preserved (it may be MMR-diversified); each kept new hit
+  // placed directly after the seed it descends from. Hits emit ONLY under a kept seed.
+  const merged: SearchResult[] = [];
+  let emittedHit = false;
+  for (const r of baseResults) {
+    if (!keep.has(r)) continue;
+    merged.push(r);
+    for (const hit of hitsByOrigin.get(r.entry.id) ?? []) {
+      if (keep.has(hit)) { merged.push(hit); emittedHit = true; }
+    }
+  }
+  return emittedHit ? merged : baseResults; // nothing new survived budget -> original base
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -343,6 +343,118 @@ export function loadRelations(
 }
 
 // ---------------------------------------------------------------------------
+// E3.2 multi-hop recall read helpers (SELECT-only; the check-graph-writes lint
+// permits these here and in the read-only consumer src/graph-recall.ts).
+// ---------------------------------------------------------------------------
+
+/** Chunk size for IN-list queries: well under SQLite's 999-bound-variable default
+ *  (leaves headroom for the tenant_id param + the doubled list in neighbour lookups). */
+const IN_LIST_CHUNK = 400;
+
+/**
+ * Map consolidated source memory ids -> their graph entities. The SEED step of E3.2
+ * multi-hop recall (recall result memory ids -> entities to traverse from). Tenant-
+ * scoped, read-only; chunks the IN-list under the SQLite variable cap.
+ */
+export function loadEntitiesByMemoryId(
+  hippoRoot: string,
+  tenantId: string,
+  memoryIds: string[],
+): Entity[] {
+  assertTenantId('loadEntitiesByMemoryId', tenantId);
+  if (memoryIds.length === 0) return [];
+  const db = openHippoDb(hippoRoot);
+  try {
+    const out: Entity[] = [];
+    for (let i = 0; i < memoryIds.length; i += IN_LIST_CHUNK) {
+      const slice = memoryIds.slice(i, i + IN_LIST_CHUNK);
+      const ph = slice.map(() => '?').join(',');
+      const rows = db.prepare(`
+        SELECT ${ENTITY_COLS} FROM entities
+        WHERE tenant_id = ? AND memory_id IN (${ph})
+      `).all(tenantId, ...slice) as EntityRow[];
+      out.push(...rows.map(rowToEntity));
+    }
+    return out;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Load entities by their primary ids. Resolves the entity rows reached during the BFS
+ * (whose `memory_id` maps back to a recall result). Tenant-scoped, read-only.
+ */
+export function loadEntitiesByIds(
+  hippoRoot: string,
+  tenantId: string,
+  ids: number[],
+): Entity[] {
+  assertTenantId('loadEntitiesByIds', tenantId);
+  if (ids.length === 0) return [];
+  const db = openHippoDb(hippoRoot);
+  try {
+    const out: Entity[] = [];
+    for (let i = 0; i < ids.length; i += IN_LIST_CHUNK) {
+      const slice = ids.slice(i, i + IN_LIST_CHUNK);
+      const ph = slice.map(() => '?').join(',');
+      const rows = db.prepare(`
+        SELECT ${ENTITY_COLS} FROM entities
+        WHERE tenant_id = ? AND id IN (${ph})
+      `).all(tenantId, ...slice) as EntityRow[];
+      out.push(...rows.map(rowToEntity));
+    }
+    return out;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * All relations touching ANY of `entityIds` in EITHER direction (from OR to) — the
+ * per-hop neighbour query for E3.2 multi-hop traversal. ONE query for the whole frontier
+ * (not one per node): this is the bidirectional read `loadRelations` (from-only) lacks,
+ * and avoids an N+1 across BFS frontier nodes. `limit` caps rows for the frontier and
+ * must be a non-negative integer (the raw `LIMIT ?` rejects a fractional value).
+ */
+export function loadNeighborRelations(
+  hippoRoot: string,
+  tenantId: string,
+  entityIds: number[],
+  opts: { limit?: number } = {},
+): Relation[] {
+  assertTenantId('loadNeighborRelations', tenantId);
+  if (entityIds.length === 0) return [];
+  const limit = opts.limit ?? 1000;
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(`loadNeighborRelations: limit must be a non-negative integer; got ${limit}`);
+  }
+  const db = openHippoDb(hippoRoot);
+  try {
+    // `limit` is applied PER CHUNK; a frontier spanning >IN_LIST_CHUNK ids could return
+    // up to limit*chunks rows before the by-id dedup below. Harmless for E3.2 (the
+    // frontier is bounded by maxNeighbors <= 200 << IN_LIST_CHUNK, so a single chunk,
+    // and the BFS re-enforces the per-hop fanout cap), but note the semantics if a
+    // tighter total cap is ever needed.
+    const byId = new Map<number, Relation>();
+    for (let i = 0; i < entityIds.length; i += IN_LIST_CHUNK) {
+      const slice = entityIds.slice(i, i + IN_LIST_CHUNK);
+      const ph = slice.map(() => '?').join(',');
+      const rows = db.prepare(`
+        SELECT ${RELATION_COLS} FROM relations
+        WHERE tenant_id = ? AND (from_entity_id IN (${ph}) OR to_entity_id IN (${ph}))
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+      `).all(tenantId, ...slice, ...slice, limit) as RelationRow[];
+      for (const r of rows) byId.set(r.id, rowToRelation(r));
+    }
+    return Array.from(byId.values());
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Extraction queue (the interface the deferred sleep enqueue-hook + E3.1 will use)
 // ---------------------------------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 export { MemoryEntry, Layer, EmotionalValence, ConfidenceLevel, DecayOptions, calculateStrength, resolveConfidence, createMemory, applyOutcome, generateId, computeSchemaFit } from './memory.js';
 export { search, hybridSearch, physicsSearch, markRetrieved, estimateTokens, textOverlap, tokenize, explainMatch, detectTemporalDirection, temporalBoost, computeTemporalRange, SearchResult, MatchExplanation } from './search.js';
 export { multihopSearch } from './multihop.js';
+export { graphExpandRecall, MAX_HOPS, DEFAULT_MAX_NEIGHBORS, type GraphExpandOpts } from './graph-recall.js';
 export {
   initStore,
   loadAllEntries,

--- a/src/search.ts
+++ b/src/search.ts
@@ -179,6 +179,9 @@ export interface SearchResult {
   rerankScore?: number;
   preRerankRank?: number;
   postRerankRank?: number;
+  /** Populated for results surfaced by E3.2 graph traversal (`recall --hops N`): how
+   *  the memory was reached from a lexical seed. Absent on normal lexical hits. */
+  graphVia?: { hops: number; relType: string; direction: 'from' | 'to' };
 }
 
 export interface ScoreBreakdown {

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.15.0';
+export const PACKAGE_VERSION = '1.16.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/graph-recall.test.ts
+++ b/tests/graph-recall.test.ts
@@ -1,0 +1,303 @@
+/**
+ * E3.2 multi-hop graph recall - engine + read-helper tests (real SQLite, no mocks).
+ * Docs: docs/plans/2026-06-02-e3.2-multihop-recall.md
+ *
+ * Covers graphExpandRecall (seed mapping, N-hop BFS, bidirectional traversal, visited/
+ * cycle safety, fanout cap, by-id load of reached memories with the recall hard filters
+ * re-applied (superseded-drop / asOf — NOT lexical gating), budget bound, no-op gate,
+ * tenant isolation, base-dedup) and the new graph.ts read helpers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
+import { estimateTokens, type SearchResult } from '../src/search.js';
+import {
+  insertEntity,
+  insertRelation,
+  loadNeighborRelations,
+  loadEntitiesByMemoryId,
+  loadEntitiesByIds,
+} from '../src/graph.js';
+import { graphExpandRecall } from '../src/graph-recall.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graphrecall-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+/** Write a distilled memory and return the full entry. Pads sub-3-char labels
+ *  (createMemory enforces a 3-char minimum) while keeping them distinct. */
+function mem(home: string, tenant: string, text: string): MemoryEntry {
+  const content = text.length < 3 ? text.repeat(3) : text;
+  const m = createMemory(content, { tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: tenant });
+  writeEntry(home, m, { actor: 'test' });
+  return m;
+}
+function sr(entry: MemoryEntry, score: number): SearchResult {
+  return { entry, score, bm25: score, cosine: 0, tokens: estimateTokens(entry.content) };
+}
+/** Decision entity from a memory (entity_type 'decision' is in the enum). */
+function ent(home: string, tenant: string, m: MemoryEntry, name: string): number {
+  return insertEntity(home, tenant, { entityType: 'decision', name, memoryId: m.id }).id;
+}
+
+describe('E3.2 graph-recall engine', () => {
+  let home: string;
+  const T = 'default';
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('1-hop surfaces a graph-linked neighbour the lexical search missed (loaded by id, not lexically gated)', () => {
+    const a = mem(home, T, 'decision alpha about cache invalidation strategy');
+    const b = mem(home, T, 'wholly unrelated wording xyzzy plugh frobnicate');
+    const ea = ent(home, T, a, 'A');
+    const eb = ent(home, T, b, 'B');
+    insertRelation(home, T, { fromEntityId: eb, toEntityId: ea, relType: 'supersedes', memoryId: b.id });
+
+    // base = only A (B is lexically orthogonal, would NOT be in any candidate set).
+    const base = [sr(a, 1.0)];
+    const out = graphExpandRecall(base, { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+
+    const ids = out.map((r) => r.entry.id);
+    expect(ids).toContain(b.id);
+    const bHit = out.find((r) => r.entry.id === b.id)!;
+    expect(bHit.graphVia).toEqual({ hops: 1, relType: 'supersedes', direction: 'from' });
+    expect(out[0].entry.id).toBe(a.id); // base result stays first
+  });
+
+  it('--hops 2 reaches the 2-hop node; --hops 1 does not', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb'); const c = mem(home, T, 'ccc');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B'); const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    insertRelation(home, T, { fromEntityId: eb, toEntityId: ec, relType: 'supersedes', memoryId: b.id });
+    const base = [sr(a, 1.0)];
+
+    // b and c are reached as the `to` endpoint of supersedes edges (superseded), so
+    // --include-superseded is needed to surface them; this test is about hop-distance.
+    const one = graphExpandRecall(base, { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, includeSuperseded: true });
+    expect(one.map((r) => r.entry.id)).toContain(b.id);
+    expect(one.map((r) => r.entry.id)).not.toContain(c.id);
+
+    const two = graphExpandRecall(base, { hops: 2, hippoRoot: home, tenantId: T, budget: 4000, includeSuperseded: true });
+    expect(two.map((r) => r.entry.id)).toEqual(expect.arrayContaining([b.id, c.id]));
+    expect(two.find((r) => r.entry.id === c.id)!.graphVia!.hops).toBe(2);
+  });
+
+  it('traverses bidirectionally (reaches a neighbour linked via to_entity_id)', () => {
+    const seed = mem(home, T, 'seed'); const other = mem(home, T, 'other');
+    const es = ent(home, T, seed, 'S'); const eo = ent(home, T, other, 'O');
+    // Edge points O -> S; seed is the `to` endpoint. Traversal must still reach O.
+    insertRelation(home, T, { fromEntityId: eo, toEntityId: es, relType: 'supersedes', memoryId: other.id });
+    const out = graphExpandRecall([sr(seed, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+    const hit = out.find((r) => r.entry.id === other.id)!;
+    expect(hit).toBeDefined();
+    expect(hit.graphVia!.direction).toBe('from'); // O is the `from` endpoint reached from seed's `to` side
+  });
+
+  it('visited set makes a cycle terminate without double-counting', () => {
+    const a = mem(home, T, 'a'); const b = mem(home, T, 'b');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    insertRelation(home, T, { fromEntityId: eb, toEntityId: ea, relType: 'supersedes', memoryId: b.id });
+    const out = graphExpandRecall([sr(a, 1.0)], { hops: 3, hippoRoot: home, tenantId: T, budget: 4000, includeSuperseded: true });
+    expect(out.filter((r) => r.entry.id === b.id)).toHaveLength(1);
+    expect(out).toHaveLength(2); // a (base) + b (reached once)
+  });
+
+  it('respects the per-hop maxNeighbors fanout cap', () => {
+    const seed = mem(home, T, 'seed');
+    const es = ent(home, T, seed, 'S');
+    const neighbours = ['nn1', 'nn2', 'nn3', 'nn4', 'nn5'].map((n) => {
+      const m = mem(home, T, n);
+      const e = ent(home, T, m, n);
+      insertRelation(home, T, { fromEntityId: es, toEntityId: e, relType: 'supersedes', memoryId: seed.id });
+      return m;
+    });
+    const out = graphExpandRecall([sr(seed, 1.0)], {
+      hops: 1, hippoRoot: home, tenantId: T, budget: 100000, maxNeighbors: 2, includeSuperseded: true,
+    });
+    expect(out.filter((r) => r.graphVia).length).toBe(2);
+    // sanity: all 5 neighbours exist, only 2 surfaced
+    expect(neighbours).toHaveLength(5);
+  });
+
+  it('drops a reached SUPERSEDED memory unless --include-superseded', () => {
+    const a = mem(home, T, 'active head decision');
+    const old = mem(home, T, 'older superseded predecessor');
+    // Mark `old` superseded (point it at `a`).
+    old.superseded_by = a.id;
+    writeEntry(home, old, { actor: 'test' });
+    const ea = ent(home, T, a, 'A'); const eo = ent(home, T, old, 'OLD');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eo, relType: 'supersedes', memoryId: a.id });
+    const base = [sr(a, 1.0)];
+
+    const dflt = graphExpandRecall(base, { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(dflt.map((r) => r.entry.id)).not.toContain(old.id); // superseded dropped by default
+
+    const incl = graphExpandRecall(base, { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, includeSuperseded: true });
+    expect(incl.map((r) => r.entry.id)).toContain(old.id); // surfaced when requested
+  });
+
+  it('graph-edge superseded semantics: the newer (from) endpoint shows by default; the older (to) endpoint needs --include-superseded (codex P2)', () => {
+    // old <- new : insertRelation(from=new, to=old) means "new supersedes old".
+    const oldD = mem(home, T, 'the older decision we moved on from');
+    const newD = mem(home, T, 'the current decision in force');
+    const eo = ent(home, T, oldD, 'OLD'); const en = ent(home, T, newD, 'NEW');
+    insertRelation(home, T, { fromEntityId: en, toEntityId: eo, relType: 'supersedes', memoryId: newD.id });
+
+    // Seed = the OLD decision (lexical hit). --hops reaches NEW as the `from` endpoint
+    // (the current version) -> shown by DEFAULT (no --include-superseded).
+    const fromOld = graphExpandRecall([sr(oldD, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(fromOld.map((r) => r.entry.id)).toContain(newD.id);
+    expect(fromOld.find((r) => r.entry.id === newD.id)!.graphVia!.direction).toBe('from');
+
+    // Seed = the NEW decision. --hops reaches OLD as the `to` endpoint (superseded) ->
+    // DROPPED by default, surfaced only with --include-superseded.
+    const fromNewDefault = graphExpandRecall([sr(newD, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(fromNewDefault.map((r) => r.entry.id)).not.toContain(oldD.id);
+    const fromNewIncl = graphExpandRecall([sr(newD, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, includeSuperseded: true });
+    expect(fromNewIncl.map((r) => r.entry.id)).toContain(oldD.id);
+  });
+
+  it('asOf drops a reached memory whose valid_from is after the as-of date', () => {
+    const a = mem(home, T, 'seed decision');
+    const future = mem(home, T, 'a future-dated linked decision');
+    const ea = ent(home, T, a, 'A'); const ef = ent(home, T, future, 'F');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: ef, relType: 'supersedes', memoryId: a.id });
+    // future.valid_from is "now"; ask as-of a date in the past -> it must be dropped.
+    const out = graphExpandRecall([sr(a, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, asOf: '2000-01-01' });
+    expect(out.map((r) => r.entry.id)).not.toContain(future.id);
+    expect(out).toHaveLength(1);
+  });
+
+  it('asOf applies the FULL bi-temporal rule: a superseded reached row is dropped once its successor was valid as-of (codex P2)', () => {
+    const seed = mem(home, T, 'current head decision');
+    const pred = mem(home, T, 'the predecessor decision lineage');
+    pred.valid_from = '2020-01-01T00:00:00.000Z';
+    pred.superseded_by = seed.id;
+    writeEntry(home, pred, { actor: 'test' });
+    // seed (the successor) became valid 2021-01-01.
+    seed.valid_from = '2021-01-01T00:00:00.000Z';
+    writeEntry(home, seed, { actor: 'test' });
+    const es = ent(home, T, seed, 'S'); const ep = ent(home, T, pred, 'P');
+    insertRelation(home, T, { fromEntityId: es, toEntityId: ep, relType: 'supersedes', memoryId: seed.id });
+
+    // as-of AFTER the successor became valid -> the predecessor is no longer the valid
+    // version, must be DROPPED (not merely valid_from <= asOf).
+    const after = graphExpandRecall([sr(seed, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, asOf: '2022-01-01' });
+    expect(after.map((r) => r.entry.id)).not.toContain(pred.id);
+
+    // as-of BEFORE the successor became valid -> the predecessor WAS the valid version,
+    // must be surfaced.
+    const before = graphExpandRecall([sr(seed, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 4000, asOf: '2020-06-01' });
+    expect(before.map((r) => r.entry.id)).toContain(pred.id);
+  });
+
+  it('expands the GLOBAL store too: a seed whose graph lives in globalRoot surfaces its neighbour (codex P2)', () => {
+    const glob = makeRoot();
+    try {
+      // The seed + its graph live in the GLOBAL store; the local store has no entities.
+      const seed = mem(glob, T, 'globally-stored seed decision');
+      const linked = mem(glob, T, 'a globally-stored linked predecessor');
+      const es = ent(glob, T, seed, 'S'); const el = ent(glob, T, linked, 'L');
+      insertRelation(glob, T, { fromEntityId: es, toEntityId: el, relType: 'supersedes', memoryId: seed.id });
+      const out = graphExpandRecall([sr(seed, 1.0)], { hops: 1, hippoRoot: home, globalRoot: glob, tenantId: T, budget: 4000, includeSuperseded: true });
+      expect(out.map((r) => r.entry.id)).toContain(linked.id);
+      expect(out.find((r) => r.entry.id === linked.id)!.graphVia).toBeDefined();
+    } finally {
+      safeRmSync(glob);
+    }
+  });
+
+  it('--hops 0 is a no-op (identity)', () => {
+    const a = mem(home, T, 'a');
+    const base = [sr(a, 1.0)];
+    expect(graphExpandRecall(base, { hops: 0, hippoRoot: home, tenantId: T, budget: 4000 })).toBe(base);
+  });
+
+  it('empty graph is a no-op (no throw)', () => {
+    const a = mem(home, T, 'a');
+    const base = [sr(a, 1.0)];
+    const out = graphExpandRecall(base, { hops: 2, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(out).toBe(base); // no seed entity -> unchanged reference
+  });
+
+  it('token budget bounds the augmented set', () => {
+    const a = mem(home, T, 'short');
+    const big = mem(home, T, 'x'.repeat(8000)); // ~2000 tokens
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, big, 'B');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    // Budget already nearly consumed by the base entry; the big neighbour overflows it.
+    // includeSuperseded so the exclusion under test is the BUDGET, not the superseded-endpoint drop.
+    const out = graphExpandRecall([sr(a, 1.0)], { hops: 1, hippoRoot: home, tenantId: T, budget: 10, includeSuperseded: true });
+    expect(out.map((r) => r.entry.id)).not.toContain(big.id);
+  });
+
+  it('does not duplicate a neighbour already present in the base results (it stays a seed, untouched)', () => {
+    const a = mem(home, T, 'a'); const b = mem(home, T, 'b');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    const base = [sr(a, 1.0), sr(b, 0.9)]; // b already returned lexically -> it is a seed too
+    const out = graphExpandRecall(base, { hops: 1, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(out.filter((r) => r.entry.id === b.id)).toHaveLength(1);
+    expect(out.find((r) => r.entry.id === b.id)!.graphVia).toBeUndefined(); // already-present neighbour left as-is
+  });
+
+  it('never reaches another tenant\'s entity', () => {
+    const a = mem(home, T, 'a');
+    const aOther = mem(home, 'other', 'other-tenant');
+    const ea = ent(home, T, a, 'A');
+    const eo = ent(home, 'other', aOther, 'O');
+    // A cross-tenant relation cannot be inserted (insertRelation rejects it), so the
+    // graphs are disjoint by construction. Expanding tenant T must not surface 'other'.
+    expect(() => insertRelation(home, T, { fromEntityId: ea, toEntityId: eo, relType: 'supersedes', memoryId: a.id }))
+      .toThrow(/another tenant/i);
+    const out = graphExpandRecall([sr(a, 1.0)], { hops: 2, hippoRoot: home, tenantId: T, budget: 4000 });
+    expect(out.map((r) => r.entry.id)).not.toContain(aOther.id);
+  });
+});
+
+describe('E3.2 graph.ts read helpers', () => {
+  let home: string;
+  const T = 'default';
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('loadEntitiesByMemoryId maps source memory ids to entities (hit + miss)', () => {
+    const a = mem(home, T, 'a');
+    const ea = ent(home, T, a, 'A');
+    const got = loadEntitiesByMemoryId(home, T, [a.id, 'nonexistent']);
+    expect(got).toHaveLength(1);
+    expect(got[0].id).toBe(ea);
+    expect(loadEntitiesByMemoryId(home, T, [])).toEqual([]);
+  });
+
+  it('loadEntitiesByIds resolves reached entity rows by id', () => {
+    const a = mem(home, T, 'a'); const b = mem(home, T, 'b');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B');
+    const got = loadEntitiesByIds(home, T, [ea, eb]).sort((x, y) => x.id - y.id);
+    expect(got.map((e) => e.id)).toEqual([ea, eb].sort((x, y) => x - y));
+  });
+
+  it('loadNeighborRelations returns edges in BOTH directions for the frontier', () => {
+    const a = mem(home, T, 'a'); const b = mem(home, T, 'b'); const c = mem(home, T, 'c');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B'); const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id }); // A->B
+    insertRelation(home, T, { fromEntityId: ec, toEntityId: ea, relType: 'supersedes', memoryId: c.id }); // C->A
+    const rels = loadNeighborRelations(home, T, [ea]); // touches A as from (A->B) and as to (C->A)
+    expect(rels).toHaveLength(2);
+  });
+
+  it('loadNeighborRelations rejects a non-integer limit (guards the raw LIMIT ?)', () => {
+    const a = mem(home, T, 'a'); const ea = ent(home, T, a, 'A');
+    expect(() => loadNeighborRelations(home, T, [ea], { limit: 1.5 })).toThrow(/non-negative integer/);
+    expect(() => loadNeighborRelations(home, T, [ea], { limit: -1 })).toThrow(/non-negative integer/);
+  });
+});


### PR DESCRIPTION
## What

`hippo recall "<query>" --hops N` augments lexical recall with memories reached by walking the E3 entities/relations graph N hops (0..3, default off) from the seed results. This is the consumer/payoff of the E3 graph substrate (E3.1 extraction + E3.3 guard already shipped).

## How

- New `src/graph-recall.ts` (SELECT-only, so the E3.3 graph-write lint permits it outside `graph.ts`): seed memory_ids to entities, bidirectional BFS, graph hits load **directly by id** (NOT the lexical candidate set, so lexically-orthogonal neighbours surface), inherit their origin seed's relevance, placed adjacent to the seed, budget-bounded with `--min-results` protection. Local AND global stores. Full bi-temporal `--as-of`.
- Three read helpers in `src/graph.ts`; `--hops`/`--max-neighbors` wiring in `cli.ts`; optional `graphVia` on `SearchResult`; `graphExpandRecall` SDK export.
- No migration (read-only over the existing E3 tables). Bumps 1.15.0 to 1.16.0.

## Behaviour note

On today's supersedes-only graph, `--hops` from an old seed shows the **newer** version by default; the older superseded predecessors surface under `--include-superseded`. Cross-object edges (future E3.1) light up the same traversal with zero rework.

## Review trail

plan-eng-critic (82) → code-review-critic (86) → independent-review-critic (88) → two codex rounds caught **6 P2s the Claude gates missed** (asOf bi-temporal, 500-id cap, global-store, superseded-by-default, min-results floor, benchmark isolation), all fixed + regression-tested.

## Test plan

- [x] 19 real-DB tests (`tests/graph-recall.test.ts`): BFS, cycle-safety, fanout cap, bidirectional, graph-edge superseded semantics, full bi-temporal asOf, global expansion, budget + min-results, tenant isolation, no-op, dedup, helpers
- [x] Full suite: 2406 pass (1 pre-existing `server-concurrency` network flake, unrelated)
- [x] tsc clean; graph-write lint green; em-dash release-notes lint green
- [x] Benchmark (`benchmarks/e3.2/multihop_benchmark.mjs`): predecessor recall 3/5 to 5/5
- [x] CLI smoke: `--hops 1.5 / -1 / 99 / bare` rejected; `--hops 2` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)