### PR TITLE
feat: E3 sleep enqueue-hook + atomic graph rebuild (v1.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## 1.19.0 (2026-06-02): E3 sleep enqueue-hook (graph auto-rebuilds during sleep)
+
+### Added
+- **Graph auto-rebuild on `hippo sleep`.** Every graph-source mutation (save/close
+  of decision/policy/customer_note, and save/close/refresh of project_brief) now
+  marks its tenant dirty via the `graph_extraction_queue`, and `hippo sleep` drains
+  the queue, rebuilding the entity/relation graph for each dirty tenant. So
+  `recall --hops` and cross-object `references` edges run on fresh data without a
+  manual `hippo graph extract`. `SleepResult` gains an optional `graph` summary
+  (`{tenants, entities, relations}`), redacted as a cross-tenant aggregate on
+  non-loopback egress.
+
+### Changed
+- **`extractGraph` is now atomic.** The clear plus all inserts run inside one
+  `BEGIN IMMEDIATE` transaction (`runGraphRebuildTransaction`), so two concurrent
+  rebuilds serialize on the SQLite write lock instead of duplicating rows, and a
+  throw mid-rebuild rolls back the clear (no bricked graph). Source reads are
+  preloaded before the transaction opens.
+- **`writeEntry` gains an `afterCommit` hook** (runs post-commit, pre-mirror) so a
+  committed save always marks the graph dirty even when a later markdown-mirror
+  write fails.
+
 ## 1.18.0 (2026-06-02): A7 recall-trace - explainable lifecycle re-ranking
 
 ### Added

--- a/docs/evals/2026-06-02-e3-sleep-enqueue-hook-result.md
+++ b/docs/evals/2026-06-02-e3-sleep-enqueue-hook-result.md
@@ -1,0 +1,93 @@
+# E3 sleep enqueue-hook — verify result (DESCRIPTIVE)
+
+- Date: 2026-06-02
+- Episode: 01KT4CP9K6BEQ4ESCTFV49A8DX (/dev-framework-rl, backend)
+- Feature: auto-rebuild the entity/relation graph during `hippo sleep` (producer
+  `markGraphDirty` on every graph-source E2 mutation + a fault-isolated drain
+  phase in `api.sleep`), so `recall --hops` and cross-object `references` edges
+  run on fresh data without a manual `hippo graph extract`.
+
+This is verify-stage evidence: correctness is structural ("the graph after sleep
+equals a manual extract, and the queue is drained"), not a tuned metric.
+
+## Runtime evidence
+
+| check | result |
+|---|---|
+| `tests/graph-sleep-hook.test.ts` (new) | **13/13 pass** (real SQLite, no mocks) |
+| full suite `npx vitest run` | **2435 pass / 4 skip / 1 fail** |
+| the 1 failure | `server-concurrency.test.ts` `ECONNRESET` under full-suite load — the known environmental flake; **passes in isolation** (re-ran: 1/1 pass); zero references to this diff |
+| `scripts/check-graph-writes.mjs` | **green** — all graph writes still funnel through `src/graph.ts` |
+| `npm run build` (tsc + benchmarks tsc) | **clean** |
+
+## What the 13 tests lock
+
+1. `saveDecision` enqueues one pending queue item for its tenant.
+2. `markGraphDirty` is fail-soft: a bogus/null memoryId neither throws nor enqueues.
+3. Coalesce: 3 decisions → 3 pending items, one tenant.
+4. `close*` and project-brief `refresh` also enqueue (dirty on every graph-source mutation).
+5. `sleep` rebuilds the dirty tenant's graph and drains its queue (`graph: {tenants:1, entities:2, relations:0}`).
+6. Only dirty tenants rebuild — a second sleep with no new writes reports no graph work.
+7. Multi-tenant: two dirty tenants both rebuild + drain; entities stay tenant-isolated.
+8. dryRun: no rebuild, no drain (items stay pending), no `graph` field.
+9. Snapshot watermark: an item enqueued DURING the rebuild stays pending.
+10. Fault isolation: one tenant's `extractGraph` throwing leaves it pending, others drain, sleep does not reject.
+11. End-to-end: a `supersedes` edge is built by sleep with NO manual extract.
+12. Redaction: `redactSleepResultForCaller` zeroes `graph.*` for a non-loopback non-self caller; loopback passes through.
+13. Clean store: sleep with no graph-source objects omits the `graph` field.
+
+## Notes / honest caveats
+
+- **Audit interaction (pre-existing, by design):** sleep's audit phase (Phase 3)
+  removes too-short "junk" memories before the graph drain (Phase 6). A decision
+  whose mirror is removed becomes invisible to the graph (null mirror skipped by
+  `extractGraph`). This is correct — the graph indexes *post-consolidation* state
+  — and is the documented "forgotten-mirror staleness" class, not introduced here.
+  (Surfaced during test authoring: short test-decision texts were being audited
+  away; tests now use realistic texts that survive, matching the passing tests.)
+- **Per-store scope:** the drain runs on whichever `hippoRoot` is slept (local is
+  primary); the global store's graph refreshes when the global store is itself
+  slept/extracted. Out of scope for this episode.
+- **No migration** — the `graph_extraction_queue` substrate already shipped in E3.3.
+
+## Cross-model review (codex `review --commit`)
+
+- **Round 1 — [P1] dirty-tenant snapshot vs. mirror deletion: FIXED.** The queue
+  rows are FK'd `ON DELETE CASCADE`; an earlier sleep phase deleting a queued
+  mirror (e.g. dedup removing a near-duplicate superseding decision) would drop
+  the tenant from a drain-time load and leave its graph stale. Fixed by
+  snapshotting dirty tenants at the start of sleep, before any memory-deleting
+  phase. Locked by test #14.
+- **Round 2 — [P2] snapshot fail-soft: FIXED.** The early snapshot ran outside
+  the graph try, so a `loadPendingExtractionTenants` failure aborted core sleep —
+  breaking fail-soft. Fixed: the snapshot is wrapped so a queue-read failure skips
+  graph refresh (recovered next sleep) without aborting consolidation. Locked by
+  test #15.
+- **Round 2 — [P2] serialize concurrent tenant rebuilds: FIXED (atomic rebuild).**
+  Two `hippo sleep` runs overlapping on the same `hippoRoot` could both run
+  `extractGraph` (a non-atomic clear-then-reinsert) and transiently duplicate
+  derived graph rows. Fixed at the root: `extractGraph` now reads all source rows
+  first (own connections), then runs clear + every insert inside ONE
+  `runGraphRebuildTransaction` (`BEGIN IMMEDIATE`) on a single connection. SQLite's
+  single-writer serializes concurrent rebuilds (the second waits, then re-derives
+  cleanly — no duplicate rows), and a throw mid-rebuild now ROLLS BACK the clear
+  (also closing the latent "throw-after-clearGraph bricks the rebuild" edge). The
+  reads are preloaded because holding the write transaction while opening a second
+  read connection dead-locks (`database is locked`). New `graph.ts` primitives:
+  `runGraphRebuildTransaction` + an optional `txDb` on `clearGraph`/`insertEntity`/
+  `insertRelation` (existing callers unchanged). Locked by test #16 (rollback-on-throw)
+  + the full 71-test graph suite green. Lint (`check-graph-writes`) still green —
+  all graph writes funnel through `graph.ts`.
+- **Round 3 — [P2] committed save unflagged on post-commit mirror failure: FIXED.**
+  `writeEntry` commits the DB row (`RELEASE SAVEPOINT`) then writes markdown
+  mirrors; the producer `markGraphDirty` ran *after* `writeEntry` returned, so a
+  mirror-write throw after the commit skipped it, leaving a committed
+  decision/policy/note/brief with no pending queue row until the next mutation /
+  manual extract. Fixed by adding a `writeEntry` **`afterCommit`** hook that runs
+  post-commit but pre-mirror; the 4 `save*` paths mark the graph dirty there, so a
+  later mirror failure can no longer skip it. (`close*` paths already mark dirty
+  after their own `COMMIT` and write no mirror.) The enqueue runs on the
+  committed, idle `writeEntry` connection, so its own handle does not contend
+  (full suite green, no `database is locked`). The only residual window — a
+  process crash between the `RELEASE SAVEPOINT` and the enqueue (microseconds) —
+  is inherent to fail-soft and self-heals on the next mutation / manual extract.

--- a/docs/plans/2026-06-02-e3-sleep-enqueue-hook.md
+++ b/docs/plans/2026-06-02-e3-sleep-enqueue-hook.md
@@ -1,0 +1,205 @@
+# E3 sleep enqueue-hook — auto-rebuild the graph during `hippo sleep`
+
+- Date: 2026-06-02
+- Episode: 01KT4CP9K6BEQ4ESCTFV49A8DX (/dev-framework-rl, backend)
+- Status: Draft (not yet engineering-reviewed)
+
+## Problem
+
+The E3 graph layer (`entities`/`relations`) is a pure derived function of the
+consolidated E2 objects (decision/policy/customer_note/project_brief). It is
+rebuilt only by the **manual** `hippo graph extract` command. So after any
+`hippo decide` / `hippo policy` / brief refresh, the graph silently goes stale,
+and `recall --hops N` + the E3.1 cross-object `references` edges operate on
+stale data until someone re-runs extract by hand. E3.3 built a
+`graph_extraction_queue` table + an `enqueueExtraction`/`loadExtractionQueue`/
+`markExtractionProcessed` API **specifically as the interface for a deferred
+`hippo sleep` hook** (see `src/graph.ts:458` docstring) — but the hook was never
+wired. No production code calls `enqueueExtraction` today (test-only).
+
+## Goal
+
+Wire both halves so the graph auto-refreshes as part of the normal consolidation
+cycle, with **no manual extract** needed in steady state:
+
+- **Producer** — every mutation of a graph-source E2 object marks its tenant
+  dirty by enqueuing into `graph_extraction_queue` (fail-soft).
+- **Consumer** — `hippo sleep` drains the pending queue: for each dirty tenant,
+  run the existing `extractGraph` full rebuild, then mark its drained items
+  processed.
+
+`hippo graph extract` stays as the immediate-refresh escape hatch.
+
+## Design
+
+### Producer — `markGraphDirty` helper + 9 call-sites
+
+New helper (in `src/graph.ts`, the sole sanctioned graph writer):
+
+```ts
+/** Fail-soft: enqueue the tenant for graph re-extraction. NEVER throws into the
+ *  caller — a graph-dirty signal failing must not abort a core E2 write. */
+export function markGraphDirty(hippoRoot: string, tenantId: string, memoryId: string | null): void {
+  if (!memoryId) return;                       // forgotten mirror -> nothing to enqueue
+  try { enqueueExtraction(hippoRoot, tenantId, memoryId); }
+  catch (err) { /* log at debug; staleness is recoverable via next sleep / manual extract */ }
+}
+```
+
+Called from all **9** graph-source mutation sites (audit-enumerated; supersede is
+internal to the `save*` calls, so one call per site covers create+supersede):
+
+| Module | Functions |
+|---|---|
+| `decisions.ts` | `saveDecision`, `closeDecision` |
+| `policies.ts` | `savePolicy`, `closePolicy` |
+| `customer-notes.ts` | `saveCustomerNote`, `closeCustomerNote` |
+| `project-briefs.ts` | `saveProjectBrief`, `closeProjectBrief`, `refreshBrief` |
+
+Each passes the object's mirror `memoryId` (still consolidated-kind on close —
+the close path does not mutate the mirror, only the row `status`). The enqueue is
+a per-tenant **dirty flag**, not a unit of work: many enqueues between sleeps
+coalesce to one rebuild.
+
+**Why fail-soft is load-bearing:** these are core commands. An enqueue throwing
+(e.g. a mirror that is somehow not consolidated-kind, a race-deleted memory) must
+not break `hippo decide`. Graph staleness is recoverable; a broken write is not.
+The `catch` logs at **warn** (not silent) so a *systematic* enqueue failure is
+operator-visible, and a happy-path test (producer test #1) fails if enqueue ever
+stops working — staleness is recoverable but not silently masked.
+
+**CRITICAL — post-commit placement (atomicity, not deadlock).** `markGraphDirty`
+is called **post-commit**, never inside the write transaction. The driver is the
+**fail-soft requirement**, not a lock deadlock: an in-transaction enqueue would be
+*atomic* but a throw would roll back the whole E2 write — the opposite of
+fail-soft. So the enqueue is deliberately **post-commit and non-atomic**: a crash
+in the µs window between the write committing and the enqueue leaves the tenant
+dirty-but-unflagged, which the next mutation or a manual `graph extract` recovers.
+Fail-soft beats atomic here. (Note: the DB runs WAL + `busy_timeout=5000`
+[db.ts:1907-1908], so `enqueueExtraction`'s second `openHippoDb` connection does
+NOT hard-deadlock against a *committed* writer — the lock is already released; the
+post-commit rule is about transaction semantics, not lock contention.)
+
+Placement differs by mutation shape (audit-confirmed):
+- **`save*` (writeEntry-based):** `writeEntry` opens, commits, and **closes** its
+  own connection before returning, so call `markGraphDirty` right after the
+  `writeEntry(...)` call returns (connection already closed) — clean.
+- **`close*` (manual `openHippoDb` + `BEGIN IMMEDIATE`, returns from inside `try`,
+  `closeHippoDb` in `finally`):** there is no post-`finally` tail to use, so call
+  `markGraphDirty` **after `db.exec('COMMIT')`, immediately before the `return`**.
+  The COMMIT has released the write lock, so the second connection proceeds
+  (busy_timeout covers any transient). `refreshBrief` delegates to
+  `saveProjectBrief`, so the save\* placement covers it.
+
+Placing the call inside the mutation function (vs at each CLI/HTTP/MCP call-site)
+keeps it DRY — every caller gets the dirty-flag automatically.
+
+### Consumer — drain phase inside `api.sleep`
+
+The rebuild belongs with consolidation (root location), so both CLI `hippo sleep`
+and HTTP `/v1/sleep` / MCP refresh the graph — not bolted onto `cmdSleepCore`
+(which would leave HTTP callers stale). New late phase in `api.sleep`, after the
+existing consolidate/dedup/audit/share/ambient phases:
+
+1. `const tenants = loadPendingExtractionTenants(hippoRoot)` — new graph.ts read,
+   `SELECT DISTINCT tenant_id FROM graph_extraction_queue WHERE status='pending'`.
+2. For each dirty tenant (fault-isolated per tenant):
+   - **Snapshot** the pending item ids first (`loadExtractionQueue(..., {status:'pending'})`).
+   - If `dryRun` → record a "would rebuild" detail, do NOT extract, do NOT mark.
+   - Else → `extractGraph(hippoRoot, tenant)` (full idempotent rebuild), then
+     `markExtractionProcessed` for **only the snapshotted ids** (items enqueued
+     during the rebuild stay pending → caught next sleep; no lost-update race).
+   - A per-tenant extract throw → leave that tenant's items pending, push an error
+     detail, continue to the next tenant. The graph phase never aborts sleep.
+
+### Reporting + redaction
+
+Add an optional structured field to `SleepResult`:
+
+```ts
+graph?: { tenants: number; entities: number; relations: number };
+```
+
+`tenants`/`entities`/`relations` are **cross-tenant aggregates**, so they belong
+in `redactSleepResultForCaller` (sleep-redact.ts) alongside the existing
+`deduped`/`audit`/`ambient` counters it zeroes. **Honest status:**
+`redactSleepResultForCaller` is currently layered-defence with **zero callers** —
+`/v1/sleep` (server.ts) sends the raw `SleepResult` and is loopback-only-gated
+upstream, so today `deduped`/`audit`/`ambient` already egress unredacted over
+HTTP. Adding `graph.*` to the redact function keeps it consistent for when the
+non-loopback serving gate lands (per the file's own D3 sequencing note); it
+introduces **no new leak vs. the status quo** and does NOT imply the HTTP path is
+redacted today. `renderSleepResult` (cli.ts) prints a one-line summary
+(`Graph: rebuilt N tenants (X entities, Y relations)`) when `graph` is present
+and non-zero. Under `dryRun`, `tenants` reflects dirty tenants but
+`entities`/`relations` stay 0 (nothing rebuilt).
+
+### Testability — `SleepPhases` DI seam
+
+Add `extractGraph` (and the new `loadPendingExtractionTenants`) to the
+`SleepPhases` interface + `DEFAULT_SLEEP_PHASES` so
+`tests/api-sleep-phase-faults.test.ts`-style tests can inject a throwing
+extractor and assert the graph phase is fault-isolated (sleep still completes;
+the failing tenant's items remain pending).
+
+## New / changed surface
+
+- `src/graph.ts`: `markGraphDirty` (fail-soft producer), `loadPendingExtractionTenants` (DISTINCT-tenant read).
+- `src/api.ts`: `SleepResult.graph?`, `SleepPhases` += `extractGraph`/`loadPendingExtractionTenants`, new graph-drain phase in `sleep()`.
+- `src/sleep-redact.ts`: redact `graph.*`.
+- `src/cli.ts`: `renderSleepResult` prints the graph line.
+- `src/decisions.ts`, `policies.ts`, `customer-notes.ts`, `project-briefs.ts`: `markGraphDirty` call at each of the 9 sites.
+- **No migration** — `graph_extraction_queue` already exists (E3.3).
+
+## Test plan (real SQLite, temp dirs — no mocks, no external DB)
+
+New `tests/graph-sleep-hook.test.ts`:
+1. Producer: `saveDecision` enqueues one pending queue item for its tenant.
+2. Producer fail-soft: enqueue failure (inject) does NOT throw out of `saveDecision`.
+3. Producer coalesce: 3 decisions → 3 pending items, all same tenant.
+4. Close enqueues (dirty on close); refreshBrief enqueues.
+5. Consumer: after `sleep`, the graph is rebuilt (entities present) and the
+   tenant's queue items are `processed`.
+6. Consumer dirty-only: a tenant with no pending items is NOT rebuilt (queue empty → skip).
+7. Multi-tenant: two dirty tenants both rebuilt + drained; tenant isolation holds.
+8. dryRun: `sleep --dry-run` does NOT rebuild and does NOT mark processed (items stay pending); `graph.tenants` reported, entities/relations 0.
+9. Snapshot race: an item enqueued after the snapshot stays pending after drain.
+10. Fault-isolation: an injected `extractGraph` throw for tenant A leaves A pending, sleep completes, tenant B still drained.
+11. End-to-end: `saveDecision` (no manual extract) → `sleep` → `recall --hops 1` traverses the freshly-built edge.
+12. Redaction: `redactSleepResultForCaller` zeroes `graph.*` for a non-loopback non-self caller; loopback passes through.
+13. SleepResult shape unchanged when no tenant is dirty (`graph` omitted or zero).
+
+Plus: existing sleep tests (`api-sleep*.test.ts`) still green; `npm test` full
+suite; `scripts/check-graph-writes.mjs` green (all graph writes still funnel
+through graph.ts).
+
+## Out of scope (explicit)
+
+- Real-time graph (the graph refreshes at **sleep**, not on every write — manual
+  `graph extract` remains for immediate refresh). This is the intended contract.
+- Incremental/partial extraction (extractGraph is a full idempotent rebuild; the
+  queue is a dirty flag, not a work unit).
+- New entity source types (incident/process/skill/prediction) — still the
+  deferred semantic-relations follow-up; the 9 call-sites cover exactly today's
+  4 graph-source object types.
+- Per-tenant scoping of the rest of `api.sleep` (the open TODOS item) — the graph
+  phase is per-dirty-tenant, but consolidation stays whole-hippoRoot as today.
+- **Global-store graph.** The drain operates on whichever `hippoRoot` is being
+  slept; `markGraphDirty` enqueues into the same root the write happened in
+  (local is the primary case). `recall --hops` reads local+global graphs (E3.2),
+  but the **global** store's graph refreshes when the global store is itself
+  slept/extracted — this hook does not cross-write a remote root's queue. Per-store
+  by design; consistent with how `autoShare` (not the E2 tables) is what crosses
+  to global.
+- **Forgotten-mirror staleness (pre-existing).** A source row whose memory mirror
+  is forgotten (memory_id nulled) *without* a `close*` call leaves an active row
+  that `extractGraph` skips, with no enqueue. This is a pre-existing class,
+  recoverable by the next sleep/manual extract, and consistent with the
+  "refresh at sleep" contract — not addressed here.
+
+## Disposition
+
+Deterministic wiring of an already-built, already-tested substrate into the
+lifecycle. Ships always-on (the hook is the feature; there is no precision/quality
+gate to clear — correctness is "graph matches a manual extract after sleep, queue
+drained"). Minor version bump (new behavior, additive `SleepResult` field).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.18.0",
+  "version": "1.19.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,6 +68,8 @@ import { consolidate } from './consolidate.js';
 import { loadConfig } from './config.js';
 import { deduplicateStore } from './dedupe.js';
 import { computeAmbientState, type AmbientState } from './ambient.js';
+import { loadPendingExtractionTenants, markPendingProcessedUpTo } from './graph.js';
+import { extractGraph } from './graph-extract.js';
 import {
   computePlanningFallacyOutput,
   type PlanningFallacyHint,
@@ -2446,6 +2448,13 @@ export interface SleepResult {
   audit?: { errorsRemoved: number; warningCount: number };
   shared?: number;
   ambient?: AmbientState | null;
+  /**
+   * E3 sleep enqueue-hook: graph re-extraction totals across the tenants rebuilt
+   * this sleep. Absent when no tenant was dirty, and under dryRun (the graph
+   * phase runs only on a real sleep). Cross-tenant aggregate — zeroed on
+   * non-loopback non-self egress by sleep-redact.ts.
+   */
+  graph?: { tenants: number; entities: number; relations: number };
   details?: string[];
 }
 
@@ -2488,6 +2497,8 @@ export interface SleepPhases {
   deleteEntry: typeof deleteEntry;
   computeAmbientState: typeof computeAmbientState;
   loadConfig: typeof loadConfig;
+  loadPendingExtractionTenants: typeof loadPendingExtractionTenants;
+  extractGraph: typeof extractGraph;
 }
 
 const DEFAULT_SLEEP_PHASES: SleepPhases = {
@@ -2499,6 +2510,8 @@ const DEFAULT_SLEEP_PHASES: SleepPhases = {
   deleteEntry,
   computeAmbientState,
   loadConfig,
+  loadPendingExtractionTenants,
+  extractGraph,
 };
 
 export async function sleep(
@@ -2519,9 +2532,31 @@ export async function sleep(
   let auditDeletedCount = 0;
   let ambientTotal = 0;
   let phaseError: Error | null = null;
+  let graphSnapshotError: string | null = null;
 
   let result: SleepResult | null = null;
   try {
+    // Snapshot dirty tenants BEFORE any memory-deleting phase (consolidate /
+    // dedup / audit). The graph_extraction_queue rows are FK'd to mirror
+    // memories with ON DELETE CASCADE, so a phase that deletes a queued mirror
+    // (e.g. dedup removing a near-duplicate superseding decision) would drop the
+    // tenant from a drain-time load and leave its graph stale (codex P1). The
+    // MAX(id) watermark captured here stays valid: arrivals during sleep get a
+    // higher id and remain pending.
+    //
+    // Fail-soft (codex P2): a queue-read failure here must NOT abort core sleep
+    // (consolidation / dedup / audit run regardless). On failure, skip graph
+    // refresh this sleep (recovered next sleep) and surface a detail once
+    // `result` exists (Phase 6).
+    let dirtyTenants: { tenantId: string; maxPendingId: number }[] = [];
+    if (!dryRun) {
+      try {
+        dirtyTenants = phases.loadPendingExtractionTenants(ctx.hippoRoot);
+      } catch (snapErr) {
+        graphSnapshotError = (snapErr as Error).message;
+      }
+    }
+
     // Phase 1: Consolidation.
     const consolidateResult = await phases.consolidate(ctx.hippoRoot, { dryRun });
     consolidationCount = consolidateResult.semanticCreated + consolidateResult.merged;
@@ -2599,6 +2634,57 @@ export async function sleep(
         result.ambient = phases.computeAmbientState(postSleepEntries);
         ambientTotal = result.ambient.totalMemories;
       }
+    }
+
+    // Phase 6: Graph extraction drain (E3 sleep enqueue-hook). Rebuild the
+    // entity/relation graph for every tenant marked dirty (by markGraphDirty)
+    // since the last sleep, so `recall --hops` + cross-object `references` edges
+    // run on fresh data without a manual `hippo graph extract`. Fully
+    // fault-isolated: the consolidation work above has already committed, so a
+    // failure here must never abort sleep; a per-tenant extract failure leaves
+    // that tenant's queue items pending for the next sleep. (Skipped under
+    // dryRun via the early return above.)
+    try {
+      if (graphSnapshotError) {
+        // The dirty-tenant snapshot failed (codex P2 fail-soft). Core sleep
+        // already succeeded; surface the skipped graph refresh as a detail.
+        result.details = [
+          ...(result.details ?? []),
+          `graph: dirty-tenant snapshot failed (skipped graph refresh): ${graphSnapshotError}`,
+        ];
+      }
+      let gTenants = 0;
+      let gEntities = 0;
+      let gRelations = 0;
+      // dirtyTenants was snapshotted before the memory-deleting phases above.
+      for (const { tenantId, maxPendingId } of dirtyTenants) {
+        try {
+          const ext = phases.extractGraph(ctx.hippoRoot, tenantId);
+          // Count the rebuild as soon as it succeeds — it happened regardless of
+          // the drain-mark below.
+          gTenants += 1;
+          gEntities += ext.entities;
+          gRelations += ext.relations;
+          // Watermark drain: mark processed only items enqueued before this
+          // rebuild started (id <= maxPendingId). Arrivals during the rebuild
+          // keep pending status and are caught next sleep; rows whose mirror was
+          // cascade-deleted earlier this sleep are already gone (no-op).
+          markPendingProcessedUpTo(ctx.hippoRoot, tenantId, maxPendingId);
+        } catch (tenantErr) {
+          result.details = [
+            ...(result.details ?? []),
+            `graph: extract failed for a dirty tenant (left pending): ${(tenantErr as Error).message}`,
+          ];
+        }
+      }
+      if (gTenants > 0) {
+        result.graph = { tenants: gTenants, entities: gEntities, relations: gRelations };
+      }
+    } catch (graphErr) {
+      result.details = [
+        ...(result.details ?? []),
+        `graph: drain phase failed (skipped): ${(graphErr as Error).message}`,
+      ];
     }
 
     return result;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2631,6 +2631,13 @@ export function renderSleepResult(result: api.SleepResult): void {
   if (result.ambient) {
     console.log(`\n${renderAmbientSummary(result.ambient)}`);
   }
+
+  if (result.graph && result.graph.tenants > 0) {
+    const { tenants, entities, relations } = result.graph;
+    console.log(
+      `\nGraph: rebuilt ${tenants} tenant${tenants === 1 ? '' : 's'} (${entities} entities, ${relations} relations).`,
+    );
+  }
 }
 
 async function cmdSleepCore(

--- a/src/customer-notes.ts
+++ b/src/customer-notes.ts
@@ -22,6 +22,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
+import { markGraphDirty } from './graph.js';
 import { createMemory, Layer, CUSTOMER_NOTE_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -289,6 +290,7 @@ export function saveCustomerNote(
         },
       });
     },
+    afterCommit: () => markGraphDirty(hippoRoot, tenantId, mem.id),
   });
 
   if (!savedRow) {
@@ -344,7 +346,9 @@ export function closeCustomerNote(
       });
 
       db.exec('COMMIT');
-      return rowToCustomerNote(row);
+      const closed = rowToCustomerNote(row);
+      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      return closed;
     } catch (e) {
       try {
         db.exec('ROLLBACK');

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -26,6 +26,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
+import { markGraphDirty } from './graph.js';
 import { createMemory, Layer, DECISION_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -237,6 +238,10 @@ export function saveDecision(
         },
       });
     },
+    // Post-commit hook: mark the tenant's graph dirty AFTER the DB row commits
+    // but BEFORE the markdown mirrors are written, so a mirror-write failure can
+    // never leave a committed save unflagged (codex). markGraphDirty is fail-soft.
+    afterCommit: () => markGraphDirty(hippoRoot, tenantId, mem.id),
   });
 
   if (!savedRow) {
@@ -295,7 +300,10 @@ export function closeDecision(
       });
 
       db.exec('COMMIT');
-      return rowToDecision(row);
+      const closed = rowToDecision(row);
+      // After COMMIT (write lock released), before the finally closes `db`.
+      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      return closed;
     } catch (e) {
       try {
         db.exec('ROLLBACK');

--- a/src/graph-extract.ts
+++ b/src/graph-extract.ts
@@ -21,7 +21,7 @@
  * `hippo sleep` enqueue-hook.
  */
 
-import { clearGraph, insertEntity, insertRelation, MAX_ENTITY_NAME_LEN, type EntityType } from './graph.js';
+import { clearGraph, insertEntity, insertRelation, runGraphRebuildTransaction, MAX_ENTITY_NAME_LEN, type EntityType, type GraphTxDb } from './graph.js';
 import { loadDecisions } from './decisions.js';
 import { loadPolicies } from './policies.js';
 import { loadCustomerNotes } from './customer-notes.js';
@@ -158,8 +158,38 @@ export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult
     { entityType: 'project', loadFn: loadProjectBriefs, nameOf: (r) => r.repo, textOf: (r) => [r.repo, r.summary].filter(Boolean).join(' ') },
   ];
 
+  // READ PHASE: load every source's rows on their own connections BEFORE the
+  // write transaction. Holding the rebuild's BEGIN IMMEDIATE write lock while
+  // opening a second connection for these reads dead-locks ('database is
+  // locked'); preloading keeps the transaction single-connection.
+  const loaded = sources.map((src) => {
+    const { rows, hitCap } = loadType(hippoRoot, tenantId, src.entityType, src.loadFn, src.nameOf, src.textOf);
+    return { entityType: src.entityType, rows, hitCap };
+  });
+
+  // WRITE PHASE (codex P2): clear + every insert run in ONE transaction, so two
+  // concurrent rebuilds serialize on the SQLite write lock (no duplicate rows)
+  // and a throw mid-rebuild rolls back the clear (no bricked graph). No second
+  // connection is opened inside.
+  return runGraphRebuildTransaction(hippoRoot, tenantId, (txDb) =>
+    rebuildGraphRows(txDb, hippoRoot, tenantId, loaded),
+  );
+}
+
+/**
+ * The deterministic rebuild WRITES, run inside `runGraphRebuildTransaction`'s
+ * transaction (`txDb` is its connection). Clears the tenant's graph then
+ * re-derives entities + `supersedes` + `references` from the preloaded rows. All
+ * DB access here is on `txDb` (or in-memory) — no other connection is opened.
+ */
+function rebuildGraphRows(
+  txDb: GraphTxDb,
+  hippoRoot: string,
+  tenantId: string,
+  loaded: Array<{ entityType: EntityType; rows: ExtractRow[]; hitCap: boolean }>,
+): ExtractResult {
   // Rebuild from scratch: the graph is derived, so clear then re-derive.
-  clearGraph(hippoRoot, tenantId);
+  clearGraph(hippoRoot, tenantId, txDb);
 
   const byType: Record<string, number> = {};
   const truncated: string[] = [];
@@ -171,10 +201,9 @@ export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult
 
   // Pass 1: entities. Skip rows whose source memory was forgotten (NULL memory_id) -
   // an entity must reference a consolidated memory (entities.memory_id is NOT NULL).
-  for (const src of sources) {
-    const { rows, hitCap } = loadType(hippoRoot, tenantId, src.entityType, src.loadFn, src.nameOf, src.textOf);
-    if (hitCap) truncated.push(src.entityType);
-    byType[src.entityType] = 0;
+  for (const { entityType, rows, hitCap } of loaded) {
+    if (hitCap) truncated.push(entityType);
+    byType[entityType] = 0;
     for (const row of rows) {
       allRows.push(row);
       if (row.memoryId === null) continue;
@@ -193,12 +222,12 @@ export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult
         entityType: row.entityType,
         name,
         memoryId: row.memoryId,
-      });
+      }, txDb);
       const k = keyOf(row.entityType, row.e2Id);
       entityIdByKey.set(k, entity.id);
       memoryIdByKey.set(k, row.memoryId);
       created.push({ entityId: entity.id, entityType: row.entityType, memoryId: row.memoryId, name, searchText: row.searchText ?? '', superseded: row.supersededBy !== null });
-      byType[src.entityType] += 1;
+      byType[entityType] += 1;
     }
   }
 
@@ -224,7 +253,7 @@ export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult
       toEntityId: toId,
       relType: 'supersedes',
       memoryId: yMemoryId,
-    });
+    }, txDb);
     supersededPairs.add(pairKey(fromId, toId));
     relations += 1;
   }
@@ -232,7 +261,7 @@ export function extractGraph(hippoRoot: string, tenantId: string): ExtractResult
   // Pass 3: cross-object `references` edges via conservative name matching. A source's
   // text containing a target entity's name -> "source references target". Sources +
   // targets are CREATED entities only, so insertRelation never sees a null source memory.
-  const references = extractReferences(hippoRoot, tenantId, created, supersededPairs, truncated);
+  const references = extractReferences(hippoRoot, tenantId, created, supersededPairs, truncated, txDb);
   relations += references;
 
   const entities = created.length;
@@ -251,6 +280,7 @@ function extractReferences(
   created: CreatedEntity[],
   supersededPairs: Set<string>,
   truncated: string[],
+  txDb: GraphTxDb,
 ): number {
   // Build the target index: normalised name -> single entity id. A name is a target only
   // if its length is in bounds; a name shared by >1 entity is AMBIGUOUS and dropped.
@@ -309,7 +339,7 @@ function extractReferences(
         toEntityId: targetId,
         relType: 'references',
         memoryId: src.memoryId, // the source object's consolidated memory
-      });
+      }, txDb);
       references += 1;
     }
   }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -21,6 +21,11 @@
 import { openHippoDb, closeHippoDb } from './db.js';
 import { assertTenantId } from './store.js';
 
+/** The DB connection handle `openHippoDb` returns. Threaded (optionally) through
+ *  the graph writers so `extractGraph` can run clear + all inserts in ONE
+ *  transaction — see `runGraphRebuildTransaction`. */
+export type GraphTxDb = ReturnType<typeof openHippoDb>;
+
 // ---------------------------------------------------------------------------
 // Domain types
 // ---------------------------------------------------------------------------
@@ -207,6 +212,7 @@ export function insertEntity(
   hippoRoot: string,
   tenantId: string,
   opts: InsertEntityOpts,
+  txDb?: GraphTxDb,
 ): Entity {
   assertTenantId('insertEntity', tenantId);
   if (!GRAPH_ENTITY_TYPES.has(opts.entityType)) {
@@ -218,7 +224,8 @@ export function insertEntity(
     throw new Error(`insertEntity: name exceeds the ${MAX_ENTITY_NAME_LEN}-char cap`);
   }
   const now = new Date().toISOString();
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     const sourceKind = resolveConsolidatedSource(db, tenantId, opts.memoryId, 'insertEntity');
     const result = db.prepare(`
@@ -230,7 +237,7 @@ export function insertEntity(
     if (!row) throw new Error('insertEntity: failed to reload inserted entity');
     return rowToEntity(row);
   } finally {
-    closeHippoDb(db);
+    if (ownDb) closeHippoDb(ownDb);
   }
 }
 
@@ -242,13 +249,15 @@ export function insertRelation(
   hippoRoot: string,
   tenantId: string,
   opts: InsertRelationOpts,
+  txDb?: GraphTxDb,
 ): Relation {
   assertTenantId('insertRelation', tenantId);
   if (!GRAPH_RELATION_TYPES.has(opts.relType)) {
     throw new Error(`insertRelation: relType must be one of ${Array.from(GRAPH_RELATION_TYPES).join('|')}; got ${opts.relType}`);
   }
   const now = new Date().toISOString();
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     for (const [eid, role] of [[opts.fromEntityId, 'from'], [opts.toEntityId, 'to']] as const) {
       const ent = db.prepare(`SELECT tenant_id FROM entities WHERE id = ?`).get(eid) as { tenant_id: string } | undefined;
@@ -267,7 +276,7 @@ export function insertRelation(
     if (!row) throw new Error('insertRelation: failed to reload inserted relation');
     return rowToRelation(row);
   } finally {
-    closeHippoDb(db);
+    if (ownDb) closeHippoDb(ownDb);
   }
 }
 
@@ -561,11 +570,122 @@ export function markExtractionProcessed(
  * writer), so the E3.3 CI lint permits this `DELETE FROM entities`. Does NOT touch
  * graph_extraction_queue (the enqueue-hook's domain).
  */
-export function clearGraph(hippoRoot: string, tenantId: string): number {
+export function clearGraph(hippoRoot: string, tenantId: string, txDb?: GraphTxDb): number {
   assertTenantId('clearGraph', tenantId);
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     const res = db.prepare(`DELETE FROM entities WHERE tenant_id = ?`).run(tenantId);
+    return Number(res.changes ?? 0);
+  } finally {
+    if (ownDb) closeHippoDb(ownDb);
+  }
+}
+
+/**
+ * Run a full graph rebuild for one tenant inside a single transaction. `clearGraph`
+ * + every `insertEntity`/`insertRelation` call made inside `fn` (passing the supplied
+ * `txDb`) share the one connection and its `BEGIN IMMEDIATE` write lock, so the
+ * rebuild is ATOMIC: two concurrent rebuilds serialize on the write lock (the second
+ * waits, then re-derives cleanly) instead of interleaving into duplicate rows, and a
+ * throw mid-rebuild ROLLS BACK the clear (no bricked/empty graph). The sole sanctioned
+ * place to wrap graph writes in a transaction.
+ */
+export function runGraphRebuildTransaction<T>(
+  hippoRoot: string,
+  tenantId: string,
+  fn: (txDb: GraphTxDb) => T,
+): T {
+  assertTenantId('runGraphRebuildTransaction', tenantId);
+  const db = openHippoDb(hippoRoot);
+  try {
+    db.exec('BEGIN IMMEDIATE');
+    let committed = false;
+    try {
+      const out = fn(db);
+      db.exec('COMMIT');
+      committed = true;
+      return out;
+    } finally {
+      if (!committed) {
+        try { db.exec('ROLLBACK'); } catch { /* preserve the original throw */ }
+      }
+    }
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// E3 sleep enqueue-hook — producer helper + drain support
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail-soft producer hook: mark a tenant dirty for graph re-extraction by
+ * enqueuing its consolidated mirror memory. NEVER throws into the caller — a
+ * graph-dirty signal failing must not abort a core E2 write. Graph staleness is
+ * recoverable (next sleep / manual `graph extract`); a broken `hippo decide` is
+ * not. Called POST-COMMIT from the E2 graph-source save/close mutations of
+ * decision, policy, customer_note and project_brief. A null memoryId (a
+ * forgotten mirror) is a no-op.
+ */
+export function markGraphDirty(hippoRoot: string, tenantId: string, memoryId: string | null): void {
+  if (!memoryId) return;
+  try {
+    enqueueExtraction(hippoRoot, tenantId, memoryId);
+  } catch (err) {
+    // Logged (warn) so a SYSTEMATIC enqueue failure surfaces to operators, but
+    // swallowed so the already-committed E2 write is never rolled back.
+    console.warn(
+      `markGraphDirty: enqueue failed for tenant=${tenantId} memory=${memoryId}: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * The dirty tenants awaiting graph re-extraction, each with the MAX pending
+ * queue id at read time (a watermark). The sleep drain rebuilds each tenant's
+ * graph, then marks only items at or below the watermark processed, so items
+ * enqueued DURING the rebuild stay pending for the next sleep (no lost-update
+ * race). Host-wide read (the queue is per-tenant but sleep is cross-tenant).
+ */
+export function loadPendingExtractionTenants(
+  hippoRoot: string,
+): { tenantId: string; maxPendingId: number }[] {
+  const db = openHippoDb(hippoRoot);
+  try {
+    const rows = db.prepare(`
+      SELECT tenant_id AS tenant_id, MAX(id) AS max_id
+      FROM graph_extraction_queue
+      WHERE status = 'pending'
+      GROUP BY tenant_id
+    `).all() as { tenant_id: string; max_id: number }[];
+    return rows.map((r) => ({ tenantId: r.tenant_id, maxPendingId: Number(r.max_id) }));
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Mark every pending queue item for a tenant with `id <= maxId` processed, in
+ * one UPDATE. Status/processed_at only, so the consolidated-source guard trigger
+ * is not involved (same as markExtractionProcessed). Returns the count marked.
+ * The `<= maxId` watermark excludes items enqueued after the drain snapshot.
+ */
+export function markPendingProcessedUpTo(
+  hippoRoot: string,
+  tenantId: string,
+  maxId: number,
+): number {
+  assertTenantId('markPendingProcessedUpTo', tenantId);
+  const now = new Date().toISOString();
+  const db = openHippoDb(hippoRoot);
+  try {
+    const res = db.prepare(`
+      UPDATE graph_extraction_queue
+      SET status = 'processed', processed_at = ?
+      WHERE tenant_id = ? AND status = 'pending' AND id <= ?
+    `).run(now, tenantId, maxId);
     return Number(res.changes ?? 0);
   } finally {
     closeHippoDb(db);

--- a/src/policies.ts
+++ b/src/policies.ts
@@ -39,6 +39,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
+import { markGraphDirty } from './graph.js';
 import { createMemory, Layer, POLICY_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -332,6 +333,7 @@ export function savePolicy(
         },
       });
     },
+    afterCommit: () => markGraphDirty(hippoRoot, tenantId, mem.id),
   });
 
   if (!savedRow) {
@@ -388,7 +390,9 @@ export function closePolicy(
       });
 
       db.exec('COMMIT');
-      return rowToPolicy(row);
+      const closed = rowToPolicy(row);
+      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      return closed;
     } catch (e) {
       try {
         db.exec('ROLLBACK');

--- a/src/project-briefs.ts
+++ b/src/project-briefs.ts
@@ -24,6 +24,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
+import { markGraphDirty } from './graph.js';
 import { createMemory, Layer, PROJECT_BRIEF_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -309,6 +310,8 @@ export function saveProjectBrief(
         },
       });
     },
+    // afterCommit covers refreshBrief (delegates here) + brief new/supersede.
+    afterCommit: () => markGraphDirty(hippoRoot, tenantId, mem.id),
   });
 
   if (!savedRow) {
@@ -364,7 +367,9 @@ export function closeProjectBrief(
       });
 
       db.exec('COMMIT');
-      return rowToProjectBrief(row);
+      const closed = rowToProjectBrief(row);
+      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      return closed;
     } catch (e) {
       try {
         db.exec('ROLLBACK');

--- a/src/sleep-redact.ts
+++ b/src/sleep-redact.ts
@@ -43,6 +43,7 @@ export interface RedactSleepCtx {
  *   - deduped.semDups, .epiDups (aggregate dedup activity across tenants)
  *   - audit.errorsRemoved, .warningCount (aggregate audit-pipeline activity)
  *   - ambient.totalMemories, .avgStrength (aggregate corpus shape)
+ *   - graph.tenants, .entities, .relations (cross-tenant graph rebuild totals)
  *
  * NOT redacted (per-invocation activity counters, not cross-tenant accounting):
  *   - active, removed, mergedEpisodic, newSemantic (this invocation's totals)
@@ -80,6 +81,11 @@ export function redactSleepResultForCaller(
       totalMemories: 0,
       avgStrength: 0,
     };
+  }
+  if (result.graph !== undefined) {
+    // E3 sleep enqueue-hook: per-tenant graph rebuild totals are cross-tenant
+    // accounting, the same class as deduped/audit/ambient above.
+    redacted.graph = { tenants: 0, entities: 0, relations: 0 };
   }
   return redacted;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1156,12 +1156,19 @@ export function writeEntry(
   opts?: {
     actor?: string;
     afterWrite?: (db: DatabaseSyncLike, memoryId: string) => void;
+    /** Runs AFTER the DB row commits (RELEASE SAVEPOINT in writeEntryDbOnly) but
+     *  BEFORE the markdown mirrors are written. Lets a caller perform a post-commit
+     *  side effect (e.g. mark the graph dirty) that must still happen even if a
+     *  mirror write then throws. Keep it best-effort — it runs on a committed,
+     *  idle connection, so opening another handle inside it is safe. */
+    afterCommit?: () => void;
   },
 ): void {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
     writeEntryDbOnly(db, entry, opts);
+    opts?.afterCommit?.();
     writeEntryMirrors(hippoRoot, db, entry);
   } finally {
     closeHippoDb(db);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.18.0';
+export const PACKAGE_VERSION = '1.19.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/graph-sleep-hook.test.ts
+++ b/tests/graph-sleep-hook.test.ts
@@ -1,0 +1,261 @@
+/**
+ * E3 sleep enqueue-hook - tests.
+ * Docs: docs/plans/2026-06-02-e3-sleep-enqueue-hook.md
+ *
+ * PRODUCER: every graph-source E2 mutation (save/close of decision/policy/
+ * customer_note/project_brief, + project-brief refresh) marks its tenant dirty
+ * via markGraphDirty -> graph_extraction_queue (fail-soft).
+ * CONSUMER: api.sleep drains the pending queue - per dirty tenant: extractGraph
+ * full rebuild, then mark only items at/below the snapshot watermark processed.
+ * Real SQLite (temp dirs), no mocks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, deleteEntry } from '../src/store.js';
+import { saveDecision, closeDecision } from '../src/decisions.js';
+import { savePolicy } from '../src/policies.js';
+import { saveProjectBrief, refreshBrief } from '../src/project-briefs.js';
+import {
+  loadExtractionQueue,
+  loadEntities,
+  loadRelations,
+  loadPendingExtractionTenants,
+  markGraphDirty,
+  runGraphRebuildTransaction,
+  insertEntity,
+} from '../src/graph.js';
+import { extractGraph as realExtractGraph } from '../src/graph-extract.js';
+import {
+  sleep,
+  adminActor,
+  type Context,
+  type SleepPhases,
+  type SleepResult,
+} from '../src/api.js';
+import { redactSleepResultForCaller } from '../src/sleep-redact.js';
+
+const T = 'default';
+
+interface TestCtx {
+  hippoRoot: string;
+  ctx: Context;
+  restore: () => void;
+}
+
+function newCtx(): TestCtx {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'hippo-sleep-hook-'));
+  const hippoRoot = join(tmpDir, '.hippo');
+  mkdirSync(hippoRoot, { recursive: true });
+  initStore(hippoRoot);
+  // Per-test HIPPO_HOME isolation (autoShare phase calls initGlobal()).
+  const globalTmp = mkdtempSync(join(tmpdir(), 'hippo-sleep-hook-global-'));
+  const origHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = globalTmp;
+  const ctx: Context = { hippoRoot, tenantId: T, actor: adminActor('test:sleep-hook') };
+  return {
+    hippoRoot,
+    ctx,
+    restore: () => {
+      rmSync(tmpDir, { recursive: true, force: true });
+      rmSync(globalTmp, { recursive: true, force: true });
+      if (origHome !== undefined) process.env.HIPPO_HOME = origHome;
+      else delete process.env.HIPPO_HOME;
+    },
+  };
+}
+
+function pending(hippoRoot: string, tenant: string = T) {
+  return loadExtractionQueue(hippoRoot, tenant, { status: 'pending', limit: 1000 });
+}
+function processed(hippoRoot: string, tenant: string = T) {
+  return loadExtractionQueue(hippoRoot, tenant, { status: 'processed', limit: 1000 });
+}
+
+describe('E3 sleep enqueue-hook', () => {
+  let tc: TestCtx;
+  beforeEach(() => { tc = newCtx(); });
+  afterEach(() => { tc.restore(); });
+
+  // -- Producer --------------------------------------------------------------
+
+  it('1. saveDecision enqueues one pending queue item for its tenant', () => {
+    const d = saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres' });
+    const q = pending(tc.hippoRoot);
+    expect(q).toHaveLength(1);
+    expect(q[0].memoryId).toBe(d.memoryId);
+    expect(q[0].status).toBe('pending');
+  });
+
+  it('2. markGraphDirty is fail-soft: a bogus/null memoryId does not throw and enqueues nothing', () => {
+    expect(() => markGraphDirty(tc.hippoRoot, T, 'does-not-exist')).not.toThrow();
+    expect(() => markGraphDirty(tc.hippoRoot, T, null)).not.toThrow();
+    expect(pending(tc.hippoRoot)).toHaveLength(0);
+  });
+
+  it('3. coalesce: 3 decisions enqueue 3 pending items, all the same tenant', () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'one' });
+    saveDecision(tc.hippoRoot, T, { decisionText: 'two' });
+    saveDecision(tc.hippoRoot, T, { decisionText: 'three' });
+    const q = pending(tc.hippoRoot);
+    expect(q).toHaveLength(3);
+    expect(new Set(q.map((i) => i.tenantId))).toEqual(new Set([T]));
+  });
+
+  it('4. close and project-brief refresh also enqueue (dirty on every graph-source mutation)', () => {
+    const d = saveDecision(tc.hippoRoot, T, { decisionText: 'to be closed' });
+    closeDecision(tc.hippoRoot, T, d.id);
+    saveProjectBrief(tc.hippoRoot, T, { repo: 'myrepo', summary: 'first' });
+    refreshBrief(tc.hippoRoot, T, 'myrepo'); // delegates to saveProjectBrief
+    // save(d) + close(d) + saveBrief + refresh(->saveBrief) = 4 enqueues
+    expect(pending(tc.hippoRoot).length).toBe(4);
+  });
+
+  // -- Consumer --------------------------------------------------------------
+
+  it('5. sleep rebuilds the graph for a dirty tenant and drains its queue', async () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres' });
+    savePolicy(tc.hippoRoot, T, { policyName: 'RetryPolicy', policyText: 'retry 3x' });
+    expect(pending(tc.hippoRoot).length).toBe(2);
+    expect(loadEntities(tc.hippoRoot, T, { limit: 100 })).toHaveLength(0); // not yet extracted
+
+    const r = await sleep(tc.ctx, { noShare: true });
+    expect(loadEntities(tc.hippoRoot, T, { limit: 100 }).length).toBe(2); // rebuilt by sleep
+    expect(pending(tc.hippoRoot)).toHaveLength(0);                        // drained
+    expect(processed(tc.hippoRoot).length).toBe(2);
+    expect(r.graph).toEqual({ tenants: 1, entities: 2, relations: 0 });
+  });
+
+  it('6. only dirty tenants rebuild: a second sleep with no new writes reports no graph work', async () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres' });
+    const r1 = await sleep(tc.ctx, { noShare: true });
+    expect(r1.graph?.tenants).toBe(1);
+    const r2 = await sleep(tc.ctx, { noShare: true }); // nothing newly dirty
+    expect(r2.graph).toBeUndefined();
+    expect(pending(tc.hippoRoot)).toHaveLength(0);
+  });
+
+  it('7. multi-tenant: two dirty tenants both rebuild + drain; entities stay tenant-isolated', async () => {
+    saveDecision(tc.hippoRoot, 'tenantA', { decisionText: 'TenantA adopts Postgres as the system of record' });
+    saveDecision(tc.hippoRoot, 'tenantB', { decisionText: 'TenantB adopts Kafka for the event streaming backbone' });
+    const r = await sleep(tc.ctx, { noShare: true });
+    expect(r.graph?.tenants).toBe(2);
+    expect(loadEntities(tc.hippoRoot, 'tenantA', { limit: 100 }).length).toBe(1);
+    expect(loadEntities(tc.hippoRoot, 'tenantB', { limit: 100 }).length).toBe(1);
+    expect(loadEntities(tc.hippoRoot, T, { limit: 100 })).toHaveLength(0);
+    expect(pending(tc.hippoRoot, 'tenantA')).toHaveLength(0);
+    expect(pending(tc.hippoRoot, 'tenantB')).toHaveLength(0);
+  });
+
+  it('8. dryRun: no rebuild, no drain (items stay pending), no graph field', async () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres' });
+    const r = await sleep(tc.ctx, { dryRun: true });
+    expect(r.graph).toBeUndefined();
+    expect(loadEntities(tc.hippoRoot, T, { limit: 100 })).toHaveLength(0);
+    expect(pending(tc.hippoRoot)).toHaveLength(1); // still dirty
+  });
+
+  it('9. snapshot watermark: an item enqueued DURING the rebuild stays pending', async () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres as the primary application datastore' });
+    // Inject an extractGraph that enqueues a NEW item (id > watermark) mid-rebuild.
+    const phases: Partial<SleepPhases> = {
+      extractGraph: (root, tid) => {
+        if (tid === T) saveDecision(root, tid, { decisionText: 'Adopt Redis as the shared caching tier' });
+        return realExtractGraph(root, tid);
+      },
+    };
+    await sleep(tc.ctx, { noShare: true, __phases: phases });
+    // The original (<= watermark) is processed; the mid-rebuild arrival is still pending.
+    const stillPending = pending(tc.hippoRoot);
+    expect(stillPending).toHaveLength(1);
+    expect(processed(tc.hippoRoot).length).toBe(1);
+  });
+
+  it('10. fault isolation: one tenant extract throwing leaves it pending, others drain, sleep completes', async () => {
+    saveDecision(tc.hippoRoot, 'tenantFail', { decisionText: 'TenantFail standardizes on the GraphQL API gateway' });
+    saveDecision(tc.hippoRoot, 'tenantOk', { decisionText: 'TenantOk migrates services onto the gRPC mesh' });
+    const phases: Partial<SleepPhases> = {
+      extractGraph: (root, tid) => {
+        if (tid === 'tenantFail') throw new Error('boom: extract failed for tenantFail');
+        return realExtractGraph(root, tid);
+      },
+    };
+    const r = await sleep(tc.ctx, { noShare: true, __phases: phases }); // must NOT reject
+    expect(loadEntities(tc.hippoRoot, 'tenantOk', { limit: 100 }).length).toBe(1);
+    expect(pending(tc.hippoRoot, 'tenantOk')).toHaveLength(0);   // ok tenant drained
+    expect(pending(tc.hippoRoot, 'tenantFail')).toHaveLength(1); // failed tenant left pending
+    expect(r.graph?.tenants).toBe(1);                            // only tenantOk counted
+    expect((r.details ?? []).some((d) => d.includes('graph: extract failed'))).toBe(true);
+  });
+
+  it('11. end-to-end: a supersede edge is built by sleep with NO manual extract', async () => {
+    const d1 = saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres' });
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres (managed)', supersedesDecisionId: d1.id });
+    // No call to graph extract / extractGraph here - sleep is the only trigger.
+    await sleep(tc.ctx, { noShare: true });
+    const rels = loadRelations(tc.hippoRoot, T, { limit: 100 });
+    expect(rels.some((r) => r.relType === 'supersedes')).toBe(true);
+  });
+
+  it('12. redaction zeroes graph.* for a non-loopback non-self caller; loopback passes through', () => {
+    const base: SleepResult = {
+      active: 1, removed: 0, mergedEpisodic: 0, newSemantic: 0, dryRun: false,
+      graph: { tenants: 2, entities: 9, relations: 4 },
+    };
+    const redacted = redactSleepResultForCaller(base, { isLoopback: false, callerTenant: 'acme' });
+    expect(redacted.graph).toEqual({ tenants: 0, entities: 0, relations: 0 });
+    const passthrough = redactSleepResultForCaller(base, { isLoopback: true, callerTenant: 'acme' });
+    expect(passthrough.graph).toEqual({ tenants: 2, entities: 9, relations: 4 });
+  });
+
+  it('13. clean store: sleep with no graph-source objects omits the graph field', async () => {
+    const r = await sleep(tc.ctx, { noShare: true });
+    expect(r.graph).toBeUndefined();
+    expect(loadPendingExtractionTenants(tc.hippoRoot)).toHaveLength(0);
+  });
+
+  it('14. P1: a tenant still rebuilds when an earlier sleep phase deletes its queued mirror (codex)', async () => {
+    const d = saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres as the system of record' });
+    expect(pending(tc.hippoRoot)).toHaveLength(1);
+    // Simulate dedup/audit removing the queued mirror mid-sleep: the queue row
+    // FK-cascade-deletes, so a drain-TIME tenant load would drop T entirely. The
+    // dirty-tenant snapshot taken before the deleting phases must still rebuild T.
+    const phases: Partial<SleepPhases> = {
+      deduplicateStore: (root) => {
+        deleteEntry(root, d.memoryId!, T);
+        return { removed: 1, pairs: [] };
+      },
+    };
+    const r = await sleep(tc.ctx, { noShare: true, __phases: phases });
+    expect(r.graph?.tenants).toBe(1);              // T rebuilt despite the mid-sleep deletion
+    expect(pending(tc.hippoRoot)).toHaveLength(0); // its queue row cascade-deleted (mark = no-op)
+  });
+
+  it('15. P2 fail-soft: a dirty-tenant snapshot failure does not abort core sleep (codex)', async () => {
+    saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres as the system of record' });
+    const phases: Partial<SleepPhases> = {
+      loadPendingExtractionTenants: () => { throw new Error('boom: queue read failed'); },
+    };
+    const r = await sleep(tc.ctx, { noShare: true, __phases: phases }); // must NOT reject
+    expect(r.active).toBeGreaterThanOrEqual(0);    // consolidation still ran (result built)
+    expect(r.graph).toBeUndefined();               // graph refresh skipped, not crashed
+    expect((r.details ?? []).some((d) => d.includes('dirty-tenant snapshot failed'))).toBe(true);
+    expect(pending(tc.hippoRoot)).toHaveLength(1); // item left pending, recovered next sleep
+  });
+
+  it('16. atomic rebuild: runGraphRebuildTransaction rolls back all writes on a throw (codex P2)', () => {
+    const d = saveDecision(tc.hippoRoot, T, { decisionText: 'Adopt Postgres as the system of record' });
+    // A rebuild that inserts then throws must leave NO partial graph rows: the
+    // whole transaction rolls back. This is what makes extractGraph atomic, so two
+    // concurrent rebuilds serialize on the write lock instead of duplicating rows.
+    expect(() =>
+      runGraphRebuildTransaction(tc.hippoRoot, T, (txDb) => {
+        insertEntity(tc.hippoRoot, T, { entityType: 'policy', name: 'TempEntity', memoryId: d.memoryId! }, txDb);
+        throw new Error('mid-rebuild boom');
+      }),
+    ).toThrow('mid-rebuild boom');
+    expect(loadEntities(tc.hippoRoot, T, { limit: 100 })).toHaveLength(0); // insert rolled back
+  });
+});


### PR DESCRIPTION
## What

Auto-rebuild the entity/relation graph during `hippo sleep` so `recall --hops` and cross-object `references` edges run on fresh data without a manual `hippo graph extract`. Wires the `graph_extraction_queue` substrate (built in E3.3) into the lifecycle.

**Producer:** a fail-soft `markGraphDirty` on every graph-source E2 mutation (save/close of decision/policy/customer_note + save/close/refresh of project_brief) enqueues the tenant. Saves mark dirty via a new `writeEntry` `afterCommit` hook (post-commit, pre-mirror) so a mirror-write failure cannot leave a committed save unflagged.

**Consumer:** a fault-isolated drain phase in `api.sleep` snapshots dirty tenants before the memory-deleting phases, rebuilds each tenant's graph, then marks the watermarked queue items processed. `SleepResult` gains a redacted `graph` summary.

**Atomicity:** `extractGraph` now runs clear + all inserts in one `BEGIN IMMEDIATE` transaction (`runGraphRebuildTransaction`), so concurrent rebuilds serialize (no duplicate rows) and a mid-rebuild throw rolls back the clear.

No migration (the queue table already exists). v1.18.0 to v1.19.0.

## Cross-model review

Codex `review --commit` ran 4 rounds and caught a P1 + 3 P2s the Claude review critics missed, all fixed (snapshot-before-delete, fail-soft snapshot, atomic rebuild, afterCommit producer hook); round 4 clean. See `docs/evals/2026-06-02-e3-sleep-enqueue-hook-result.md`.

## Test plan

- [x] 16 new real-DB tests in `tests/graph-sleep-hook.test.ts` (producer / fail-soft / coalesce / consumer / dirty-only / multi-tenant / dryRun / watermark / fault-isolation / end-to-end / redaction / clean-store, plus P1 cascade-delete #14, P2 fail-soft #15, atomic rollback #16)
- [x] Full suite: 2438 pass / 4 skip / 1 known `server-concurrency` env flake (passes in isolation)
- [x] 71 graph tests pass
- [x] `check-graph-writes`, `check-manifest-versions`, `check-em-dashes-in-release-notes` green
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
