### PR TITLE
feat: L1 graph-retrieval stream into RRF (recall --graph-stream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+## 1.21.0 (2026-06-02): graph-retrieval stream into RRF (Track L / L1)
+
+### Added
+- **Graph-retrieval RRF stream.** `hippo recall --graph-stream` fuses a third
+  retrieval stream into the RRF ranking (beside BM25 and dense), re-ranking the
+  in-pool candidates by graph proximity to the strong lexical seeds: a lexically-weak
+  memory that is graph-adjacent to a strong hit gets lifted. Opt-in and default-off;
+  the library exposes it as a `graphStream` option on `hybridSearch` (rrf scoring
+  mode). Tune with `--graph-hops` (1..3, default 2) and `--graph-seeds` (anchor count,
+  default 10). Read-only over the consolidated E3 graph; reuses the E3.2 traversal.
+  Distinct from `--hops` (E3.2), which injects out-of-pool neighbours; this re-ranks
+  within the candidate pool.
+
+### Notes
+- The stream lives in the rrf fusion path, so it needs embeddings (it stays inert
+  until `hippo embed` has run) and anchors on the top-`seeds` lexical hits, so on a
+  pool with fewer than `seeds` candidates it degrades to the 2-list fusion. Local
+  store only in the CLI for now.
+- Validated by a pre-registered hippo-native mechanism ablation: a graph-adjacent,
+  lexically-weak answer moves from rank 8/8 to 4/8 (into top-5) with no harm on
+  controls. This is a mechanism result, not a population R@5 claim; the
+  LongMemEval-oracle population ablation is deferred as L1-eval (it needs a hippo
+  entity graph built over the LME corpus). See `docs/evals/2026-06-02-l1-graph-stream-*`.
+
 ## 1.20.0 (2026-06-02): graph observability + visualization
 
 ### Added

--- a/docs/evals/2026-06-02-l1-graph-stream-prereg.md
+++ b/docs/evals/2026-06-02-l1-graph-stream-prereg.md
@@ -1,0 +1,56 @@
+# L1 graph-retrieval stream — pre-registration
+
+**Date:** 2026-06-02
+**Plan:** `docs/plans/2026-06-02-l1-graph-rrf-stream.md`
+**Episode:** `01KT5302T7P2E2RGSZBMSMH03Y`
+**Predecessor discipline:** mirrors `docs/evals/2026-05-20-f9-hybrid-rrf-prereg.md` (pre-registration gates rule, v1.8.1).
+
+## Scope of this pre-registration (binding)
+
+This pre-registers the **hippo-native mechanism ablation** for the L1 graph-retrieval stream.
+It is **NOT** the LongMemEval-oracle population ablation: the F9 oracle harness fuses
+*session_ids* and LME has no native hippo entity graph, so an oracle-split graph stream
+requires E3.1 extraction over ~199K LME turns — a separate eval-infra lift deferred as
+**L1-eval**. Per the plan's claim-scoping clause, a PASS here proves *"the mechanism
+rescues the targeted lexically-weak-but-graph-adjacent class without harming controls,"*
+**not** a population-level R@5 lift on a representative query distribution (that is L1-eval).
+
+## Gate (a) — source-read findings (PASS)
+
+Read at worktree HEAD = `origin/master` `20cfcc2` (v1.20.0), 2026-06-02. Recorded in the plan §2. Key facts that constrain the design:
+- `rrfFuse` (src/rrf.ts) is generic over N ranked lists; `absentRank` is passed explicitly as `entries.length+1` and is independent of the list count → adding a 3rd list does not change the BM25/dense streams' absent-contribution.
+- `hybridSearch` rrf path (src/search.ts:466-482) builds `bm25Ranked` + `cosineRanked` over `entries[]` indices; `scoring:'rrf'` only, default `'blend'`; `entries[]` already bi-temporally filtered before fusion.
+- rrf-mode has zero production callers; the F9 benchmark calls `rrfFuse` directly in the `.mjs`, not through `hybridSearch` → the wiring is additive/opt-in and does not touch the F9 benchmark.
+- Graph read helpers (`loadEntitiesByMemoryId`/`loadEntitiesByIds`/`loadNeighborRelations`) are SELECT-only and already imported by graph-recall.ts; a sibling read-only module is E3.3-lint green.
+
+**Verdict: Gate (a) PASS** (plan-eng-critic independently verified each claim, score 82).
+
+## Gate (b) — dry-run "structural work" criterion (PASS)
+
+Test: `tests/search-graph-stream-rrf.test.ts` — "Gate-(b) dry-run" case, real SQLite.
+Fixture: an 8-entry pool; the answer (`weak`, index 7) is lexically last in BOTH the BM25
+and dense rankings (rank 8/8) but graph-adjacent (1-hop) to a top lexical seed (`strong`,
+index 0). Seeds = top-3 lexical (`weak` is NOT a seed). Weights `[0.4, 0.6, 0.5]`,
+`absentRank = 9`, `k = 60`.
+
+Measured fused ranks of the answer:
+- **2-stream (BM25 + dense):** rank **8/8** (outside top-5).
+- **3-stream (+ graph):** rank **4/8** (inside top-5).
+
+The answer is lexically-weak-but-graph-adjacent and moves from rank 8 to rank 4 purely
+from the graph stream — structural work, not a tiebreaker swap at irrelevant positions.
+
+**Verdict: Gate (b) PASS.**
+
+## Binding gate (Gate-B, this episode)
+
+- **G (mechanism):** the targeted lexically-weak-but-graph-adjacent answer enters top-5
+  under the 3-stream fusion when it was outside top-5 under the 2-stream baseline. **MET**
+  (rank 8/8 → 4/8).
+- **C (no-harm):** a strong lexical answer with no graph path keeps its top rank; an empty
+  graph yields an empty stream and the 2-list path is taken unchanged. **MET** (control
+  answer stays rank 1; `graphRankStream` returns `[]` → 3rd list skipped).
+- **Honest-null clause:** had G not improved or C dropped, the mechanism would still ship
+  as opt-in infra with the null disclosed and **no "lifts R@5" claim**.
+
+This pre-registration is **LOCKED** (both gates PASS). Result: `2026-06-02-l1-graph-stream-result.md`.

--- a/docs/evals/2026-06-02-l1-graph-stream-result.md
+++ b/docs/evals/2026-06-02-l1-graph-stream-result.md
@@ -21,10 +21,15 @@ lexical seeds.
 | Query class | n | Answer fused rank, 2-stream | Answer fused rank, 3-stream | Verdict |
 |---|---|---|---|---|
 | **G** (lexically-weak, graph-adjacent to a seed) | 1 | **8 / 8** (outside top-5) | **4 / 8** (inside top-5) | rescued |
-| **C** (lexically-strong, no graph path) | 1 | **1 / 5** | **1 / 5** (stream empty → 2-list path) | no harm |
+| **C-empty** (lexically-strong, empty graph) | 1 | **1 / 5** | **1 / 5** (stream empty → 2-list path) | no harm |
+| **C-noise** (lexically-strong, no path; graph POPULATED, boosts a non-answer distractor) | 1 | **1 / 6** | **1 / 6** (distractor lifted but never reaches top) | no harm |
 
 Per-query rank delta (G): **+4 positions** (rank 8 → 4). The graph stream is the only
-changed input; the BM25 and dense rankings are identical in both runs.
+changed input; the BM25 and dense rankings are identical in both runs. The **C-noise**
+control is the stronger no-harm test (added at review on the independent-review-critic's
+HIGH): with a *populated* graph that boosts a graph-adjacent distractor into the stream, a
+true lexical answer with no graph path keeps rank 1 — the stream adds signal without
+displacing a strong answer.
 
 ## Supporting evidence
 
@@ -32,8 +37,9 @@ changed input; the BM25 and dense rankings are identical in both runs.
   ordering, fanout cap, local+global expansion, deterministic ties, empty-graph no-op,
   not-in-pool ignored, seeds-never-scored (incl. seed-adjacent-to-another-seed),
   `selectGraphSeeds` correctness.
-- `tests/search-graph-stream-rrf.test.ts` — 3 fusion tests (the G dry-run, the C no-harm,
-  and the empty-graph skip-path = byte-identical to the 2-list fusion).
+- `tests/search-graph-stream-rrf.test.ts` — 4 fusion tests (the G dry-run, the C-empty
+  no-harm, the **C-noise populated-graph no-displacement** control, and the empty-graph
+  skip-path = byte-identical to the 2-list fusion).
 - `tests/cli-graph-stream.test.ts` — 3 CLI smoke/validation tests.
 - Full suite: 2483 passed (the single `server-concurrency.test.ts` failure is the known
   ECONNRESET env flake under full-suite parallelism — passes in isolation, no graph code).

--- a/docs/evals/2026-06-02-l1-graph-stream-result.md
+++ b/docs/evals/2026-06-02-l1-graph-stream-result.md
@@ -1,0 +1,56 @@
+# L1 graph-retrieval stream — result
+
+**Date:** 2026-06-02
+**Prereg:** `docs/evals/2026-06-02-l1-graph-stream-prereg.md` (LOCKED — Gate (a) + Gate (b) PASS)
+**Episode:** `01KT5302T7P2E2RGSZBMSMH03Y`
+**Version:** 1.21.0
+
+## Headline (honestly scoped)
+
+The graph-retrieval stream **rescues the targeted lexically-weak-but-graph-adjacent class
+into top-5 without harming controls**. This is a **mechanism result**, NOT a population-level
+R@5 claim on a representative distribution — that is deferred to **L1-eval** (the
+LongMemEval-oracle ablation, which needs a hippo entity graph built over the LME corpus).
+Do not cite this as "L1 lifts R@5 on the oracle split."
+
+## Mechanism ablation (real SQLite, `tests/search-graph-stream-rrf.test.ts`)
+
+8-entry pool. Weights `[bm25=0.4, dense=0.6, graph=0.5]`, `k=60`, `absentRank=9`, top-3
+lexical seeds.
+
+| Query class | n | Answer fused rank, 2-stream | Answer fused rank, 3-stream | Verdict |
+|---|---|---|---|---|
+| **G** (lexically-weak, graph-adjacent to a seed) | 1 | **8 / 8** (outside top-5) | **4 / 8** (inside top-5) | rescued |
+| **C** (lexically-strong, no graph path) | 1 | **1 / 5** | **1 / 5** (stream empty → 2-list path) | no harm |
+
+Per-query rank delta (G): **+4 positions** (rank 8 → 4). The graph stream is the only
+changed input; the BM25 and dense rankings are identical in both runs.
+
+## Supporting evidence
+
+- `tests/graph-stream.test.ts` — 11 producer tests: seed→neighbour scoring, per-hop decay
+  ordering, fanout cap, local+global expansion, deterministic ties, empty-graph no-op,
+  not-in-pool ignored, seeds-never-scored (incl. seed-adjacent-to-another-seed),
+  `selectGraphSeeds` correctness.
+- `tests/search-graph-stream-rrf.test.ts` — 3 fusion tests (the G dry-run, the C no-harm,
+  and the empty-graph skip-path = byte-identical to the 2-list fusion).
+- `tests/cli-graph-stream.test.ts` — 3 CLI smoke/validation tests.
+- Full suite: 2483 passed (the single `server-concurrency.test.ts` failure is the known
+  ECONNRESET env flake under full-suite parallelism — passes in isolation, no graph code).
+
+## Scope boundaries (binding)
+
+- **Within-pool only.** The stream re-ranks candidates already in the pool; it cannot
+  rescue an answer absent from the pool (that is `graph-recall.ts`'s out-of-pool injection).
+- **Anchors on the top-`seedCount` lexical hits.** On a pool with `<= seedCount` candidates,
+  every candidate is a seed and the stream is inert (degrades to the 2-list fusion). The CLI
+  default `seedCount` is 10; tune with `--graph-seeds`.
+- **rrf-mode + embeddings required.** The stream lives in the rrf fusion path; without
+  embeddings `hybridSearch` falls back to BM25-only and the stream is inert (the CLI says so).
+
+## Deferred: L1-eval (population ablation)
+
+Build a hippo entity graph over the LongMemEval oracle corpus (E3.1 extraction over the
+sessions, entity→session mapping), then run the graph-stream-vs-no-graph-stream ablation
+through a harness analogous to `benchmarks/longmemeval/chunk_per_turn_hybrid_retrieve.mjs`
+to measure population R@5. Only L1-eval can substantiate "lifts R@5 on the oracle split."

--- a/docs/plans/2026-06-02-l1-graph-rrf-stream.md
+++ b/docs/plans/2026-06-02-l1-graph-rrf-stream.md
@@ -1,0 +1,119 @@
+# L1 — Graph-retrieval stream into RRF (plan)
+
+**Date:** 2026-06-02
+**Roadmap:** `ROADMAP-RESEARCH.md` Track L item L1 `[next, depends on E3.1]` — "a new graph ranked-list producer that feeds `src/rrf.ts` as a third fusion input beside BM25 + dense, distinct from `src/graph-recall.ts`."
+**Episode:** `01KT5302T7P2E2RGSZBMSMH03Y`
+**Target version:** 1.21.0 (minor).
+
+## 1. Problem & scope
+
+Add a **graph-retrieval ranked list** as a 3rd RRF stream in `hybridSearch` (`scoring:'rrf'`), beside BM25 + dense. The stream **re-ranks within the candidate pool** by graph proximity to the strong lexical seeds: a memory that is lexically weak for the query but graph-adjacent to a strong lexical hit gets lifted. Opt-in, default-off.
+
+**In scope:** the producer, the `hybridSearch` rrf-path wiring, a thin CLI surface, a pre-registered hippo-native ablation, real-DB tests.
+**Out of scope (deferred, named):**
+- **L1-eval** — the LongMemEval-oracle graph-stream ablation. The F9 oracle harness fuses *session_ids* and LME has **no native hippo entity graph**; building one needs E3.1 extraction over ~199K LME turns — a separate eval-infra lift, not "pure win." Pre-registered as a follow-up.
+- Production `'blend'`-mode graph signal (rrf-mode is L1's surface; `'blend'` is separate).
+- PPR/HippoRAG personalized walk (rejected Framing 1 — wasted on today's `supersedes`-mostly graph; revisit when E3.1 cross-object edges densify).
+- Orthogonal out-of-pool injection — that is `graph-recall.ts`'s job and already ships. L1 is the complementary within-pool lever.
+
+## 2. Source-read findings (pre-reg Gate (a))
+
+Read at worktree HEAD = `origin/master` `20cfcc2` (v1.20.0) on 2026-06-02:
+- **`src/search.ts:466-482`** — rrf fusion builds `bm25Ranked` + `cosineRanked` (orderings of `entries[]` indices over the `eligible` set `bm25>0||cosine>0`), then `rrfFuse([bm25Ranked, cosineRanked], [bm25Weight, embeddingWeight], { absentRank: entries.length + 1 })`. Only under `scoring:'rrf'` **and** `useEmbeddings`; default `scoring='blend'`.
+- **`src/rrf.ts`** — `rrfFuse<T>` is already generic over **N** ranked lists; `absentRank` default = `max(list.length)+1`. A 3rd list is mechanically supported with zero change to rrf.ts.
+- **`src/search.ts:400-418`** — `entries[]` is **already bi-temporally filtered** (as-of / superseded-drop) *before* fusion. The graph stream therefore needs no re-filtering — it only assigns ranks to entries already in the filtered pool.
+- **`src/graph-recall.ts`** — the E3.2 traversal to reuse: `loadEntitiesByMemoryId(root,tenant,memIds)` → seed entities; BFS both directions via `loadNeighborRelations(root,tenant,frontier,{limit})` with a per-hop fanout cap + `visited` set; `loadEntitiesByIds` to resolve reached → memoryId. Expands across local **and** global roots. (graph-recall does post-hoc injection + score inheritance; L1 reuses only the *traversal*.)
+- **`src/graph.ts`** read helpers exist: `loadEntitiesByMemoryId` (401), `loadEntitiesByIds` (430), `loadNeighborRelations` (464). Read-only; an L1 module that only SELECTs may live outside graph.ts (E3.3 `check-graph-writes` lint permits reads).
+- **rrf-mode has ZERO production callers** (`grep scoring: src/ scripts/ bench/` = empty); the F9 benchmark calls `rrfFuse` **directly in the `.mjs`** (`benchmarks/longmemeval/chunk_per_turn_hybrid_retrieve.mjs:319`), **not** through `hybridSearch`. ∴ wiring a 3rd stream into `hybridSearch` does not touch the F9 benchmark or any production recall path — it is additive and opt-in.
+- **13 `hybridSearch` call sites** (api.ts, cli.ts×2, eval.ts, mcp/server.ts×2, shared.ts×2, internal×5). The new option is an optional field → all 13 keep byte-identical behaviour.
+
+## 3. Design — the graph-rank-stream producer
+
+New module **`src/graph-stream.ts`** (read-only; SELECTs only → E3.3 lint green):
+
+```ts
+export interface GraphStreamOpts {
+  hippoRoot: string;
+  tenantId: string;
+  globalRoot?: string;          // expand global seeds in their own store, like graph-recall
+  hops?: number;                // default 2; hard cap MAX_HOPS=3 (reuse)
+  decay?: number;               // per-hop multiplicative decay; default 0.5
+  maxNeighbors?: number;        // per-hop fanout cap; default 25 (DEFAULT_MAX_NEIGHBORS)
+  seedCount?: number;           // # top lexical seeds to expand from; default min(10, pool)
+}
+/** Returns entries[] indices ordered by graph-proximity score (desc).
+ *  Only indices that are graph-reached AND in-pool appear; the rest are
+ *  absent (→ rrfFuse absentRank). Pure reads. */
+export function graphRankStream(
+  entries: MemoryEntry[],
+  seedIndices: number[],        // top lexical seeds (by combined bm25/cosine pre-rank)
+  bm25Ranked: number[],         // for seed lexical-strength ordering
+  cosineRanked: number[],
+  opts: GraphStreamOpts,
+): number[];
+```
+
+Algorithm:
+1. Build `memId → entryIndex` map over `entries[]` (one pass).
+2. `seedMemIds = seedIndices.map(i => entries[i].id)`. Per seed, a **seed strength** = `1/(lexRank)` where `lexRank` is the seed's best of (bm25Ranked position, cosineRanked position) — so a neighbour of a *top* seed outranks a neighbour of a weak seed. **Note (plan-eng-critic):** this scale only sets the *within-graph-stream ordering*; RRF then re-ranks the graph list by `1/(k + graphRank)`, so the absolute `1/lexRank` magnitude is **washed out** by fusion — do not tune this curve expecting a fused-score effect, only the induced order matters.
+3. For each root in `[hippoRoot, globalRoot?]`: `loadEntitiesByMemoryId` for the seeds present in that store; record `originSeedStrength` per seed entity. BFS both directions up to `hops`, per-hop fanout cap, `visited` set (cycle-safe) — the `produceHitsForRoot` shape from graph-recall.ts.
+4. For each **reached** entity at depth `d` (d≥1, i.e. **neighbours only — seeds themselves are NOT scored by the graph stream**, since they already rank via bm25/cosine; scoring them would double-count and dilute the orthogonal graph signal): map `entity.memoryId → entryIndex`; if in-pool, `graphScore[idx] = max(graphScore[idx], originSeedStrength × decay^d)`.
+5. **Seed-exclusion guard (plan-eng-critic MED).** `graphScore` is keyed by `entryIndex` **globally across roots**, but each root's BFS seeds its own `visited` set per-root — so a memory that is a seed in the local store could be *reached as a neighbour* in the global store's traversal and pick up a score via `max()`. After accumulation, **explicitly delete every `idx ∈ seedIndices` from `graphScore`** (belt-and-suspenders) so the "seeds are never scored by the graph stream" invariant holds across roots, not just within one.
+6. Return `[...graphScore.keys()]` sorted by score desc (ties broken by index asc for determinism).
+
+Defaults: `hops=2, decay=0.5, maxNeighbors=25, seedCount=min(10,pool)`. No new constants beyond these; `k` stays `RRF_K=60` (the rrf.ts JSDoc forbids tuning k without a cross-corpus eval).
+
+## 4. Wiring in `hybridSearch`
+
+New option on the `hybridSearch` options object:
+```ts
+graphStream?: { weight: number } & GraphStreamOpts;   // weight = RRF weight for the graph list
+```
+- Active **only** when `graphStream && graphStream.weight > 0 && scoringMode==='rrf' && useEmbeddings`. Otherwise the code path is the existing 2-list fusion — **byte-identical** (locked by a snapshot test).
+- When active: compute `seedIndices` (top `seedCount` by combined lexical pre-rank), call `graphRankStream` → `graphRanked`. If `graphRanked.length === 0` (empty graph / no seed maps to an entity / nothing in-pool) → **skip the 3rd list** (fall back to the identical 2-list fusion; no ordering change). **(plan-eng-critic MED:** must *skip*, not "include an empty list" — an all-absent 3rd list adds a uniform constant `w_g/(k+absentRank)` to the RRF base, but `search.ts` multiplies the base by **non-uniform** per-entry multipliers (strength/recency/decision/path/scope/extraction), so `(base+C)·m_i = base·m_i + C·m_i` is **not** order-preserving. Skip-when-empty is the only byte-identical path.**)** Else:
+  `rrfFuse([bm25Ranked, cosineRanked, graphRanked], [bm25Weight, embeddingWeight, graphStream.weight], { absentRank: entries.length + 1 })`.
+- `absentRank` stays `entries.length + 1` (explicit) so the BM25/dense streams' absent-contribution is unchanged whether or not the 3rd list is present.
+- Default graph weight when a caller enables it without specifying: caller must pass `weight` (no implicit default — opt-in is explicit). The ablation/dry-run picks the recommended value.
+
+## 5. CLI surface (thin)
+
+Add `hippo recall --graph-stream` (boolean) + `--graph-hops <N>` (optional): forces `scoring:'rrf'` and sets `graphStream` with a default weight (e.g. 0.5) + defaults above. **Disclosure (for the critic):** `--graph-stream` *implies* rrf-mode recall (production default is `'blend'`), so the flag bundles two behaviours. Rationale to include: makes L1 reachable + manually testable end-to-end on a real store; small wrapper. Alternative if the critic objects: library-API + ablation only, defer the flag. **Decision deferred to plan-eng-critic.**
+
+## 6. Ablation — the success criterion (hippo-native, pre-registered)
+
+**Surface:** a real-DB fixture store with E2 objects → E3 `entities`/`relations`, built so that:
+- **Graph queries (G):** the answer memory is **in-pool but lexically weak** (ranks > 5 under 2-stream fusion) and **graph-adjacent** (≤`hops`) to a **strong lexical seed**. This is the case the graph stream should rescue into top-5.
+- **Control queries (C):** the answer is a strong lexical hit with **no graph path** from a seed. The graph stream must be **inert / no-harm** here.
+
+**Metric:** R@5 (+ R@3) over G and C, `graphStream` ON vs OFF, same store, same seeds.
+
+**Gate-A (workload validity):** graph non-empty; every G-answer has ≥1 relation path (≤hops) to a seed; every G-answer is in-pool; every G-answer ranks **> 5** under the 2-stream baseline (else there is nothing to lift — a G query that already passes is dropped from G).
+
+**Gate (b) dry-run (BLOCKING before the binding run):** one G query shows its answer at **rank > 5 under 2-stream** and **≤ 5 under 3-stream** — proving the graph stream does **structural work** (moves a real lexically-weak-but-graph-adjacent answer into top-5), not a tiebreaker swap at irrelevant positions. If it fails, the mechanism is inert at the chosen weight → fix weight/design before locking.
+
+**Gate-B (binding):**
+- On **G**: `R@5(3-stream) > R@5(2-stream)`, reported as **raw answer counts** (e.g. "4/6 → 6/6"), no pp-smuggling.
+- On **C**: `R@5(3-stream) ≥ R@5(2-stream)` — **no harm** on non-graph queries.
+- **If G does not improve OR C drops → NULL/PARTIAL.** Report honestly (Honest Reporting rule). The mechanism may still ship as **opt-in infra with the null disclosed** (value = the wiring + the deferred L1-eval), but with **no "lifts R@5" claim**. Ship-vs-hold decided at verify against the actual numbers.
+
+**Claim-scoping (plan-eng-critic MED — binding).** Gate-A keeps only G answers that rank `>5` AND are graph-adjacent to a strong seed — i.e. the fixture is hand-built to contain exactly the class the lever targets. So a PASS proves **"the mechanism rescues the targeted lexically-weak-but-graph-adjacent class without harming controls"** — it is a **mechanism test, NOT evidence of population-level R@5 lift on a representative query distribution** (that is what the deferred L1-eval must show on the oracle split). The result doc and any CHANGELOG/README line must use the mechanism-scoped wording, never an unqualified "L1 lifts R@5." The result doc reports **C-set raw counts AND per-query rank deltas** (not just G/C pass-fail), so an *inert-but-harmless* result is distinguishable from a *genuinely-helpful* one.
+
+Prereg doc: `docs/evals/2026-06-02-l1-graph-stream-prereg.md` — locked only after Gate (a) [done] + Gate (b) dry-run PASS are both recorded with verdicts (F9 discipline). Result doc: `docs/evals/2026-06-02-l1-graph-stream-result.md`.
+
+## 7. Tests (real-DB, no mocks — project rule)
+
+`tests/graph-stream.test.ts`:
+- seed→neighbour scoring; per-hop `decay^d`; fanout cap; local+global expansion; dedup keeps max score; deterministic order (ties by index).
+- empty graph → `[]` (no-op); reached entity **not in pool** → ignored; a **superseded** entity already filtered out of `entries[]` → never scored (it can't be in-pool).
+- seeds themselves not scored by the stream (neighbours only) — **incl. the cross-root case: a memory that is a seed AND a neighbour of another seed in the *other* store must NOT appear in the stream** (locks the §3.5 seed-exclusion guard).
+
+`tests/search-graph-stream-rrf.test.ts`:
+- `graphStream` off / `weight:0` / `scoring:'blend'` → **byte-identical** to the 2-stream rrf result (snapshot).
+- `graphStream` on with a graph-adjacent lexically-weak entry → that entry's fused rank improves.
+- empty graph with `graphStream` on → ordering unchanged (3rd list **skipped**, not included-empty — asserts the §4 skip path).
+
+CLI test (flag ships, plan-eng-critic LOW): `recall --graph-stream` sets `scoring='rrf'` and returns results; **a plain `recall` (no flag) stays `scoring='blend'` byte-for-byte** — locks the rrf-mode coupling as documented behaviour, not a silent mode flip.
+
+## 8. Ship
+
+minor `1.20.0 → 1.21.0`; bump 5 manifests + `src/version.ts` `PACKAGE_VERSION`; CHANGELOG `## 1.21.0`; plan + prereg + result docs. `prepublishOnly` gates (manifest-versions, em-dashes-in-release-notes, check-graph-writes, build) must pass. PR → merge → publish → tag → GitHub release → global install verify.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.20.0",
+  "version": "1.21.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.15.0",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.15.0",
+      "version": "1.21.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,6 +213,7 @@ import { refineStore } from './refine-llm.js';
 import { wmPush, wmRead, wmClear, wmFlush, WorkingMemoryItem } from './working-memory.js';
 import { multihopSearch } from './multihop.js';
 import { graphExpandRecall, MAX_HOPS, DEFAULT_MAX_NEIGHBORS } from './graph-recall.js';
+import { DEFAULT_GRAPH_STREAM_WEIGHT } from './graph-stream.js';
 import { getReranker } from './rerankers/index.js';
 import { computeSalience } from './salience.js';
 import { computeAmbientState, renderAmbientSummary } from './ambient.js';
@@ -959,8 +960,59 @@ async function cmdRecall(
 
   const useMultihop = flags['multihop'] === true || config.multihop.enabled;
 
+  // L1 — graph-retrieval stream. `--graph-stream` forces rrf fusion + the graph stream
+  // (see src/graph-stream.ts). NOTE: it implies `scoring:'rrf'` (production default is
+  // 'blend'), so the flag bundles two behaviours by design. CLI surface is local-store
+  // only for now; the library API supports a globalRoot for callers who need it.
+  const useGraphStream = flags['graph-stream'] === true;
+  let graphStreamHops: number | undefined;
+  if (useGraphStream && flags['graph-hops'] !== undefined) {
+    if (typeof flags['graph-hops'] === 'boolean') {
+      console.error(`--graph-hops requires an integer value 1..${MAX_HOPS} (e.g. --graph-hops 2).`);
+      process.exit(1);
+    }
+    const h = Number(flags['graph-hops']);
+    if (!Number.isInteger(h) || h < 1 || h > MAX_HOPS) {
+      console.error(`Invalid --graph-hops: "${String(flags['graph-hops'])}". Must be an integer 1..${MAX_HOPS}.`);
+      process.exit(1);
+    }
+    graphStreamHops = h;
+  }
+  let graphStreamSeeds: number | undefined;
+  if (useGraphStream && flags['graph-seeds'] !== undefined) {
+    if (typeof flags['graph-seeds'] === 'boolean') {
+      console.error('--graph-seeds requires a positive integer value (e.g. --graph-seeds 10).');
+      process.exit(1);
+    }
+    const s = Number(flags['graph-seeds']);
+    if (!Number.isInteger(s) || s < 1) {
+      console.error(`Invalid --graph-seeds: "${String(flags['graph-seeds'])}". Must be a positive integer.`);
+      process.exit(1);
+    }
+    graphStreamSeeds = s;
+  }
+
   let results;
-  if (useMultihop) {
+  if (useGraphStream) {
+    if (!isEmbeddingAvailable()) {
+      // The graph stream fuses inside the rrf path, which only runs with embeddings; without
+      // them hybridSearch falls back to BM25-only and the stream is inert. Say so plainly
+      // rather than silently no-op.
+      console.error('[note] --graph-stream needs embeddings (rrf fusion); none available, so the graph stream is inert. Run `hippo embed` first.');
+    }
+    if (hasGlobal) {
+      console.error('[note] --graph-stream searches the local store only; global graph fusion is a follow-up.');
+    }
+    // The stream anchors on the top-`seedCount` lexical hits and re-ranks the rank>seedCount
+    // tail; on a pool with <= seedCount candidates EVERY candidate is a seed and the stream
+    // is inert (it degrades to the 2-list fusion). Tune the anchor count with --graph-seeds.
+    results = await hybridSearch(query, localEntries, {
+      budget, hippoRoot, mmr: mmrEnabled, mmrLambda, minResults, scope: recallActiveScope,
+      includeSuperseded, asOf,
+      scoring: 'rrf',
+      graphStream: { weight: DEFAULT_GRAPH_STREAM_WEIGHT, tenantId, hops: graphStreamHops, seedCount: graphStreamSeeds },
+    });
+  } else if (useMultihop) {
     const allEntries = [...localEntries, ...globalEntries];
     results = multihopSearch(query, allEntries, {
       budget,
@@ -7391,6 +7443,15 @@ Commands:
                            graph holds supersedes edges (E3.1); cross-object edges
                            light up the same traversal once extracted.
     --max-neighbors <n>    Per-hop fanout cap for --hops (1..200, default 25).
+    --graph-stream         L1: fuse a graph-retrieval stream into RRF, re-ranking
+                           in-pool results by graph proximity to the strong lexical
+                           seeds. Implies rrf scoring (default is blend). Local store
+                           only. Distinct from --hops (which injects out-of-pool
+                           neighbours); this re-ranks within the candidate pool.
+    --graph-hops <n>       Hops for --graph-stream (1..3, default 2).
+    --graph-seeds <n>      Lexical anchors for --graph-stream (default 10). The stream
+                           re-ranks the rank>seeds tail; on a pool with <= n candidates
+                           every candidate is a seed and the stream is inert.
     --no-mmr               Disable MMR diversity re-ranking
     --mmr-lambda <f>       MMR balance 0..1 (default: 0.7, 1.0 = pure relevance)
     --evc-adaptive         ACC-style: when top-K shows high inter-item overlap

--- a/src/graph-stream.ts
+++ b/src/graph-stream.ts
@@ -136,9 +136,13 @@ function accumulateForRoot(
     const rels = loadNeighborRelations(root, tenantId, frontier, {
       limit: Math.max(maxNeighbors, maxNeighbors * frontier.length),
     });
-    const nextFrontier: number[] = [];
-    const nextStrength = new Map<number, number>();
     const hopFactor = Math.pow(decay, depth);
+    // Pass 1: accumulate the STRONGEST reaching-seed strength per new neighbour across ALL
+    // relations at this depth BEFORE committing any to `visited` (codex P2). Marking a node
+    // visited mid-loop would lock it to whichever relation SQLite returned first, so a later
+    // edge from a STRONGER lexical seed would be dropped and the neighbour mis-scored. A node
+    // already in `visited` was committed at an earlier (shorter) depth and keeps that score.
+    const bestStrengthThisDepth = new Map<number, number>();
     for (const rel of rels) {
       const fromIn = frontierSet.has(rel.fromEntityId);
       const toIn = frontierSet.has(rel.toEntityId);
@@ -148,17 +152,24 @@ function accumulateForRoot(
       else if (toIn && !fromIn) { neighborId = rel.fromEntityId; reacherId = rel.toEntityId; }
       else continue;
       if (visited.has(neighborId)) continue;
-      visited.add(neighborId);
       const seedStrength = frontierStrength.get(reacherId) ?? originStrength.get(reacherId) ?? 0;
-      const propagated = seedStrength * hopFactor;
-      // `visited` is set the moment a node is reached, so a node enters reachedScore at its
-      // FIRST (shortest) path only; the Math.max here is defensive for a same-frontier
-      // duplicate, not a true max over multiple distinct paths. Matches graph-recall.ts and
-      // is washed out by RRF anyway (only the induced order matters — see module docstring).
-      reachedScore.set(neighborId, Math.max(reachedScore.get(neighborId) ?? 0, propagated));
-      nextStrength.set(neighborId, Math.max(nextStrength.get(neighborId) ?? 0, seedStrength));
+      bestStrengthThisDepth.set(neighborId, Math.max(bestStrengthThisDepth.get(neighborId) ?? 0, seedStrength));
+    }
+    // Pass 2: commit strongest-first (then id asc — deterministic), so the per-hop fanout cap
+    // keeps the highest-scoring neighbours rather than whichever SQLite happened to return.
+    const nextFrontier: number[] = [];
+    const nextStrength = new Map<number, number>();
+    const ordered = [...bestStrengthThisDepth.keys()].sort((a, b) => {
+      const d = bestStrengthThisDepth.get(b)! - bestStrengthThisDepth.get(a)!;
+      return d !== 0 ? d : a - b;
+    });
+    for (const neighborId of ordered) {
+      if (nextFrontier.length >= maxNeighbors) break; // per-hop fanout cap (strongest kept)
+      const seedStrength = bestStrengthThisDepth.get(neighborId)!;
+      visited.add(neighborId);
+      reachedScore.set(neighborId, Math.max(reachedScore.get(neighborId) ?? 0, seedStrength * hopFactor));
+      nextStrength.set(neighborId, seedStrength);
       nextFrontier.push(neighborId);
-      if (nextFrontier.length >= maxNeighbors) break; // per-hop fanout cap
     }
     frontier = nextFrontier;
     frontierStrength = nextStrength;

--- a/src/graph-stream.ts
+++ b/src/graph-stream.ts
@@ -1,0 +1,222 @@
+/**
+ * L1 — graph-retrieval ranked-list stream for RRF fusion
+ * (docs/plans/2026-06-02-l1-graph-rrf-stream.md).
+ *
+ * READ-ONLY consumer of the E3 graph substrate (entities/relations built by E3.1,
+ * guarded by E3.3). Produces a ranked list of `entries[]` indices ordered by graph
+ * proximity to the strong lexical seeds, for use as a 3rd fusion input to `rrfFuse`
+ * beside BM25 + dense (src/search.ts hybridSearch, scoring:'rrf').
+ *
+ * DISTINCT from graph-recall.ts: that INJECTS out-of-pool neighbours post-hoc; this
+ * RE-RANKS within the already-filtered candidate pool. It only assigns ranks to
+ * entries that are (a) graph-reached from a seed AND (b) present in `entries[]`. Seeds
+ * themselves are never scored (they already rank via BM25/dense; scoring them would
+ * double-count and dilute the orthogonal graph signal).
+ *
+ * Reuses the E3.2 BFS traversal shape from graph-recall.ts (loadEntitiesByMemoryId
+ * seeds -> loadNeighborRelations BFS both directions, per-hop fanout cap, visited set
+ * -> loadEntitiesByIds to resolve reached -> memoryId). Expands across the local AND
+ * global stores. Pure reads (SELECTs only via graph.ts helpers), so the E3.3
+ * check-graph-writes lint permits this module living outside graph.ts.
+ *
+ * The graph stream's score scale (1/lexRank seed strength x decay^hops) only sets the
+ * WITHIN-graph-stream ORDERING; RRF then re-ranks the list by 1/(k + graphRank), so the
+ * absolute magnitude is washed out by fusion. Do not tune the scale expecting a
+ * fused-score effect — only the induced order matters.
+ */
+import type { MemoryEntry } from './memory.js';
+import {
+  loadEntitiesByMemoryId,
+  loadEntitiesByIds,
+  loadNeighborRelations,
+} from './graph.js';
+import { MAX_HOPS, DEFAULT_MAX_NEIGHBORS } from './graph-recall.js';
+
+/** Default hops expanded from each seed (MVP; hard cap MAX_HOPS=3 reused from graph-recall). */
+export const DEFAULT_GRAPH_HOPS = 2;
+/** Default per-hop multiplicative decay applied to the seed strength. */
+export const DEFAULT_GRAPH_DECAY = 0.5;
+/** Default number of top lexical seeds expanded from. */
+export const DEFAULT_GRAPH_SEED_COUNT = 10;
+/** Recommended RRF weight for the graph stream — a CLI-only convenience default. The
+ *  library `graphStream.weight` option stays REQUIRED (opt-in is explicit). */
+export const DEFAULT_GRAPH_STREAM_WEIGHT = 0.5;
+
+/** A lexical seed to expand the graph from: a candidate index + its lexical strength. */
+export interface GraphSeed {
+  /** Index into the caller's `entries[]`. */
+  index: number;
+  /** Lexical strength (1/lexRank); higher = stronger seed. Propagated x decay^hops. */
+  strength: number;
+}
+
+export interface GraphStreamOpts {
+  hippoRoot: string;
+  tenantId: string;
+  /** The global store root, when distinct + initialized (where global seeds' graph lives). */
+  globalRoot?: string;
+  /** Hops to expand from each seed. Clamped to [1, MAX_HOPS]. Default DEFAULT_GRAPH_HOPS. */
+  hops?: number;
+  /** Per-hop multiplicative decay on the seed strength. Default DEFAULT_GRAPH_DECAY. */
+  decay?: number;
+  /** Per-hop fanout cap. Default DEFAULT_MAX_NEIGHBORS. */
+  maxNeighbors?: number;
+}
+
+/**
+ * Pick the top `seedCount` candidates by best lexical rank (lowest position across the
+ * BM25 and dense ranked lists), with strength = 1/(bestRank + 1). Pure; exported for
+ * direct unit testing. A candidate present in either ranked list is eligible.
+ */
+export function selectGraphSeeds(
+  bm25Ranked: ReadonlyArray<number>,
+  cosineRanked: ReadonlyArray<number>,
+  seedCount: number,
+): GraphSeed[] {
+  if (seedCount <= 0) return [];
+  const bestPos = new Map<number, number>();
+  const consider = (list: ReadonlyArray<number>) => {
+    for (let p = 0; p < list.length; p++) {
+      const idx = list[p];
+      const prev = bestPos.get(idx);
+      if (prev === undefined || p < prev) bestPos.set(idx, p);
+    }
+  };
+  consider(bm25Ranked);
+  consider(cosineRanked);
+  return [...bestPos.entries()]
+    .sort((a, b) => a[1] - b[1] || a[0] - b[0]) // best rank asc, then index asc (deterministic)
+    .slice(0, seedCount)
+    .map(([index, best]) => ({ index, strength: 1 / (best + 1) }));
+}
+
+/**
+ * Accumulate per-entryIndex graph-proximity scores from ONE store's graph into
+ * `graphScore`. Pure reads. `seeds` are the lexical seeds (index + strength); only the
+ * seeds whose entities live in THIS store are expanded. The origin seed strength is
+ * carried UNCHANGED along each BFS path; the per-hop decay is applied as decay^depth so
+ * a neighbour's score = originSeedStrength x decay^(graph distance).
+ */
+function accumulateForRoot(
+  root: string,
+  seeds: ReadonlyArray<GraphSeed>,
+  entries: ReadonlyArray<MemoryEntry>,
+  memIdToIndex: ReadonlyMap<string, number>,
+  graphScore: Map<number, number>,
+  hops: number,
+  decay: number,
+  maxNeighbors: number,
+  tenantId: string,
+): void {
+  if (seeds.length === 0) return;
+  // The strongest seed strength per source memory id (a memId could appear once, but
+  // guard against dup indices mapping to the same memId).
+  const strengthByMemId = new Map<string, number>();
+  for (const s of seeds) {
+    const memId = entries[s.index].id;
+    strengthByMemId.set(memId, Math.max(strengthByMemId.get(memId) ?? 0, s.strength));
+  }
+  const seedEntities = loadEntitiesByMemoryId(root, tenantId, [...strengthByMemId.keys()]);
+  if (seedEntities.length === 0) return;
+
+  // entityId -> origin seed strength (carried unchanged along the path).
+  const originStrength = new Map<number, number>();
+  for (const e of seedEntities) {
+    const st = strengthByMemId.get(e.memoryId) ?? 0;
+    originStrength.set(e.id, Math.max(originStrength.get(e.id) ?? 0, st));
+  }
+
+  const visited = new Set<number>(seedEntities.map((e) => e.id)); // seeds never re-reached
+  const reachedScore = new Map<number, number>();                 // entityId -> best score
+  let frontier: number[] = seedEntities.map((e) => e.id);
+  let frontierStrength = new Map<number, number>(originStrength);  // entityId -> seed strength
+
+  for (let depth = 1; depth <= hops && frontier.length > 0; depth++) {
+    const frontierSet = new Set(frontier);
+    const rels = loadNeighborRelations(root, tenantId, frontier, {
+      limit: Math.max(maxNeighbors, maxNeighbors * frontier.length),
+    });
+    const nextFrontier: number[] = [];
+    const nextStrength = new Map<number, number>();
+    const hopFactor = Math.pow(decay, depth);
+    for (const rel of rels) {
+      const fromIn = frontierSet.has(rel.fromEntityId);
+      const toIn = frontierSet.has(rel.toEntityId);
+      let neighborId: number;
+      let reacherId: number;
+      if (fromIn && !toIn) { neighborId = rel.toEntityId; reacherId = rel.fromEntityId; }
+      else if (toIn && !fromIn) { neighborId = rel.fromEntityId; reacherId = rel.toEntityId; }
+      else continue;
+      if (visited.has(neighborId)) continue;
+      visited.add(neighborId);
+      const seedStrength = frontierStrength.get(reacherId) ?? originStrength.get(reacherId) ?? 0;
+      const propagated = seedStrength * hopFactor;
+      // `visited` is set the moment a node is reached, so a node enters reachedScore at its
+      // FIRST (shortest) path only; the Math.max here is defensive for a same-frontier
+      // duplicate, not a true max over multiple distinct paths. Matches graph-recall.ts and
+      // is washed out by RRF anyway (only the induced order matters — see module docstring).
+      reachedScore.set(neighborId, Math.max(reachedScore.get(neighborId) ?? 0, propagated));
+      nextStrength.set(neighborId, Math.max(nextStrength.get(neighborId) ?? 0, seedStrength));
+      nextFrontier.push(neighborId);
+      if (nextFrontier.length >= maxNeighbors) break; // per-hop fanout cap
+    }
+    frontier = nextFrontier;
+    frontierStrength = nextStrength;
+  }
+  if (reachedScore.size === 0) return;
+
+  // Reached entity ids -> source memory ids -> in-pool entry indices.
+  const reachedEntities = loadEntitiesByIds(root, tenantId, [...reachedScore.keys()]);
+  for (const ent of reachedEntities) {
+    const idx = memIdToIndex.get(ent.memoryId);
+    if (idx === undefined) continue;             // reached memory is not in the candidate pool
+    const score = reachedScore.get(ent.id) ?? 0;
+    if (score <= 0) continue;
+    graphScore.set(idx, Math.max(graphScore.get(idx) ?? 0, score));
+  }
+}
+
+/**
+ * Produce the graph-retrieval ranked list: `entries[]` indices ordered by graph
+ * proximity (desc) to the lexical `seeds`. Only graph-reached, in-pool, non-seed
+ * indices appear; the rest are absent (-> rrfFuse absentRank). Pure reads.
+ *
+ * Returns `[]` when there are no seeds/entries, the graph is empty, no seed maps to an
+ * entity, or nothing reached is in-pool — the caller then skips the 3rd fusion list.
+ */
+export function graphRankStream(
+  entries: ReadonlyArray<MemoryEntry>,
+  seeds: ReadonlyArray<GraphSeed>,
+  opts: GraphStreamOpts,
+): number[] {
+  if (seeds.length === 0 || entries.length === 0) return [];
+  const hops = Math.min(Math.max(opts.hops ?? DEFAULT_GRAPH_HOPS, 1), MAX_HOPS);
+  const decay = opts.decay ?? DEFAULT_GRAPH_DECAY;
+  const maxNeighbors = opts.maxNeighbors ?? DEFAULT_MAX_NEIGHBORS;
+
+  const memIdToIndex = new Map<string, number>();
+  for (let i = 0; i < entries.length; i++) memIdToIndex.set(entries[i].id, i);
+
+  const graphScore = new Map<number, number>();
+  const roots = opts.globalRoot && opts.globalRoot !== opts.hippoRoot
+    ? [opts.hippoRoot, opts.globalRoot]
+    : [opts.hippoRoot];
+  for (const root of roots) {
+    accumulateForRoot(
+      root, seeds, entries, memIdToIndex, graphScore, hops, decay, maxNeighbors, opts.tenantId,
+    );
+  }
+
+  // Seed-exclusion guard (plan-eng-critic MED): graphScore is keyed by entryIndex
+  // GLOBALLY across roots, but each root's BFS visited-set is per-root, so a memory that
+  // is a seed in one store could be reached as a neighbour in the other store and pick up
+  // a score via max(). Drop every seed index so the "seeds are never scored by the graph
+  // stream" invariant holds across roots, not just within a single store's traversal.
+  for (const s of seeds) graphScore.delete(s.index);
+
+  if (graphScore.size === 0) return [];
+  return [...graphScore.keys()].sort((a, b) => {
+    const d = (graphScore.get(b) ?? 0) - (graphScore.get(a) ?? 0);
+    return d !== 0 ? d : a - b; // score desc, then index asc (deterministic)
+  });
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -21,6 +21,7 @@ import { DEFAULT_PHYSICS_CONFIG } from './physics-config.js';
 import { loadPhysicsState } from './physics-state.js';
 import { openHippoDb, closeHippoDb } from './db.js';
 import { rrfFuse } from './rrf.js';
+import { graphRankStream, selectGraphSeeds, DEFAULT_GRAPH_SEED_COUNT } from './graph-stream.js';
 
 // ---------------------------------------------------------------------------
 // Tokenizer
@@ -382,6 +383,22 @@ export async function hybridSearch(
     /** v0.30 / E4 — enable rebuilt-within-7-days micro-boost (1.05) on L2
      *  summaries with fresh last_rebuilt_at. Default true. */
     summaryFreshness?: boolean;
+    /** L1 — graph-retrieval stream (opt-in): adds a 3rd RRF input ranking in-pool
+     *  candidates by graph proximity to the strong lexical seeds. Active ONLY in
+     *  `scoring:'rrf'` mode with embeddings + a `hippoRoot`. Absent/`weight<=0`/empty
+     *  graph -> the byte-identical 2-list (BM25 + dense) fusion. See src/graph-stream.ts. */
+    graphStream?: {
+      /** RRF weight for the graph list. Required (opt-in is explicit; no implicit default). */
+      weight: number;
+      tenantId: string;
+      /** Global store root, when distinct (where global seeds' graph lives). */
+      globalRoot?: string;
+      hops?: number;
+      decay?: number;
+      maxNeighbors?: number;
+      /** # of top lexical seeds to expand from. Default DEFAULT_GRAPH_SEED_COUNT. */
+      seedCount?: number;
+    };
   } = {}
 ): Promise<SearchResult[]> {
   const now = options.now ?? new Date();
@@ -474,11 +491,39 @@ export async function hybridSearch(
       .filter((i) => bm25Scores[i] > 0 || cosineScores[i] > 0);
     const bm25Ranked = [...eligible].sort((a, b) => bm25Scores[b] - bm25Scores[a]);
     const cosineRanked = [...eligible].sort((a, b) => cosineScores[b] - cosineScores[a]);
-    rrfScores = rrfFuse(
-      [bm25Ranked, cosineRanked],
-      [bm25Weight, embeddingWeight],
-      { absentRank: entries.length + 1 },
-    );
+
+    // L1 graph-retrieval stream (opt-in): a 3rd RRF input ranking in-pool candidates by
+    // graph proximity to the strong lexical seeds. When absent / weight<=0 / the graph
+    // yields nothing in-pool, `graphRanked` is empty and the fusion below is the
+    // byte-identical 2-list (BM25 + dense) path. An all-absent 3rd list would NOT be a
+    // no-op: it adds a uniform constant to the RRF base, which the per-entry multipliers
+    // below turn non-uniform — so we SKIP it rather than fuse an empty list.
+    const gs = options.graphStream;
+    let graphRanked: number[] = [];
+    if (gs && gs.weight > 0 && options.hippoRoot) {
+      const seedCount = Math.min(gs.seedCount ?? DEFAULT_GRAPH_SEED_COUNT, eligible.length);
+      const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, seedCount);
+      graphRanked = graphRankStream(entries, seeds, {
+        hippoRoot: options.hippoRoot,
+        tenantId: gs.tenantId,
+        globalRoot: gs.globalRoot,
+        hops: gs.hops,
+        decay: gs.decay,
+        maxNeighbors: gs.maxNeighbors,
+      });
+    }
+
+    rrfScores = graphRanked.length > 0
+      ? rrfFuse(
+          [bm25Ranked, cosineRanked, graphRanked],
+          [bm25Weight, embeddingWeight, gs!.weight],
+          { absentRank: entries.length + 1 },
+        )
+      : rrfFuse(
+          [bm25Ranked, cosineRanked],
+          [bm25Weight, embeddingWeight],
+          { absentRank: entries.length + 1 },
+        );
   }
 
   // Score each entry

--- a/src/search.ts
+++ b/src/search.ts
@@ -498,9 +498,16 @@ export async function hybridSearch(
     // byte-identical 2-list (BM25 + dense) path. An all-absent 3rd list would NOT be a
     // no-op: it adds a uniform constant to the RRF base, which the per-entry multipliers
     // below turn non-uniform — so we SKIP it rather than fuse an empty list.
+    // Gate the graph stream on the candidate set actually having cached document vectors
+    // (codex P2): when the transformers package is installed but this store has not been
+    // embedded yet, `useEmbeddings` is true (only the QUERY vector was produced) while every
+    // `cosineScore` is 0, so `cosineRanked` collapses to entry order. Without this gate the
+    // stream would select seeds from that meaningless dense ranking; instead it stays inert
+    // (degrades to the 2-list path) until `hippo embed` has run.
+    const hasDocVectors = hadCachedVecs.some(Boolean);
     const gs = options.graphStream;
     let graphRanked: number[] = [];
-    if (gs && gs.weight > 0 && options.hippoRoot) {
+    if (gs && gs.weight > 0 && options.hippoRoot && hasDocVectors) {
       const seedCount = Math.min(gs.seedCount ?? DEFAULT_GRAPH_SEED_COUNT, eligible.length);
       const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, seedCount);
       graphRanked = graphRankStream(entries, seeds, {

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.20.0';
+export const PACKAGE_VERSION = '1.21.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/cli-graph-stream.test.ts
+++ b/tests/cli-graph-stream.test.ts
@@ -1,0 +1,53 @@
+/**
+ * L1 — `hippo recall --graph-stream` CLI smoke + flag validation (real subprocess).
+ * Docs: docs/plans/2026-06-02-l1-graph-rrf-stream.md
+ *
+ * The internal scoring-mode switch (blend -> rrf) and the graph fusion are not black-box
+ * observable from CLI stdout and the rrf path needs embeddings (unavailable in CI), so the
+ * mechanism is covered by the library/fusion unit tests. Here we only assert the flag is
+ * wired (exits 0 on a real store) and that --graph-hops / --graph-seeds validation fires.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const HIPPO_BIN = join(process.cwd(), 'bin', 'hippo.js');
+
+function hippo(cwd: string, env: Record<string, string>, ...args: string[]): string {
+  return execFileSync('node', [HIPPO_BIN, ...args], { cwd, env: { ...process.env, ...env }, encoding: 'utf-8' });
+}
+
+describe('recall --graph-stream (L1 CLI)', () => {
+  let home: string;
+  let env: Record<string, string>;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hippo-l1cli-'));
+    env = { HIPPO_HOME: join(home, 'global-hippo'), HIPPO_SKIP_AUTO_INTEGRATIONS: '1' };
+    hippo(home, env, 'init', '--no-hooks', '--no-schedule', '--no-learn');
+  });
+  afterEach(() => { if (home) rmSync(home, { recursive: true, force: true }); });
+
+  it('runs without error on a real store (degrades safely; stream inert without embeddings)', () => {
+    hippo(home, env, 'remember', 'cache invalidation decision for the deploy pipeline');
+    // Exits 0 (execFileSync throws on non-zero). Output is the normal recall result.
+    const out = hippo(home, env, 'recall', 'cache', '--graph-stream', '--limit', '5');
+    expect(typeof out).toBe('string');
+  });
+
+  it('--graph-hops out of range is rejected', () => {
+    let err = '';
+    try { hippo(home, env, 'recall', 'anything', '--graph-stream', '--graph-hops', '99'); }
+    catch (e) { err = String((e as { stderr?: Buffer }).stderr ?? ''); }
+    expect(err).toMatch(/Invalid --graph-hops/);
+  });
+
+  it('--graph-seeds non-positive is rejected', () => {
+    let err = '';
+    try { hippo(home, env, 'recall', 'anything', '--graph-stream', '--graph-seeds', '0'); }
+    catch (e) { err = String((e as { stderr?: Buffer }).stderr ?? ''); }
+    expect(err).toMatch(/Invalid --graph-seeds/);
+  });
+});

--- a/tests/graph-stream.test.ts
+++ b/tests/graph-stream.test.ts
@@ -1,0 +1,152 @@
+/**
+ * L1 — graph-retrieval stream producer tests (real SQLite, no mocks).
+ * Docs: docs/plans/2026-06-02-l1-graph-rrf-stream.md
+ *
+ * Covers selectGraphSeeds (pure top-by-lexical-rank) and graphRankStream (seed->neighbour
+ * scoring, per-hop decay ordering, fanout cap, local+global expansion, dedup max-score,
+ * deterministic ties, empty-graph no-op, not-in-pool ignored, seeds-never-scored incl.
+ * the seed-linked-to-another-seed case).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
+import { insertEntity, insertRelation } from '../src/graph.js';
+import {
+  selectGraphSeeds,
+  graphRankStream,
+  type GraphSeed,
+} from '../src/graph-stream.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graphstream-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+function mem(home: string, tenant: string, text: string): MemoryEntry {
+  const content = text.length < 3 ? text.repeat(3) : text;
+  const m = createMemory(content, { tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: tenant });
+  writeEntry(home, m, { actor: 'test' });
+  return m;
+}
+function ent(home: string, tenant: string, m: MemoryEntry, name: string): number {
+  return insertEntity(home, tenant, { entityType: 'decision', name, memoryId: m.id }).id;
+}
+const seed = (index: number, strength = 1.0): GraphSeed => ({ index, strength });
+
+describe('selectGraphSeeds (pure)', () => {
+  it('picks top-N by best lexical rank across both lists; strength = 1/(bestRank+1)', () => {
+    // bm25Ranked=[2,0,1] -> 2@0,0@1,1@2 ; cosineRanked=[1,2,0] -> 1@0,2@1,0@2
+    // bestPos: {2:0, 0:1, 1:0} -> sorted (pos asc, index asc): idx1@0, idx2@0, idx0@1
+    const seeds = selectGraphSeeds([2, 0, 1], [1, 2, 0], 2);
+    expect(seeds).toEqual([
+      { index: 1, strength: 1 / 1 },
+      { index: 2, strength: 1 / 1 },
+    ]);
+  });
+  it('seedCount<=0 -> []', () => {
+    expect(selectGraphSeeds([0, 1], [1, 0], 0)).toEqual([]);
+  });
+  it('a candidate present in only one list is still eligible', () => {
+    // idx 5 only in cosine; bm25=[0] -> 0@0 ; cosine=[5,0] -> 5@0,0@1. bestPos {0:0,5:0}
+    const seeds = selectGraphSeeds([0], [5, 0], 5);
+    expect(seeds.map((s) => s.index).sort((a, b) => a - b)).toEqual([0, 5]);
+  });
+});
+
+describe('L1 graphRankStream (real SQLite)', () => {
+  let home: string;
+  const T = 'default';
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('scores a 1-hop neighbour; excludes the seed and unrelated in-pool entries', () => {
+    const a = mem(home, T, 'alpha cache invalidation decision');
+    const b = mem(home, T, 'unrelated wording xyzzy plugh');
+    const x = mem(home, T, 'no graph path at all');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B');
+    ent(home, T, x, 'X');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+
+    const entries = [a, b, x];
+    const out = graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T });
+    expect(out).toEqual([1]);          // only b; seed(0) and x(2) excluded
+  });
+
+  it('orders a 1-hop neighbour above a 2-hop neighbour (per-hop decay)', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb'); const c = mem(home, T, 'ccc');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B'); const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    insertRelation(home, T, { fromEntityId: eb, toEntityId: ec, relType: 'supersedes', memoryId: b.id });
+
+    const entries = [a, b, c];
+    const out = graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T, hops: 2 });
+    expect(out).toEqual([1, 2]);       // b (1-hop) before c (2-hop)
+    // hops:1 reaches only b
+    expect(graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T, hops: 1 })).toEqual([1]);
+  });
+
+  it('enforces the per-hop fanout cap', () => {
+    const a = mem(home, T, 'seed node');
+    const ns = [0, 1, 2].map((i) => mem(home, T, `neighbour ${i} xyz`));
+    const ea = ent(home, T, a, 'A');
+    for (const n of ns) {
+      const en = ent(home, T, n, `N${n.id}`);
+      insertRelation(home, T, { fromEntityId: ea, toEntityId: en, relType: 'supersedes', memoryId: a.id });
+    }
+    const entries = [a, ...ns];
+    const out = graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T, maxNeighbors: 2 });
+    expect(out.length).toBe(2);        // capped at 2 of the 3 neighbours
+  });
+
+  it('deterministic ties: equal hop+strength neighbours order by index asc', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb'); const c = mem(home, T, 'ccc');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B'); const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: ec, relType: 'supersedes', memoryId: a.id });
+    const out = graphRankStream([a, b, c], [seed(0)], { hippoRoot: home, tenantId: T });
+    expect(out).toEqual([1, 2]);       // b and c both 1-hop from a -> index asc
+  });
+
+  it('empty graph -> [] (no-op; caller skips the 3rd list)', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb');
+    // no entities, no relations
+    expect(graphRankStream([a, b], [seed(0)], { hippoRoot: home, tenantId: T })).toEqual([]);
+  });
+
+  it('a reached neighbour NOT in the candidate pool is ignored', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    // pool excludes b
+    const entries = [a, mem(home, T, 'other in pool but no path')];
+    expect(graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T })).toEqual([]);
+  });
+
+  it('seeds are never scored — even when a seed is graph-adjacent to another seed', () => {
+    const a = mem(home, T, 'aaa'); const b = mem(home, T, 'bbb'); const c = mem(home, T, 'ccc');
+    const ea = ent(home, T, a, 'A'); const eb = ent(home, T, b, 'B'); const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id }); // a-b (both seeds)
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: ec, relType: 'supersedes', memoryId: a.id }); // a-c (c not a seed)
+    const out = graphRankStream([a, b, c], [seed(0), seed(1, 0.5)], { hippoRoot: home, tenantId: T });
+    expect(out).toEqual([2]);          // only c; seeds 0 and 1 excluded
+  });
+
+  it('expands across the global store (a global seed reaches a global neighbour)', () => {
+    const glob = makeRoot();
+    try {
+      const g = mem(glob, T, 'global seed'); const gn = mem(glob, T, 'global neighbour');
+      const eg = ent(glob, T, g, 'G'); const egn = ent(glob, T, gn, 'GN');
+      insertRelation(glob, T, { fromEntityId: eg, toEntityId: egn, relType: 'supersedes', memoryId: g.id });
+      const entries = [g, gn];         // pool = the two global memories
+      const out = graphRankStream(entries, [seed(0)], { hippoRoot: home, tenantId: T, globalRoot: glob });
+      expect(out).toEqual([1]);        // gn reached via the global graph
+    } finally { safeRmSync(glob); }
+  });
+});

--- a/tests/graph-stream.test.ts
+++ b/tests/graph-stream.test.ts
@@ -138,6 +138,32 @@ describe('L1 graphRankStream (real SQLite)', () => {
     expect(out).toEqual([2]);          // only c; seeds 0 and 1 excluded
   });
 
+  it('a neighbour reachable from two seeds at the same hop takes the STRONGER seed (codex P2)', () => {
+    // nShared is 1-hop from a strong seed AND a weak seed; nWeakOnly is 1-hop from the weak
+    // seed only. With the strongest-same-hop-seed fix, nShared outscores nWeakOnly and ranks
+    // above it even though nShared has the HIGHER index (so it is strength order, not index
+    // order — which would have tied them if nShared were locked to the weak seed's strength).
+    const seedStrong = mem(home, T, 'strong seed aaa');
+    const seedWeak = mem(home, T, 'weak seed bbb');
+    const nWeakOnly = mem(home, T, 'weak-only neighbour ccc');  // index 2
+    const filler = mem(home, T, 'filler no edge ddd');          // index 3
+    const nShared = mem(home, T, 'shared neighbour eee');       // index 4
+    const eStrong = ent(home, T, seedStrong, 'STRONG');
+    const eWeak = ent(home, T, seedWeak, 'WEAK');
+    const eWeakOnly = ent(home, T, nWeakOnly, 'WONLY');
+    ent(home, T, filler, 'FILL');
+    const eShared = ent(home, T, nShared, 'SHARED');
+    // Insert strong->shared FIRST (lower id) then weak->shared (higher id, returned first by
+    // the loader's id-DESC order) — the exact ordering that would mis-score under the bug.
+    insertRelation(home, T, { fromEntityId: eStrong, toEntityId: eShared, relType: 'supersedes', memoryId: seedStrong.id });
+    insertRelation(home, T, { fromEntityId: eWeak, toEntityId: eShared, relType: 'supersedes', memoryId: seedWeak.id });
+    insertRelation(home, T, { fromEntityId: eWeak, toEntityId: eWeakOnly, relType: 'supersedes', memoryId: seedWeak.id });
+
+    const entries = [seedStrong, seedWeak, nWeakOnly, filler, nShared];
+    const out = graphRankStream(entries, [seed(0, 1.0), seed(1, 0.3)], { hippoRoot: home, tenantId: T });
+    expect(out).toEqual([4, 2]);       // nShared (strong, index 4) ranks ABOVE nWeakOnly (weak, index 2)
+  });
+
   it('expands across the global store (a global seed reaches a global neighbour)', () => {
     const glob = makeRoot();
     try {

--- a/tests/search-graph-stream-rrf.test.ts
+++ b/tests/search-graph-stream-rrf.test.ts
@@ -113,6 +113,33 @@ describe('L1 graph stream x RRF fusion (real SQLite)', () => {
     expect(order2[0]).toBe(0);         // strong control answer stays rank 1
   });
 
+  it('noise control: a POPULATED graph that boosts a non-answer distractor does NOT displace a strong lexical answer from the top', () => {
+    // The empty-graph no-harm case proves the skip path; this proves the harder thing —
+    // when the graph IS populated and lifts a graph-adjacent *distractor*, a true lexical
+    // answer with no graph path keeps its rank (the stream adds signal, not displacing noise).
+    const answer = mem(home, T, 'control answer matched strongly by every query term present');
+    const mids = [1, 2, 3].map((i) => mem(home, T, `mid pool distractor ${i} partial match`));
+    const adjacent = mem(home, T, 'orthogonal non-answer wording barely matched zzz'); // index 5
+    const entries = [answer, ...mids, mem(home, T, 'another mid distractor four'), adjacent];
+
+    // Graph edge: a strong seed (mids[0], index 1) -> adjacent (index 5). The ANSWER has no path.
+    const eSeed = ent(home, T, mids[0], 'SEED');
+    const eAdj = ent(home, T, adjacent, 'ADJ');
+    insertRelation(home, T, { fromEntityId: eSeed, toEntityId: eAdj, relType: 'supersedes', memoryId: mids[0].id });
+
+    const bm25Ranked = [0, 1, 2, 3, 4, 5];   // answer rank1, adjacent rank6 (tail)
+    const cosineRanked = [0, 1, 2, 3, 4, 5];
+    const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, 3); // top-3: 0,1,2 ; adjacent(5) NOT a seed
+    const graphRanked = graphRankStream(entries, seeds, { hippoRoot: home, tenantId: T });
+    expect(graphRanked).toContain(5);        // the graph IS populated and boosts the distractor
+
+    const order2 = fusedOrder(entries.length, [bm25Ranked, cosineRanked], [BM25_W, DENSE_W]);
+    const order3 = fusedOrder(entries.length, [bm25Ranked, cosineRanked, graphRanked], [BM25_W, DENSE_W, 0.5]);
+    expect(order2[0]).toBe(0);               // answer is rank 1 under 2-stream
+    expect(order3[0]).toBe(0);               // ...and STILL rank 1 under 3-stream (no displacement)
+    expect(order3.indexOf(5)).toBeGreaterThan(0); // boosted distractor did not reach the top
+  });
+
   it('empty graphRanked -> the 3rd list is skipped -> fused order is byte-identical to the 2-list path', () => {
     const entries = [0, 1, 2, 3].map((i) => mem(home, T, `entry ${i} some lexical content`));
     const bm25Ranked = [0, 1, 2, 3];

--- a/tests/search-graph-stream-rrf.test.ts
+++ b/tests/search-graph-stream-rrf.test.ts
@@ -1,0 +1,131 @@
+/**
+ * L1 — graph stream x RRF fusion tests (real SQLite, no mocks).
+ * Docs: docs/plans/2026-06-02-l1-graph-rrf-stream.md
+ *
+ * hybridSearch's rrf path requires a loaded embedding model (unavailable in CI — same
+ * constraint tests/hybrid-search.test.ts documents), so we exercise the EXACT fusion the
+ * wiring performs at the rrfFuse layer: build bm25Ranked + cosineRanked + a real-DB
+ * graphRanked (via graphRankStream), then compare the 2-list vs 3-list fused ordering.
+ * This is also the plan's Gate-(b) dry-run "structural work" criterion: a lexically-weak
+ * but graph-adjacent answer (rank > 5 under 2-list) must enter top-5 under 3-list.
+ *
+ * The graph stream anchors on the top-`seedCount` lexical hits and re-ranks the
+ * rank>seedCount TAIL (seeds are excluded), so these fixtures pass an explicit small
+ * seedCount; the CLI/library default (10) targets realistic large pools.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
+import { insertEntity, insertRelation } from '../src/graph.js';
+import { rrfFuse } from '../src/rrf.js';
+import { selectGraphSeeds, graphRankStream } from '../src/graph-stream.js';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-gstream-rrf-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+function mem(home: string, tenant: string, text: string): MemoryEntry {
+  const m = createMemory(text, { tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: tenant });
+  writeEntry(home, m, { actor: 'test' });
+  return m;
+}
+function ent(home: string, tenant: string, m: MemoryEntry, name: string): number {
+  return insertEntity(home, tenant, { entityType: 'decision', name, memoryId: m.id }).id;
+}
+
+// Default fusion weights, mirroring hybridSearch: [1-embeddingWeight, embeddingWeight, w_g].
+const BM25_W = 0.4;
+const DENSE_W = 0.6;
+
+/** Fused ranking (entries[] indices, best first) from N ranked lists — the exact rrfFuse
+ *  call the wiring makes, with the explicit absentRank=entries.length+1. */
+function fusedOrder(
+  poolSize: number,
+  lists: number[][],
+  weights: number[],
+): number[] {
+  const scores = rrfFuse(lists, weights, { absentRank: poolSize + 1 });
+  return [...scores.entries()].sort((a, b) => b[1] - a[1] || a[0] - b[0]).map(([i]) => i);
+}
+
+describe('L1 graph stream x RRF fusion (real SQLite)', () => {
+  let home: string;
+  const T = 'default';
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('Gate-(b) dry-run: a lexically-weak, graph-adjacent answer (rank>5 in 2-list) enters top-5 under the 3-list fusion', () => {
+    // 8-entry pool. strong=0 is a top lexical hit; weak=7 is the answer: lexically last
+    // but graph-adjacent (1-hop) to strong.
+    const strong = mem(home, T, 'primary topic strongly matched by the query terms here');
+    const distractors = [1, 2, 3, 4, 5, 6].map((i) => mem(home, T, `distractor number ${i} mid pool lexical`));
+    const weak = mem(home, T, 'orthogonal wording the query barely matches zzz');
+    const entries: MemoryEntry[] = [strong, ...distractors, weak];
+
+    const es = ent(home, T, strong, 'STRONG');
+    const ew = ent(home, T, weak, 'WEAK');
+    insertRelation(home, T, { fromEntityId: es, toEntityId: ew, relType: 'supersedes', memoryId: strong.id });
+
+    // Lexical rankings: strong rank1 ... weak rank8 (last) in BOTH streams.
+    const bm25Ranked = [0, 1, 2, 3, 4, 5, 6, 7];
+    const cosineRanked = [0, 1, 2, 3, 4, 5, 6, 7];
+
+    // 2-list baseline: weak is outside top-5.
+    const order2 = fusedOrder(entries.length, [bm25Ranked, cosineRanked], [BM25_W, DENSE_W]);
+    const rank2 = order2.indexOf(7);
+    expect(rank2).toBeGreaterThanOrEqual(5); // outside top-5 (0-indexed >=5)
+
+    // Graph stream: anchor on the top-3 lexical seeds; weak(7) is in the tail, reached
+    // from strong(0). seedCount=3 keeps weak a non-seed.
+    const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, 3);
+    expect(seeds.map((s) => s.index)).not.toContain(7); // weak is NOT a seed
+    const graphRanked = graphRankStream(entries, seeds, { hippoRoot: home, tenantId: T });
+    expect(graphRanked).toContain(7); // the graph stream surfaces weak
+
+    // 3-list fusion lifts weak into top-5.
+    const order3 = fusedOrder(entries.length, [bm25Ranked, cosineRanked, graphRanked], [BM25_W, DENSE_W, 0.5]);
+    const rank3 = order3.indexOf(7);
+    expect(rank3).toBeLessThan(5);     // now in top-5
+    expect(rank3).toBeLessThan(rank2); // strictly improved
+  });
+
+  it('no-harm: a strong lexical hit with no graph path keeps its top rank when the stream is added', () => {
+    const answer = mem(home, T, 'control answer strongly matched by every query term');
+    const others = [1, 2, 3, 4].map((i) => mem(home, T, `weaker control distractor ${i}`));
+    const entries = [answer, ...others];
+    // No relations at all -> empty graph.
+    const bm25Ranked = [0, 1, 2, 3, 4];
+    const cosineRanked = [0, 1, 2, 3, 4];
+
+    const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, 3);
+    const graphRanked = graphRankStream(entries, seeds, { hippoRoot: home, tenantId: T });
+    expect(graphRanked).toEqual([]);   // no graph -> empty -> wiring skips the 3rd list
+
+    const order2 = fusedOrder(entries.length, [bm25Ranked, cosineRanked], [BM25_W, DENSE_W]);
+    expect(order2[0]).toBe(0);         // strong control answer stays rank 1
+  });
+
+  it('empty graphRanked -> the 3rd list is skipped -> fused order is byte-identical to the 2-list path', () => {
+    const entries = [0, 1, 2, 3].map((i) => mem(home, T, `entry ${i} some lexical content`));
+    const bm25Ranked = [0, 1, 2, 3];
+    const cosineRanked = [3, 2, 1, 0];
+    const seeds = selectGraphSeeds(bm25Ranked, cosineRanked, 2);
+    const graphRanked = graphRankStream(entries, seeds, { hippoRoot: home, tenantId: T });
+    expect(graphRanked).toEqual([]);
+
+    // The wiring's skip branch: rrfFuse over the 2 lists. Identical scores either way.
+    const twoList = rrfFuse([bm25Ranked, cosineRanked], [BM25_W, DENSE_W], { absentRank: entries.length + 1 });
+    const order = [...twoList.entries()].sort((a, b) => b[1] - a[1] || a[0] - b[0]).map(([i]) => i);
+    // Symmetric reverse lists + equal-ish weights -> deterministic tie-broken order.
+    expect(order.length).toBe(4);
+    expect(new Set(order)).toEqual(new Set([0, 1, 2, 3]));
+  });
+});


### PR DESCRIPTION
## Summary
Track L item **L1**: a 3rd RRF fusion input (beside BM25 + dense) that re-ranks in-pool
candidates by graph proximity to the strong lexical seeds. A lexically-weak memory that is
graph-adjacent to a strong hit gets lifted. Opt-in, default-off. Reuses the E3.2 traversal;
read-only over the consolidated E3 graph. Distinct from `--hops` (E3.2, out-of-pool
injection); this re-ranks within the candidate pool.

## What's in it
- `src/graph-stream.ts` (new): `selectGraphSeeds` + `graphRankStream` (read-only producer)
- `src/search.ts`: `graphStream` option on the `hybridSearch` rrf path (byte-identical 2-list skip when empty; gated on cached doc vectors)
- `src/cli.ts`: `recall --graph-stream` / `--graph-hops` / `--graph-seeds` (local store)
- 19 real-DB tests; pre-registered hippo-native mechanism ablation + plan/prereg/result docs

## Validation (honestly scoped)
- Mechanism ablation: a graph-adjacent, lexically-weak answer moves rank **8/8 to 4/8** (into top-5); no harm on empty-graph and populated-graph controls.
- This is a **mechanism result, NOT a population R@5 claim**. The LongMemEval-oracle population ablation is deferred as **L1-eval** (it needs a hippo entity graph built over the LME corpus).
- Reviews: plan-eng 82, code-review 88, independent-review 78 (HIGH closed), codex (2 P2s fixed, round 2 clean), ship-readiness 94.

## Test plan
- [x] 19 new real-DB tests pass
- [x] Full suite 2485 pass (1 known `server-concurrency` ECONNRESET flake, passes isolated)
- [x] build clean; check-manifest-versions / check-em-dashes / check-graph-writes OK
- [ ] merge + npm publish 1.21.0 (awaiting go-ahead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
