### PR TITLE
feat: anchor graph provenance to the authoritative E2 object (v38)

### DIFF
--- a/docs/plans/2026-06-03-graph-e2-provenance.md
+++ b/docs/plans/2026-06-03-graph-e2-provenance.md
@@ -1,8 +1,8 @@
 # Plan: Anchor graph entity/relation provenance to the authoritative E2 object
 
-Status: SCOPED (build deferred until the `feat/e3-*` branches land on master)
+Status: IN BUILD (episode 01KT6PY1H6EWDQF85R30Z15XWJ; worktree feat/graph-e2-provenance off origin/master@7963506). The E3 graph code IS on master (shipped via squash #86/#87/#88/#94); open branches feat/e3.1-cross-object-references, feat/e3.2-multihop-recall, feat/e3-sleep-enqueue still touch graph-extract.ts/graph-recall.ts/db.ts -> flag merge-time overlap at deploy.
 Date: 2026-06-03
-Owner: TBD (own /dev-framework-rl episode, project_type=library)
+Owner: /dev-framework-rl episode, project_type=library
 
 ## Problem
 
@@ -57,36 +57,139 @@ an E2 object, "consolidated" is established by being an E2 object at all -- not 
 memory's `kind`. So ADD an authoritative-object provenance path alongside the existing
 memory-kind path (keep the latter for prose / future NLP-sourced entities).
 
-### Change surface
+### Change surface (audit-informed, concrete)
 
-1. **Migration (next version):**
-   - Add nullable `source_object_type` (`decision|policy|customer|project`) +
-     `source_object_id INTEGER` to `entities` (and to `relations` for the edge's
-     sourcing object).
-   - Relax `entities.memory_id` and `relations.memory_id` to NULLABLE.
-   - Add a CHECK / trigger requiring AT LEAST ONE provenance: a live distilled/superseded
-     `memory_id`, OR a valid `source_object_*` referencing an `active|superseded` E2 row
-     in the same tenant. Preserve the existing no-raw guarantee on the memory path.
+**1. Migration v38** (current head is v37; graph tables were created in v37). The graph
+is a PURE DERIVED CACHE (`clearGraph` + rebuild on every `graph extract` / `sleep`), so
+v38 does NOT copy data -- it DROPs and recreates the two changed tables and repopulates
+on the next extract. `graph_extraction_queue` schema is unchanged (left alone).
 
-2. **Guard rework (db.ts:1730-1790 triggers + `resolveConsolidatedSource` in graph.ts):**
-   accept EITHER provenance. When `memory_id` is present it must still equal the FK'd
-   memory's kind (raw still ABORTs). When absent, the `source_object_*` row must exist
-   and be `active|superseded`. Keep the cross-tenant match triggers.
+- `DROP TABLE relations;` then `DROP TABLE entities;` (relations FK entities -> drop
+  child first). Recreate both with:
+  - `memory_id TEXT` (NULLABLE; was `NOT NULL`) `REFERENCES memories(id) ON DELETE SET NULL`
+    (was CASCADE -- now a null-able recall pointer that survives mirror loss, matching the
+    E2 tables' own `ON DELETE SET NULL`). FK-action/guard interaction: SQLite FK actions do
+    NOT fire triggers unless `recursive_triggers` is ON, so the `ON DELETE SET NULL` will not
+    trip the rewritten BEFORE UPDATE guard; the execute stage MUST confirm hippo's
+    `recursive_triggers` PRAGMA state and, if ON, prove the all-null guard tolerates the
+    SET-NULL transition for an E2-sourced row (which still has `source_object_*`, so it stays
+    valid). Today every entity is E2-sourced (extraction is 100% E2-driven; prose/NLP is
+    deferred), so a SET NULL never yields an all-null row in practice.
+  - new `source_object_type TEXT` CHECK in (`decision|policy|customer|project`) + `source_object_id INTEGER`,
+    both NULLABLE (memory-sourced prose/NLP entities have these null; E2-sourced entities
+    have these set).
+  - `source_kind` stays, but is now derivable from EITHER path.
+  - Recreate indices (`idx_entities_tenant/memory`, `idx_relations_tenant/from/to/memory`)
+    + a new partial index `idx_entities_source_object ON entities(source_object_type, source_object_id) WHERE source_object_id IS NOT NULL`.
+- Recreate EVERY trigger that lives ON the dropped tables (verified against the full v37
+  DDL db.ts:1660-1866) -- there are **5**, not 4:
+  1. `trg_entities_consolidated_only_insert` (REWRITTEN for dual-provenance)
+  2. `trg_entities_consolidated_only_update` (REWRITTEN)
+  3. `trg_relations_consolidated_only_insert` (REWRITTEN)
+  4. `trg_relations_consolidated_only_update` (REWRITTEN)
+  5. `trg_entities_no_tenant_move_when_referenced` (recreated AS-IS -- queries relations by
+     entity id; logic unchanged). **This is the one the round-1 critic caught as missing.**
+  NOT recreated (correctly): `trg_memories_graph_referenced_guard` lives on the **memories**
+  table (db.ts:1838), which v38 does NOT drop, so it survives. It stays correct for the
+  nullable change: its `EXISTS (... WHERE memory_id = OLD.id)` checks never match a
+  null-memory entity, so a mirror-less entity simply does not constrain any memory's
+  kind/tenant (which is right). `trg_graph_queue_consolidated_only_{insert,update}` are on
+  `graph_extraction_queue` (not dropped) -> survive, not recreated.
 
-3. **graph-extract.ts:** Pass 1 stops skipping `memoryId === null` for E2 rows -- anchor
-   the entity to the E2 row (`source_object_type/id`), set `memory_id` only when the
-   mirror exists. Pass 2 (`supersedes`) and Pass 3 (`references`) source edges from the
-   E2 object, with `memory_id` as an optional recall pointer.
+**2. Guard rework -- BOTH sites kept in lockstep (audit rule 2):**
+- **SQL triggers (db.ts).** Rewrite `trg_*_consolidated_only_{insert,update}` to enforce
+  "AT LEAST ONE valid provenance, no raw": (a) if `memory_id IS NOT NULL` then
+  `source_kind` must equal the FK'd memory's `kind` AND that kind is `distilled|superseded`
+  (raw still ABORTs); (b) if `memory_id IS NULL` then `source_object_type/id` must reference
+  an EXISTING same-tenant E2 row whose status is `active|superseded` (not `closed`); (c)
+  reject the all-null case (`RAISE(ABORT, 'graph row needs a memory or a source object')`).
+  Keep the cross-tenant ABORT.
+- **Rule 11 bidirectional (parent-side).** Today `trg_memories_graph_referenced_guard`
+  blocks `UPDATE memories SET kind='raw'` while referenced. Add the analogous E2-side
+  protection: an E2 row referenced by a graph entity via `source_object_*` must not be
+  hard-DELETEd out from under it -- but since the graph is a rebuilt cache and E2 rows are
+  `close`d (status change) not deleted, the chosen handling is: `source_object_id` carries
+  NO hard FK (it is a soft (type,id) pointer the rebuild re-validates), and a `closed`
+  status simply makes the next extract drop the entity. State this explicitly; do NOT add a
+  hard FK that would block legitimate E2 hard-deletes. (The forward trigger already rejects
+  an entity pointing at a `closed`/absent object at insert time.)
+- **TS `resolveConsolidatedSource` (graph.ts:184).** Signature becomes
+  `(db, tenantId, memoryId: string | null, sourceObject: {type,id} | null, label)`; returns
+  `source_kind`. memory path unchanged (looks up kind, rejects raw); object path validates
+  the E2 row is active|superseded same-tenant and sets `source_kind='distilled'` (E2 objects
+  are consolidated by construction). 3 callers updated: `insertEntity:230`, `insertRelation:269`,
+  `enqueueExtraction:585` (the enqueue path stays memory-keyed -> passes the memory, null object).
 
-4. **graph-recall.ts:** handle a graph-reached entity whose `memory_id` is null -- either
-   surface from the E2 object's content, or count the hop without a recall-mirror row,
-   instead of breaking on the by-id memory load (`loadEntriesByIds`). Re-check the
-   bi-temporal / superseded-drop filters still apply via the E2 object's status.
+**3. graph.ts `insertEntity` / `insertRelation`:** add optional
+`sourceObject?: {type,id}` to `InsertEntityOpts`/`InsertRelationOpts`; `memoryId` becomes
+`string | null`. Insert `source_object_type/id`. Both go through the reworked guard.
+
+**4. graph-extract.ts:** Pass 1 no longer `continue`s on `memoryId === null` for an E2
+row -- it always creates the entity, anchored to the E2 row via `sourceObject:{type,id}`,
+passing `memoryId` only when the mirror still exists. Pass 2 (`supersedes`) + Pass 3
+(`references`) attach `sourceObject` of the EDGE's sourcing E2 object (the successor for
+supersedes; the source object for references), `memoryId` optional. `closed` E2 rows are
+still excluded (loadType loads active+superseded only -- unchanged). The `created`/
+`memoryIdByKey` maps gain the object key so edges can carry it.
+
+**5. graph-recall.ts + graph-stream.ts (null-safety -- see Deferred for surfacing).**
+`Entity.memoryId` (graph.ts:57, set by `rowToEntity`:138) widens from `string` to
+`string | null`. Both consumers of `Entity.memoryId` must be made null-safe (mirror-less
+entities cannot be lexical seeds -- seeds come from `loadEntitiesByMemoryId` over base recall
+results -- but they CAN be reached by traversal):
+- **graph-recall.ts** (`produceHitsForRoot`): (a) `originMemByEntityId` becomes
+  `Map<number, string | null>` and the seed `.set(se.id, se.memoryId)` (line 121) tolerates
+  null; (b) the reached-id load at line ~153
+  `reachedEntities.map(e => e.memoryId).filter(id => !seenMemoryIds.has(id))` must DROP null
+  ids before they reach `loadByIdsChunked`/the `Set<string>` (a null entity has no mirror to
+  load); (c) `loadedById.get(ent.memoryId)` at line ~165 with null -> `undefined` -> the
+  existing `if (!mem) continue` correctly skips it (mirror-less node not recall-surfaced).
+- **graph-stream.ts** (L1 RRF graph stream, #94): `strengthByMemId.get(e.memoryId)` (line
+  125, already `?? 0`) and `memIdToIndex.get(ent.memoryId)` (line 182) must skip/short-circuit
+  on a null `memoryId` rather than look up `null`. Seeds here are also memory-derived so
+  null-memory entities only appear as reached nodes.
+This episode VERIFIES both with tests and adds NO new surfacing. The recall/stream paths do
+not regress; mirror-less nodes are simply not recall-surfaced (they ARE in entities/relations
+for `graph extract`/visualization, which IS the reported bug).
+
+**6. Version-bump (audit rule 3) -- CORRECTED COUNT: 21 assertions across 10 files** (a
+full `tests/` grep, not a head-limited one): `CURRENT_SCHEMA_VERSION` 37 -> 38 (db.ts:26)
+AND every hard-coded `37`:
+- a5-tenant-migration.test.ts:12,13
+- a3-envelope-migration.test.ts:11,17
+- auth-role-migration.test.ts:19,26
+- b3-goal-stack-migration.test.ts:12,13
+- dag-summary-metadata.test.ts:39,45
+- db-migration-v27-self-heal.test.ts:77,137 (string `'37'` -> `'38'`)
+- graph-schema.test.ts:28
+- pr2-session-continuity.test.ts:39,40  (omitted in round 1)
+- v039-slack-hardening.test.ts:46,49     (omitted in round 1)
+- v039-gdpr-path-a.test.ts:37,40,110,153 (omitted in round 1)
+
+(pr3-working-memory.test.ts reads it dynamically via `getCurrentSchemaVersion()` -- no
+change.) The verify stage runs the FULL suite, so a missed assertion hard-fails there.
+NOT an npm version bump: deploy = merge; the npm/schema RELEASE is a separate follow-up
+episode.
+
+**7. Caller ripple (audit rule 5):**
+- `insertEntity`/`insertRelation` callers: graph-extract.ts (above) + 6 test files use them
+  directly (graph-store, graph-stream, graph-extract, graph-recall, graph-sleep-hook,
+  search-graph-stream-rrf). Back-compat: a memory-only call still compiles since
+  `sourceObject` is optional and `memoryId` stays accepted -- but the type widens, so TS will
+  flag any site that assumed non-null.
+- `Entity.memoryId` consumers (the now-nullable field): **src/graph-recall.ts AND
+  src/graph-stream.ts** (both MODULES, per section 5) -- not just the graph-stream TEST file.
+  Confirm with a grep for `\.memoryId` across `src/` that no other module dereferences it
+  assuming non-null.
 
 ### Test plan (real DB, no mocks)
 
-- forget-then-extract: active object STAYS in the graph; arcs preserved.
-- consolidation-prune-then-extract: mirror pruned -> object STAYS in the graph.
+**Success criterion (explicit):** after a mirror is forgotten or pruned, the active E2 object
+STAYS in the `entities`/`relations` TABLES (asserted by querying those tables directly, not
+via recall). That is the reported bug; recall surfacing of mirror-less nodes is out of scope.
+
+- forget-then-extract: active object STAYS in entities/relations (direct table query); arcs preserved; its `memory_id` is now NULL and `source_object_type/id` is set.
+- consolidation-prune-then-extract: mirror pruned -> object STAYS in entities/relations.
 - `closed` E2 object: still excluded (status, not mirror presence, drives exclusion).
 - raw memory: still REJECTED by the guard (no-raw invariant intact).
 - multihop recall traverses an entity whose mirror was forgotten.
@@ -102,9 +205,86 @@ memory-kind path (keep the latter for prose / future NLP-sourced entities).
   (Outside Voice). Watch the scored-BFS visited-ordering and the cached-doc-vector
   gating lessons from the L1 v1.21.0 episode when editing graph-recall.
 
-## Open questions for the episode
+## Resolved decisions (were open questions)
 
-- Should a `references` edge whose SOURCE object is still active but whose mirror was
-  pruned keep firing? (Yes under this fix -- provenance is the object.)
-- Do we backfill `source_object_*` for existing entities at migration time, or only on
-  the next `graph extract` rebuild? (Rebuild is idempotent; lean rebuild-only.)
+- `references` edge whose source object is active but mirror pruned: KEEPS firing --
+  provenance is the object.
+- Backfill: REBUILD-ONLY. v38 DROPs+recreates the cache; the next `graph extract`/`sleep`
+  repopulates. No row copy (graph entity ids are already non-stable across rebuilds, so
+  nothing depends on them persisting).
+- `source_object_id` is a SOFT (type,id) pointer, not a hard FK -- the rebuild re-validates
+  it -- so a legitimate E2 hard-delete is never blocked; a `closed` E2 row drops at next
+  extract.
+
+## Deferred from THIS episode (tracked follow-up)
+
+- **Synthesize-from-E2-object recall surfacing.** Making a mirror-less E2 object surfaceable
+  via `recall --multihop` (load the E2 object by `source_object_*`, build a synthetic
+  `SearchResult` from its text + score it) is a real additional chunk (new loaders, synthetic
+  MemoryEntry shape, scoring/temporal rules). This episode delivers the actual reported bug
+  (the object STAYS in the graph for `extract`/visualization) + recall null-safety. Recall
+  surfacing of mirror-less nodes is a clean follow-up.
+
+- **Tenant-level graph-rebuild signal (codex review round 6) — coordinate with e3-sleep-enqueue.**
+  The graph is a GLOBALLY-derived cache, but its rebuild scheduling (`graph_extraction_queue`)
+  is memory-keyed, so it cannot express "rebuild this whole tenant." Two paths this episode
+  added need that and currently leave the graph UNDER-derived until the next memory-write dirty
+  event (self-healing; data never lost):
+  1. **v38 cache-drop on upgrade.** The migration DROP+recreates entities/relations; a store
+     with no pending queue items has no tenant for `sleep` to rebuild, so the graph is empty
+     until a manual `hippo graph extract` or the next write. (The npm-RELEASE episode should
+     also consider preserving the rows via a copy-migration instead of drop-empty.)
+  2. **Mirrorless-object close.** `removeGraphEntitiesForObject` targeted-deletes the closed
+     object's rows, but references are derived globally (e.g. closing one of two same-name
+     policies should un-suppress an ambiguous edge elsewhere) — only a full rebuild derives
+     that. With no queued item, sleep does not re-derive until the next dirty event.
+  Proper fix: a tenant-level dirty/rebuild signal (e.g. a `graph_dirty_tenants` row or a
+  tenant-scoped queue entry), enqueued after the v38 invalidation and on a mirrorless close.
+  This is sleep/enqueue-subsystem territory (the concurrent `feat/e3-sleep-enqueue` branch owns
+  the queue), so it is deferred to coordinate with that branch rather than churn the queue here.
+  Accepted for THIS episode (deploy = merge to master, not the npm release) by operator decision
+  at the codex review-cap gate; the guard correctness (rounds 1-5) is fully fixed.
+
+## Grill (self-interrogation, plan stage)
+
+- *Weakest premise:* "an entity with null memory_id but a valid source_object is still
+  'consolidated, not raw'." Defence: E2 objects (decisions/policies/notes/briefs) are
+  consolidated BY CONSTRUCTION -- they are never raw ingest; the no-raw invariant is about
+  excluding `kind='raw'` MEMORIES, which the memory path still enforces. The object path
+  can only point at an E2 table row, none of which are raw. So the invariant holds.
+- *What would falsify the design:* a graph entity that is NEITHER from an E2 object NOR a
+  distilled/superseded memory. The all-null guard branch makes that unrepresentable.
+- *Scope-creep check:* the tempting over-reach is rebuilding recall surfacing now; explicitly
+  deferred above. The tempting under-reach is leaving graph-recall to crash on null memory;
+  covered by the null-safety test.
+- *Migration risk:* DROP+recreate loses no irreplaceable data (pure cache) BUT must recreate
+  EVERY trigger + index the v37 DDL created, or a guard silently disappears. The plan
+  enumerates all 5 triggers + all indices; the verify stage greps the recreated schema to
+  confirm none dropped.
+
+## Execute checklist (plan-eng round 2 advisories -- must be honoured in code)
+
+1. **Object-path guard = explicit 4-way CASE.** SQLite cannot parametrize a table name in a
+   trigger/CHECK, so the object-path validation (both the SQL trigger branch AND the TS
+   `resolveConsolidatedSource` object path) must branch on `source_object_type` with one arm
+   per E2 table: `decision`->`decisions`, `policy`->`policies`, `customer`->`customer_notes`,
+   `project`->`project_briefs`, each subquerying that table's `status IN ('active','superseded')`
+   and same-tenant. This 4-branch structure is the most error-prone piece -- write it
+   explicitly, test each of the 4 types.
+2. **SET NULL leaves `source_kind` untouched -- by design.** When a mirror delete nulls
+   `memory_id` via `ON DELETE SET NULL`, the row's `source_kind` keeps its old value and is
+   NOT re-derived. The reworked guard only re-checks `source_kind` against the memory when
+   `memory_id IS NOT NULL`, so a stale `source_kind` on a null-memory row is intentionally
+   tolerated (object path is distilled-by-construction). Do NOT add code to "fix" it.
+   (`recursive_triggers` is default-OFF and never set in `openHippoDb`, so the SET NULL does
+   not fire the BEFORE UPDATE guard -- confirmed; assert this in a test.)
+3. **graph-view.ts is an audited-SAFE Entity consumer.** It reads only `e.id/entityType/name`
+   (never `e.memoryId`), so the nullable widening is safe there -- named here so the
+   execute-stage `\.memoryId` grep does not treat it as a surprise. The only `Entity.memoryId`
+   derefs to fix are in graph-recall.ts and graph-stream.ts.
+4. **Pass 2/3 edge-emit guard switches from memory-presence to entity-presence.** Today Pass 2
+   gates on `yMemoryId === undefined -> continue` (graph-extract.ts ~249-256) and Pass 3 uses
+   `src.memoryId` as the edge's source (~336-342). After the fix, a null-memory successor/
+   source must STILL emit its edge, so switch the guard to `entityIdByKey` presence and carry
+   the edge's `source_object` (Pass 2 = successor's object; Pass 3 = source object), with
+   `memoryId` optional.

--- a/src/customer-notes.ts
+++ b/src/customer-notes.ts
@@ -22,7 +22,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
-import { markGraphDirty } from './graph.js';
+import { markGraphDirty, removeGraphEntitiesForObject } from './graph.js';
 import { createMemory, Layer, CUSTOMER_NOTE_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -347,7 +347,15 @@ export function closeCustomerNote(
 
       db.exec('COMMIT');
       const closed = rowToCustomerNote(row);
-      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      // Closing removes the object from the graph. Remove its rows DIRECTLY (deterministic),
+      // not only via an enqueued rebuild whose queue item is lost if the mirror is later
+      // forgotten (the queue row cascade-deletes with the memory), which would leave the closed
+      // object stale and could block that forget (codex P1). Still enqueue when a mirror exists
+      // so a concurrent rebuild re-derives consistently (harmless if it also runs).
+      removeGraphEntitiesForObject(hippoRoot, tenantId, 'customer', closed.id);
+      if (closed.memoryId) {
+        markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      }
       return closed;
     } catch (e) {
       try {

--- a/src/db.ts
+++ b/src/db.ts
@@ -23,7 +23,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 37;
+const CURRENT_SCHEMA_VERSION = 38;
 
 type Migration = {
   version: number;
@@ -1864,6 +1864,275 @@ const MIGRATIONS: Migration[] = [
           END
         `);
       }
+    },
+  },
+  {
+    version: 38,
+    up: (db) => {
+      // E2-provenance: anchor graph entity/relation provenance to the authoritative E2
+      // object (decision/policy/customer-note/project-brief) instead of the decaying
+      // memory mirror (docs/plans/2026-06-03-graph-e2-provenance.md). An in-force E2
+      // object must STAY in the graph after its mirror memory is forgotten or
+      // consolidation-pruned. The graph is a PURE DERIVED CACHE (clearGraph + rebuild on
+      // every `graph extract` / `sleep`), so v38 DROPs+recreates entities/relations (no
+      // data copy) and the next extract repopulates. graph_extraction_queue is untouched.
+      //
+      // Two provenance paths, "at least one, no raw":
+      //  - memory path (memory_id NOT NULL): source_kind must equal the FK'd memory's live
+      //    kind and that kind is distilled|superseded (raw still ABORTs) + tenant-match.
+      //  - object path (memory_id NULL): source_object_type/id must reference an EXISTING
+      //    same-tenant E2 row whose status is active|superseded (not closed). E2 objects
+      //    are consolidated BY CONSTRUCTION, so the no-raw invariant still holds.
+      //  - all-null is rejected.
+      //
+      // memory_id is now NULLABLE with ON DELETE SET NULL (was NOT NULL / CASCADE), so a
+      // mirror forget/consolidate nulls the recall pointer without dropping the row. NOTE
+      // (empirically verified, contradicts the SQLite docs): node:sqlite DOES fire the
+      // BEFORE UPDATE guard from the FK SET NULL action even with recursive_triggers OFF.
+      // So the *_consolidated_only_UPDATE triggers deliberately OMIT the all-null ABORT
+      // (kept on INSERT) - otherwise a mirror delete of a memory-only row would be blocked.
+      // See the per-trigger comments below. A SET NULL leaves source_kind at its old value
+      // by design (the object path is distilled-by-construction; source_kind is only
+      // re-checked when memory_id NOT NULL).
+      // source_object_id is a SOFT (type,id) pointer (no hard FK) the rebuild re-validates,
+      // so a legitimate E2 hard-delete is never blocked; a `closed` E2 row drops at next
+      // extract. SQLite cannot parametrize a table name in a trigger, so the object-path
+      // validation is an explicit 4-way CASE (one arm per E2 table).
+
+      // Drop child (relations FK entities) first, then parent.
+      db.exec('DROP TABLE IF EXISTS relations');
+      db.exec('DROP TABLE IF EXISTS entities');
+
+      db.exec(`
+        CREATE TABLE entities (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          tenant_id TEXT NOT NULL,
+          entity_type TEXT NOT NULL
+            CHECK (entity_type IN ('person', 'project', 'customer', 'system', 'policy', 'decision')),
+          name TEXT NOT NULL,
+          memory_id TEXT,
+          source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled', 'superseded')),
+          source_object_type TEXT
+            CHECK (source_object_type IS NULL OR source_object_type IN ('decision', 'policy', 'customer', 'project')),
+          source_object_id INTEGER,
+          created_at TEXT NOT NULL,
+          FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE SET NULL
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_tenant ON entities(tenant_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_memory ON entities(memory_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_source_object ON entities(source_object_type, source_object_id) WHERE source_object_id IS NOT NULL`);
+
+      db.exec(`
+        CREATE TABLE relations (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          tenant_id TEXT NOT NULL,
+          from_entity_id INTEGER NOT NULL,
+          to_entity_id INTEGER NOT NULL,
+          rel_type TEXT NOT NULL
+            CHECK (rel_type IN ('owns', 'supersedes', 'depends-on', 'blocked-by', 'references')),
+          memory_id TEXT,
+          source_kind TEXT NOT NULL CHECK (source_kind IN ('distilled', 'superseded')),
+          source_object_type TEXT
+            CHECK (source_object_type IS NULL OR source_object_type IN ('decision', 'policy', 'customer', 'project')),
+          source_object_id INTEGER,
+          created_at TEXT NOT NULL,
+          FOREIGN KEY (from_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+          FOREIGN KEY (to_entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+          FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE SET NULL
+        )
+      `);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_tenant ON relations(tenant_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_from ON relations(from_entity_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_to ON relations(to_entity_id)`);
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_memory ON relations(memory_id)`);
+      // Mirrors idx_entities_source_object: removeGraphEntitiesForObject (close-time cleanup)
+      // deletes relations by (source_object_type, source_object_id), so index that pair.
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_relations_source_object ON relations(source_object_type, source_object_id) WHERE source_object_id IS NOT NULL`);
+
+      // entities guard (dual-provenance): at least one valid provenance, no raw.
+      //  - all-null  -> ABORT.
+      //  - memory path (memory_id NOT NULL): source_kind == the FK'd memory's kind
+      //    (raw / lying source_kind ABORT) AND tenant-match.
+      //  - object path (memory_id NULL): the (type,id) points at an EXISTING same-tenant
+      //    E2 row whose status is active|superseded (explicit 4-way CASE per table).
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_entities_consolidated_only_insert
+        BEFORE INSERT ON entities
+        BEGIN
+          SELECT CASE
+            WHEN (NEW.source_object_type IS NULL AND NEW.source_object_id IS NOT NULL)
+              OR (NEW.source_object_type IS NOT NULL AND NEW.source_object_id IS NULL)
+            THEN RAISE(ABORT, 'source_object_type and source_object_id must be set together (all-or-none)')
+            WHEN NEW.memory_id IS NULL AND NEW.source_object_id IS NULL
+            THEN RAISE(ABORT, 'graph row needs a memory or a source object')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'entities.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'entities.tenant_id must match memories.tenant_id for the referenced memory')
+            WHEN NEW.source_object_type ='decision'
+              AND NOT EXISTS (SELECT 1 FROM decisions WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded decision in the same tenant')
+            WHEN NEW.source_object_type ='policy'
+              AND NOT EXISTS (SELECT 1 FROM policies WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded policy in the same tenant')
+            WHEN NEW.source_object_type ='customer'
+              AND NOT EXISTS (SELECT 1 FROM customer_notes WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded customer_note in the same tenant')
+            WHEN NEW.source_object_type ='project'
+              AND NOT EXISTS (SELECT 1 FROM project_briefs WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded project_brief in the same tenant')
+          END;
+        END
+      `);
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_entities_consolidated_only_update
+        BEFORE UPDATE ON entities
+        WHEN NEW.memory_id IS NOT OLD.memory_id
+          OR NEW.source_kind IS NOT OLD.source_kind
+          OR NEW.tenant_id IS NOT OLD.tenant_id
+          OR NEW.source_object_type IS NOT OLD.source_object_type
+          OR NEW.source_object_id IS NOT OLD.source_object_id
+        BEGIN
+          -- NO all-null ABORT on UPDATE: node:sqlite fires this BEFORE UPDATE trigger from
+          -- the FK ON DELETE SET NULL action even with recursive_triggers OFF (empirically
+          -- verified - the plan's "SET NULL does not fire the guard" premise is false for
+          -- this build). A mirror forget on a memory-only entity legitimately produces an
+          -- all-null row; aborting here would block the memory delete. The INSERT guard
+          -- still forbids CREATING a provenance-less row, and the next graph rebuild clears
+          -- any all-null orphan. A raw UPDATE to all-null is harmless (not recall-surfaced).
+          -- Object-path STATUS is validated only when the object columns THEMSELVES change
+          -- (an explicit re-point), NOT on the FK ON DELETE SET NULL transition (which changes
+          -- only memory_id). This threads the needle (codex P1 + P2 round 4): the SET NULL of a
+          -- since-closed object's mirror is NOT blocked (object cols unchanged -> object checks
+          -- skip), while an explicit raw UPDATE that re-points the row to a bad/closed/cross-
+          -- tenant object IS rejected. all-or-none + memory-path (raw/tenant) always apply.
+          SELECT CASE
+            WHEN (NEW.source_object_type IS NULL AND NEW.source_object_id IS NOT NULL)
+              OR (NEW.source_object_type IS NOT NULL AND NEW.source_object_id IS NULL)
+            THEN RAISE(ABORT, 'entities.source_object_type and source_object_id must be set together (all-or-none)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'entities.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'entities.tenant_id must match memories.tenant_id for the referenced memory')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='decision'
+              AND NOT EXISTS (SELECT 1 FROM decisions WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded decision in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='policy'
+              AND NOT EXISTS (SELECT 1 FROM policies WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded policy in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='customer'
+              AND NOT EXISTS (SELECT 1 FROM customer_notes WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded customer_note in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='project'
+              AND NOT EXISTS (SELECT 1 FROM project_briefs WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'entities.source_object must reference an active/superseded project_brief in the same tenant')
+          END;
+        END
+      `);
+
+      // relations guard (dual-provenance) + the existing from/to endpoint same-tenant checks.
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_relations_consolidated_only_insert
+        BEFORE INSERT ON relations
+        BEGIN
+          SELECT CASE
+            WHEN (NEW.source_object_type IS NULL AND NEW.source_object_id IS NOT NULL)
+              OR (NEW.source_object_type IS NOT NULL AND NEW.source_object_id IS NULL)
+            THEN RAISE(ABORT, 'source_object_type and source_object_id must be set together (all-or-none)')
+            WHEN NEW.memory_id IS NULL AND NEW.source_object_id IS NULL
+            THEN RAISE(ABORT, 'graph row needs a memory or a source object')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'relations.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match memories.tenant_id for the referenced memory')
+            WHEN NEW.source_object_type ='decision'
+              AND NOT EXISTS (SELECT 1 FROM decisions WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded decision in the same tenant')
+            WHEN NEW.source_object_type ='policy'
+              AND NOT EXISTS (SELECT 1 FROM policies WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded policy in the same tenant')
+            WHEN NEW.source_object_type ='customer'
+              AND NOT EXISTS (SELECT 1 FROM customer_notes WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded customer_note in the same tenant')
+            WHEN NEW.source_object_type ='project'
+              AND NOT EXISTS (SELECT 1 FROM project_briefs WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded project_brief in the same tenant')
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.from_entity_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match the from_entity tenant (no cross-tenant edges)')
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.to_entity_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match the to_entity tenant (no cross-tenant edges)')
+          END;
+        END
+      `);
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_relations_consolidated_only_update
+        BEFORE UPDATE ON relations
+        WHEN NEW.memory_id IS NOT OLD.memory_id
+          OR NEW.source_kind IS NOT OLD.source_kind
+          OR NEW.tenant_id IS NOT OLD.tenant_id
+          OR NEW.source_object_type IS NOT OLD.source_object_type
+          OR NEW.source_object_id IS NOT OLD.source_object_id
+          OR NEW.from_entity_id IS NOT OLD.from_entity_id
+          OR NEW.to_entity_id IS NOT OLD.to_entity_id
+        BEGIN
+          -- NO all-null ABORT on UPDATE (same reason as the entities UPDATE trigger): the FK
+          -- ON DELETE SET NULL fires this trigger in node:sqlite, and a mirror forget on a
+          -- memory-only relation legitimately nulls memory_id. The INSERT guard still forbids
+          -- creating a provenance-less relation; the rebuild clears any orphan.
+          -- Object-path STATUS validated only on an explicit object-column change, NOT on the
+          -- FK SET NULL transition (see the entities UPDATE trigger): SET NULL of a since-closed
+          -- object's mirror is not blocked (object cols unchanged), while an explicit re-point to
+          -- a bad object is rejected. all-or-none + memory-path + endpoint checks always apply.
+          SELECT CASE
+            WHEN (NEW.source_object_type IS NULL AND NEW.source_object_id IS NOT NULL)
+              OR (NEW.source_object_type IS NOT NULL AND NEW.source_object_id IS NULL)
+            THEN RAISE(ABORT, 'relations.source_object_type and source_object_id must be set together (all-or-none)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.source_kind != (SELECT kind FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'relations.source_kind must equal the referenced memory kind; the graph indexes consolidated state only (no raw)')
+            WHEN NEW.memory_id IS NOT NULL AND NEW.tenant_id != (SELECT tenant_id FROM memories WHERE id = NEW.memory_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match memories.tenant_id for the referenced memory')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='decision'
+              AND NOT EXISTS (SELECT 1 FROM decisions WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded decision in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='policy'
+              AND NOT EXISTS (SELECT 1 FROM policies WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded policy in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='customer'
+              AND NOT EXISTS (SELECT 1 FROM customer_notes WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded customer_note in the same tenant')
+            WHEN (NEW.source_object_type IS NOT OLD.source_object_type OR NEW.source_object_id IS NOT OLD.source_object_id OR NEW.tenant_id IS NOT OLD.tenant_id)
+              AND NEW.source_object_type ='project'
+              AND NOT EXISTS (SELECT 1 FROM project_briefs WHERE id = NEW.source_object_id AND tenant_id = NEW.tenant_id AND status IN ('active', 'superseded'))
+            THEN RAISE(ABORT, 'relations.source_object must reference an active/superseded project_brief in the same tenant')
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.from_entity_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match the from_entity tenant (no cross-tenant edges)')
+            WHEN NEW.tenant_id != (SELECT tenant_id FROM entities WHERE id = NEW.to_entity_id)
+            THEN RAISE(ABORT, 'relations.tenant_id must match the to_entity tenant (no cross-tenant edges)')
+          END;
+        END
+      `);
+
+      // Recreated VERBATIM from v37 (logic unchanged): an entity that is a relation
+      // endpoint cannot be moved cross-tenant while referenced. trg_memories_graph_referenced_guard
+      // (on memories) and trg_graph_queue_* (on graph_extraction_queue) are NOT recreated
+      // here: those tables are not dropped by v38, so the triggers survive.
+      db.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_entities_no_tenant_move_when_referenced
+        BEFORE UPDATE ON entities
+        WHEN NEW.tenant_id IS NOT OLD.tenant_id
+          AND EXISTS (SELECT 1 FROM relations WHERE from_entity_id = OLD.id OR to_entity_id = OLD.id)
+        BEGIN
+          SELECT RAISE(ABORT, 'cannot move an entity cross-tenant while a relation references it as an endpoint (E3.3 graph-on-consolidated guard); rebuild/remove the relations first');
+        END
+      `);
     },
   },
 ];

--- a/src/decisions.ts
+++ b/src/decisions.ts
@@ -26,7 +26,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
-import { markGraphDirty } from './graph.js';
+import { markGraphDirty, removeGraphEntitiesForObject } from './graph.js';
 import { createMemory, Layer, DECISION_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -302,7 +302,15 @@ export function closeDecision(
       db.exec('COMMIT');
       const closed = rowToDecision(row);
       // After COMMIT (write lock released), before the finally closes `db`.
-      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      // Closing removes the object from the graph. Remove its rows DIRECTLY (deterministic),
+      // not only via an enqueued rebuild whose queue item is lost if the mirror is later
+      // forgotten (the queue row cascade-deletes with the memory), which would leave the closed
+      // object stale and could block that forget (codex P1). Still enqueue when a mirror exists
+      // so a concurrent rebuild re-derives consistently (harmless if it also runs).
+      removeGraphEntitiesForObject(hippoRoot, tenantId, 'decision', closed.id);
+      if (closed.memoryId) {
+        markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      }
       return closed;
     } catch (e) {
       try {

--- a/src/graph-extract.ts
+++ b/src/graph-extract.ts
@@ -21,7 +21,7 @@
  * `hippo sleep` enqueue-hook.
  */
 
-import { clearGraph, insertEntity, insertRelation, runGraphRebuildTransaction, MAX_ENTITY_NAME_LEN, type EntityType, type GraphTxDb } from './graph.js';
+import { clearGraph, insertEntity, insertRelation, runGraphRebuildTransaction, MAX_ENTITY_NAME_LEN, type EntityType, type GraphTxDb, type SourceObjectType, type SourceObjectRef } from './graph.js';
 import { loadDecisions } from './decisions.js';
 import { loadPolicies } from './policies.js';
 import { loadCustomerNotes } from './customer-notes.js';
@@ -76,6 +76,22 @@ function keyOf(entityType: EntityType, e2Id: number): string {
   return `${entityType}:${e2Id}`;
 }
 
+/** The four E2-derived extraction entity types map 1:1 to source_object_type. */
+const ENTITY_TYPE_TO_SOURCE_OBJECT: Partial<Record<EntityType, SourceObjectType>> = {
+  decision: 'decision',
+  policy: 'policy',
+  customer: 'customer',
+  project: 'project',
+};
+
+/** The E2 source-object ref for an extraction row (always set: every extracted row is an
+ *  E2 object). Throws on an unmappable entityType (a graph invariant violation). */
+function sourceObjectOf(entityType: EntityType, e2Id: number): SourceObjectRef {
+  const type = ENTITY_TYPE_TO_SOURCE_OBJECT[entityType];
+  if (!type) throw new Error(`graph-extract: entityType '${entityType}' has no source_object_type mapping`);
+  return { type, id: e2Id };
+}
+
 /** Escape a string for safe use as a literal inside a RegExp alternation. */
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -121,13 +137,18 @@ function loadType(
   return { rows, hitCap };
 }
 
-/** A Pass-1-created entity, the unit Pass 3 traverses (never `allRows` - a row with a
- *  null memory or empty name produced NO entity and must never be a references source,
- *  or insertRelation would throw on a null source memory after clearGraph). */
+/** A Pass-1-created entity, the unit Pass 3 traverses (never `allRows` - a row with an
+ *  empty name produced NO entity and must never be a references source). Carries its E2
+ *  source object so a references edge stays anchored to the object even when the mirror
+ *  memory is gone (memoryId null). */
 interface CreatedEntity {
   entityId: number;
   entityType: EntityType;
-  memoryId: string;
+  /** The source mirror memory, or null once forgotten/pruned (the edge then anchors to
+   *  the source object only). */
+  memoryId: string | null;
+  /** The E2 source object this entity descends from (always set). */
+  sourceObject: SourceObjectRef;
   name: string;
   searchText: string;
   /** True when this row was superseded by a successor. References are extracted among
@@ -195,18 +216,22 @@ function rebuildGraphRows(
   const truncated: string[] = [];
   const allRows: ExtractRow[] = [];
   const entityIdByKey = new Map<string, number>();
-  const memoryIdByKey = new Map<string, string>();
+  // The mirror memory per extracted key, null once forgotten/pruned (so a supersedes
+  // edge anchors to the successor's object when the mirror is gone but still passes the
+  // memory through when it lives).
+  const memoryIdByKey = new Map<string, string | null>();
   // Created entities ONLY (drives Pass 3 sources + targets), in stable insertion order.
   const created: CreatedEntity[] = [];
 
-  // Pass 1: entities. Skip rows whose source memory was forgotten (NULL memory_id) -
-  // an entity must reference a consolidated memory (entities.memory_id is NOT NULL).
+  // Pass 1: entities. Every ACTIVE/SUPERSEDED E2 row becomes an entity ANCHORED to its
+  // authoritative E2 object (source_object_type/id) - it survives a forgotten mirror
+  // (memory_id NULL). The mirror memory is passed through only when it still exists
+  // (it remains a recall pointer until forgotten/pruned).
   for (const { entityType, rows, hitCap } of loaded) {
     if (hitCap) truncated.push(entityType);
     byType[entityType] = 0;
     for (const row of rows) {
       allRows.push(row);
-      if (row.memoryId === null) continue;
       // Normalise the label so a long/odd-but-valid E2 name can never throw in
       // insertEntity and (because clearGraph already ran) brick the rebuild
       // unrebuildably. E2 name fields (decisionText / policyName) are UNCAPPED at
@@ -218,22 +243,26 @@ function rebuildGraphRows(
       // rather than throw. This closes the entire name-brick class.
       const name = (row.name ?? '').trim().slice(0, MAX_ENTITY_NAME_LEN);
       if (name.length === 0) continue;
+      const sourceObject = sourceObjectOf(row.entityType, row.e2Id);
       const entity = insertEntity(hippoRoot, tenantId, {
         entityType: row.entityType,
         name,
         memoryId: row.memoryId,
+        sourceObject,
       }, txDb);
       const k = keyOf(row.entityType, row.e2Id);
       entityIdByKey.set(k, entity.id);
       memoryIdByKey.set(k, row.memoryId);
-      created.push({ entityId: entity.id, entityType: row.entityType, memoryId: row.memoryId, name, searchText: row.searchText ?? '', superseded: row.supersededBy !== null });
+      created.push({ entityId: entity.id, entityType: row.entityType, memoryId: row.memoryId, sourceObject, name, searchText: row.searchText ?? '', superseded: row.supersededBy !== null });
       byType[entityType] += 1;
     }
   }
 
   // Pass 2: `supersedes` relations. For X superseded by Y (Y is the successor), emit
-  // "Y supersedes X" - but only when BOTH X and Y were extracted (e.g. Y may be closed
-  // and absent). The relation is sourced from Y's consolidated memory.
+  // "Y supersedes X" - but only when BOTH X and Y were EXTRACTED (e.g. Y may be closed
+  // and absent). The emit guard is ENTITY presence (entityIdByKey), not memory presence:
+  // a forgotten successor mirror must still emit the edge. The relation is anchored to Y's
+  // authoritative E2 object; Y's mirror memory is passed only when it still lives.
   let relations = 0;
   // Entity-id pairs already related by supersedes (unordered). Pass 3 skips a references
   // edge for such a pair: a version-extends-its-predecessor's-name containment (e.g.
@@ -246,13 +275,14 @@ function rebuildGraphRows(
     const yKey = keyOf(row.entityType, row.supersededBy);
     const fromId = entityIdByKey.get(yKey); // successor Y
     const toId = entityIdByKey.get(xKey); // superseded X
-    const yMemoryId = memoryIdByKey.get(yKey);
-    if (fromId === undefined || toId === undefined || yMemoryId === undefined) continue;
+    if (fromId === undefined || toId === undefined) continue;
+    const yMemoryId = memoryIdByKey.get(yKey) ?? null; // successor's mirror, null if gone
     insertRelation(hippoRoot, tenantId, {
       fromEntityId: fromId,
       toEntityId: toId,
       relType: 'supersedes',
       memoryId: yMemoryId,
+      sourceObject: sourceObjectOf(row.entityType, row.supersededBy), // successor Y's object
     }, txDb);
     supersededPairs.add(pairKey(fromId, toId));
     relations += 1;
@@ -260,7 +290,8 @@ function rebuildGraphRows(
 
   // Pass 3: cross-object `references` edges via conservative name matching. A source's
   // text containing a target entity's name -> "source references target". Sources +
-  // targets are CREATED entities only, so insertRelation never sees a null source memory.
+  // targets are CREATED entities only, each anchored to its E2 source object (so the
+  // edge survives a forgotten source mirror).
   const references = extractReferences(hippoRoot, tenantId, created, supersededPairs, truncated, txDb);
   relations += references;
 
@@ -272,7 +303,8 @@ function rebuildGraphRows(
  * Pass 3. Build a target-name index from the created entities (names within the length
  * bounds, ambiguous names dropped), scan each created entity's text once with one
  * combined word-boundary regex, and emit `references` edges (self-skipped, deduped,
- * per-source capped). Returns the number of references edges written.
+ * per-source capped). Each edge is anchored to the source entity's E2 object (memoryId
+ * passed through only when the mirror lives). Returns the number of references edges written.
  */
 function extractReferences(
   hippoRoot: string,
@@ -338,7 +370,9 @@ function extractReferences(
         fromEntityId: src.entityId,
         toEntityId: targetId,
         relType: 'references',
-        memoryId: src.memoryId, // the source object's consolidated memory
+        // Anchored to the source object; its mirror memory is passed only when it lives.
+        memoryId: src.memoryId,
+        sourceObject: src.sourceObject,
       }, txDb);
       references += 1;
     }

--- a/src/graph-recall.ts
+++ b/src/graph-recall.ts
@@ -117,7 +117,10 @@ function produceHitsForRoot(
   // from (for adjacency placement + score inheritance).
   const visitedEntityIds = new Set<number>(seedEntities.map((e) => e.id));
   const reached = new Map<number, GraphVia>();
-  const originMemByEntityId = new Map<number, string>();
+  // A seed/reached entity whose mirror was forgotten/pruned has a null memoryId; the map
+  // tolerates null so traversal still propagates origin, and the null is dropped before
+  // any memory load below (a mirror-less node has no memory to surface).
+  const originMemByEntityId = new Map<number, string | null>();
   for (const se of seedEntities) originMemByEntityId.set(se.id, se.memoryId);
   let frontier: number[] = seedEntities.map((e) => e.id);
 
@@ -149,8 +152,15 @@ function produceHitsForRoot(
   if (reached.size === 0) return;
 
   // Reached entities -> source memory ids -> load DIRECTLY by id (chunked), not lexical.
+  // A mirror-less reached entity (memoryId === null) has no memory to load: drop its null
+  // id BEFORE it reaches loadByIdsChunked / the Set<string> (it cannot be recall-surfaced;
+  // it stays in entities/relations for graph extract / visualization).
   const reachedEntities = loadEntitiesByIds(root, tenantId, [...reached.keys()]);
-  const needLoad = [...new Set(reachedEntities.map((e) => e.memoryId).filter((id) => !seenMemoryIds.has(id)))];
+  const needLoad = [...new Set(
+    reachedEntities
+      .map((e) => e.memoryId)
+      .filter((id): id is string => id !== null && !seenMemoryIds.has(id)),
+  )];
   const loadedById = new Map(loadByIdsChunked(root, tenantId, needLoad).map((m) => [m.id, m]));
 
   // For the bi-temporal as-of rule on a superseded reached row we need its successor's
@@ -162,6 +172,7 @@ function produceHitsForRoot(
   }
 
   for (const ent of reachedEntities) {
+    if (ent.memoryId === null) continue;      // mirror-less node: not recall-surfaced
     const mem = loadedById.get(ent.memoryId);
     if (!mem) continue;                       // not found / wrong tenant / already in base
     if (seenMemoryIds.has(mem.id)) continue;  // another reached entity already added it

--- a/src/graph-stream.ts
+++ b/src/graph-stream.ts
@@ -119,9 +119,12 @@ function accumulateForRoot(
   const seedEntities = loadEntitiesByMemoryId(root, tenantId, [...strengthByMemId.keys()]);
   if (seedEntities.length === 0) return;
 
-  // entityId -> origin seed strength (carried unchanged along the path).
+  // entityId -> origin seed strength (carried unchanged along the path). A seed entity is
+  // loaded by memory id, so its memoryId is non-null here; the guard keeps the widened
+  // (string | null) type honest (a null-memory entity is not a lexical seed).
   const originStrength = new Map<number, number>();
   for (const e of seedEntities) {
+    if (e.memoryId === null) continue;
     const st = strengthByMemId.get(e.memoryId) ?? 0;
     originStrength.set(e.id, Math.max(originStrength.get(e.id) ?? 0, st));
   }
@@ -179,6 +182,7 @@ function accumulateForRoot(
   // Reached entity ids -> source memory ids -> in-pool entry indices.
   const reachedEntities = loadEntitiesByIds(root, tenantId, [...reachedScore.keys()]);
   for (const ent of reachedEntities) {
+    if (ent.memoryId === null) continue;         // mirror-less node: no pool memory to re-rank
     const idx = memIdToIndex.get(ent.memoryId);
     if (idx === undefined) continue;             // reached memory is not in the candidate pool
     const score = reachedScore.get(ent.id) ?? 0;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -35,6 +35,26 @@ export type RelationType = 'owns' | 'supersedes' | 'depends-on' | 'blocked-by' |
 export type GraphQueueStatus = 'pending' | 'processed' | 'skipped';
 /** The consolidated source kinds the graph is permitted to index (never 'raw'). */
 export type SourceKind = 'distilled' | 'superseded';
+/** The authoritative E2 object types a graph row may be anchored to (the object
+ *  provenance path, alongside the memory path). Maps to source_object_type. */
+export type SourceObjectType = 'decision' | 'policy' | 'customer' | 'project';
+
+/** A soft (type,id) pointer to the authoritative E2 row a graph row descends from.
+ *  Survives a mirror memory forget/prune (memory_id may go NULL); the rebuild
+ *  re-validates it (it is not a hard FK). */
+export interface SourceObjectRef {
+  type: SourceObjectType;
+  id: number;
+}
+
+/** source_object_type -> its E2 table, for the object-path validation 4-way branch.
+ *  SQLite cannot parametrize a table name, so the SQL trigger mirrors this explicitly. */
+const SOURCE_OBJECT_TABLE: Record<SourceObjectType, string> = {
+  decision: 'decisions',
+  policy: 'policies',
+  customer: 'customer_notes',
+  project: 'project_briefs',
+};
 
 export const GRAPH_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'person', 'project', 'customer', 'system', 'policy', 'decision',
@@ -53,9 +73,15 @@ export interface Entity {
   tenantId: string;
   entityType: EntityType;
   name: string;
-  /** The consolidated source memory this entity was extracted from. */
-  memoryId: string;
+  /** The consolidated source memory this entity was extracted from. NULL once the
+   *  mirror is forgotten/pruned (ON DELETE SET NULL) - the entity then survives via
+   *  its source_object provenance. */
+  memoryId: string | null;
   sourceKind: SourceKind;
+  /** The authoritative E2 object this entity is anchored to (E2-provenance path).
+   *  Set for E2-sourced entities; absent for memory-only (prose/NLP) entities. */
+  sourceObjectType?: SourceObjectType;
+  sourceObjectId?: number;
   createdAt: string;
 }
 
@@ -65,8 +91,11 @@ export interface Relation {
   fromEntityId: number;
   toEntityId: number;
   relType: RelationType;
-  memoryId: string;
+  /** NULL once the mirror is forgotten/pruned; the relation survives via source_object. */
+  memoryId: string | null;
   sourceKind: SourceKind;
+  sourceObjectType?: SourceObjectType;
+  sourceObjectId?: number;
   createdAt: string;
 }
 
@@ -83,16 +112,23 @@ export interface GraphQueueItem {
 export interface InsertEntityOpts {
   entityType: EntityType;
   name: string;
-  /** A consolidated (distilled/superseded) memory; raw is rejected. */
-  memoryId: string;
+  /** A consolidated (distilled/superseded) memory; raw is rejected. NULL/omitted when
+   *  the entity is anchored only to its E2 source object (mirror forgotten/pruned). */
+  memoryId?: string | null;
+  /** The authoritative E2 object this entity descends from. Required when memoryId is
+   *  null; optional alongside a live memory (both paths may be set). */
+  sourceObject?: SourceObjectRef;
 }
 
 export interface InsertRelationOpts {
   fromEntityId: number;
   toEntityId: number;
   relType: RelationType;
-  /** A consolidated (distilled/superseded) memory; raw is rejected. */
-  memoryId: string;
+  /** A consolidated (distilled/superseded) memory; raw is rejected. NULL/omitted when
+   *  the relation is anchored only to its E2 source object. */
+  memoryId?: string | null;
+  /** The authoritative E2 object this relation descends from. */
+  sourceObject?: SourceObjectRef;
 }
 
 // ---------------------------------------------------------------------------
@@ -104,8 +140,10 @@ interface EntityRow {
   tenant_id: string;
   entity_type: string;
   name: string;
-  memory_id: string;
+  memory_id: string | null;
   source_kind: string;
+  source_object_type: string | null;
+  source_object_id: number | null;
   created_at: string;
 }
 interface RelationRow {
@@ -114,8 +152,10 @@ interface RelationRow {
   from_entity_id: number;
   to_entity_id: number;
   rel_type: string;
-  memory_id: string;
+  memory_id: string | null;
   source_kind: string;
+  source_object_type: string | null;
+  source_object_id: number | null;
   created_at: string;
 }
 interface QueueRow {
@@ -136,6 +176,8 @@ function rowToEntity(row: EntityRow): Entity {
     name: row.name,
     memoryId: row.memory_id,
     sourceKind: row.source_kind as SourceKind,
+    sourceObjectType: row.source_object_type === null ? undefined : (row.source_object_type as SourceObjectType),
+    sourceObjectId: row.source_object_id === null ? undefined : row.source_object_id,
     createdAt: row.created_at,
   };
 }
@@ -148,6 +190,8 @@ function rowToRelation(row: RelationRow): Relation {
     relType: row.rel_type as RelationType,
     memoryId: row.memory_id,
     sourceKind: row.source_kind as SourceKind,
+    sourceObjectType: row.source_object_type === null ? undefined : (row.source_object_type as SourceObjectType),
+    sourceObjectId: row.source_object_id === null ? undefined : row.source_object_id,
     createdAt: row.created_at,
   };
 }
@@ -163,8 +207,8 @@ function rowToQueueItem(row: QueueRow): GraphQueueItem {
   };
 }
 
-const ENTITY_COLS = `id, tenant_id, entity_type, name, memory_id, source_kind, created_at`;
-const RELATION_COLS = `id, tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at`;
+const ENTITY_COLS = `id, tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at`;
+const RELATION_COLS = `id, tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, source_object_type, source_object_id, created_at`;
 const QUEUE_COLS = `id, tenant_id, memory_id, kind, status, enqueued_at, processed_at`;
 
 // ---------------------------------------------------------------------------
@@ -176,28 +220,75 @@ interface DbLike {
 }
 
 /**
- * Look up a memory and assert it is a valid CONSOLIDATED source for the graph: it
- * exists, belongs to `tenantId`, and is not raw. Returns its kind (the source_kind to
- * store). Throws a clear error otherwise. This is the code-level mirror of the DB
- * trigger guard (which is the unbypassable backstop).
+ * Resolve the `source_kind` for a graph row from AT LEAST ONE valid provenance path,
+ * with the no-raw invariant intact. The code-level mirror of the DB trigger guard (the
+ * trigger is the unbypassable backstop). Two paths:
+ *  - MEMORY path (`memoryId` not null): the memory must exist, be same-tenant, and be
+ *    consolidated (distilled/superseded); raw is rejected. Returns its kind.
+ *  - OBJECT path (`memoryId` null, `sourceObject` set): the E2 row must exist, be
+ *    same-tenant, and have status active|superseded (4-way per E2 table). E2 objects are
+ *    consolidated BY CONSTRUCTION, so this returns 'distilled'.
+ * All-null (no memory AND no source object) is rejected.
  */
-function resolveConsolidatedSource(db: DbLike, tenantId: string, memoryId: string, label: string): SourceKind {
-  const row = db.prepare(`SELECT kind, tenant_id FROM memories WHERE id = ?`).get(memoryId) as
-    | { kind: string; tenant_id: string }
-    | undefined;
-  if (!row) {
-    throw new Error(`${label}: source memory ${memoryId} not found`);
+function resolveConsolidatedSource(
+  db: DbLike,
+  tenantId: string,
+  memoryId: string | null,
+  sourceObject: SourceObjectRef | null,
+  label: string,
+): { sourceKind: SourceKind; memoryId: string | null } {
+  let memKind: SourceKind | null = null;
+  let effectiveMemoryId: string | null = memoryId;
+  if (memoryId != null) {
+    const row = db.prepare(`SELECT kind, tenant_id FROM memories WHERE id = ?`).get(memoryId) as
+      | { kind: string; tenant_id: string }
+      | undefined;
+    if (!row) {
+      // Stale / forgotten mirror. Tolerate it IFF a valid source object provides provenance:
+      // graph-extract reads E2 rows then inserts, and a mirror forgotten/pruned in that window
+      // must NOT roll back the whole tenant rebuild - the active E2 object survives mirror loss
+      // (v38 contract; codex round-4 race). Anchor to the object; drop the dead memory pointer.
+      if (sourceObject == null) {
+        throw new Error(`${label}: source memory ${memoryId} not found`);
+      }
+      effectiveMemoryId = null;
+    } else if (row.tenant_id !== tenantId) {
+      throw new Error(`${label}: source memory ${memoryId} belongs to another tenant`);
+    } else if (row.kind === 'raw') {
+      throw new Error(`${label}: source memory ${memoryId} is raw; the graph indexes consolidated state only`);
+    } else if (row.kind !== 'distilled' && row.kind !== 'superseded') {
+      throw new Error(`${label}: source memory ${memoryId} has unsupported kind '${row.kind}'`);
+    } else {
+      memKind = row.kind;
+    }
   }
-  if (row.tenant_id !== tenantId) {
-    throw new Error(`${label}: source memory ${memoryId} belongs to another tenant`);
+
+  // Validate the object pointer WHENEVER it is provided - not only when memory is null
+  // (codex review): a dual-set row whose object is wrong/closed/cross-tenant would become
+  // the active provenance after ON DELETE SET NULL and could then block the memory delete.
+  if (sourceObject != null) {
+    const table = SOURCE_OBJECT_TABLE[sourceObject.type];
+    if (!table) {
+      throw new Error(`${label}: unsupported source_object_type '${sourceObject.type}'`);
+    }
+    // `table` is a fixed value from the SOURCE_OBJECT_TABLE map (never user-supplied), so
+    // this string interpolation is safe; `id`/`tenant_id` stay parametrized.
+    const row = db.prepare(
+      `SELECT status FROM ${table} WHERE id = ? AND tenant_id = ?`,
+    ).get(sourceObject.id, tenantId) as { status: string } | undefined;
+    if (!row) {
+      throw new Error(`${label}: source ${sourceObject.type} ${sourceObject.id} not found for tenant ${tenantId}`);
+    }
+    if (row.status !== 'active' && row.status !== 'superseded') {
+      throw new Error(`${label}: source ${sourceObject.type} ${sourceObject.id} has status '${row.status}' (must be active|superseded)`);
+    }
   }
-  if (row.kind === 'raw') {
-    throw new Error(`${label}: source memory ${memoryId} is raw; the graph indexes consolidated state only`);
-  }
-  if (row.kind !== 'distilled' && row.kind !== 'superseded') {
-    throw new Error(`${label}: source memory ${memoryId} has unsupported kind '${row.kind}'`);
-  }
-  return row.kind;
+
+  // source_kind is the memory's kind when a memory is present, else 'distilled' for an
+  // object-only row (E2 objects are consolidated by construction). All-null is rejected.
+  if (memKind != null) return { sourceKind: memKind, memoryId: effectiveMemoryId };
+  if (sourceObject != null) return { sourceKind: 'distilled', memoryId: null };
+  throw new Error(`${label}: graph row needs a memory or a source object`);
 }
 
 // ---------------------------------------------------------------------------
@@ -224,14 +315,16 @@ export function insertEntity(
     throw new Error(`insertEntity: name exceeds the ${MAX_ENTITY_NAME_LEN}-char cap`);
   }
   const now = new Date().toISOString();
+  const memoryId = opts.memoryId ?? null;
+  const sourceObject = opts.sourceObject ?? null;
   const ownDb = txDb ? null : openHippoDb(hippoRoot);
   const db = txDb ?? ownDb!;
   try {
-    const sourceKind = resolveConsolidatedSource(db, tenantId, opts.memoryId, 'insertEntity');
+    const { sourceKind, memoryId: effectiveMemoryId } = resolveConsolidatedSource(db, tenantId, memoryId, sourceObject, 'insertEntity');
     const result = db.prepare(`
-      INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `).run(tenantId, opts.entityType, name, opts.memoryId, sourceKind, now);
+      INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(tenantId, opts.entityType, name, effectiveMemoryId, sourceKind, sourceObject?.type ?? null, sourceObject?.id ?? null, now);
     const id = Number(result.lastInsertRowid ?? 0);
     const row = db.prepare(`SELECT ${ENTITY_COLS} FROM entities WHERE id = ?`).get(id) as EntityRow | undefined;
     if (!row) throw new Error('insertEntity: failed to reload inserted entity');
@@ -256,6 +349,8 @@ export function insertRelation(
     throw new Error(`insertRelation: relType must be one of ${Array.from(GRAPH_RELATION_TYPES).join('|')}; got ${opts.relType}`);
   }
   const now = new Date().toISOString();
+  const memoryId = opts.memoryId ?? null;
+  const sourceObject = opts.sourceObject ?? null;
   const ownDb = txDb ? null : openHippoDb(hippoRoot);
   const db = txDb ?? ownDb!;
   try {
@@ -266,11 +361,11 @@ export function insertRelation(
         throw new Error(`insertRelation: ${role}_entity ${eid} belongs to another tenant (no cross-tenant edges)`);
       }
     }
-    const sourceKind = resolveConsolidatedSource(db, tenantId, opts.memoryId, 'insertRelation');
+    const { sourceKind, memoryId: effectiveMemoryId } = resolveConsolidatedSource(db, tenantId, memoryId, sourceObject, 'insertRelation');
     const result = db.prepare(`
-      INSERT INTO relations(tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(tenantId, opts.fromEntityId, opts.toEntityId, opts.relType, opts.memoryId, sourceKind, now);
+      INSERT INTO relations(tenant_id, from_entity_id, to_entity_id, rel_type, memory_id, source_kind, source_object_type, source_object_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(tenantId, opts.fromEntityId, opts.toEntityId, opts.relType, effectiveMemoryId, sourceKind, sourceObject?.type ?? null, sourceObject?.id ?? null, now);
     const id = Number(result.lastInsertRowid ?? 0);
     const row = db.prepare(`SELECT ${RELATION_COLS} FROM relations WHERE id = ?`).get(id) as RelationRow | undefined;
     if (!row) throw new Error('insertRelation: failed to reload inserted relation');
@@ -582,11 +677,13 @@ export function enqueueExtraction(
   const now = new Date().toISOString();
   const db = openHippoDb(hippoRoot);
   try {
-    const kind = resolveConsolidatedSource(db, tenantId, memoryId, 'enqueueExtraction');
+    // enqueue is memory-keyed (no source object), so a missing memory still throws (correct -
+    // you cannot enqueue a forgotten mirror); memoryId is non-null here by construction.
+    const { sourceKind } = resolveConsolidatedSource(db, tenantId, memoryId, null, 'enqueueExtraction');
     const result = db.prepare(`
       INSERT INTO graph_extraction_queue(tenant_id, memory_id, kind, status, enqueued_at, processed_at)
       VALUES (?, ?, ?, 'pending', ?, NULL)
-    `).run(tenantId, memoryId, kind, now);
+    `).run(tenantId, memoryId, sourceKind, now);
     const id = Number(result.lastInsertRowid ?? 0);
     const row = db.prepare(`SELECT ${QUEUE_COLS} FROM graph_extraction_queue WHERE id = ?`).get(id) as QueueRow | undefined;
     if (!row) throw new Error('enqueueExtraction: failed to reload queue item');
@@ -739,6 +836,47 @@ export function markGraphDirty(hippoRoot: string, tenantId: string, memoryId: st
     // swallowed so the already-committed E2 write is never rolled back.
     console.warn(
       `markGraphDirty: enqueue failed for tenant=${tenantId} memory=${memoryId}: ${(err as Error).message}`,
+    );
+  }
+}
+
+/**
+ * Remove the graph rows sourced from one E2 object, by its (type, id). Used when a
+ * MIRRORLESS object is closed: it has no mirror memory, so `markGraphDirty` cannot
+ * enqueue a rebuild (the queue is memory-keyed). Closing must still drop the object's
+ * now-stale entity + edges from the graph, so we remove them directly here. Fail-soft
+ * like `markGraphDirty` (never throws into the E2 close caller; graph staleness is
+ * recoverable). Deleting the entity cascade-deletes any relation where it is an endpoint
+ * (relations FK entities ON DELETE CASCADE); the explicit relations DELETE also covers a
+ * relation whose OWN provenance is this object (defensive — every such edge has the object
+ * as an endpoint today, so the cascade already covers it). DELETE fires no BEFORE
+ * INSERT/UPDATE guard trigger.
+ */
+export function removeGraphEntitiesForObject(
+  hippoRoot: string,
+  tenantId: string,
+  sourceObjectType: SourceObjectType,
+  sourceObjectId: number,
+): void {
+  try {
+    assertTenantId('removeGraphEntitiesForObject', tenantId);
+    const db = openHippoDb(hippoRoot);
+    try {
+      db.exec('BEGIN');
+      db.prepare(`DELETE FROM relations WHERE tenant_id = ? AND source_object_type = ? AND source_object_id = ?`)
+        .run(tenantId, sourceObjectType, sourceObjectId);
+      db.prepare(`DELETE FROM entities WHERE tenant_id = ? AND source_object_type = ? AND source_object_id = ?`)
+        .run(tenantId, sourceObjectType, sourceObjectId);
+      db.exec('COMMIT');
+    } catch (e) {
+      try { db.exec('ROLLBACK'); } catch { /* preserve original throw */ }
+      throw e;
+    } finally {
+      closeHippoDb(db);
+    }
+  } catch (err) {
+    console.warn(
+      `removeGraphEntitiesForObject: failed for tenant=${tenantId} ${sourceObjectType}#${sourceObjectId}: ${(err as Error).message}`,
     );
   }
 }

--- a/src/policies.ts
+++ b/src/policies.ts
@@ -39,7 +39,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
-import { markGraphDirty } from './graph.js';
+import { markGraphDirty, removeGraphEntitiesForObject } from './graph.js';
 import { createMemory, Layer, POLICY_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -391,7 +391,15 @@ export function closePolicy(
 
       db.exec('COMMIT');
       const closed = rowToPolicy(row);
-      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      // Closing removes the object from the graph. Remove its rows DIRECTLY (deterministic),
+      // not only via an enqueued rebuild whose queue item is lost if the mirror is later
+      // forgotten (the queue row cascade-deletes with the memory), which would leave the closed
+      // object stale and could block that forget (codex P1). Still enqueue when a mirror exists
+      // so a concurrent rebuild re-derives consistently (harmless if it also runs).
+      removeGraphEntitiesForObject(hippoRoot, tenantId, 'policy', closed.id);
+      if (closed.memoryId) {
+        markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      }
       return closed;
     } catch (e) {
       try {

--- a/src/project-briefs.ts
+++ b/src/project-briefs.ts
@@ -24,7 +24,7 @@
 
 import { openHippoDb, closeHippoDb } from './db.js';
 import { writeEntry, assertTenantId } from './store.js';
-import { markGraphDirty } from './graph.js';
+import { markGraphDirty, removeGraphEntitiesForObject } from './graph.js';
 import { createMemory, Layer, PROJECT_BRIEF_HALF_LIFE_DAYS } from './memory.js';
 import { appendAuditEvent } from './audit.js';
 
@@ -368,7 +368,15 @@ export function closeProjectBrief(
 
       db.exec('COMMIT');
       const closed = rowToProjectBrief(row);
-      markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      // Closing removes the object from the graph. Remove its rows DIRECTLY (deterministic),
+      // not only via an enqueued rebuild whose queue item is lost if the mirror is later
+      // forgotten (the queue row cascade-deletes with the memory), which would leave the closed
+      // object stale and could block that forget (codex P1). Still enqueue when a mirror exists
+      // so a concurrent rebuild re-derives consistently (harmless if it also runs).
+      removeGraphEntitiesForObject(hippoRoot, tenantId, 'project', closed.id);
+      if (closed.memoryId) {
+        markGraphDirty(hippoRoot, tenantId, closed.memoryId);
+      }
       return closed;
     } catch (e) {
       try {

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+    expect(getCurrentSchemaVersion()).toBe(38);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(37);
+    expect(getSchemaVersion(db)).toBe(38);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
-      expect(getCurrentSchemaVersion()).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
+      expect(getCurrentSchemaVersion()).toBe(38);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+    expect(getCurrentSchemaVersion()).toBe(38);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
-      expect(getCurrentSchemaVersion()).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
+      expect(getCurrentSchemaVersion()).toBe(38);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+    expect(getCurrentSchemaVersion()).toBe(38);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -74,7 +74,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db, 'schema_version')).toBe('37');
+      expect(getMeta(db, 'schema_version')).toBe('38');
     } finally {
       closeHippoDb(db);
     }
@@ -134,7 +134,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db2);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db2, 'schema_version')).toBe('37');
+      expect(getMeta(db2, 'schema_version')).toBe('38');
     } finally {
       closeHippoDb(db2);
     }

--- a/tests/graph-cross-object.test.ts
+++ b/tests/graph-cross-object.test.ts
@@ -115,13 +115,21 @@ describe('E3.1 cross-object references (Pass 3 name-match)', () => {
     expect(refs(home)).toHaveLength(1);
   });
 
-  it('a forgotten (null memory_id) source emits no edge and does not throw', () => {
+  it('a forgotten (null memory_id) source STILL emits its edge, anchored to the E2 object (v38 provenance)', () => {
     savePolicy(home, T, { policyName: 'AlphaPolicy', policyText: 'p' });
     const dec = saveDecision(home, T, { decisionText: 'uses AlphaPolicy heavily' });
-    // Delete the decision's memory -> ON DELETE SET NULL nulls the decision's memory_id.
+    // Delete the decision's mirror memory -> ON DELETE SET NULL nulls memory_id, but the
+    // decision row stays active and authoritative. v38 anchors the entity to the E2 object,
+    // so the forgotten-mirror decision is STILL a Pass-3 source (provenance = the object,
+    // not the decaying mirror). This is the whole point of the graph/E2 provenance fix.
     deleteEntry(home, dec.memoryId!, T);
     expect(() => extractGraph(home, T)).not.toThrow();
-    expect(refs(home)).toHaveLength(0); // the forgotten decision is never a Pass-3 source
+    const edges = refs(home);
+    expect(edges).toHaveLength(1); // forgotten-mirror decision still references AlphaPolicy
+    const decEnt = entByName(home, 'uses AlphaPolicy heavily')!;
+    const polEnt = entByName(home, 'AlphaPolicy')!;
+    expect(edges[0].fromEntityId).toBe(decEnt.id);
+    expect(edges[0].toEntityId).toBe(polEnt.id);
   });
 
   it('a supersedes pair is not ALSO given a references edge (name-containment artifact)', () => {

--- a/tests/graph-e2-provenance.test.ts
+++ b/tests/graph-e2-provenance.test.ts
@@ -1,0 +1,381 @@
+/**
+ * v38 E2-provenance: graph entity/relation provenance is anchored to the authoritative
+ * E2 object (decision/policy/customer-note/project-brief), not the decaying memory
+ * mirror. An in-force E2 object STAYS in the entities/relations tables after its mirror
+ * memory is forgotten or consolidation-pruned.
+ * Docs: docs/plans/2026-06-03-graph-e2-provenance.md
+ *
+ * Real DB, no mocks (mirrors tests/graph-extract.test.ts + tests/graph-store.test.ts).
+ * The success criterion is asserted by querying the entities/relations TABLES directly,
+ * not via recall (recall surfacing of mirror-less nodes is an out-of-scope follow-up).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, deleteEntry, writeEntry } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { saveDecision, closeDecision } from '../src/decisions.js';
+import { savePolicy } from '../src/policies.js';
+import { extractGraph } from '../src/graph-extract.js';
+import { insertEntity, loadEntities, loadRelations } from '../src/graph.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+
+const T = 'default';
+
+function makeRoot(): string {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-graph-e2-prov-'));
+  mkdirSync(join(home, '.hippo'), { recursive: true });
+  initStore(home);
+  return home;
+}
+
+/** Write a memory and (optionally) force its kind. Returns its id. */
+function addMemory(home: string, kind: 'distilled' | 'superseded' | 'raw'): string {
+  const mem = createMemory('graph e2-provenance test memory', {
+    tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: T,
+  });
+  writeEntry(home, mem, { actor: 'test' });
+  if (kind !== 'distilled') {
+    const db = openHippoDb(home);
+    try { db.prepare(`UPDATE memories SET kind = ? WHERE id = ?`).run(kind, mem.id); }
+    finally { closeHippoDb(db); }
+  }
+  return mem.id;
+}
+
+/** Raw rows straight out of the entities table (the success criterion is a TABLE query). */
+function entityRows(home: string): Array<{
+  id: number; name: string; memory_id: string | null;
+  source_object_type: string | null; source_object_id: number | null;
+}> {
+  const db = openHippoDb(home);
+  try {
+    return db.prepare(
+      `SELECT id, name, memory_id, source_object_type, source_object_id FROM entities ORDER BY id`,
+    ).all() as never;
+  } finally { closeHippoDb(db); }
+}
+
+function relationRows(home: string): Array<{
+  id: number; from_entity_id: number; to_entity_id: number; rel_type: string;
+  memory_id: string | null; source_object_type: string | null; source_object_id: number | null;
+}> {
+  const db = openHippoDb(home);
+  try {
+    return db.prepare(
+      `SELECT id, from_entity_id, to_entity_id, rel_type, memory_id, source_object_type, source_object_id FROM relations ORDER BY id`,
+    ).all() as never;
+  } finally { closeHippoDb(db); }
+}
+
+describe('v38 E2-provenance (graph anchored to the authoritative E2 object)', () => {
+  let home: string;
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('extract: a policy + a decision that mentions it produce entities + a references arc', () => {
+    const policy = savePolicy(home, T, {
+      policyName: 'Data Retention Policy',
+      policyText: 'Delete logs after 90 days',
+    });
+    const decision = saveDecision(home, T, {
+      decisionText: 'Adopt the Data Retention Policy for all log pipelines',
+    });
+
+    const r = extractGraph(home, T);
+    expect(r.entities).toBe(2);
+    expect(r.references).toBe(1); // the decision references the policy by name
+
+    const ents = entityRows(home);
+    expect(ents.length).toBe(2);
+    const policyEnt = ents.find((e) => e.source_object_type === 'policy')!;
+    const decisionEnt = ents.find((e) => e.source_object_type === 'decision')!;
+    expect(policyEnt.source_object_id).toBe(policy.id);
+    expect(decisionEnt.source_object_id).toBe(decision.id);
+    // both mirrors are live, so memory_id is set on the freshly-extracted rows.
+    expect(policyEnt.memory_id).not.toBeNull();
+    expect(decisionEnt.memory_id).not.toBeNull();
+
+    const rels = relationRows(home);
+    expect(rels.length).toBe(1);
+    expect(rels[0].rel_type).toBe('references');
+    expect(rels[0].from_entity_id).toBe(decisionEnt.id); // decision -> policy
+    expect(rels[0].to_entity_id).toBe(policyEnt.id);
+    expect(rels[0].source_object_type).toBe('decision');
+    expect(rels[0].source_object_id).toBe(decision.id);
+  });
+
+  it('SUCCESS CRITERION: forget the decision mirror -> the active decision STAYS in the entities table (memory_id NULL, source_object set); its references arc preserved', () => {
+    const policy = savePolicy(home, T, {
+      policyName: 'Data Retention Policy',
+      policyText: 'Delete logs after 90 days',
+    });
+    const decision = saveDecision(home, T, {
+      decisionText: 'Adopt the Data Retention Policy for all log pipelines',
+    });
+
+    // Forget ONLY the decision's mirror memory. decisions.memory_id -> NULL (ON DELETE SET
+    // NULL); the decision row stays active and authoritative.
+    deleteEntry(home, decision.memoryId!);
+
+    const r = extractGraph(home, T);
+    expect(r.entities).toBe(2); // BOTH still extracted (the forgotten-mirror decision survives)
+    expect(r.references).toBe(1); // the references arc is preserved (provenance is the object)
+
+    const ents = entityRows(home);
+    const decisionEnt = ents.find((e) => e.source_object_type === 'decision')!;
+    expect(decisionEnt).toBeDefined();
+    expect(decisionEnt.memory_id).toBeNull();           // mirror gone
+    expect(decisionEnt.source_object_id).toBe(decision.id); // anchored to the object
+
+    const policyEnt = ents.find((e) => e.source_object_type === 'policy')!;
+    expect(policyEnt.memory_id).not.toBeNull();          // policy mirror still live
+
+    const rels = relationRows(home);
+    expect(rels.length).toBe(1);
+    expect(rels[0].rel_type).toBe('references');
+    expect(rels[0].from_entity_id).toBe(decisionEnt.id);
+    expect(rels[0].memory_id).toBeNull();               // edge mirror gone, anchored to object
+    expect(rels[0].source_object_type).toBe('decision');
+    expect(rels[0].source_object_id).toBe(decision.id);
+
+    // It is verifiable in loadEntities too (the API maps the object columns).
+    const apiEnt = loadEntities(home, T, { limit: 100 }).find((e) => e.sourceObjectType === 'decision')!;
+    expect(apiEnt.memoryId).toBeNull();
+    expect(apiEnt.sourceObjectId).toBe(decision.id);
+  });
+
+  it('a closed E2 object is excluded from the graph (status, not mirror presence, drives exclusion)', () => {
+    const keep = saveDecision(home, T, { decisionText: 'Keep this active decision' });
+    const gone = saveDecision(home, T, { decisionText: 'Retire this one' });
+    closeDecision(home, T, gone.id);
+
+    extractGraph(home, T);
+    const ents = entityRows(home);
+    expect(ents.length).toBe(1);
+    expect(ents[0].source_object_id).toBe(keep.id);
+    expect(ents.some((e) => e.source_object_id === gone.id)).toBe(false);
+  });
+
+  it('the no-raw invariant holds: inserting an entity that references a raw memory still ABORTs', () => {
+    const raw = addMemory(home, 'raw');
+    expect(() => insertEntity(home, T, { entityType: 'system', name: 'x', memoryId: raw }))
+      .toThrow(/raw|consolidated/i);
+    // and via a direct raw SQL INSERT claiming distilled -> the trigger ABORTs.
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(
+        `INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, created_at)
+         VALUES (?, 'system', 'x', ?, 'distilled', ?)`,
+      ).run(T, raw, new Date().toISOString())).toThrow(/source_kind must equal|raw|consolidated/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('the all-null guard: inserting an entity with neither memory nor source_object ABORTs', () => {
+    // helper-level rejection.
+    expect(() => insertEntity(home, T, { entityType: 'system', name: 'x' }))
+      .toThrow(/needs a memory or a source object/i);
+    // direct raw SQL with both null -> the BEFORE INSERT trigger ABORTs.
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(
+        `INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at)
+         VALUES (?, 'system', 'x', NULL, 'distilled', NULL, NULL, ?)`,
+      ).run(T, new Date().toISOString())).toThrow(/needs a memory or a (complete )?source object/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('P2-B guard (codex): memory NULL + source_object_id set + source_object_type NULL ABORTs (incomplete object provenance)', () => {
+    // The first guard WHEN requires BOTH source_object columns when memory is null, so an
+    // id-set/type-null row cannot slip past (previously the type-keyed CASE arms were all
+    // false on a NULL type, accepting a provenance-less row).
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(
+        `INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at)
+         VALUES (?, 'decision', 'x', NULL, 'distilled', NULL, 7, ?)`,
+      ).run(T, new Date().toISOString())).toThrow(/set together|all-or-none/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('object-path guard: inserting an entity pointing at a non-existent / wrong-tenant E2 row ABORTs', () => {
+    // memory-null + a source_object that does not exist -> ABORT (helper + trigger).
+    expect(() => insertEntity(home, T, { entityType: 'decision', name: 'ghost', sourceObject: { type: 'decision', id: 99999 } }))
+      .toThrow(/not found|active\/superseded|active|superseded/i);
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(
+        `INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at)
+         VALUES (?, 'decision', 'ghost', NULL, 'distilled', 'decision', 99999, ?)`,
+      ).run(T, new Date().toISOString())).toThrow(/source_object must reference|active|superseded/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('mirror forget on a memory-only entity succeeds and leaves an all-null row (UPDATE trigger tolerates the FK SET NULL)', () => {
+    // Insert a memory-only entity (no source_object), then forget the memory. The FK
+    // ON DELETE SET NULL nulls memory_id. NOTE (deviation from plan premise, verified):
+    // node:sqlite DOES fire the BEFORE UPDATE trigger from the FK action even with
+    // recursive_triggers OFF, so the all-null ABORT was removed from the UPDATE triggers
+    // (kept on INSERT). The delete therefore succeeds and the row survives all-null.
+    const md = addMemory(home, 'distilled');
+    const e = insertEntity(home, T, { entityType: 'system', name: 'mem-only', memoryId: md });
+    expect(() => deleteEntry(home, md)).not.toThrow();
+    const ents = entityRows(home);
+    const row = ents.find((r) => r.id === e.id)!;
+    expect(row).toBeDefined();
+    expect(row.memory_id).toBeNull();
+    expect(row.source_object_id).toBeNull(); // all-null, intentionally tolerated post-forget
+  });
+
+  it('supersedes + references edges survive a mirror forget on an endpoint', () => {
+    // A policy referenced by a decision, and a decision superseded by a successor. Forget
+    // the successor's mirror (a supersedes-edge endpoint) AND the referencing decision's
+    // mirror; both edges must still be present (anchored to their source objects).
+    const policy = savePolicy(home, T, {
+      policyName: 'Data Retention Policy',
+      policyText: 'Delete logs after 90 days',
+    });
+    const v1 = savePolicy(home, T, {
+      policyName: 'Access Control Policy',
+      policyText: 'least privilege v1',
+    });
+    const v2 = savePolicy(home, T, {
+      policyName: 'Access Control Policy',
+      policyText: 'least privilege v2',
+      supersedesPolicyId: v1.id,
+    });
+    const decision = saveDecision(home, T, {
+      decisionText: 'Adopt the Data Retention Policy across all services',
+    });
+
+    // Forget the successor (v2) mirror AND the decision mirror.
+    deleteEntry(home, v2.memoryId!);
+    deleteEntry(home, decision.memoryId!);
+
+    extractGraph(home, T);
+    const rels = relationRows(home);
+    const sup = rels.find((r) => r.rel_type === 'supersedes')!;
+    const ref = rels.find((r) => r.rel_type === 'references')!;
+
+    // supersedes edge: present, anchored to the successor (policy v2) object, mirror gone.
+    expect(sup).toBeDefined();
+    expect(sup.memory_id).toBeNull();
+    expect(sup.source_object_type).toBe('policy');
+    expect(sup.source_object_id).toBe(v2.id);
+
+    // references edge: present, anchored to the decision object, mirror gone.
+    expect(ref).toBeDefined();
+    expect(ref.memory_id).toBeNull();
+    expect(ref.source_object_type).toBe('decision');
+    expect(ref.source_object_id).toBe(decision.id);
+
+    // The referenced policy entity is still there with a live mirror.
+    const policyEnt = entityRows(home).find((e) => e.source_object_id === policy.id && e.source_object_type === 'policy')!;
+    expect(policyEnt).toBeDefined();
+  });
+
+  it('P2 (codex round 2): a VALID memory + a BAD source_object is REJECTED (object validated even when memory present)', () => {
+    // The dual-provenance object pointer is validated whenever provided, not only when
+    // memory is null - so a wrong/closed/nonexistent object cannot ride along with a live
+    // memory and become a forget-blocking landmine after ON DELETE SET NULL.
+    const md = addMemory(home, 'distilled');
+    expect(() => insertEntity(home, T, {
+      entityType: 'decision', name: 'x', memoryId: md, sourceObject: { type: 'decision', id: 99999 },
+    })).toThrow(/not found|active|superseded/i);
+
+    // raw SQL: live distilled memory + bad object -> the INSERT trigger validates the object too.
+    const md2 = addMemory(home, 'distilled');
+    const db = openHippoDb(home);
+    try {
+      expect(() => db.prepare(
+        `INSERT INTO entities(tenant_id, entity_type, name, memory_id, source_kind, source_object_type, source_object_id, created_at)
+         VALUES (?, 'decision', 'x', ?, 'distilled', 'decision', 99999, ?)`,
+      ).run(T, md2, new Date().toISOString())).toThrow(/source_object must reference|active|superseded/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('P2 round-4 (codex): a stale-missing mirror is tolerated when a valid object is present (rebuild not rolled back)', () => {
+    // The extraction race: a memory id that no longer exists (forgotten mid-rebuild) but a valid
+    // source object. insertEntity must anchor to the object (memory_id null), NOT throw - else a
+    // mirror forgotten during a rebuild would roll back the WHOLE tenant rebuild.
+    const policy = savePolicy(home, T, { policyName: 'Retention', policyText: 'p' });
+    const ent = insertEntity(home, T, {
+      entityType: 'policy', name: 'Retention', memoryId: 'sem_doesnotexist', sourceObject: { type: 'policy', id: policy.id },
+    });
+    expect(ent.memoryId).toBeNull();            // dead mirror pointer dropped
+    expect(ent.sourceObjectId).toBe(policy.id); // anchored to the object
+    // a stale-missing mirror with NO object still throws (no provenance to fall back on).
+    expect(() => insertEntity(home, T, { entityType: 'system', name: 'x', memoryId: 'sem_doesnotexist' }))
+      .toThrow(/not found/i);
+  });
+
+  it('P2 round-4 (codex): an explicit UPDATE re-pointing a row to a bad object ABORTs (object cols changed); memory-only SET NULL still does not', () => {
+    const policy = savePolicy(home, T, { policyName: 'Retention', policyText: 'p' });
+    extractGraph(home, T);
+    const polEnt = entityRows(home).find((e) => e.source_object_type === 'policy')!;
+    const db = openHippoDb(home);
+    try {
+      // explicit re-point to a nonexistent object -> object cols changed -> object path validated -> ABORT.
+      expect(() => db.prepare(`UPDATE entities SET source_object_id = 99999 WHERE id = ?`).run(polEnt.id))
+        .toThrow(/source_object must reference|active|superseded/i);
+      // half-set via UPDATE -> all-or-none ABORT.
+      expect(() => db.prepare(`UPDATE entities SET source_object_type = NULL WHERE id = ?`).run(polEnt.id))
+        .toThrow(/set together|all-or-none/i);
+    } finally { closeHippoDb(db); }
+    // (the memory-only SET NULL not-blocked case is covered by the memory-only forget test above.)
+  });
+
+  it('P2 round-5 (codex): a tenant-only move of an object-backed (mirrorless) row revalidates the object and ABORTs', () => {
+    const policy = savePolicy(home, T, { policyName: 'Retention', policyText: 'p' });
+    // object-only (mirrorless) entity in tenant T - the memory-path tenant check does not apply.
+    const ent = insertEntity(home, T, { entityType: 'policy', name: 'Retention', sourceObject: { type: 'policy', id: policy.id } });
+    expect(ent.memoryId).toBeNull();
+    const db = openHippoDb(home);
+    try {
+      // moving it to another tenant: the object-validation gate now includes tenant change, so the
+      // object is re-checked against the NEW tenant (policy is in T, not 'other-tenant') -> ABORT.
+      expect(() => db.prepare(`UPDATE entities SET tenant_id = 'other-tenant' WHERE id = ?`).run(ent.id))
+        .toThrow(/source_object must reference|active|superseded/i);
+    } finally { closeHippoDb(db); }
+  });
+
+  it('P2-A close lifecycle (codex): closing a MIRRORLESS object removes its graph rows directly (no rebuild)', () => {
+    const policy = savePolicy(home, T, { policyName: 'Data Retention Policy', policyText: 'Delete logs after 90 days' });
+    const decision = saveDecision(home, T, { decisionText: 'Adopt the Data Retention Policy widely' });
+    // Forget the decision mirror, then extract -> the decision is in the graph, mirrorless.
+    deleteEntry(home, decision.memoryId!);
+    extractGraph(home, T);
+    expect(entityRows(home).some((e) => e.source_object_type === 'decision' && e.source_object_id === decision.id)).toBe(true);
+    expect(relationRows(home).length).toBe(1); // decision -> policy references arc
+
+    // Close the mirrorless decision. close* cannot enqueue a rebuild (no mirror to key the
+    // queue), so it must drop the decision's graph rows DIRECTLY. NO extractGraph after close.
+    closeDecision(home, T, decision.id);
+
+    expect(entityRows(home).some((e) => e.source_object_type === 'decision' && e.source_object_id === decision.id)).toBe(false); // gone
+    expect(relationRows(home).some((r) => r.source_object_type === 'decision' && r.source_object_id === decision.id)).toBe(false); // edge gone
+    // the policy entity (untouched, live mirror) remains.
+    expect(entityRows(home).some((e) => e.source_object_type === 'policy' && e.source_object_id === policy.id)).toBe(true);
+  });
+
+  it('P1 (codex round 3): forgetting the mirror of a CLOSED-but-not-yet-rebuilt object does NOT block the delete (core sleep/forget safe)', () => {
+    // A mirror-present close enqueues a rebuild but leaves the graph row pointing at the
+    // now-closed object until that rebuild runs. If the mirror is then forgotten or pruned
+    // (sleep deletes memories BEFORE the graph drain), the FK ON DELETE SET NULL fires the
+    // BEFORE UPDATE trigger - which must NOT abort the delete on the object's (closed) status.
+    const decision = saveDecision(home, T, { decisionText: 'Adopt the retention rule for logs' });
+    extractGraph(home, T);
+    expect(entityRows(home).length).toBe(1); // entity created with a live mirror + object (active)
+
+    // Close removes the object's graph rows DIRECTLY (deterministic), so it never lingers.
+    closeDecision(home, T, decision.id);
+    expect(entityRows(home).length).toBe(0); // gone immediately, not lingering until a rebuild
+
+    // Forgetting the now-orphaned mirror afterwards must not throw - and with the object-status
+    // checks removed from the UPDATE trigger, even a lingering row (if removal had failed soft)
+    // would not block the SET NULL. Core sleep/forget stays safe.
+    expect(() => deleteEntry(home, decision.memoryId!)).not.toThrow();
+  });
+});

--- a/tests/graph-extract.test.ts
+++ b/tests/graph-extract.test.ts
@@ -79,15 +79,23 @@ describe('graph extraction (E3.1 deterministic, from consolidated E2 objects)', 
     expect(loadRelations(home, 'default', { limit: 100 }).length).toBe(1);
   });
 
-  it('skips an E2 object whose source memory was forgotten (NULL memory_id)', () => {
+  it('KEEPS an active E2 object whose source memory was forgotten (v38 E2-provenance): memory_id NULL, source_object set', () => {
+    // v38: extraction anchors provenance to the authoritative E2 object, so an in-force
+    // decision STAYS in the graph after its mirror is forgotten (memory_id -> NULL), now
+    // anchored via source_object_type/id.
     const dn = saveDecision(home, 'default', { decisionText: 'Will lose its memory' });
     deleteEntry(home, dn.memoryId!); // distilled delete is allowed; decisions.memory_id -> NULL
     saveDecision(home, 'default', { decisionText: 'Keeps its memory' });
     const r = extractGraph(home, 'default');
-    expect(r.byType.decision).toBe(1); // only the one with a live memory
-    const names = loadEntities(home, 'default', { limit: 100 }).map((e) => e.name);
+    expect(r.byType.decision).toBe(2); // BOTH extracted (the forgotten-mirror one survives)
+    const ents = loadEntities(home, 'default', { limit: 100 });
+    const names = ents.map((e) => e.name);
     expect(names).toContain('Keeps its memory');
-    expect(names).not.toContain('Will lose its memory');
+    expect(names).toContain('Will lose its memory');
+    const lost = ents.find((e) => e.name === 'Will lose its memory')!;
+    expect(lost.memoryId).toBeNull();
+    expect(lost.sourceObjectType).toBe('decision');
+    expect(lost.sourceObjectId).toBe(dn.id);
   });
 
   it('skips a supersedes relation when the successor is not extracted (closed)', () => {

--- a/tests/graph-schema.test.ts
+++ b/tests/graph-schema.test.ts
@@ -24,8 +24,8 @@ describe('graph schema v37 (E3.3)', () => {
   beforeEach(() => { home = makeRoot(); });
   afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
 
-  it('CURRENT_SCHEMA_VERSION is 37', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+  it('CURRENT_SCHEMA_VERSION is 38', () => {
+    expect(getCurrentSchemaVersion()).toBe(38);
   });
 
   it('creates entities + relations + graph_extraction_queue tables', () => {

--- a/tests/graph-store.test.ts
+++ b/tests/graph-store.test.ts
@@ -193,7 +193,14 @@ describe('graph store (E3.3 graph-on-consolidated guard)', () => {
     expect(loadExtractionQueue(home, 'default', { status: 'processed' }).length).toBe(1);
   });
 
-  it('ON DELETE CASCADE: forgetting a consolidated memory removes its entities + relations + queue rows', () => {
+  it('ON DELETE SET NULL (v38): forgetting a memory nulls graph rows memory_id but keeps them; queue still cascades', () => {
+    // v38 (E2-provenance): entities/relations.memory_id is now NULLABLE with ON DELETE
+    // SET NULL (was NOT NULL / CASCADE), so a mirror forget no longer drops a graph row -
+    // it nulls the recall pointer and the row survives. graph_extraction_queue is untouched
+    // by v38 (still ON DELETE CASCADE), so its rows still disappear on a memory delete.
+    // (These rows are memory-only - no source_object - so the SET NULL leaves an all-null
+    // provenance row; that is tolerated because the SET NULL does NOT fire the BEFORE
+    // UPDATE guard: recursive_triggers is default-OFF.)
     const md = addMemory(home, 'default', 'distilled');
     const a = insertEntity(home, 'default', { entityType: 'system', name: 'a', memoryId: md });
     const b = insertEntity(home, 'default', { entityType: 'system', name: 'b', memoryId: md });
@@ -202,9 +209,13 @@ describe('graph store (E3.3 graph-on-consolidated guard)', () => {
     expect(countRows(home, 'entities')).toBe(2);
     expect(countRows(home, 'relations')).toBe(1);
     expect(countRows(home, 'graph_extraction_queue')).toBe(1);
-    deleteEntry(home, md); // distilled deletes are allowed (raw is append-only); cascades to graph rows
-    expect(countRows(home, 'entities')).toBe(0);
-    expect(countRows(home, 'relations')).toBe(0);
+    deleteEntry(home, md); // distilled deletes are allowed (raw is append-only)
+    // entities + relations SURVIVE, their memory_id nulled (SET NULL).
+    expect(countRows(home, 'entities')).toBe(2);
+    expect(countRows(home, 'relations')).toBe(1);
+    expect(loadEntityById(home, 'default', a.id)!.memoryId).toBeNull();
+    expect(loadEntityById(home, 'default', b.id)!.memoryId).toBeNull();
+    // the queue row still cascades away (graph_extraction_queue is untouched by v38).
     expect(countRows(home, 'graph_extraction_queue')).toBe(0);
   });
 

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
-      expect(getCurrentSchemaVersion()).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
+      expect(getCurrentSchemaVersion()).toBe(38);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+    expect(getCurrentSchemaVersion()).toBe(38);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(37);
+      expect(getSchemaVersion(db2)).toBe(38);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(37);
+      expect(getSchemaVersion(db2)).toBe(38);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(37);
+    expect(getCurrentSchemaVersion()).toBe(38);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(37);
+      expect(getSchemaVersion(db)).toBe(38);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
## What
Migration **v38**: anchor knowledge-graph entity/relation provenance to the authoritative E2 object (decision/policy/customer-note/project-brief) instead of the decaying memory mirror. An in-force E2 object now **stays in the graph after its mirror memory is forgotten or consolidation-pruned** (the reported bug).

## How
- `entities`/`relations`: `memory_id` nullable (`ON DELETE SET NULL`) + new `source_object_type`/`source_object_id`; graph is a pure derived cache so v38 DROP+recreates them.
- Dual-path guard (SQL triggers + TS `resolveConsolidatedSource`): memory path rejects raw/cross-tenant; object path requires an `active|superseded` same-tenant E2 row; `source_object` all-or-none; validated at INSERT and on explicit object/tenant UPDATE, **never on the FK SET NULL transition** (so a mirror forget never blocks).
- `resolveConsolidatedSource` tolerates a stale-missing mirror when a valid object is present (rebuild not rolled back).
- Closing an object removes its graph rows directly.
- `CURRENT_SCHEMA_VERSION` 37 -> 38 (+ 21 assertion sites across 10 test files).

## Review
6 codex (gpt-5.5 high) rounds + plan-eng/code-review/independent-review critics. Rounds 1-5 fixed real guard bugs the Claude critics missed, including a **P1 that would have broken core `sleep`/`forget`**.

## Deferred (coordinate with e3-sleep-enqueue)
A tenant-level graph-rebuild signal (v38 cache-drop on upgrade; mirrorless-close global re-derivation). Both self-heal on the next memory write; the memory-keyed queue cannot express a tenant-level rebuild. See the plan doc.

## Tests (real DB)
251 graph+E2 tests green; tsc + build clean. New `tests/graph-e2-provenance.test.ts` asserts the success criterion by querying the entities/relations tables directly (forget-then-keep, closed-excluded, raw-rejected, all-or-none, race-tolerance, explicit-update + tenant-move validation, mirrorless-close removal, P1 forget-after-close).

## Overlap note
Open branches `feat/e3.1-cross-object-references`, `feat/e3.2-multihop-recall`, `feat/e3-sleep-enqueue` touch the same files (graph-extract/graph-recall/db.ts) -> sequence the merge.

Plan: `docs/plans/2026-06-03-graph-e2-provenance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)