### PR TITLE
docs: surface live site link in README + repo About

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/hippo-memory)](https://npmjs.com/package/hippo-memory)
 [![license](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
+[![website](https://img.shields.io/badge/website-hippo--memory.pages.dev-7c3aed)](https://hippo-memory.pages.dev)
 
 <p align="center">
   <img src="./assets/hippo-init.svg" alt="hippo init --scan ~ — initializing memory across all repos" width="720">


### PR DESCRIPTION
Adds a website badge (hippo-memory.pages.dev) to the README badge row so the live site is visible on the repo landing page. The repo About website field was also set to the same URL via gh repo edit. Docs-only, one line.