### PR TITLE
feat: graph observability + visualization (v1.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## 1.20.0 (2026-06-02): graph observability + visualization
+
+### Added
+- **Inspect the graph.** `hippo graph show [--entity NAME] [--json]` dumps the
+  entity/relation graph (entities grouped by type, then their edges) as text or
+  JSON. `GET /v1/graph [?entity=NAME&limit=N]` returns the tenant's graph as JSON
+  (auth-gated + tenant-scoped like sibling routes; reuses the shared list-limit
+  validator so a fractional `?limit` is a 400, not a 500).
+- **Visualize the graph.** `hippo graph view [--out FILE] [--open]
+  [--format html|canvas] [--entity NAME]` generates a self-contained,
+  dependency-free, offline, interactive HTML node-link diagram (server-computed
+  deterministic layout; pan / zoom / hover / click-to-highlight; user strings
+  escaped per sink so a name cannot inject script), or a JSON Canvas export that
+  opens in Obsidian. `--entity` renders a focus subgraph (the named entity, its
+  1-hop neighbours, and the edges among them).
+
+### Notes
+- Read-only over the graph (uses `loadEntities` / `loadRelations` and new read
+  helpers; no graph writes, so the graph-on-consolidated lint stays green). No
+  migration. All reads run inside a single read snapshot so a concurrent rebuild
+  cannot produce an inconsistent view.
+
 ## 1.19.0 (2026-06-02): E3 sleep enqueue-hook (graph auto-rebuilds during sleep)
 
 ### Added

--- a/docs/evals/2026-06-02-graph-observability-result.md
+++ b/docs/evals/2026-06-02-graph-observability-result.md
@@ -1,0 +1,86 @@
+# Graph observability + visualization — verify result (DESCRIPTIVE)
+
+- Date: 2026-06-02
+- Episode: 01KT4V9ZS1QAYZMY091FFFHECW (/dev-framework-rl, backend)
+- Feature: read-only graph observability — `hippo graph show` (CLI), `GET /v1/graph`
+  (HTTP), and `hippo graph view` (a self-contained interactive HTML node-link
+  diagram + JSON Canvas export) over the E3 entity/relation graph.
+
+Correctness is structural (the model equals the graph; the viewer is valid + safe)
+and there is no graph mutation, so no behavioural metric — just runtime evidence.
+
+## Runtime evidence
+
+| check | result |
+|---|---|
+| `tests/graph-view.test.ts` (new) | **14/14 pass** (real SQLite) |
+| full suite `npx vitest run` | **2461 pass / 4 skip / 1 fail** |
+| the 1 failure | `server-concurrency.test.ts` `ECONNRESET` under full-suite load — the known environmental flake; **passes in isolation**; zero references to this diff |
+| `scripts/check-graph-writes.mjs` | **green** — read-only; `graph-view.ts` uses only `loadEntities`/`loadRelations` |
+| `npm run build` (tsc + benchmarks tsc) | **clean** |
+
+## End-to-end CLI smoke (temp store)
+
+`hippo init` → `hippo decide "…RetryPolicy…"` → `hippo graph extract` →
+
+- `hippo graph show` →
+  ```
+  Graph: 1 entities, 0 relations
+
+  decision (1):
+    [1] We adopt RetryPolicy across all services
+  ```
+- `hippo graph view --out g.html` → wrote a **3603-byte self-contained HTML** file
+  beginning `<svg id="g" viewBox="0 0 1000 700" preserveAspectRatio="xMidYMid meet">`
+  — a valid, offline, dependency-free node-link diagram.
+
+## What the 14 tests lock
+
+1-6 `buildGraphModel`: entities→nodes / relations→edges; `--entity` focus subgraph;
+unknown entity → empty; empty store → empty; `truncated` flag on limit; dangling
+edges dropped. 7-8 `layoutGraph` deterministic (no `Math.random`) + 0/1-node
+without NaN. 9 **XSS**: a `</script>`-injecting entity name is inert in the HTML
+(escaped in the SVG `<title>` and unicode-escaped in the inlined JSON). 10 viewer
+self-contained (no external/CDN refs). 11 JSON Canvas valid + 1:1 with the model.
+12 `/v1/graph` tenant-scoped (another tenant's entities absent). 13 fractional
+`?limit=1.5` → 400 (reuses `parseListLimit`). 14 empty graph → 200 `{nodes:[],edges:[]}`.
+
+## Notes / honest caveats
+
+- **Read-only.** No graph writes added; `check-graph-writes` stays green. The
+  graph is rebuilt only by the existing `hippo graph extract` / sleep hook.
+- **Layout** is a deterministic server-side force layout (testable, stable). Pan /
+  zoom / hover (native SVG `<title>`) / click-to-highlight are the interactivity;
+  client-side drag-rearrange and a live-served `/graph` page are documented
+  follow-ups.
+- **Large graphs:** `--entity` focus + the default 500 limit bound the rendered
+  set; a very large full graph renders but may be cluttered (`truncated` is
+  surfaced, conservative — may over-report, never under-report).
+
+## Cross-model review (codex `review --commit`)
+
+Codex ran **7 rounds** and caught a P1 + 8 P2s on the focus-subgraph / read path
+that all three Claude critics missed. All fixed + regression-tested:
+
+1. **Focus entity beyond the global cap.** `--entity` filtered a globally-capped
+   list, so a focus query on a graph larger than `limit` falsely reported "no such
+   entity". Fixed with a direct by-name lookup (`loadEntitiesByName`). (test #15)
+2. **Duplicate-name focus uncapped** + **missing neighbour-to-neighbour edges.**
+   A name mapping to many entities blew past the cap; only focus-touching edges
+   were loaded. Fixed: cap the focus + union, and load edges AMONG the union
+   (`loadRelationsAmong`, both endpoints in the set). (tests #16, #17)
+3. **Limit pushed into SQL.** `loadEntitiesByName` now caps in SQL (no
+   materializing every same-name row).
+4. **Truncation under-reporting (×2).** A capped neighbour scan / an early union
+   break could omit a neighbour while reporting `truncated:false`. Fixed by adding
+   `hop.length >= limit` and an early-break flag. (test #18)
+5. **HTTP entity-name cap.** The route capped `?entity=` at the id-shaped 256, but
+   entity names are valid to 512; aligned to `MAX_ENTITY_NAME_LEN`. (test #19)
+6. **Single read snapshot.** The 2–4 loader reads weren't one snapshot, so a
+   concurrent rebuild could mix old entity ids with new relation ids. Fixed:
+   `withGraphReadSnapshot` threads one connection (one WAL read transaction)
+   through all six graph read loaders, so the whole model is built from one
+   consistent snapshot.
+
+Round 7 clean: "no discrete correctness, security, or blocking maintainability
+issues; the graph read/model/render paths are bounded, tenant-scoped, build cleanly."

--- a/docs/plans/2026-06-02-graph-observability.md
+++ b/docs/plans/2026-06-02-graph-observability.md
@@ -1,0 +1,163 @@
+# Graph observability + visualization
+
+- Date: 2026-06-02
+- Episode: 01KT4V9ZS1QAYZMY091FFFHECW (/dev-framework-rl, backend)
+- Status: Draft (not yet engineering-reviewed)
+
+## Problem
+
+hippo's E3 graph (`entities`/`relations`) is **headless**: the only surfaces are
+`hippo graph extract` (rebuild) and inline `[graph: Nhop rel]` recall
+annotations. There is no way to **inspect** the entities/relations or to **see**
+the graph. The data + typed structure are there; there's no viewer.
+
+## Goal (all READ-ONLY — no graph writes; E3.3 lint stays green)
+
+1. **Inspect (CLI):** `hippo graph show [--entity NAME] [--json]` — dump entities
+   (grouped by type) + their edges, as text or JSON.
+2. **Inspect (HTTP):** `GET /v1/graph [?entity=NAME&limit=N]` — the tenant's graph
+   as JSON, tenant-scoped + auth-gated like sibling read routes.
+3. **Visualize:** `hippo graph view [--out FILE] [--open] [--format html|canvas]
+   [--entity NAME]` — generate a **self-contained, dependency-free, offline,
+   interactive** HTML node-link diagram (default), or a JSON Canvas export that
+   opens in Obsidian.
+
+## Design
+
+### New module `src/graph-view.ts` (pure, no DB writes, fully testable)
+
+The shared core, so CLI + HTTP + viewer all build the same view-model.
+
+```ts
+export interface GraphNode { id: number; type: EntityType; name: string; }
+export interface GraphEdge { from: number; to: number; relType: RelationType; }
+export interface GraphModel { nodes: GraphNode[]; edges: GraphEdge[]; truncated: boolean; }
+
+/** Build the view-model from the graph (loadEntities + loadRelations — reads only).
+ *  --entity NAME → a focus subgraph: that entity + its 1-hop neighbours + the
+ *  edges among them. Drops dangling edges (endpoint not in the node set). */
+export function buildGraphModel(hippoRoot, tenantId, opts?: { entity?: string; limit?: number }): GraphModel;
+
+/** Deterministic force-directed layout (seeded circular init + N fixed relaxation
+ *  iterations; NO Math.random → reproducible positions for tests). */
+export function layoutGraph(model: GraphModel, opts?: { width; height; iterations }): Map<number, {x;y}>;
+
+/** Self-contained HTML: inlined positioned SVG (<circle>/<line>/<text>, ALL user
+ *  strings HTML-escaped) + a small <script> for pan / zoom / hover-tooltip /
+ *  click-to-highlight-neighbours. No external/CDN deps; opens in any browser offline. */
+export function renderGraphHtml(model: GraphModel): string;
+
+/** JSON Canvas (jsoncanvas.org): nodes[] {id,x,y,width,height,type:'text',text} +
+ *  edges[] {id,fromNode,toNode,label}. Opens natively in Obsidian. */
+export function renderGraphCanvas(model: GraphModel): string;
+
+function escapeHtml(s: string): string; // &<>"' → entities (XSS guard, grill)
+```
+
+**XSS (grill):** entity `name` is USER data (decision text, policy names). Every
+user string embedded in the HTML/SVG/inlined-JSON is `escapeHtml`'d. The inlined
+model JSON is emitted via `JSON.stringify` then `<`/`>`/`&` escaped so it can't
+break out of the `<script>`/SVG context. Test asserts a `<script>`-containing
+entity name is inert in the output.
+
+**Layout server-side in TS** (not a client physics sim): deterministic, testable,
+and keeps the client JS tiny (pan/zoom/hover/highlight only — no client-side
+simulation). Positions are fixed at generation time.
+
+### Grill-hardened constraints
+
+- **XSS — escape per embedding context (not one blanket pass).** Three distinct
+  sinks, each escaped correctly: (a) SVG `<text>` / `<title>` content →
+  `escapeHtml` (`& < > " '`); (b) the model inlined for the client script →
+  emitted in a `<script type="application/json" id="graph-data">…</script>` block
+  with `JSON.stringify` then `<` and `&` replaced by `<`/`&` (or `&lt;`)
+  so a `</script>` inside an entity name cannot break out; the client reads/parses
+  that block, never `innerHTML`. (c) No user string is ever placed in an inline
+  event handler or an unquoted attribute. Test: an entity named
+  `</script><script>alert(1)</script>` is inert in the output.
+- **Layout edge cases:** 0 nodes → empty `<svg>`; 1 node → centred; disconnected
+  components are allowed to drift apart; clamp any non-finite coordinate
+  (NaN/Infinity from a degenerate force step) to the viewport centre so the SVG is
+  always valid.
+- **`--entity NAME` semantics:** exact-name match. 0 matches → empty model + a
+  `truncated:false` note ("no entity named NAME"); ≥1 matches → all matching
+  entities + their 1-hop neighbours + edges among the union.
+- **Limit / truncation:** `loadEntities`/`loadRelations` are each `limit`-bounded
+  (default 100); `buildGraphModel` drops edges whose endpoint is not in the node
+  set (dangling), and sets `truncated:true` when either loader returns exactly
+  `limit` rows (the graph may be incomplete). This is a conservative "maybe
+  incomplete" flag: it can over-report (exactly `limit` rows that happen to be the
+  complete set) but never under-report. `graph show`/`/v1/graph` surface
+  `truncated` so the cap is never silent.
+
+### CLI (`cli.ts` `cmdGraph`, extend the `subcommand` switch — currently only `extract`)
+
+- `graph show [--entity NAME] [--json]`: `buildGraphModel` → text (entities by
+  type, then `from --[relType]--> to` edges) or `--json` (the GraphModel).
+- `graph view [--out FILE] [--open] [--format html|canvas] [--entity NAME]`:
+  build → render (html default | canvas) → write FILE (default
+  `hippo-graph.html` / `hippo-graph.canvas`) → `--open` launches the OS browser
+  (`start`/`open`/`xdg-open` by platform; best-effort, never fails the command).
+
+New flags `--entity/--out/--open/--format/--json` are all single/boolean — NOT
+repeatable, so the `parseArgs` repeatable-flag allow-list is untouched.
+`cmdGraph`'s third param is currently `_flags` (unused) — rename it to `flags` to
+read these. Both `show` and `view` apply a **default limit (500)** when
+`--limit`/`--entity` is unset, so the viewer never lays out an unbounded set
+(`loadEntities`/`loadRelations` default to only 100 each — the CLI passes an
+explicit bound).
+
+### HTTP (`server.ts`, register `GET /v1/graph` in the route chain)
+
+Mirror `GET /v1/memories` (server.ts:683): `const ctx = buildContextWithAuth(req,
+opts.hippoRoot)` (tenant-scoped, loopback-no-auth=admin, /v1/ rate-limited) →
+`buildGraphModel(ctx.hippoRoot, ctx.tenantId, {entity, limit})` →
+`sendJson(res, 200, model)`. **Limit validation REUSES the existing shared
+`parseListLimit` helper (server.ts:264)** — it already implements the
+`Number.isInteger` guard (default 100, cap 1000, the 400 message) and its comment
+documents the exact sibling bug (codex 2026-05-30 P2: a fractional `?limit=` →
+node:sqlite datatype-mismatch 500 on the policy route). Do NOT reinvent an inline
+check — reuse the helper so the guard can't drift (this is the sibling-clone
+audit rule). `?entity=` is length-capped (256) like sibling id params.
+
+## New / changed surface
+
+- `src/graph-view.ts` — NEW (buildGraphModel, layoutGraph, renderGraphHtml, renderGraphCanvas, escapeHtml).
+- `src/cli.ts` — `cmdGraph`: add `show` + `view` subcommands; help text; usage.
+- `src/server.ts` — add `GET /v1/graph`.
+- **No migration. No graph writes** (only `loadEntities`/`loadRelations` reads).
+
+## Test plan (real SQLite, temp dirs, no mocks)
+
+New `tests/graph-view.test.ts`:
+1. `buildGraphModel`: N entities → N nodes (id/type/name), M relations → M edges (from/to/relType).
+2. `--entity NAME` focus: returns that entity + its 1-hop neighbours + only edges among them; dangling edges dropped.
+3. Empty graph → `{nodes:[], edges:[]}`.
+4. `layoutGraph` deterministic: same model → identical positions across two runs (no Math.random).
+5. **XSS:** an entity named `<script>alert(1)</script>` (and one with `&"'`) appears HTML-escaped in `renderGraphHtml` output (no raw `<script>` tag; `&lt;script&gt;`).
+6. `renderGraphHtml`: self-contained (no `http`/`src=` external refs; contains the inlined model + a `<svg>` with a `<circle>` per node).
+7. `renderGraphCanvas`: parses as JSON; `nodes.length === model.nodes.length`, `edges.length === model.edges.length`; node shape `{id,type:'text',x,y,width,height,text}`.
+8. CLI `graph show`: text output lists entity names by type; `--json` emits the GraphModel.
+9. `/v1/graph`: tenant-scoped — tenant A's request returns only A's graph (B's entities absent).
+10. `/v1/graph` limit validation: `?limit=1.5` → 400; `?limit=2` → 200 with ≤2 nodes.
+11. `/v1/graph` empty graph → 200 `{nodes:[],edges:[]}`.
+12. `graph view --format canvas` writes a `.canvas` file that parses as JSON Canvas.
+
+Plus: `scripts/check-graph-writes.mjs` green (NO graph writes added); full `npm test` green; `tsc` build clean.
+
+## Out of scope (explicit)
+
+- A LIVE served web view (`hippo serve` → `/graph` page) — the generated HTML file
+  is the proportionate first slice; a served interactive page is a follow-up.
+- A website/frontend visualization — REJECTED: the graph is LOCAL per-user SQLite;
+  a marketing site has no access to it.
+- Client-side physics / drag-to-rearrange — the layout is computed server-side
+  (deterministic). Pan/zoom/hover/highlight is the interactivity; drag-rearrange
+  is a follow-up.
+- Large-graph scaling: `--entity` focus + `limit` bound the rendered set; a very
+  large full graph renders but may be cluttered (documented, not solved here).
+
+## Disposition
+
+Read-only observability + a self-contained viewer over an existing substrate.
+Minor version bump (new commands + route + viewer). No migration, no graph writes.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.19.0",
+  "version": "1.20.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,6 +167,7 @@ import * as skillsModule from './skills.js';
 import * as briefsModule from './project-briefs.js';
 import * as customerNotesModule from './customer-notes.js';
 import { extractGraph } from './graph-extract.js';
+import { buildGraphModel, renderGraphHtml, renderGraphCanvas, DEFAULT_VIEW_LIMIT } from './graph-view.js';
 import { createHash } from 'node:crypto';
 import {
   detectAnchoring,
@@ -4947,7 +4948,7 @@ function noteUsage(): void {
 function cmdGraph(
   hippoRoot: string,
   args: string[],
-  _flags: Record<string, string | boolean | string[]>
+  flags: Record<string, string | boolean | string[]>
 ): void {
   requireInit(hippoRoot);
   const tenantId = resolveTenantId({});
@@ -4966,7 +4967,79 @@ function cmdGraph(
     return;
   }
 
-  console.error('Usage: hippo graph extract   (rebuild the entity/relation graph from consolidated decisions/policies/customer-notes/project-briefs)');
+  const entity = typeof flags['entity'] === 'string' ? (flags['entity'] as string) : undefined;
+
+  if (subcommand === 'show') {
+    const model = buildGraphModel(hippoRoot, tenantId, { entity, limit: DEFAULT_VIEW_LIMIT });
+    if (flags['json']) {
+      console.log(JSON.stringify(model, null, 2));
+      return;
+    }
+    if (model.nodes.length === 0) {
+      console.log(entity ? `No entity named "${entity}".` : 'Graph is empty. Run `hippo graph extract` first.');
+      return;
+    }
+    console.log(`Graph: ${model.nodes.length} entities, ${model.edges.length} relations${model.truncated ? ' (truncated)' : ''}`);
+    const byType = new Map<string, { id: number; name: string }[]>();
+    for (const n of model.nodes) {
+      const arr = byType.get(n.type) ?? [];
+      arr.push({ id: n.id, name: n.name });
+      byType.set(n.type, arr);
+    }
+    for (const [type, ns] of byType) {
+      console.log(`\n${type} (${ns.length}):`);
+      for (const n of ns) console.log(`  [${n.id}] ${n.name}`);
+    }
+    if (model.edges.length > 0) {
+      const nameById = new Map(model.nodes.map((n) => [n.id, n.name]));
+      console.log('\nrelations:');
+      for (const e of model.edges) {
+        console.log(`  ${nameById.get(e.from)} --${e.relType}--> ${nameById.get(e.to)}`);
+      }
+    }
+    return;
+  }
+
+  if (subcommand === 'view') {
+    const format = typeof flags['format'] === 'string' ? (flags['format'] as string) : 'html';
+    if (format !== 'html' && format !== 'canvas') {
+      console.error("graph view: --format must be 'html' or 'canvas'");
+      process.exit(1);
+    }
+    const model = buildGraphModel(hippoRoot, tenantId, { entity, limit: DEFAULT_VIEW_LIMIT });
+    const content = format === 'canvas' ? renderGraphCanvas(model) : renderGraphHtml(model);
+    const defaultOut = format === 'canvas' ? 'hippo-graph.canvas' : 'hippo-graph.html';
+    const out = typeof flags['out'] === 'string' ? (flags['out'] as string) : defaultOut;
+    fs.writeFileSync(out, content, 'utf8');
+    console.log(`Wrote ${model.nodes.length} entities + ${model.edges.length} relations to ${out}${model.truncated ? ' (truncated)' : ''}`);
+    if (flags['open'] && format === 'html') {
+      // Best-effort browser launch; never fail the command if it doesn't work.
+      try {
+        const [cmd, cmdArgs] =
+          process.platform === 'win32'
+            ? ['cmd', ['/c', 'start', '', out]]
+            : process.platform === 'darwin'
+              ? ['open', [out]]
+              : ['xdg-open', [out]];
+        const child = spawn(cmd, cmdArgs as string[], { detached: true, stdio: 'ignore' });
+        // A missing launcher (e.g. xdg-open absent) emits 'error' asynchronously;
+        // an unhandled 'error' event would throw, so swallow it — the file is
+        // already written and its path printed above.
+        child.on('error', () => { /* best-effort launch */ });
+        child.unref();
+      } catch {
+        /* ignore — the file is written; the path is printed above */
+      }
+    }
+    return;
+  }
+
+  console.error(
+    'Usage:\n' +
+      '  hippo graph extract                     Rebuild the entity/relation graph from consolidated objects\n' +
+      '  hippo graph show [--entity NAME] [--json]   Inspect entities + their edges (text or JSON)\n' +
+      '  hippo graph view [--out FILE] [--open] [--format html|canvas] [--entity NAME]   Generate an interactive node-link diagram',
+  );
   process.exit(1);
 }
 

--- a/src/graph-view.ts
+++ b/src/graph-view.ts
@@ -1,0 +1,365 @@
+/**
+ * E3 graph observability + visualization — READ-ONLY over the entity/relation
+ * graph (docs/plans/2026-06-02-graph-observability.md).
+ *
+ * This module only READS the graph (`loadEntities` / `loadRelations`) and renders
+ * view-models; it issues no INSERT/UPDATE/DELETE, so `scripts/check-graph-writes.mjs`
+ * stays green. Used by the CLI (`hippo graph show` / `hippo graph view`) and the
+ * HTTP `GET /v1/graph` route, which all build the same `GraphModel`.
+ */
+
+import {
+  loadEntities,
+  loadEntitiesByName,
+  loadEntitiesByIds,
+  loadRelations,
+  loadNeighborRelations,
+  loadRelationsAmong,
+  withGraphReadSnapshot,
+  type Entity,
+  type Relation,
+  type EntityType,
+  type RelationType,
+} from './graph.js';
+
+export interface GraphNode {
+  id: number;
+  type: EntityType;
+  name: string;
+}
+export interface GraphEdge {
+  from: number;
+  to: number;
+  relType: RelationType;
+}
+export interface GraphModel {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  /** Conservative "maybe incomplete" flag: true when a loader returned exactly
+   *  its limit (the graph MAY be truncated). Can over-report, never under-report. */
+  truncated: boolean;
+}
+
+/** Default bound for the CLI viewer / show so an unbounded set is never laid out. */
+export const DEFAULT_VIEW_LIMIT = 500;
+
+/**
+ * Build the view-model from the graph (reads only). With `opts.entity`, returns a
+ * focus subgraph: every entity whose name === entity, plus their 1-hop neighbours,
+ * plus the edges among that union. Dangling edges (an endpoint outside the node
+ * set) are always dropped.
+ */
+export function buildGraphModel(
+  hippoRoot: string,
+  tenantId: string,
+  opts: { entity?: string; limit?: number } = {},
+): GraphModel {
+  const limit = opts.limit ?? DEFAULT_VIEW_LIMIT;
+
+  // All reads run inside ONE read snapshot so a concurrent `graph extract` /
+  // sleep-drain rebuild can't make the model mix old entity ids with new relation
+  // ids (codex P2). Every load* call below is passed the snapshot connection `db`.
+  return withGraphReadSnapshot(hippoRoot, (db) => {
+    let nodeEntities: Entity[];
+    let relations: Relation[];
+    let truncated: boolean;
+
+    if (opts.entity !== undefined) {
+      // Focus subgraph. (1) Query the named entity DIRECTLY (by name, not from a
+      // globally-capped list) so it is found even on a graph larger than `limit`.
+      // (2) A name can map to MANY entities (e.g. many notes for one customer), so
+      // cap the focus matches. (3) Discover 1-hop neighbours and cap the UNION to
+      // `limit` nodes. (4) Load ALL edges AMONG the union so neighbour-to-neighbour
+      // edges that don't touch the focus are included too. (codex P2s.)
+      const focus = loadEntitiesByName(hippoRoot, tenantId, opts.entity, { limit }, db);
+      if (focus.length === 0) return { nodes: [], edges: [], truncated: false };
+      const focusIds = focus.map((e) => e.id);
+      const hop = loadNeighborRelations(hippoRoot, tenantId, focusIds, { limit }, db);
+      const union = new Set<number>(focusIds);
+      let neighboursCapped = false;
+      for (const r of hop) {
+        if (union.size >= limit) {
+          neighboursCapped = true; // node cap filled before all neighbours were added
+          break;
+        }
+        union.add(r.fromEntityId);
+        union.add(r.toEntityId);
+      }
+      const unionIds = [...union].slice(0, limit);
+      nodeEntities = loadEntitiesByIds(hippoRoot, tenantId, unionIds, db);
+      // Edges AMONG the union (BOTH endpoints in the set): includes
+      // neighbour-to-neighbour edges, and the LIMIT can never drop a valid in-union
+      // edge in favour of out-of-union rows (codex P2).
+      relations = loadRelationsAmong(hippoRoot, tenantId, unionIds, { limit }, db);
+      truncated =
+        focus.length >= limit ||
+        hop.length >= limit || // neighbour scan capped -> a 1-hop neighbour may be omitted (codex P2)
+        neighboursCapped || // node cap filled before all neighbours were consumed (codex P2)
+        union.size > unionIds.length ||
+        relations.length >= limit;
+    } else {
+      nodeEntities = loadEntities(hippoRoot, tenantId, { limit }, db);
+      relations = loadRelations(hippoRoot, tenantId, { limit }, db);
+      truncated = nodeEntities.length >= limit || relations.length >= limit;
+    }
+
+    const nodeIds = new Set(nodeEntities.map((e) => e.id));
+    const nodes: GraphNode[] = nodeEntities.map((e) => ({
+      id: e.id,
+      type: e.entityType,
+      name: e.name,
+    }));
+    const edges: GraphEdge[] = relations
+      .filter((r) => nodeIds.has(r.fromEntityId) && nodeIds.has(r.toEntityId))
+      .map((r) => ({ from: r.fromEntityId, to: r.toEntityId, relType: r.relType }));
+
+    return { nodes, edges, truncated };
+  });
+}
+
+const LAYOUT_W = 1000;
+const LAYOUT_H = 700;
+
+/**
+ * Deterministic Fruchterman-Reingold-style force layout. Seeded circular init +
+ * fixed iterations, NO `Math.random`, so the same model always yields the same
+ * positions (testable, stable output). Non-finite coordinates from a degenerate
+ * step are clamped to the viewport centre; all positions are clamped in-bounds.
+ */
+export function layoutGraph(
+  model: GraphModel,
+  opts: { width?: number; height?: number; iterations?: number } = {},
+): Map<number, { x: number; y: number }> {
+  const width = opts.width ?? LAYOUT_W;
+  const height = opts.height ?? LAYOUT_H;
+  const iterations = opts.iterations ?? 300;
+  const cx = width / 2;
+  const cy = height / 2;
+  const nodes = model.nodes;
+  const n = nodes.length;
+  const pos = new Map<number, { x: number; y: number }>();
+  if (n === 0) return pos;
+  if (n === 1) {
+    pos.set(nodes[0].id, { x: cx, y: cy });
+    return pos;
+  }
+
+  const radius = Math.min(width, height) * 0.4;
+  nodes.forEach((node, i) => {
+    const angle = (2 * Math.PI * i) / n;
+    pos.set(node.id, { x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) });
+  });
+
+  const idIndex = new Map<number, number>(nodes.map((node, i) => [node.id, i]));
+  const k = Math.sqrt((width * height) / n); // ideal edge length
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const disp = nodes.map(() => ({ x: 0, y: 0 }));
+    // Repulsion between all pairs.
+    for (let i = 0; i < n; i++) {
+      const pi = pos.get(nodes[i].id)!;
+      for (let j = i + 1; j < n; j++) {
+        const pj = pos.get(nodes[j].id)!;
+        const dx = pi.x - pj.x;
+        const dy = pi.y - pj.y;
+        const dist = Math.hypot(dx, dy) || 0.01;
+        const rep = (k * k) / dist;
+        const ux = dx / dist;
+        const uy = dy / dist;
+        disp[i].x += ux * rep;
+        disp[i].y += uy * rep;
+        disp[j].x -= ux * rep;
+        disp[j].y -= uy * rep;
+      }
+    }
+    // Attraction along edges.
+    for (const e of model.edges) {
+      const i = idIndex.get(e.from);
+      const j = idIndex.get(e.to);
+      if (i === undefined || j === undefined) continue;
+      const pi = pos.get(e.from)!;
+      const pj = pos.get(e.to)!;
+      const dx = pi.x - pj.x;
+      const dy = pi.y - pj.y;
+      const dist = Math.hypot(dx, dy) || 0.01;
+      const att = (dist * dist) / k;
+      const ux = dx / dist;
+      const uy = dy / dist;
+      disp[i].x -= ux * att;
+      disp[i].y -= uy * att;
+      disp[j].x += ux * att;
+      disp[j].y += uy * att;
+    }
+    // Apply with cooling; clamp.
+    const temp = Math.max(1, (width / 10) * (1 - iter / iterations));
+    nodes.forEach((node, i) => {
+      const p = pos.get(node.id)!;
+      const dl = Math.hypot(disp[i].x, disp[i].y) || 0.01;
+      let nx = p.x + (disp[i].x / dl) * Math.min(dl, temp);
+      let ny = p.y + (disp[i].y / dl) * Math.min(dl, temp);
+      if (!Number.isFinite(nx)) nx = cx;
+      if (!Number.isFinite(ny)) ny = cy;
+      p.x = Math.max(20, Math.min(width - 20, nx));
+      p.y = Math.max(20, Math.min(height - 20, ny));
+    });
+  }
+  return pos;
+}
+
+/** HTML-escape for SVG text / title / markup content (XSS guard). */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const NODE_COLORS: Record<string, string> = {
+  decision: '#6366f1',
+  policy: '#10b981',
+  customer: '#f59e0b',
+  project: '#ec4899',
+  person: '#3b82f6',
+  system: '#64748b',
+};
+
+// Client script: pan (drag bg), zoom (wheel), click-to-highlight a node's edges +
+// neighbours. Reads the inlined model via JSON.parse (never innerHTML), so user
+// strings never reach an HTML sink here. No template literals / `${}` so it nests
+// safely inside this module's own template strings.
+const CLIENT_JS = [
+  "(function(){",
+  "  var svg=document.getElementById('g');",
+  "  var vb=svg.getAttribute('viewBox').split(' ').map(Number);",
+  "  var view={x:vb[0],y:vb[1],w:vb[2],h:vb[3]};",
+  "  function apply(){svg.setAttribute('viewBox',view.x+' '+view.y+' '+view.w+' '+view.h);}",
+  "  var panning=false,sx=0,sy=0;",
+  "  svg.addEventListener('mousedown',function(e){if(e.target.closest('.node'))return;panning=true;sx=e.clientX;sy=e.clientY;});",
+  "  window.addEventListener('mouseup',function(){panning=false;});",
+  "  window.addEventListener('mousemove',function(e){if(!panning)return;var r=svg.getBoundingClientRect();var k=view.w/r.width;view.x-=(e.clientX-sx)*k;view.y-=(e.clientY-sy)*k;sx=e.clientX;sy=e.clientY;apply();});",
+  "  svg.addEventListener('wheel',function(e){e.preventDefault();var r=svg.getBoundingClientRect();var mx=view.x+(e.clientX-r.left)/r.width*view.w;var my=view.y+(e.clientY-r.top)/r.height*view.h;var f=e.deltaY<0?0.9:1.1;view.x=mx-(mx-view.x)*f;view.y=my-(my-view.y)*f;view.w*=f;view.h*=f;apply();},{passive:false});",
+  "  var data={};try{data=JSON.parse(document.getElementById('graph-data').textContent);}catch(_){}",
+  "  var adj={};(data.edges||[]).forEach(function(e){(adj[e.from]=adj[e.from]||[]).push(e.to);(adj[e.to]=adj[e.to]||[]).push(e.from);});",
+  "  var active=null;",
+  "  document.querySelectorAll('.node').forEach(function(g){g.addEventListener('click',function(ev){ev.stopPropagation();var id=g.getAttribute('data-id');if(active===id){clearHi();active=null;return;}active=id;highlight(id);});});",
+  "  svg.addEventListener('click',function(){clearHi();active=null;});",
+  "  function clearHi(){svg.classList.remove('focused');document.querySelectorAll('.hi').forEach(function(el){el.classList.remove('hi');});}",
+  "  function highlight(id){clearHi();svg.classList.add('focused');var keep={};keep[id]=1;(adj[id]||[]).forEach(function(n){keep[n]=1;});document.querySelectorAll('.node').forEach(function(g){if(keep[g.getAttribute('data-id')])g.classList.add('hi');});document.querySelectorAll('.edge').forEach(function(l){if(l.getAttribute('data-from')===id||l.getAttribute('data-to')===id)l.classList.add('hi');});}",
+  "})();",
+].join("\n");
+
+const STYLE = [
+  "html,body{margin:0;height:100%;background:#0b1020;font-family:ui-sans-serif,system-ui,sans-serif}",
+  "#g{width:100vw;height:100vh;cursor:grab}",
+  "#g:active{cursor:grabbing}",
+  ".edge{stroke:#475569;stroke-width:1}",
+  ".node circle{stroke:#0b1020;stroke-width:1.5}",
+  ".node text{fill:#e2e8f0;font-size:11px;pointer-events:none}",
+  ".node{cursor:pointer}",
+  "#g.focused .node{opacity:.18}",
+  "#g.focused .edge{opacity:.07}",
+  "#g.focused .node.hi{opacity:1}",
+  "#g.focused .edge.hi{opacity:1;stroke:#e2e8f0}",
+  ".legend{position:fixed;top:10px;left:12px;color:#94a3b8;font-size:12px;line-height:1.6}",
+  ".legend b{color:#e2e8f0}",
+].join("\n");
+
+/**
+ * Render the model as a SELF-CONTAINED, dependency-free, offline interactive HTML
+ * node-link diagram. Positions are computed server-side (deterministic). User
+ * strings are escaped per sink: SVG `<text>`/`<title>` via `escapeHtml`; the model
+ * is inlined in a `<script type="application/json">` block with `<`/`>`/`&`
+ * unicode-escaped so a `</script>` inside an entity name cannot break out (the
+ * client `JSON.parse`s it back and never `innerHTML`s a user string).
+ */
+export function renderGraphHtml(model: GraphModel): string {
+  const pos = layoutGraph(model);
+  const color = (t: string): string => NODE_COLORS[t] ?? '#64748b';
+
+  const edgeSvg = model.edges
+    .map((e) => {
+      const a = pos.get(e.from);
+      const b = pos.get(e.to);
+      if (!a || !b) return '';
+      return (
+        `<line class="edge" data-from="${e.from}" data-to="${e.to}" ` +
+        `x1="${a.x.toFixed(1)}" y1="${a.y.toFixed(1)}" x2="${b.x.toFixed(1)}" y2="${b.y.toFixed(1)}"/>`
+      );
+    })
+    .join('');
+
+  const nodeSvg = model.nodes
+    .map((node) => {
+      const p = pos.get(node.id);
+      if (!p) return '';
+      const label = node.name.length > 22 ? node.name.slice(0, 21) + '…' : node.name;
+      return (
+        `<g class="node" data-id="${node.id}" transform="translate(${p.x.toFixed(1)},${p.y.toFixed(1)})">` +
+        `<title>${escapeHtml(node.type + ': ' + node.name)}</title>` +
+        `<circle r="7" fill="${color(node.type)}"/>` +
+        `<text x="10" y="4">${escapeHtml(label)}</text>` +
+        `</g>`
+      );
+    })
+    .join('');
+
+  // Safe inline JSON for the client: unicode-escape the HTML-significant chars so
+  // the content cannot terminate the <script> block; JSON.parse restores them.
+  const dataJson = JSON.stringify(model)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+
+  const types = [...new Set(model.nodes.map((nd) => nd.type))];
+  const legend = types
+    .map((t) => `<span style="color:${color(t)}">●</span> ${escapeHtml(t)}`)
+    .join('  ');
+
+  return [
+    '<!doctype html>',
+    '<html lang="en"><head><meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    '<title>hippo graph</title>',
+    '<style>' + STYLE + '</style></head><body>',
+    `<div class="legend"><b>hippo graph</b> · ${model.nodes.length} entities · ${model.edges.length} relations` +
+      (model.truncated ? ' · <b style="color:#f59e0b">truncated</b>' : '') +
+      `<br>${legend}<br><span style="color:#64748b">drag to pan · scroll to zoom · click a node to focus</span></div>`,
+    `<svg id="g" viewBox="0 0 ${LAYOUT_W} ${LAYOUT_H}" preserveAspectRatio="xMidYMid meet">`,
+    `<g id="edges">${edgeSvg}</g><g id="nodes">${nodeSvg}</g>`,
+    '</svg>',
+    `<script type="application/json" id="graph-data">${dataJson}</script>`,
+    '<script>' + CLIENT_JS + '</script>',
+    '</body></html>',
+  ].join('\n');
+}
+
+/**
+ * Render the model as a JSON Canvas (jsoncanvas.org) document — `nodes[]` of
+ * type `text` positioned by the same deterministic layout, `edges[]` linking
+ * them by id. Opens natively in Obsidian. Pure JSON; entity names live in the
+ * `text` field (Obsidian renders/sanitizes them).
+ */
+export function renderGraphCanvas(model: GraphModel): string {
+  const pos = layoutGraph(model, { width: 2400, height: 1600 });
+  const nodes = model.nodes.map((node) => {
+    const p = pos.get(node.id) ?? { x: 0, y: 0 };
+    return {
+      id: `n${node.id}`,
+      type: 'text',
+      x: Math.round(p.x),
+      y: Math.round(p.y),
+      width: 240,
+      height: 60,
+      text: `**${node.type}**\n${node.name}`,
+    };
+  });
+  const edges = model.edges.map((e, i) => ({
+    id: `e${i}`,
+    fromNode: `n${e.from}`,
+    toNode: `n${e.to}`,
+    label: e.relType,
+  }));
+  return JSON.stringify({ nodes, edges }, null, 2);
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -292,17 +292,48 @@ export function loadEntityById(hippoRoot: string, tenantId: string, id: number):
   }
 }
 
+/** Entities with an exact `name` (read), bounded by `limit` in SQL with a
+ *  deterministic order. Lets the graph-view focus query find the `--entity NAME`
+ *  entity DIRECTLY (not from a globally-capped list) WITHOUT materializing every
+ *  same-name row when a name maps to many entities. */
+export function loadEntitiesByName(
+  hippoRoot: string,
+  tenantId: string,
+  name: string,
+  opts: { limit?: number } = {},
+  txDb?: GraphTxDb,
+): Entity[] {
+  assertTenantId('loadEntitiesByName', tenantId);
+  const limit = opts.limit ?? 100;
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(`loadEntitiesByName: limit must be a non-negative integer; got ${limit}`);
+  }
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
+  try {
+    const rows = db.prepare(`
+      SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? AND name = ?
+      ORDER BY id ASC LIMIT ?
+    `).all(tenantId, name, limit) as EntityRow[];
+    return rows.map(rowToEntity);
+  } finally {
+    if (ownDb) closeHippoDb(ownDb);
+  }
+}
+
 export function loadEntities(
   hippoRoot: string,
   tenantId: string,
   opts: { entityType?: EntityType; limit?: number } = {},
+  txDb?: GraphTxDb,
 ): Entity[] {
   assertTenantId('loadEntities', tenantId);
   const limit = opts.limit ?? 100;
   if (opts.entityType && !GRAPH_ENTITY_TYPES.has(opts.entityType)) {
     throw new Error(`loadEntities: entityType must be one of ${Array.from(GRAPH_ENTITY_TYPES).join('|')}; got ${opts.entityType}`);
   }
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     const clauses = ['tenant_id = ?'];
     const params: unknown[] = [tenantId];
@@ -319,7 +350,7 @@ export function loadEntities(
     `).all(...params) as EntityRow[];
     return rows.map(rowToEntity);
   } finally {
-    closeHippoDb(db);
+    if (ownDb) closeHippoDb(ownDb);
   }
 }
 
@@ -327,10 +358,12 @@ export function loadRelations(
   hippoRoot: string,
   tenantId: string,
   opts: { fromEntityId?: number; limit?: number } = {},
+  txDb?: GraphTxDb,
 ): Relation[] {
   assertTenantId('loadRelations', tenantId);
   const limit = opts.limit ?? 100;
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     const clauses = ['tenant_id = ?'];
     const params: unknown[] = [tenantId];
@@ -347,7 +380,7 @@ export function loadRelations(
     `).all(...params) as RelationRow[];
     return rows.map(rowToRelation);
   } finally {
-    closeHippoDb(db);
+    if (ownDb) closeHippoDb(ownDb);
   }
 }
 
@@ -398,10 +431,12 @@ export function loadEntitiesByIds(
   hippoRoot: string,
   tenantId: string,
   ids: number[],
+  txDb?: GraphTxDb,
 ): Entity[] {
   assertTenantId('loadEntitiesByIds', tenantId);
   if (ids.length === 0) return [];
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     const out: Entity[] = [];
     for (let i = 0; i < ids.length; i += IN_LIST_CHUNK) {
@@ -415,7 +450,7 @@ export function loadEntitiesByIds(
     }
     return out;
   } finally {
-    closeHippoDb(db);
+    if (ownDb) closeHippoDb(ownDb);
   }
 }
 
@@ -431,6 +466,7 @@ export function loadNeighborRelations(
   tenantId: string,
   entityIds: number[],
   opts: { limit?: number } = {},
+  txDb?: GraphTxDb,
 ): Relation[] {
   assertTenantId('loadNeighborRelations', tenantId);
   if (entityIds.length === 0) return [];
@@ -438,7 +474,8 @@ export function loadNeighborRelations(
   if (!Number.isInteger(limit) || limit < 0) {
     throw new Error(`loadNeighborRelations: limit must be a non-negative integer; got ${limit}`);
   }
-  const db = openHippoDb(hippoRoot);
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
   try {
     // `limit` is applied PER CHUNK; a frontier spanning >IN_LIST_CHUNK ids could return
     // up to limit*chunks rows before the by-id dedup below. Harmless for E3.2 (the
@@ -458,6 +495,70 @@ export function loadNeighborRelations(
       for (const r of rows) byId.set(r.id, rowToRelation(r));
     }
     return Array.from(byId.values());
+  } finally {
+    if (ownDb) closeHippoDb(ownDb);
+  }
+}
+
+/**
+ * Relations with BOTH endpoints in `entityIds` (edges AMONG the set, not merely
+ * touching it). Read. Used by the graph-view focus subgraph so the displayed
+ * edges are exactly the intra-union edges: the `LIMIT` only caps genuinely-many
+ * intra-union edges — no out-of-union row can evict a valid in-set edge. The
+ * caller bounds `entityIds` (<= the view limit), so a single query is safe.
+ */
+export function loadRelationsAmong(
+  hippoRoot: string,
+  tenantId: string,
+  entityIds: number[],
+  opts: { limit?: number } = {},
+  txDb?: GraphTxDb,
+): Relation[] {
+  assertTenantId('loadRelationsAmong', tenantId);
+  if (entityIds.length === 0) return [];
+  const limit = opts.limit ?? 1000;
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(`loadRelationsAmong: limit must be a non-negative integer; got ${limit}`);
+  }
+  const ownDb = txDb ? null : openHippoDb(hippoRoot);
+  const db = txDb ?? ownDb!;
+  try {
+    const ph = entityIds.map(() => '?').join(',');
+    const rows = db.prepare(`
+      SELECT ${RELATION_COLS} FROM relations
+      WHERE tenant_id = ? AND from_entity_id IN (${ph}) AND to_entity_id IN (${ph})
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).all(tenantId, ...entityIds, ...entityIds, limit) as RelationRow[];
+    return rows.map(rowToRelation);
+  } finally {
+    if (ownDb) closeHippoDb(ownDb);
+  }
+}
+
+/**
+ * Run `fn` inside ONE read transaction (a single WAL snapshot) so every graph read
+ * it performs — pass the supplied `txDb` to the `load*` functions — sees a consistent
+ * view, even if a `graph extract` / sleep-drain rebuild commits concurrently between
+ * reads (the rebuild clears + reinserts entities, so separate reads could otherwise
+ * mix old entity ids with new relation ids). Reads only; the connection is opened
+ * once and closed after.
+ */
+export function withGraphReadSnapshot<T>(
+  hippoRoot: string,
+  fn: (txDb: GraphTxDb) => T,
+): T {
+  const db = openHippoDb(hippoRoot);
+  try {
+    db.exec('BEGIN');
+    try {
+      const out = fn(db);
+      db.exec('COMMIT');
+      return out;
+    } catch (e) {
+      try { db.exec('ROLLBACK'); } catch { /* ignore */ }
+      throw e;
+    }
   } finally {
     closeHippoDb(db);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,8 @@ import {
 } from './api.js';
 import type { MemoryKind } from './memory.js';
 import type { AuditOp } from './audit.js';
+import { buildGraphModel } from './graph-view.js';
+import { MAX_ENTITY_NAME_LEN } from './graph.js';
 import {
   savePrediction,
   closePrediction,
@@ -676,6 +678,24 @@ async function handleRequest(
       tags: getStringArray(body, 'tags'),
     });
     sendJson(res, 200, result);
+    return;
+  }
+
+  // GET /v1/graph?entity=NAME&limit=N — read-only entity/relation graph (tenant-scoped)
+  if (method === 'GET' && path === '/v1/graph') {
+    const entityRaw = query.get('entity');
+    // Cap at the graph entity-name cap (512), not the id-shaped 256, so a valid
+    // long decision/policy name remains focusable over HTTP (codex P2).
+    if (entityRaw !== null && entityRaw.length > MAX_ENTITY_NAME_LEN) {
+      throw new HttpError(400, `entity exceeds the ${MAX_ENTITY_NAME_LEN}-character cap`);
+    }
+    const limit = parseListLimit(query.get('limit'));
+    const ctx = buildContextWithAuth(req, opts.hippoRoot);
+    const model = buildGraphModel(ctx.hippoRoot, ctx.tenantId, {
+      entity: entityRaw ?? undefined,
+      limit,
+    });
+    sendJson(res, 200, model);
     return;
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.19.0';
+export const PACKAGE_VERSION = '1.20.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/graph-view.test.ts
+++ b/tests/graph-view.test.ts
@@ -1,0 +1,271 @@
+/**
+ * E3 graph observability + visualization - tests.
+ * Docs: docs/plans/2026-06-02-graph-observability.md
+ *
+ * READ-ONLY over the graph: buildGraphModel (loadEntities/loadRelations), the
+ * deterministic layout, the self-contained HTML viewer (XSS-escaped), the JSON
+ * Canvas export, and the GET /v1/graph route. Real SQLite, no mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { saveDecision } from '../src/decisions.js';
+import { savePolicy } from '../src/policies.js';
+import { saveCustomerNote } from '../src/customer-notes.js';
+import { extractGraph } from '../src/graph-extract.js';
+import {
+  buildGraphModel,
+  layoutGraph,
+  renderGraphHtml,
+  renderGraphCanvas,
+  type GraphModel,
+} from '../src/graph-view.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+const T = 'default';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graphview-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+/** Seed: a policy + a decision that names it -> 2 entities + 1 `references` edge. */
+function seedGraph(home: string, tenant = T): void {
+  savePolicy(home, tenant, { policyName: 'RetryPolicy', policyText: 'retry up to 3x' });
+  saveDecision(home, tenant, { decisionText: 'We adopt RetryPolicy across all services' });
+  extractGraph(home, tenant);
+}
+
+describe('graph-view: buildGraphModel (real DB)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('1. maps entities -> nodes and relations -> edges', () => {
+    seedGraph(home);
+    const m = buildGraphModel(home, T);
+    expect(m.nodes).toHaveLength(2);
+    expect(m.nodes.some((n) => n.type === 'policy' && n.name === 'RetryPolicy')).toBe(true);
+    expect(m.nodes.some((n) => n.type === 'decision')).toBe(true);
+    expect(m.edges).toHaveLength(1);
+    expect(m.edges[0].relType).toBe('references');
+    expect(m.truncated).toBe(false);
+  });
+
+  it('2. --entity focus returns the match + its 1-hop neighbours + edges among them', () => {
+    seedGraph(home);
+    const m = buildGraphModel(home, T, { entity: 'RetryPolicy' });
+    // RetryPolicy + the decision that references it.
+    expect(m.nodes).toHaveLength(2);
+    expect(m.nodes.some((n) => n.name === 'RetryPolicy')).toBe(true);
+    expect(m.edges).toHaveLength(1);
+  });
+
+  it('3. unknown --entity yields an empty model', () => {
+    seedGraph(home);
+    const m = buildGraphModel(home, T, { entity: 'NoSuchThing' });
+    expect(m.nodes).toHaveLength(0);
+    expect(m.edges).toHaveLength(0);
+  });
+
+  it('4. empty store -> empty model, truncated false', () => {
+    const m = buildGraphModel(home, T);
+    expect(m).toEqual({ nodes: [], edges: [], truncated: false });
+  });
+
+  it('5. truncated flag set when a loader hits its limit', () => {
+    seedGraph(home);
+    const m = buildGraphModel(home, T, { limit: 1 }); // 2 entities, limit 1 -> truncated
+    expect(m.truncated).toBe(true);
+    expect(m.nodes.length).toBeLessThanOrEqual(1);
+  });
+
+  it('6. dangling edges (endpoint outside the node set) are dropped', () => {
+    seedGraph(home);
+    // limit 1 keeps 1 entity; the references edge's other endpoint is excluded -> dropped.
+    const m = buildGraphModel(home, T, { limit: 1 });
+    for (const e of m.edges) {
+      const ids = new Set(m.nodes.map((n) => n.id));
+      expect(ids.has(e.from) && ids.has(e.to)).toBe(true);
+    }
+  });
+
+  it('15. focus query finds an entity beyond the global limit window (codex P2)', () => {
+    // Many entities so that a small `limit`, under the old global-cap-then-filter,
+    // would miss the focus entity / its neighbour. The by-name focus query (which
+    // looks up the entity directly, then its bidirectional edges) must still find it.
+    savePolicy(home, T, { policyName: 'FocusPol', policyText: 'the focus policy' });
+    for (let i = 0; i < 6; i++) savePolicy(home, T, { policyName: `Filler${i}`, policyText: 'x' });
+    saveDecision(home, T, { decisionText: 'We adopt FocusPol across every service now' });
+    extractGraph(home, T);
+    const m = buildGraphModel(home, T, { entity: 'FocusPol', limit: 2 });
+    expect(m.nodes.some((n) => n.name === 'FocusPol')).toBe(true); // found despite limit 2
+    expect(m.edges.length).toBeGreaterThanOrEqual(1); // its references edge is present
+    const ids = new Set(m.nodes.map((n) => n.id));
+    expect(m.edges.every((e) => ids.has(e.from) && ids.has(e.to))).toBe(true);
+  });
+
+  it('16. focus subgraph includes neighbour-to-neighbour edges, not just focus-touching (codex P2)', () => {
+    savePolicy(home, T, { policyName: 'PolA', policyText: 'PolA works closely with PolB' });
+    savePolicy(home, T, { policyName: 'PolB', policyText: 'a standalone policy' });
+    saveDecision(home, T, { decisionText: 'Adopt PolA and PolB across the org now' });
+    extractGraph(home, T);
+    const m = buildGraphModel(home, T, { entity: 'Adopt PolA and PolB across the org now' });
+    const nameById = new Map(m.nodes.map((n) => [n.id, n.name]));
+    // PolA --references--> PolB connects two NEIGHBOURS (neither is the focus decision);
+    // it would be missing if only focus-touching edges were loaded.
+    const interNeighbour = m.edges.some(
+      (e) => nameById.get(e.from) === 'PolA' && nameById.get(e.to) === 'PolB',
+    );
+    expect(interNeighbour).toBe(true);
+  });
+
+  it('17. focus on a name shared by many entities is capped to the limit (codex P2)', () => {
+    for (let i = 0; i < 8; i++) saveCustomerNote(home, T, { customer: 'Acme', note: `note ${i}` });
+    extractGraph(home, T);
+    const m = buildGraphModel(home, T, { entity: 'Acme', limit: 3 });
+    expect(m.nodes.length).toBeLessThanOrEqual(3); // 8 same-name entities capped to 3
+    expect(m.truncated).toBe(true);
+  });
+
+  it('18. focus truncation is reported when the neighbour scan hits the cap (codex P2)', () => {
+    for (const p of ['PolA', 'PolB', 'PolC', 'PolD']) savePolicy(home, T, { policyName: p, policyText: 'x' });
+    saveDecision(home, T, { decisionText: 'Adopt PolA and PolB and PolC and PolD now' });
+    extractGraph(home, T);
+    // limit 3: the decision references 4 policies; one 1-hop neighbour cannot fit,
+    // so the model must report truncated (not silently omit a neighbour).
+    const m = buildGraphModel(home, T, { entity: 'Adopt PolA and PolB and PolC and PolD now', limit: 3 });
+    expect(m.nodes.length).toBeLessThanOrEqual(3);
+    expect(m.truncated).toBe(true);
+  });
+});
+
+describe('graph-view: layout + renderers (pure)', () => {
+  const model: GraphModel = {
+    nodes: [
+      { id: 1, type: 'decision', name: 'Adopt Postgres' },
+      { id: 2, type: 'policy', name: 'RetryPolicy' },
+      { id: 3, type: 'customer', name: 'Acme' },
+    ],
+    edges: [{ from: 1, to: 2, relType: 'references' }],
+    truncated: false,
+  };
+
+  it('7. layout is deterministic (no Math.random): identical positions across runs', () => {
+    const a = layoutGraph(model);
+    const b = layoutGraph(model);
+    expect([...a.entries()]).toEqual([...b.entries()]);
+    for (const p of a.values()) {
+      expect(Number.isFinite(p.x) && Number.isFinite(p.y)).toBe(true);
+    }
+  });
+
+  it('8. layout handles 0 and 1 node without NaN', () => {
+    expect(layoutGraph({ nodes: [], edges: [], truncated: false }).size).toBe(0);
+    const one = layoutGraph({ nodes: [{ id: 9, type: 'system', name: 'x' }], edges: [], truncated: false });
+    expect(one.size).toBe(1);
+    const p = one.get(9)!;
+    expect(Number.isFinite(p.x) && Number.isFinite(p.y)).toBe(true);
+  });
+
+  it('9. XSS: a </script>-injecting entity name is inert in the HTML', () => {
+    const evil: GraphModel = {
+      nodes: [{ id: 1, type: 'policy', name: '</script><script>alert(1)</script>' }],
+      edges: [],
+      truncated: false,
+    };
+    const html = renderGraphHtml(evil);
+    // No raw breakout: the literal attack string must not appear unescaped.
+    expect(html).not.toContain('<script>alert(1)</script>');
+    // Escaped in the SVG <title> (HTML entities) AND in the inlined JSON (<).
+    expect(html).toContain('&lt;/script&gt;');
+    expect(html).toContain('\\u003c/script');
+  });
+
+  it('10. HTML viewer is self-contained (no external/CDN refs) and renders the graph', () => {
+    const html = renderGraphHtml(model);
+    expect(html).toContain('<svg');
+    expect(html).toContain('<circle');
+    expect(html).toContain('id="graph-data"');
+    // No external resource loads — fully offline.
+    expect(html).not.toMatch(/src\s*=\s*["']https?:/i);
+    expect(html).not.toMatch(/<link[^>]+href\s*=\s*["']https?:/i);
+  });
+
+  it('11. JSON Canvas export is valid and 1:1 with the model', () => {
+    const canvas = JSON.parse(renderGraphCanvas(model)) as {
+      nodes: { id: string; type: string; x: number; y: number; width: number; height: number; text: string }[];
+      edges: { id: string; fromNode: string; toNode: string; label: string }[];
+    };
+    expect(canvas.nodes).toHaveLength(model.nodes.length);
+    expect(canvas.edges).toHaveLength(model.edges.length);
+    for (const n of canvas.nodes) {
+      expect(n.type).toBe('text');
+      expect(typeof n.x === 'number' && typeof n.y === 'number').toBe(true);
+      expect(typeof n.text).toBe('string');
+    }
+    expect(canvas.edges[0].fromNode).toBe('n1');
+    expect(canvas.edges[0].toNode).toBe('n2');
+  });
+});
+
+describe('graph-view: GET /v1/graph (live server)', () => {
+  let home: string;
+  let globalHome: string;
+  let origHippoHome: string | undefined;
+  let handle: ServerHandle;
+
+  beforeEach(async () => {
+    home = makeRoot();
+    globalHome = makeRoot();
+    origHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalHome;
+    handle = await serve({ hippoRoot: home, port: 0 });
+  });
+  afterEach(async () => {
+    await handle.stop();
+    if (origHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = origHippoHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(globalHome, { recursive: true, force: true });
+  });
+
+  it('12. returns the caller-tenant graph; another tenant\'s entities are absent', async () => {
+    seedGraph(home, T);
+    // A separate tenant's graph in the same store must NOT leak to the default caller.
+    savePolicy(home, 'tenantB', { policyName: 'TenantBOnlyPolicy', policyText: 'x' });
+    extractGraph(home, 'tenantB');
+
+    const res = await fetch(`${handle.url}/v1/graph`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GraphModel;
+    expect(body.nodes.some((n) => n.name === 'RetryPolicy')).toBe(true);
+    expect(body.nodes.some((n) => n.name === 'TenantBOnlyPolicy')).toBe(false);
+  });
+
+  it('13. fractional ?limit= is a 400 (not a SQLite datatype-mismatch 500)', async () => {
+    const res = await fetch(`${handle.url}/v1/graph?limit=1.5`);
+    expect(res.status).toBe(400);
+  });
+
+  it('14. empty graph returns 200 with empty nodes/edges', async () => {
+    const res = await fetch(`${handle.url}/v1/graph`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as GraphModel;
+    expect(body.nodes).toEqual([]);
+    expect(body.edges).toEqual([]);
+  });
+
+  it('19. accepts a valid entity name longer than 256 chars (codex P2)', async () => {
+    const longName = 'Adopt ' + 'X'.repeat(300); // ~306 chars, within MAX_ENTITY_NAME_LEN (512)
+    saveDecision(home, T, { decisionText: longName });
+    extractGraph(home, T);
+    const res = await fetch(`${handle.url}/v1/graph?entity=${encodeURIComponent(longName)}`);
+    expect(res.status).toBe(200); // not a 400 length rejection
+    const body = (await res.json()) as GraphModel;
+    expect(body.nodes.some((n) => n.name === longName)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Make hippo's E3 graph (`entities`/`relations`) **observable** — it was previously "headless" (only `hippo graph extract` + inline recall annotations). Read-only; no graph writes (the graph-on-consolidated lint stays green); no migration.

**Inspect**
- `hippo graph show [--entity NAME] [--json]` — dump entities (by type) + their edges, text or JSON.
- `GET /v1/graph [?entity=NAME&limit=N]` — the tenant's graph as JSON (auth-gated + tenant-scoped via `buildContextWithAuth`; reuses `parseListLimit` so a fractional `?limit` is a 400, not a 500; `?entity=` capped at the 512 entity-name cap).

**Visualize**
- `hippo graph view [--out FILE] [--open] [--format html|canvas] [--entity NAME]` — generate a **self-contained, dependency-free, offline, interactive** HTML node-link diagram (deterministic server-side layout; pan / zoom / hover / click-to-highlight; user strings escaped per sink so a name can't inject script), or a JSON Canvas export that opens in Obsidian.
- `--entity` renders a focus subgraph: the named entity (found by a direct, SQL-bounded by-name lookup), its 1-hop neighbours, and the edges among that union.

All reads run inside a single read snapshot (`withGraphReadSnapshot`) so a concurrent `graph extract` can't produce an inconsistent view.

## Cross-model review

Codex `review --commit` ran **7 rounds** and caught a P1 + 8 P2s on the focus/read path that the Claude review critics missed — entity-beyond-cap, duplicate-name uncapping, missing neighbour-to-neighbour edges, SQL-limit pushdown, truncation under-reporting (×2), the 256-vs-512 entity cap, and the single-read-snapshot consistency. All fixed + regression-tested; round 7 clean. See `docs/evals/2026-06-02-graph-observability-result.md`.

## Test plan

- [x] 19 new real-DB tests in `tests/graph-view.test.ts` (model, focus subgraph incl. inter-neighbour edges + caps + beyond-limit lookup, deterministic layout, XSS `</script>` injection inert, self-contained HTML, JSON Canvas, `/v1/graph` tenant-scoping + fractional-limit 400 + empty + >256-char entity).
- [x] Full suite: 2466 pass / 4 skip / 1 known `server-concurrency` env flake (passes isolated).
- [x] `check-graph-writes`, `check-manifest-versions`, `check-em-dashes-in-release-notes` green; `npm run build` clean.
- [x] End-to-end CLI smoke: `graph show` lists entities; `graph view` writes a valid self-contained HTML `<svg>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
