### PR TITLE
feat: pluggable embedding providers (local default + opt-in API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 1.23.0 (2026-06-08): pluggable embedding providers (bring a frontier embedder)
+
+### Added
+- **Pluggable embedding providers.** `config.embeddings.provider` now accepts `local` (default, zero-dependency `@xenova/transformers`) or an opt-in API provider: `openai`, `voyage`, or `cohere`. Bring a frontier embedder such as OpenAI `text-embedding-3-large` for frontier-class retrieval, while the default stays fully local with no API keys and no new runtime dependencies (API providers use the native `fetch` on Node 22.5+). The key is read from `OPENAI_API_KEY` / `VOYAGE_API_KEY` / `COHERE_API_KEY`. Optional `embeddings.apiBaseUrl` (https only; localhost may use http) and `embeddings.batchSize` (positive integer, default 64). API requests are bounded by a 30s timeout.
+
+### Changed
+- **Provider-aware reindex identity.** The local provider keeps the bare model string as its identity, so existing stores are NOT re-indexed on upgrade. Switching to or from an API embedder (or changing the model or vector dimension) triggers the existing reindex path.
+- **`embeddings.enabled: false` now hard-disables embedding** for both local and API providers, which prevents unwanted paid API calls.
+- **Status surface.** `hippo status` and `hippo embed --status` now show the active provider, model, whether the API key is present, the vector dimension, and a reindex-pending hint, and still report cached counts when embeddings are disabled or a key was removed.
+
+### Notes
+- Embedding stays best-effort on the add path: a provider failure never rejects a write. The explicit `hippo embed` backfill checkpoints progress per chunk and surfaces hard failures, so it never reports a false success. A malformed API response (wrong vector count or an empty vector) is treated as a hard failure so a reindex aborts atomically.
+- A real frontier-embedder LongMemEval benchmark (dual numbers: the zero-dependency local floor plus the frontier number) is a follow-up that must run on a host with API egress and a key. See `docs/FRONTIER_EMBEDDER_BENCHMARK.md`.
+
 ## 1.22.0 (2026-06-03): graph provenance anchored to the authoritative E2 object
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ One command. Every git repo on your machine gets memory.
 Works with:    Claude Code, Codex, Cursor, OpenClaw, OpenCode, Pi, any MCP client
 Imports from:  ChatGPT, Claude (CLAUDE.md), Cursor (.cursorrules), Slack, markdown
 Storage:       SQLite backbone with markdown mirrors. Git-trackable, human-readable.
-Dependencies:  Zero runtime deps. Node.js 22.5+. Optional embeddings via @xenova/transformers.
+Dependencies:  Zero runtime deps. Node.js 22.5+. Optional embeddings: local @xenova/transformers (default) or an opt-in API embedder (OpenAI/Voyage/Cohere).
 ```
 
 ---

--- a/docs/FRONTIER_EMBEDDER_BENCHMARK.md
+++ b/docs/FRONTIER_EMBEDDER_BENCHMARK.md
@@ -1,0 +1,72 @@
+# Frontier-embedder LongMemEval benchmark (Workstream C handoff)
+
+**Status:** TODO. Must run on a host with API egress and a key. The build sandbox
+blocks `api.openai.com` (and the HF Hub), so this cannot run in CI / in-sandbox.
+
+## Why
+
+Every local F-track measurement (F9 hybrid RRF, F14/F15/F16 embedder swaps)
+reached the same conclusion: on the comparable `longmemeval_s` split, the
+**local embedder is the structural ceiling**, not the fusion or chunking signal
+mix. gbrain v0.28.8's 97.6 R@5 uses OpenAI `text-embedding-3-large`. v1.23.0
+makes the embedder pluggable (see `src/embedding-provider.ts`), so we can finally
+measure hippo's retrieval with a frontier embedder and publish the number
+honestly, next to the zero-dependency local floor.
+
+## What to measure (dual numbers, honestly labelled)
+
+Report BOTH, never just the frontier number:
+
+| Configuration | What it represents |
+|---|---|
+| **Zero-dep local floor** | the shipped default: BM25 + local `@xenova/transformers` (MiniLM). Published today as R@5 = 74.0 (BM25 lineage) / 76.2 (canonical hybrid harness). |
+| **Frontier** | `provider: openai`, `model: text-embedding-3-large`, same harness/split. |
+
+Carry the same split-mismatch disclosure the F-track docs carry: oracle (3
+sessions/haystack) is cross-comparison only; the binding gbrain-comparable number
+is on `longmemeval_s` (~40 sessions/haystack) acquired from the documented mirror
+with no signed chain-of-custody to the canonical HF release.
+
+## Procedure
+
+Prereqs: a host with outbound HTTPS to `api.openai.com`, `OPENAI_API_KEY`
+exported, and the local LongMemEval harness (maintained under the gitignored
+`benchmarks/longmemeval/` working tree, not shipped in the package).
+
+1. **Wire the provider into the harness embed step.** The LongMemEval harness
+   embeds turns with its own script (e.g. `chunk_per_turn_embed.mjs`), which calls
+   an embedder directly rather than through hippo's CLI. Point that embed step at
+   the new provider: either import `resolveEmbeddingProvider(hippoRoot)` and call
+   `provider.embed(texts, 'passage')`, or replicate the OpenAI call (POST
+   `/v1/embeddings`, `text-embedding-3-large`, L2-normalize). Use the same
+   provider for the query side with role `'query'`.
+2. **Build the index** for the chosen split (oracle for cross-comparison, `_s`
+   for the binding gate). text-embedding-3-large is 3072-dim, so expect a larger
+   index than the 768-dim BGE runs.
+3. **Run the canonical retrieval eval.** Use the in-process hybrid harness with
+   `budget 1000000` and `min-results 10`. **Never** use `retrieve.py --budget
+   4000` (documented trap: caps recall at ~14.8%; see
+   `benchmarks/longmemeval/LONGMEMEVAL_RESOLVED.md`).
+4. **Score** with `evaluate_retrieval.py` (R@1/3/5/10 + answer_in_content@5).
+5. **Re-run the zero-dep local floor** through the identical harness/split so the
+   two numbers are apples-to-apples.
+
+## Reporting template
+
+```
+LongMemEval <split> (<N> questions, <M> sessions/haystack)
+  Zero-dep local default (BM25 + MiniLM):   R@5 = XX.X
+  Frontier (text-embedding-3-large):        R@5 = YY.Y   (+Z.Z)
+  gbrain v0.28.8 reference:                 R@5 = 97.6   (text-embedding-3-large, _s)
+Split / embedder comparability caveats: <disclosure>
+```
+
+Publish the pair on the site/README only after an outside-voice review of the
+result doc, per the established eval-publishing discipline. The honest framing is
+"zero-dep floor + opt-in frontier ceiling", not a single headline number.
+
+## Cost note
+
+text-embedding-3-large is billed per token. Embedding the full `_s` corpus
+(~200k turns) is a non-trivial spend; estimate before running and use the
+provider `batchSize` to control request volume.

--- a/docs/plans/2026-06-08-b-pluggable-embedding-provider.md
+++ b/docs/plans/2026-06-08-b-pluggable-embedding-provider.md
@@ -1,0 +1,183 @@
+# B — Pluggable EmbeddingProvider (opt-in API embedders; local stays the zero-dep default)
+
+**Episode:** `01KTM0X9GF97MSE8RQY054X210` (dev-framework-rl)
+**Branch:** `feat/embedding-provider` off `origin/master` 4f8c7cc
+**Date:** 2026-06-08
+
+## Why
+
+Every F-track (F9/F14/F16) reached the same conclusion: on the comparable LongMemEval
+`_s` split the **local embedder is the structural ceiling**, not the fusion/chunking
+signal mix. gbrain's 97.6 uses OpenAI `text-embedding-3-large`. The only lever that
+moves the score people compare is the embedder itself. B makes the embedder pluggable
+so a user can bring a frontier API embedder, while the default stays local + zero-dep.
+
+## Goal
+
+Let a user opt in to an API embedder (OpenAI / Voyage / Cohere) via config + an env key,
+getting frontier-class retrieval, while the out-of-box default remains the local
+`@xenova/transformers` path with zero API keys and zero new runtime dependencies.
+
+## Non-goals
+
+- No plugin marketplace / user-registerable provider DI. (Simplicity First.)
+- No change to default behavior. `provider` defaults to `local`; existing stores must
+  never be force-reindexed on upgrade.
+- No rerank, no chunk-per-turn ingestion (those are Workstream A — separate).
+- No real-API integration test in this episode — `api.openai.com` is egress-blocked
+  in-sandbox. That test is Workstream C, on a box with egress + key.
+
+## Design
+
+### 1. Provider interface — `src/embedding-provider.ts` (new)
+
+```ts
+export interface EmbeddingProvider {
+  /** Identity token recorded in DB meta to drive reindex-on-change.
+   *  local  -> bare model string (BACK-COMPAT, unchanged): 'Xenova/all-MiniLM-L6-v2'
+   *  api    -> '<provider>:<model>': 'openai:text-embedding-3-large'           */
+  readonly id: string;
+  /** Fixed output dimension if known (api models), else undefined (local). */
+  readonly dimensions?: number;
+  /** Batch embed. Returns one row per input; a row is [] on per-item failure.
+   *  Batch-first because API cost/latency demands it; local maps over the
+   *  existing single-text path. */
+  embed(texts: string[], role?: EmbeddingRole): Promise<number[][]>;
+}
+```
+
+### 2. Resolution — `resolveEmbeddingProvider(hippoRoot, config)`
+
+- `local` (default) → wraps the existing `loadPipeline` / per-model `poolingFor` /
+  `prefixFor` / `preferredBackend` logic **byte-identically**. No behavior change.
+- `openai` / `voyage` / `cohere` → native `fetch` (Node >= 22.5, **no new dep**),
+  key from a conventional env var (`OPENAI_API_KEY` / `VOYAGE_API_KEY` /
+  `COHERE_API_KEY`), provider endpoint, batched request, L2-normalize the returned
+  vectors to match the local contract (`getEmbedding` returns normalized vectors).
+- Provider value validated against an allow-list. Provider != local with a missing
+  key → throw a clear, **key-redacted** error at resolve time (fail fast at the
+  boundary; never write a partial index).
+
+### 3. Config — `src/config.ts`
+
+Extend `embeddings`:
+
+```ts
+embeddings: {
+  enabled: boolean | 'auto';
+  model: string;
+  hybridWeight: number;
+  provider?: 'local' | 'openai' | 'voyage' | 'cohere'; // default 'local'
+  apiBaseUrl?: string;   // optional endpoint override (self-host / proxy)
+  batchSize?: number;    // default 64 for api providers
+}
+```
+
+Merge with defaults the same way every other sub-object is merged in `loadConfig`.
+
+### 4. Identity & reindex (the back-compat crux — each gets a test)
+
+- Local identity stays the **bare model string** → existing stores with meta
+  `embedding_model = 'Xenova/all-MiniLM-L6-v2'` see **no identity change, no forced
+  reindex** on upgrade.
+- API identity = `'<provider>:<model>'`.
+- `embeddingModelRequiresReindex` compares stored identity vs resolved provider `id`.
+  Switching to/from an API embedder (or a dim change 384/768/3072) triggers the
+  **existing** full `rebuildEmbeddingIndex` + `resetPhysicsFromIndex` path. No new
+  migration machinery.
+
+### 5. Wiring — `src/embeddings.ts`
+
+- `getEmbedding(text, model, role)` keeps its signature (back-compat); routes through
+  the resolved provider's `embed([text], role)[0]`.
+- `embedAll` / `rebuildEmbeddingIndex` call the provider's **batch** `embed(texts)` in
+  chunks of `batchSize` → large speed/cost win for API providers; local is effectively
+  one-at-a-time as today.
+- `isEmbeddingAvailable()` unchanged for local (dependency check). For API providers,
+  "available" = key present (surfaced, not thrown, where the codebase currently treats
+  embeddings as best-effort on the add path).
+
+### 6. CLI — `src/cli.ts`
+
+`hippo embed` / status surfaces the active provider, model, and **key-present yes/no**
+(never the key value). No other CLI change — provider is resolved inside the embedding
+layer.
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/embedding-provider.ts` | NEW — interface + `resolveEmbeddingProvider` + local & api impls (split api into `src/embedding-providers/{openai,voyage,cohere}.ts` if the file grows past ~300 lines). |
+| `src/embeddings.ts` | EDIT — route get/embedAll/embedMemory/rebuild through provider; identity helper. |
+| `src/config.ts` | EDIT — add `provider`/`apiBaseUrl`/`batchSize` + merge. |
+| `src/cli.ts` | EDIT — surface provider + key-present in embed/status output. |
+| `tests/embedding-provider.test.ts` | NEW — provider units (mocked `fetch`), identity/back-compat, missing-key error, batch chunking. |
+| `README.md` / `CHANGELOG.md` | EDIT at ship (publish-repo workflow). |
+
+## Backwards-compat guarantees (each is a test)
+
+1. `provider` unset / `local` → behavior byte-identical; `embeddings.json` + meta
+   untouched; no reindex on upgrade.
+2. Switching `provider` -> `openai` triggers exactly one full reindex (identity change),
+   then stable across runs.
+3. `provider` set, key missing → clear redacted error, **no** partial index writes.
+
+## Security
+
+- Keys read from env only; never written to config, DB, logs, or error text (redact in
+  all error paths).
+- HTTPS endpoints only; `provider` validated against the allow-list before any fetch.
+
+## Verification (goal-driven; loop until green)
+
+- `npm run build` clean (tsc + benchmarks tsconfig).
+- `npx vitest run` all green incl. new provider tests (mocked fetch — no network).
+- Existing embeddings / search / config tests unchanged and passing (proves the local
+  default path is untouched).
+- Manual integration (DEFERRED to Workstream C, documented in README): set
+  `OPENAI_API_KEY`, run `hippo embed`, confirm 3072-dim vectors + recall lift.
+
+## Deferred / handoff
+
+- **Workstream C:** matched-split LongMemEval with the API embedder, on a box with
+  egress + key; publish dual numbers (local zero-dep floor + frontier number, honestly
+  labeled). Ship a one-command runner as part of C.
+- **Workstream A:** RRF-as-default + chunk-per-turn ingestion port — separate, later.
+
+## Consolidated review revisions (senior-code-reviewer, applied 2026-06-08)
+
+Plan-stage outside-voice review found 2 blocking seam bugs + 10 more. Corrected design:
+
+**Provider encapsulates its model.** `resolveEmbeddingProvider(hippoRoot, config?)` returns
+a provider that already knows its model + identity + availability. Callers stop passing a
+bare `model` string and use `provider.embed()` / `provider.isAvailable()`.
+
+1. **(C1) Availability is provider-aware at ALL gate sites.** `isEmbeddingAvailable()` (local
+   package check) is replaced at the 8 gate sites (`embeddings.ts` getEmbedding/embedMemory/
+   embedAll, `search.ts` hybridSearch+physicsSearch query-embed, `capture.ts`, `cli.ts`
+   add/embed) with `resolveEmbeddingProvider(hippoRoot).isAvailable()` — local→package check,
+   api→key present. `isEmbeddingAvailable()` is retained as the local provider's check.
+2. **(C2) Reindex compares identity, not bare model.** New `resolveEmbeddingIdentity(hippoRoot,
+   config?)` returns `provider.id` (local→bare model, api→`provider:model`). Every
+   `embeddingModelRequiresReindex` comparison + every `saveStoredEmbeddingModel` uses the
+   identity. Local identity = bare model preserves no-reindex-on-upgrade.
+3. Back-compat test uses a real DB fixture (`embedding_model='Xenova/all-MiniLM-L6-v2'`) →
+   assert `requiresReindex===false` + byte-identical `embeddings.json`.
+4. **Failure semantics per site.** `resolveEmbeddingProvider` never throws. Hot paths
+   (getEmbedding, add, search) swallow to `[]`/BM25 (back-compat — `getEmbedding` never throws).
+   Only the explicit `hippo embed`/`embedAll` path throws a redacted fatal when a set provider's
+   key is missing. `provider.embed()` may throw on HTTP/auth error; callers apply their contract.
+5. Dim-change (384→3072): test local→api asserts full rebuild + physics reset count>0 + no
+   mixed-dim vectors survive.
+6. **Atomic reindex.** On any batch error during `rebuildEmbeddingIndex`, abort WITHOUT saving
+   index/identity (old index + identity preserved). Incremental `embedAll` may save partial
+   (resumable). Test mid-rebuild failure.
+7. Role mapping: API providers map `role`→`input_type` (Voyage/Cohere) / no-op (OpenAI);
+   `prefixFor` (e5) stays local-only.
+8. `enabled:'auto'` for non-local provider = enabled iff key present.
+9. Mocked-fetch tests pin request contract (endpoint, auth header, batch body, input_type) AND
+   assert returned-vector L2 norm ≈ 1.0 (the `normalize:true` contract `cosineSimilarity` needs).
+10. `redactKey(err)` wrapper on every provider `throw`; test a 401 with key in body asserts key
+    absent from the surfaced error.
+11. CLI status surfaces provider:model, dims, key-present, and reindex-pending.
+12. `apiBaseUrl` validated `https:` (or explicit localhost); allow-list governs the provider name.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.22.0",
+  "version": "1.23.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -20,7 +20,8 @@ import {
   updateStats,
 } from './store.js';
 import { getGlobalRoot, initGlobal } from './shared.js';
-import { isEmbeddingAvailable, embedMemory } from './embeddings.js';
+import { embedMemory } from './embeddings.js';
+import { isEmbeddingConfigured } from './embedding-provider.js';
 
 // ---------------------------------------------------------------------------
 // Pattern definitions
@@ -594,7 +595,7 @@ function cmdCaptureCore(
       updateStats(targetRoot, { remembered: 1 });
       existing.push(entry); // within-batch dedup
 
-      if (isEmbeddingAvailable()) {
+      if (isEmbeddingConfigured(targetRoot)) {
         embedMemory(targetRoot, entry).catch(() => {});
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,9 @@ import {
   embedMemory,
   loadEmbeddingIndex,
   resolveEmbeddingModel,
+  embeddingModelRequiresReindex,
 } from './embeddings.js';
+import { isEmbeddingConfigured, resolveEmbeddingProvider } from './embedding-provider.js';
 import { loadPhysicsState, resetAllPhysicsState } from './physics-state.js';
 import { computeSystemEnergy, vecNorm } from './physics.js';
 import { loadConfig } from './config.js';
@@ -796,8 +798,8 @@ async function cmdRemember(
   if (entry.tags.length > 0) console.log(`   Tags: ${entry.tags.join(', ')}`);
   if (entry.pinned) console.log('   Pinned (no decay)');
 
-  // Auto-embed if available
-  if (isEmbeddingAvailable()) {
+  // Auto-embed if available (provider-aware: local dep installed, or API key present)
+  if (isEmbeddingConfigured(targetRoot)) {
     embedMemory(targetRoot, entry).catch(() => {
       // Silently ignore embedding errors
     });
@@ -3082,18 +3084,45 @@ function cmdStatus(hippoRoot: string): void {
     console.log(`Last sleep:        never`);
   }
 
-  // Embedding status
-  const embAvail = isEmbeddingAvailable();
+  // Embedding status (provider-aware)
+  const embedProvider = (() => {
+    try {
+      return resolveEmbeddingProvider(hippoRoot);
+    } catch {
+      return null;
+    }
+  })();
   console.log('');
-  console.log(`Embeddings:        ${embAvail ? 'available' : 'not installed (BM25 only)'}`);
-  if (embAvail) {
+  if (!embedProvider) {
+    console.log(`Embeddings:        misconfigured (check embeddings.provider / apiBaseUrl), BM25 only`);
+  } else {
+    const embeddingsDisabled = loadConfig(hippoRoot).embeddings.enabled === false;
+    const embAvail = embedProvider.isAvailable();
+    if (embeddingsDisabled) {
+      console.log(`Embeddings:        disabled in config (embeddings.enabled = false), BM25 only`);
+    } else if (embedProvider.kind === 'local') {
+      console.log(`Embeddings:        ${embAvail ? `available [${embedProvider.id}]` : 'not installed (BM25 only)'}`);
+    } else if (embAvail) {
+      console.log(`Embeddings:        ${embedProvider.kind} api [${embedProvider.id}]`);
+    } else {
+      console.log(`Embeddings:        ${embedProvider.kind} configured but ${embedProvider.keyEnv} not set (BM25 only)`);
+    }
+    // Show cached counts whenever vectors exist on disk (even when disabled or
+    // the key was removed), so the user still sees what is already indexed.
     const embIndex = loadEmbeddingIndex(hippoRoot);
-    const activeIds = new Set(entries.map((e) => e.id));
-    const activeEmbedded = Object.keys(embIndex).filter((id) => activeIds.has(id)).length;
-    const orphaned = Object.keys(embIndex).length - activeEmbedded;
-    let line = `Embedded:          ${activeEmbedded}/${entries.length} memories`;
-    if (orphaned > 0) line += ` (${orphaned} orphaned — run \`hippo embed\` to prune)`;
-    console.log(line);
+    if (embAvail || Object.keys(embIndex).length > 0) {
+      const activeIds = new Set(entries.map((e) => e.id));
+      const activeEmbedded = Object.keys(embIndex).filter((id) => activeIds.has(id)).length;
+      const orphaned = Object.keys(embIndex).length - activeEmbedded;
+      const dims = Object.values(embIndex)[0]?.length;
+      let line = `Embedded:          ${activeEmbedded}/${entries.length} memories`;
+      if (dims) line += ` (${dims}-dim)`;
+      if (orphaned > 0) line += ` (${orphaned} orphaned, run \`hippo embed\` to prune)`;
+      console.log(line);
+      if (embeddingModelRequiresReindex(hippoRoot, embedProvider.id, embIndex)) {
+        console.log(`                   model changed, run \`hippo embed\` to reindex`);
+      }
+    }
   }
 
   // Physics status
@@ -5523,12 +5552,9 @@ async function cmdEmbed(
 ): Promise<void> {
   requireInit(hippoRoot);
 
-  if (!isEmbeddingAvailable()) {
-    console.log('Embeddings not available. Install @xenova/transformers to enable:');
-    console.log('  npm install @xenova/transformers');
-    return;
-  }
-
+  // --status and --reset-physics only read cached state, so they must work even
+  // when no provider key is present (e.g. embedded earlier with a key that was
+  // later removed). The provider-availability gate is deferred to the embed path.
   if (flags['reset-physics']) {
     const entries = loadAllEntries(hippoRoot);
     const embIndex = loadEmbeddingIndex(hippoRoot);
@@ -5559,8 +5585,50 @@ async function cmdEmbed(
     return;
   }
 
+  // Embedding (unlike status/reset) needs an available provider.
+  const embedProvider = (() => {
+    try {
+      return resolveEmbeddingProvider(hippoRoot);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  })();
+  if (!embedProvider) {
+    process.exitCode = 1;
+    return;
+  }
+  if (!embedProvider.isAvailable()) {
+    if (loadConfig(hippoRoot).embeddings.enabled === false) {
+      console.log('Embeddings are disabled in config (embeddings.enabled = false). Set it to true or "auto" to enable.');
+      return;
+    }
+    if (embedProvider.kind === 'local') {
+      console.log('Embeddings not available. Install @xenova/transformers to enable:');
+      console.log('  npm install @xenova/transformers');
+    } else {
+      console.error(
+        `Embedding provider '${embedProvider.kind}' is configured but ${embedProvider.keyEnv} is not set.`,
+      );
+      console.error(`Export ${embedProvider.keyEnv}, or set config.embeddings.provider back to 'local'.`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   console.log('Embedding all memories (this may take a moment on first run to download model)...');
-  const count = await embedAll(hippoRoot, resolveEmbeddingModel(hippoRoot));
+  let count: number;
+  try {
+    count = await embedAll(hippoRoot, resolveEmbeddingModel(hippoRoot));
+  } catch (err) {
+    console.error(`Embedding failed: ${err instanceof Error ? err.message : String(err)}`);
+    const partial = loadEmbeddingIndex(hippoRoot);
+    console.error(
+      `Partial progress saved: ${Object.keys(partial).length} embeddings on disk. Re-run \`hippo embed\` to resume.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
   const entriesAfter = loadAllEntries(hippoRoot);
   const embIndexAfter = loadEmbeddingIndex(hippoRoot);
   console.log(`Done. ${count} new embeddings created. ${Object.keys(embIndexAfter).length}/${entriesAfter.length} total.`);
@@ -5599,7 +5667,7 @@ async function cmdWatch(command: string, hippoRoot: string): Promise<void> {
   writeEntry(hippoRoot, entry);
   updateStats(hippoRoot, { remembered: 1 });
 
-  if (isEmbeddingAvailable()) {
+  if (isEmbeddingConfigured(hippoRoot)) {
     embedMemory(hippoRoot, entry).catch(() => {});
   }
 
@@ -5682,7 +5750,7 @@ function learnFromRepo(
     writeEntry(hippoRoot, entry);
     updateStats(hippoRoot, { remembered: 1 });
 
-    if (isEmbeddingAvailable()) {
+    if (isEmbeddingConfigured(hippoRoot)) {
       embedMemory(hippoRoot, entry).catch(() => {});
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,9 +20,19 @@ export interface HippoConfig {
     threshold: number;  // trigger sleep after this many new memories
   };
   embeddings: {
-    enabled: boolean | 'auto';  // 'auto' = use if dependency installed
+    enabled: boolean | 'auto';  // 'auto' = use if dependency installed (local) / key present (api)
     model: string;
     hybridWeight: number;
+    /** Embedding backend. 'local' (default) = zero-dependency transformers.js.
+     *  'openai' | 'voyage' | 'cohere' = opt-in API embedder; needs the provider's
+     *  API key in env (OPENAI_API_KEY / VOYAGE_API_KEY / COHERE_API_KEY).
+     *  See src/embedding-provider.ts. */
+    provider?: 'local' | 'openai' | 'voyage' | 'cohere';
+    /** Optional API base-URL override (self-host / proxy). HTTPS only (localhost
+     *  may use http). Ignored by the local provider. */
+    apiBaseUrl?: string;
+    /** Batch size for API embedding requests. Default 64. */
+    batchSize?: number;
   };
   global: {
     enabled: boolean;
@@ -92,6 +102,7 @@ const DEFAULT_CONFIG: HippoConfig = {
     enabled: 'auto',
     model: 'Xenova/all-MiniLM-L6-v2',
     hybridWeight: 0.6,
+    provider: 'local',
   },
   global: {
     enabled: true,

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -1,0 +1,378 @@
+/**
+ * Pluggable embedding providers for Hippo.
+ *
+ * The local `@xenova/transformers` path stays the zero-DEPENDENCY DEFAULT. Opt-in
+ * API providers (OpenAI / Voyage / Cohere) let a user bring a frontier embedder
+ * (e.g. text-embedding-3-large) for frontier-class retrieval. They use the native
+ * `fetch` global (Node >= 22.5, see package.json engines — NO new dependency) and
+ * read their key from a conventional env var. The provider is selected by
+ * `config.embeddings.provider` (default `'local'`).
+ *
+ * Design contract (see docs/plans/2026-06-08-b-pluggable-embedding-provider.md):
+ *   - Local provider `id` is the BARE model string, so existing stores whose DB
+ *     meta `embedding_model` is `Xenova/all-MiniLM-L6-v2` see NO identity change
+ *     and are NOT force-reindexed on upgrade.
+ *   - API provider `id` is `${kind}:${model}`; switching to/from an API embedder
+ *     (or a dimension change) flips the identity and triggers the existing
+ *     reindex-on-change path.
+ *   - `resolveEmbeddingProvider` NEVER throws. `isAvailable()` is provider-aware
+ *     (local -> dependency installed; api -> key present). `embed()` MAY throw on
+ *     a hard transport/auth failure so a reindex can abort atomically; hot paths
+ *     wrap it and fall back to BM25.
+ *
+ * The exact request/response shapes for the API providers are documented from each
+ * vendor's public embeddings API; they are unit-tested here against a mocked
+ * `fetch` and are integration-verified in Workstream C (real API calls are
+ * egress-blocked in the build sandbox).
+ */
+
+import {
+  type EmbeddingRole,
+  getEmbedding,
+  isEmbeddingAvailable,
+  resolveEmbeddingModel,
+  DEFAULT_EMBEDDING_MODEL,
+} from './embeddings.js';
+import { loadConfig } from './config.js';
+
+export type EmbeddingProviderKind = 'local' | 'openai' | 'voyage' | 'cohere';
+
+export const API_PROVIDER_KINDS: readonly EmbeddingProviderKind[] = ['openai', 'voyage', 'cohere'];
+
+const DEFAULT_API_BATCH_SIZE = 64;
+/** Per-request timeout for API embedding calls. A provider/proxy that accepts
+ *  the connection but never responds must not hang embed/recall indefinitely. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export interface EmbeddingProvider {
+  readonly kind: EmbeddingProviderKind;
+  readonly model: string;
+  /**
+   * Identity recorded in DB meta to drive reindex-on-change.
+   * local -> bare model string (back-compat); api -> `${kind}:${model}`.
+   */
+  readonly id: string;
+  /** Known fixed output dimension, if any (undefined for local / unknown). */
+  readonly dimensions?: number;
+  /** Env var holding this provider's API key (undefined for the local provider). */
+  readonly keyEnv?: string;
+  /** local -> dependency installed; api -> key present. NEVER throws. */
+  isAvailable(): boolean;
+  /**
+   * Batch-embed. Returns one row per input in order; a row is `[]` when that
+   * single item could not be embedded. MAY throw on a hard transport/auth
+   * failure (so a reindex aborts before saving a partial index).
+   */
+  embed(texts: string[], role?: EmbeddingRole): Promise<number[][]>;
+}
+
+// ---------------------------------------------------------------------------
+// Local provider — wraps the existing zero-dep transformers.js path.
+// ---------------------------------------------------------------------------
+
+class LocalEmbeddingProvider implements EmbeddingProvider {
+  readonly kind = 'local' as const;
+  constructor(readonly model: string, private readonly enabled: boolean = true) {}
+  get id(): string {
+    return this.model;
+  }
+  isAvailable(): boolean {
+    return this.enabled && isEmbeddingAvailable();
+  }
+  async embed(texts: string[], role?: EmbeddingRole): Promise<number[][]> {
+    // Sequential to preserve the historical single-pipeline behaviour and avoid
+    // contending the one cached pipeline instance with N concurrent calls.
+    const out: number[][] = [];
+    for (const text of texts) {
+      out.push(await getEmbedding(text, this.model, role));
+    }
+    return out;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// API providers — OpenAI / Voyage / Cohere over native fetch.
+// ---------------------------------------------------------------------------
+
+interface ApiProviderShape {
+  keyEnv: string;
+  defaultBaseUrl: string;
+  /** Endpoint path appended to baseUrl ('embeddings' for OpenAI/Voyage, 'embed' for Cohere). */
+  path: string;
+  /** Provider flagship model, used when config selects the provider but no API model. */
+  defaultModel: string;
+  /** Build the POST body for a batch of texts. */
+  buildBody(model: string, texts: string[], role?: EmbeddingRole): Record<string, unknown>;
+  /** Extract the ordered vectors from the parsed JSON response. */
+  extractVectors(json: unknown): number[][];
+}
+
+const API_SHAPES: Record<'openai' | 'voyage' | 'cohere', ApiProviderShape> = {
+  openai: {
+    keyEnv: 'OPENAI_API_KEY',
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    path: 'embeddings',
+    defaultModel: 'text-embedding-3-large',
+    // OpenAI has no asymmetric query/passage input type for embeddings.
+    buildBody: (model, texts) => ({ model, input: texts }),
+    extractVectors: (json) => {
+      const data = (json as { data?: Array<{ embedding?: number[] }> }).data ?? [];
+      return data.map((d) => d.embedding ?? []);
+    },
+  },
+  voyage: {
+    keyEnv: 'VOYAGE_API_KEY',
+    defaultBaseUrl: 'https://api.voyageai.com/v1',
+    path: 'embeddings',
+    defaultModel: 'voyage-3',
+    buildBody: (model, texts, role) => {
+      const body: Record<string, unknown> = { model, input: texts };
+      if (role) body.input_type = role === 'query' ? 'query' : 'document';
+      return body;
+    },
+    extractVectors: (json) => {
+      const data = (json as { data?: Array<{ embedding?: number[] }> }).data ?? [];
+      return data.map((d) => d.embedding ?? []);
+    },
+  },
+  cohere: {
+    keyEnv: 'COHERE_API_KEY',
+    defaultBaseUrl: 'https://api.cohere.com/v2',
+    path: 'embed',
+    defaultModel: 'embed-v4.0',
+    buildBody: (model, texts, role) => ({
+      model,
+      texts,
+      input_type: role === 'query' ? 'search_query' : 'search_document',
+      embedding_types: ['float'],
+    }),
+    extractVectors: (json) => {
+      // Cohere v2: { embeddings: { float: number[][] } }
+      const emb = (json as { embeddings?: { float?: number[][] } }).embeddings;
+      return emb?.float ?? [];
+    },
+  },
+};
+
+/** Remove a secret substring from any string before it surfaces in an error. */
+function redact(text: string, secret: string | undefined): string {
+  if (!secret) return text;
+  return text.split(secret).join('***');
+}
+
+function l2normalize(v: number[]): number[] {
+  let norm = 0;
+  for (const x of v) norm += x * x;
+  norm = Math.sqrt(norm);
+  if (norm < 1e-12) return v;
+  return v.map((x) => x / norm);
+}
+
+class ApiEmbeddingProvider implements EmbeddingProvider {
+  constructor(
+    readonly kind: 'openai' | 'voyage' | 'cohere',
+    readonly model: string,
+    private readonly baseUrl: string,
+    private readonly batchSize: number,
+    private readonly enabled: boolean = true,
+  ) {}
+
+  get id(): string {
+    return `${this.kind}:${this.model}`;
+  }
+
+  get keyEnv(): string {
+    return API_SHAPES[this.kind].keyEnv;
+  }
+
+  isAvailable(): boolean {
+    return this.enabled && !!process.env[this.keyEnv]?.trim();
+  }
+
+  async embed(texts: string[], role?: EmbeddingRole): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const key = process.env[this.keyEnv]?.trim();
+    if (!key) {
+      // Hard, actionable failure — never includes a key value (there is none).
+      throw new Error(
+        `Embedding provider '${this.kind}' is configured but ${this.keyEnv} is not set. ` +
+          `Export ${this.keyEnv} or set config.embeddings.provider back to 'local'.`,
+      );
+    }
+
+    const out: number[][] = [];
+    for (let i = 0; i < texts.length; i += this.batchSize) {
+      const chunk = texts.slice(i, i + this.batchSize);
+      const vecs = await this.embedChunk(chunk, key, role);
+      for (const v of vecs) out.push(v.length > 0 ? l2normalize(v) : v);
+    }
+    return out;
+  }
+
+  private async embedChunk(chunk: string[], key: string, role?: EmbeddingRole): Promise<number[][]> {
+    const shape = API_SHAPES[this.kind];
+    const url = `${this.baseUrl.replace(/\/$/, '')}/${shape.path}`;
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify(shape.buildBody(this.model, chunk, role)),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(redact(`embedding request to ${this.kind} failed: ${msg}`, key));
+    }
+
+    if (!resp.ok) {
+      let detail = '';
+      try {
+        detail = await resp.text();
+      } catch {
+        /* ignore body read error */
+      }
+      throw new Error(
+        redact(`${this.kind} embeddings HTTP ${resp.status}: ${detail.slice(0, 300)}`, key),
+      );
+    }
+
+    let json: unknown;
+    try {
+      json = await resp.json();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(redact(`${this.kind} embeddings returned invalid JSON: ${msg}`, key));
+    }
+
+    const vectors = shape.extractVectors(json);
+    // A 200 response with the wrong number of vectors (or any empty/malformed
+    // vector) is a provider/proxy contract violation, NOT a per-item miss. Throw
+    // so a reindex aborts atomically (preserving the prior usable index) and the
+    // explicit backfill surfaces it, instead of silently saving []-padded rows.
+    if (vectors.length !== chunk.length) {
+      throw new Error(
+        redact(`${this.kind} embeddings returned ${vectors.length} vectors for ${chunk.length} inputs`, key),
+      );
+    }
+    for (let i = 0; i < vectors.length; i++) {
+      if (!vectors[i] || vectors[i].length === 0) {
+        throw new Error(redact(`${this.kind} embeddings returned an empty vector at index ${i}`, key));
+      }
+    }
+    return vectors;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+function readEmbeddingsConfig(hippoRoot: string): {
+  enabled?: boolean | 'auto';
+  provider?: string;
+  model?: string;
+  apiBaseUrl?: string;
+  batchSize?: number;
+} {
+  try {
+    return loadConfig(hippoRoot).embeddings;
+  } catch {
+    return {};
+  }
+}
+
+/** Validate a user-supplied API base URL: HTTPS only (or explicit localhost). */
+function validateBaseUrl(url: string | undefined, fallback: string): string {
+  const candidate = url?.trim();
+  if (!candidate) return fallback;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new Error(`config.embeddings.apiBaseUrl is not a valid URL: ${candidate}`);
+  }
+  const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+  if (parsed.protocol !== 'https:' && !isLocalhost) {
+    throw new Error(
+      `config.embeddings.apiBaseUrl must use https (got ${parsed.protocol}//${parsed.hostname}). ` +
+        `Plaintext http is only allowed for localhost.`,
+    );
+  }
+  return candidate;
+}
+
+export interface ResolveProviderOptions {
+  /** Explicit model override (mirrors resolveEmbeddingModel's explicitModel). */
+  model?: string;
+  /** Explicit provider override (mainly for tests). */
+  provider?: EmbeddingProviderKind;
+}
+
+/**
+ * Build the active embedding provider from config (or an explicit override).
+ * Never throws for a missing key — that surfaces via `isAvailable()` on the hot
+ * paths and as a hard error only from the explicit `hippo embed` command. The
+ * only hard throw is an invalid config (e.g. an insecure apiBaseUrl), a
+ * deliberate loud failure; hot-path callers (search) wrap this in try/catch.
+ */
+export function resolveEmbeddingProvider(
+  hippoRoot: string,
+  opts: ResolveProviderOptions = {},
+): EmbeddingProvider {
+  const cfg = readEmbeddingsConfig(hippoRoot);
+  const requested = (opts.provider ?? cfg.provider ?? 'local') as string;
+  // An explicit embeddings.enabled=false hard-disables embedding for BOTH local
+  // and API providers — for API this prevents unwanted paid off-box calls.
+  const enabled = cfg.enabled !== false;
+
+  if (requested === 'local') {
+    return new LocalEmbeddingProvider(resolveEmbeddingModel(hippoRoot, opts.model), enabled);
+  }
+  if (!API_PROVIDER_KINDS.includes(requested as EmbeddingProviderKind)) {
+    // Fail loud on a typo'd provider rather than silently using local (which
+    // would reindex with the local model and clobber the intended identity).
+    throw new Error(
+      `Unknown embeddings.provider '${requested}'. Valid values: local, ${API_PROVIDER_KINDS.filter((k) => k !== 'local').join(', ')}.`,
+    );
+  }
+
+  const kind = requested as 'openai' | 'voyage' | 'cohere';
+  const shape = API_SHAPES[kind];
+  // If no API model was chosen (config left the local default in place), fall
+  // back to the provider's flagship model rather than POSTing a local model id.
+  const requestedModel = (opts.model ?? cfg.model)?.trim();
+  const model =
+    requestedModel && requestedModel !== DEFAULT_EMBEDDING_MODEL ? requestedModel : shape.defaultModel;
+  const baseUrl = validateBaseUrl(cfg.apiBaseUrl, shape.defaultBaseUrl);
+  const batchSize =
+    typeof cfg.batchSize === 'number' && Number.isInteger(cfg.batchSize) && cfg.batchSize > 0
+      ? cfg.batchSize
+      : DEFAULT_API_BATCH_SIZE;
+  return new ApiEmbeddingProvider(kind, model, baseUrl, batchSize, enabled);
+}
+
+/**
+ * The reindex identity for the active provider. Use this (NOT resolveEmbeddingModel)
+ * everywhere `embeddingModelRequiresReindex` / stored-model comparisons happen.
+ */
+export function resolveEmbeddingIdentity(hippoRoot: string, opts: ResolveProviderOptions = {}): string {
+  return resolveEmbeddingProvider(hippoRoot, opts).id;
+}
+
+/**
+ * Provider-aware availability for a store: local -> dependency installed;
+ * api -> key present. Use at the call sites that decide whether to embed.
+ */
+export function isEmbeddingConfigured(hippoRoot: string): boolean {
+  try {
+    return resolveEmbeddingProvider(hippoRoot).isAvailable();
+  } catch {
+    // Invalid embedding config (e.g. an insecure apiBaseUrl) must not crash the
+    // best-effort ingestion guard — treat it as "not configured" and skip.
+    return false;
+  }
+}

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -12,6 +12,7 @@ import { loadAllEntries } from './store.js';
 import { openHippoDb, closeHippoDb, getMeta, setMeta } from './db.js';
 import { initializeParticle, savePhysicsState, loadPhysicsState, resetAllPhysicsState } from './physics-state.js';
 import { loadConfig } from './config.js';
+import { resolveEmbeddingProvider, type EmbeddingProvider } from './embedding-provider.js';
 
 // Use createRequire for synchronous module resolution check in ESM
 const _require = createRequire(import.meta.url);
@@ -23,7 +24,7 @@ let _embeddingAvailable: boolean | null = null;
 const _pipelineInstances = new Map<string, unknown>();
 const _pipelineLoading = new Map<string, Promise<unknown>>();
 
-const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
+export const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
 const EMBEDDING_MODEL_META_KEY = 'embedding_model';
 
 /**
@@ -227,15 +228,20 @@ export function embeddingModelRequiresReindex(
 
 async function rebuildEmbeddingIndex(
   entries: MemoryEntry[],
-  model: string,
+  provider: EmbeddingProvider,
 ): Promise<Record<string, number[]>> {
   const rebuilt: Record<string, number[]> = {};
+  if (entries.length === 0) return rebuilt;
 
-  for (const entry of entries) {
-    const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
-    const vector = await getEmbedding(text, model, 'passage');
-    if (vector.length > 0) {
-      rebuilt[entry.id] = vector;
+  const texts = entries.map((e) => `${e.content} ${e.tags.join(' ')}`.trim());
+  // provider.embed batches internally; on a hard transport/auth failure it
+  // throws, so the caller aborts WITHOUT saving a partial index (atomic
+  // reindex: the old index + stored identity are preserved).
+  const vectors = await provider.embed(texts, 'passage');
+  for (let i = 0; i < entries.length; i++) {
+    const vec = vectors[i];
+    if (vec && vec.length > 0) {
+      rebuilt[entries[i].id] = vec;
     }
   }
 
@@ -367,48 +373,57 @@ export async function embedMemory(
   entry: MemoryEntry,
   model?: string
 ): Promise<void> {
-  if (!isEmbeddingAvailable()) return;
+  const provider = resolveEmbeddingProvider(hippoRoot, { model });
+  if (!provider.isAvailable()) return;
 
   return withEmbedLock(async () => {
-    const effectiveModel = resolveEmbeddingModel(hippoRoot, model);
-    const existingIndex = loadEmbeddingIndex(hippoRoot);
-
-    if (embeddingModelRequiresReindex(hippoRoot, effectiveModel, existingIndex)) {
-      // L9: host-wide rebuild. The embedding index is keyed by entry.id
-      // (which is tenant-scoped) but the index itself is one per hippoRoot.
-      // Cross-tenant content equivalence is visible at the vector level.
-      // Per-tenant indices would be a larger architecture change.
-      const entries = loadAllEntries(hippoRoot);
-      const rebuiltIndex = await rebuildEmbeddingIndex(entries, effectiveModel);
-      saveEmbeddingIndex(hippoRoot, rebuiltIndex);
-      saveStoredEmbeddingModel(hippoRoot, effectiveModel);
-      resetPhysicsFromIndex(hippoRoot, entries, rebuiltIndex);
-      return;
-    }
-
-    const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
-    const vector = await getEmbedding(text, effectiveModel, 'passage');
-    if (vector.length === 0) return;
-
-    const index = existingIndex;
-    index[entry.id] = vector;
-    saveEmbeddingIndex(hippoRoot, index);
-    saveStoredEmbeddingModel(hippoRoot, effectiveModel);
-
-    // Initialize physics state for this memory
+    // embedMemory is best-effort: an embedding failure (API down / bad key / 5xx)
+    // must not reject the caller's write — `getEmbedding` historically swallowed
+    // failures and returned []. The explicit `hippo embed` / `embedAll` path is
+    // where failures surface. On any failure we leave the existing index as-is.
     try {
-      const db = openHippoDb(hippoRoot);
+      const identity = provider.id;
+      const existingIndex = loadEmbeddingIndex(hippoRoot);
+
+      if (embeddingModelRequiresReindex(hippoRoot, identity, existingIndex)) {
+        // L9: host-wide rebuild. The embedding index is keyed by entry.id
+        // (which is tenant-scoped) but the index itself is one per hippoRoot.
+        // Cross-tenant content equivalence is visible at the vector level.
+        // Per-tenant indices would be a larger architecture change.
+        const entries = loadAllEntries(hippoRoot);
+        const rebuiltIndex = await rebuildEmbeddingIndex(entries, provider);
+        saveEmbeddingIndex(hippoRoot, rebuiltIndex);
+        saveStoredEmbeddingModel(hippoRoot, identity);
+        resetPhysicsFromIndex(hippoRoot, entries, rebuiltIndex);
+        return;
+      }
+
+      const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
+      const [vector] = await provider.embed([text], 'passage');
+      if (!vector || vector.length === 0) return;
+
+      const index = existingIndex;
+      index[entry.id] = vector;
+      saveEmbeddingIndex(hippoRoot, index);
+      saveStoredEmbeddingModel(hippoRoot, identity);
+
+      // Initialize physics state for this memory
       try {
-        const existing = loadPhysicsState(db, [entry.id]);
-        if (!existing.has(entry.id)) {
-          const particle = initializeParticle(entry, vector);
-          savePhysicsState(db, [particle]);
+        const db = openHippoDb(hippoRoot);
+        try {
+          const existing = loadPhysicsState(db, [entry.id]);
+          if (!existing.has(entry.id)) {
+            const particle = initializeParticle(entry, vector);
+            savePhysicsState(db, [particle]);
+          }
+        } finally {
+          closeHippoDb(db);
         }
-      } finally {
-        closeHippoDb(db);
+      } catch {
+        // Physics init is best-effort — don't break embedding
       }
     } catch {
-      // Physics init is best-effort — don't break embedding
+      // Provider failure (API down / bad key). Best-effort: leave the index as-is.
     }
   });
 }
@@ -422,25 +437,42 @@ export async function embedAll(
   hippoRoot: string,
   model?: string
 ): Promise<number> {
-  if (!isEmbeddingAvailable()) return 0;
+  const provider = resolveEmbeddingProvider(hippoRoot, { model });
+  if (!provider.isAvailable()) {
+    // A configured (non-disabled) API provider with a missing key is a
+    // misconfiguration, not a no-op: surface it so programmatic callers of the
+    // exported embedAll() learn nothing was written. Local-not-installed and an
+    // explicit enabled=false stay silent no-ops (best-effort / intentional).
+    const cfg = loadConfig(hippoRoot).embeddings;
+    if (
+      provider.kind !== 'local' &&
+      cfg.enabled !== false &&
+      provider.keyEnv &&
+      !process.env[provider.keyEnv]?.trim()
+    ) {
+      throw new Error(
+        `Embedding provider '${provider.kind}' is configured but ${provider.keyEnv} is not set.`,
+      );
+    }
+    return 0;
+  }
 
   return withEmbedLock(async () => {
-    const effectiveModel = resolveEmbeddingModel(hippoRoot, model);
+    const identity = provider.id;
     // L9: host-wide by design. embedAll backfills vectors for all tenants'
     // entries into the per-host embedding index. Per-tenant filtering would
     // produce partial indices and break recall.
     const entries = loadAllEntries(hippoRoot);
     const index = loadEmbeddingIndex(hippoRoot);
 
-    if (embeddingModelRequiresReindex(hippoRoot, effectiveModel, index)) {
-      const rebuiltIndex = await rebuildEmbeddingIndex(entries, effectiveModel);
+    if (embeddingModelRequiresReindex(hippoRoot, identity, index)) {
+      const rebuiltIndex = await rebuildEmbeddingIndex(entries, provider);
       saveEmbeddingIndex(hippoRoot, rebuiltIndex);
-      saveStoredEmbeddingModel(hippoRoot, effectiveModel);
+      saveStoredEmbeddingModel(hippoRoot, identity);
       resetPhysicsFromIndex(hippoRoot, entries, rebuiltIndex);
       return Object.keys(rebuiltIndex).length;
     }
 
-    let count = 0;
     let dirty = false;
 
     // Prune orphaned embeddings for deleted memories
@@ -452,23 +484,51 @@ export async function embedAll(
       }
     }
 
-    for (const entry of entries) {
-      if (index[entry.id]) continue; // already embedded
-
-      const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
-      const vector = await getEmbedding(text, effectiveModel, 'passage');
-      if (vector.length > 0) {
-        index[entry.id] = vector;
-        count++;
-        dirty = true;
+    // Embed entries without a cached vector in save-checkpointed chunks.
+    // provider.embed batches internally (one HTTP request per batchSize for API
+    // providers; sequential for local). A `[]` row means that single item could
+    // not be embedded and is left for a later run (resumable). On a hard provider
+    // failure mid-backfill we persist the chunks already embedded this run rather
+    // than discarding paid progress, then stop and resume on the next run.
+    const pending = entries.filter((e) => !index[e.id]);
+    let count = 0;
+    let backfillError: unknown = null;
+    const SAVE_CHUNK = 64;
+    for (let i = 0; i < pending.length; i += SAVE_CHUNK) {
+      const chunk = pending.slice(i, i + SAVE_CHUNK);
+      let vectors: number[][];
+      try {
+        vectors = await provider.embed(
+          chunk.map((e) => `${e.content} ${e.tags.join(' ')}`.trim()),
+          'passage',
+        );
+      } catch (err) {
+        // Preserve the chunks already saved this run, then surface the failure
+        // below so the explicit `hippo embed` path never reports a false success.
+        backfillError = err;
+        break;
       }
+      let chunkDirty = false;
+      for (let j = 0; j < chunk.length; j++) {
+        const vec = vectors[j];
+        if (vec && vec.length > 0) {
+          index[chunk[j].id] = vec;
+          count++;
+          dirty = true;
+          chunkDirty = true;
+        }
+      }
+      if (chunkDirty) saveEmbeddingIndex(hippoRoot, index);
     }
 
     if (dirty) {
       saveEmbeddingIndex(hippoRoot, index);
     }
-    saveStoredEmbeddingModel(hippoRoot, effectiveModel);
+    saveStoredEmbeddingModel(hippoRoot, identity);
 
+    // Partial progress is now persisted; surface a hard backfill failure so the
+    // explicit embed path reports it (best-effort callers go via embedMemory).
+    if (backfillError) throw backfillError;
     return count;
   });
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,13 +7,11 @@ import { MemoryEntry, calculateStrength } from './memory.js';
 import { extractPathTags, pathOverlapScore } from './path-context.js';
 import { detectScope, scopeMatch } from './scope.js';
 import {
-  isEmbeddingAvailable,
-  getEmbedding,
   cosineSimilarity,
   embeddingModelRequiresReindex,
   loadEmbeddingIndex,
-  resolveEmbeddingModel,
 } from './embeddings.js';
+import { resolveEmbeddingProvider } from './embedding-provider.js';
 import { physicsScore as computePhysicsScores } from './physics.js';
 import type { PhysicsParticle } from './physics.js';
 import type { PhysicsConfig } from './physics-config.js';
@@ -452,14 +450,22 @@ export async function hybridSearch(
   let embeddingIndex: Record<string, number[]> = {};
   let queryVector: number[] = [];
 
-  if (isEmbeddingAvailable() && options.hippoRoot) {
+  if (options.hippoRoot) {
     try {
-      const model = resolveEmbeddingModel(options.hippoRoot);
-      if (!embeddingModelRequiresReindex(options.hippoRoot, model)) {
-        queryVector = await getEmbedding(query, model, 'query');
-        if (queryVector.length > 0) {
-          embeddingIndex = loadEmbeddingIndex(options.hippoRoot);
-          useEmbeddings = true;
+      const provider = resolveEmbeddingProvider(options.hippoRoot);
+      if (provider.isAvailable() && !embeddingModelRequiresReindex(options.hippoRoot, provider.id)) {
+        const idx = loadEmbeddingIndex(options.hippoRoot);
+        // Only spend a (possibly paid, off-box) query embedding when at least one
+        // of THIS search's entries has a cached vector to compare against. An
+        // index of only orphaned / out-of-scope vectors yields a meaningless
+        // dense ranking, so stay BM25-only in that case.
+        if (entries.some((e) => (idx[e.id]?.length ?? 0) > 0)) {
+          const [vec] = await provider.embed([query], 'query');
+          queryVector = vec ?? [];
+          if (queryVector.length > 0) {
+            embeddingIndex = idx;
+            useEmbeddings = true;
+          }
         }
       }
     } catch {
@@ -878,14 +884,22 @@ export async function physicsSearch(
   // Get query embedding (use pre-computed if provided)
   let queryVector = options.queryEmbedding ?? [];
   if (queryVector.length === 0) {
-    if (!isEmbeddingAvailable()) {
+    // Both resolveEmbeddingProvider (invalid config) and provider.embed (API
+    // network/auth/5xx) can throw; fall back to hybrid/BM25 rather than reject
+    // recall, matching the surrounding fallback contract. NOTE: physics search
+    // scores against its own cached particle-state vectors (loaded below), NOT
+    // embeddings.json, so we do not gate the query embedding on the index here
+    // (doing so would skip valid physics when the embedding index is pruned).
+    try {
+      const provider = resolveEmbeddingProvider(options.hippoRoot);
+      if (!provider.isAvailable() || embeddingModelRequiresReindex(options.hippoRoot, provider.id)) {
+        return hybridSearch(query, entries, options);
+      }
+      const [vec] = await provider.embed([query], 'query');
+      queryVector = vec ?? [];
+    } catch {
       return hybridSearch(query, entries, options);
     }
-    const model = resolveEmbeddingModel(options.hippoRoot);
-    if (embeddingModelRequiresReindex(options.hippoRoot, model)) {
-      return hybridSearch(query, entries, options);
-    }
-    queryVector = await getEmbedding(query, model, 'query');
     if (queryVector.length === 0) {
       return hybridSearch(query, entries, options);
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.22.0';
+export const PACKAGE_VERSION = '1.23.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/embedding-model-config.test.ts
+++ b/tests/embedding-model-config.test.ts
@@ -17,6 +17,7 @@ describe('embedding model configuration', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unmock('../src/embeddings.js');
+    vi.unmock('../src/embedding-provider.js');
     vi.unmock('../src/search.js');
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-embed-model-'));
   });
@@ -36,18 +37,35 @@ describe('embedding model configuration', () => {
     expect(embeddings.resolveEmbeddingModel?.(tmpDir)).toBe('custom/model');
   });
 
-  it('hybridSearch passes the configured model to getEmbedding', async () => {
+  it('hybridSearch embeds the query via the provider built from the configured model', async () => {
     writeConfig(tmpDir, 'custom/model');
 
-    const getEmbeddingMock = vi.fn(async () => [1, 0, 0]);
     const entryId = 'mem_custom_model';
+    const embedMock = vi.fn(async (texts: string[]) => texts.map(() => [1, 0, 0]));
+    let resolvedId: string | undefined;
+
+    // The query-embedding seam moved from a direct getEmbedding(text, model, role)
+    // call to resolveEmbeddingProvider(...).embed(texts, role). Delegate to the
+    // REAL resolver so the configured model ('custom/model') is genuinely read
+    // into the provider id, then force availability and capture the embed call.
+    vi.doMock('../src/embedding-provider.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/embedding-provider.js')>(
+        '../src/embedding-provider.js',
+      );
+      return {
+        ...actual,
+        resolveEmbeddingProvider: (hippoRoot: string) => {
+          const real = actual.resolveEmbeddingProvider(hippoRoot);
+          resolvedId = real.id;
+          return { kind: real.kind, model: real.model, id: real.id, isAvailable: () => true, embed: embedMock };
+        },
+      };
+    });
 
     vi.doMock('../src/embeddings.js', async () => {
       const actual = await vi.importActual<typeof import('../src/embeddings.js')>('../src/embeddings.js');
       return {
         ...actual,
-        isEmbeddingAvailable: () => true,
-        getEmbedding: getEmbeddingMock,
         embeddingModelRequiresReindex: () => false,
         loadEmbeddingIndex: () => ({ [entryId]: [1, 0, 0] }),
         cosineSimilarity: () => 1,
@@ -62,11 +80,11 @@ describe('embedding model configuration', () => {
 
     await hybridSearch('query text', [entry], { hippoRoot: tmpDir, budget: 1000 });
 
-    // hybridSearch passes a third `role` argument ('query'|'passage') so e5-family
-    // models receive the correct "query: " / "passage: " prefix; non-e5 models
-    // ignore it. The query path always passes 'query'. (Added with the F12
-    // multilingual-e5-large embedding work; see src/embeddings.ts + src/search.ts.)
-    expect(getEmbeddingMock).toHaveBeenCalledWith('query text', 'custom/model', 'query');
+    // The provider is built from the configured model...
+    expect(resolvedId).toBe('custom/model');
+    // ...and the query path embeds with role 'query' (so e5-family models get the
+    // correct "query: " prefix; non-e5 models ignore it).
+    expect(embedMock).toHaveBeenCalledWith(['query text'], 'query');
   });
 
   it('treats a legacy embedding index as stale when the configured model changes', async () => {
@@ -102,6 +120,44 @@ describe('embedding model configuration', () => {
     const results = await hybridSearch('query text', [entry], { hippoRoot: tmpDir, budget: 1000 });
 
     expect(getEmbeddingMock).not.toHaveBeenCalled();
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('stays BM25-only on an unembedded store (no query embedding spent)', async () => {
+    writeConfig(tmpDir, 'custom/model');
+    const embedMock = vi.fn(async (texts: string[]) => texts.map(() => [1, 0, 0]));
+
+    vi.doMock('../src/embedding-provider.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/embedding-provider.js')>(
+        '../src/embedding-provider.js',
+      );
+      return {
+        ...actual,
+        resolveEmbeddingProvider: () => ({
+          kind: 'local',
+          model: 'custom/model',
+          id: 'custom/model',
+          isAvailable: () => true,
+          embed: embedMock,
+        }),
+      };
+    });
+
+    vi.doMock('../src/embeddings.js', async () => {
+      const actual = await vi.importActual<typeof import('../src/embeddings.js')>('../src/embeddings.js');
+      return { ...actual, embeddingModelRequiresReindex: () => false, loadEmbeddingIndex: () => ({}) };
+    });
+
+    const { hybridSearch } = await import('../src/search.js');
+    const { createMemory } = await import('../src/memory.js');
+
+    const results = await hybridSearch('query text', [createMemory('query text match')], {
+      hippoRoot: tmpDir,
+      budget: 1000,
+    });
+
+    // Empty index -> no cached doc vectors -> the query embedding is skipped.
+    expect(embedMock).not.toHaveBeenCalled();
     expect(results.length).toBeGreaterThan(0);
   });
 });

--- a/tests/embedding-provider.test.ts
+++ b/tests/embedding-provider.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  resolveEmbeddingProvider,
+  resolveEmbeddingIdentity,
+  isEmbeddingConfigured,
+} from '../src/embedding-provider.js';
+import { saveEmbeddingIndex, embeddingModelRequiresReindex } from '../src/embeddings.js';
+
+function mkRoot(embeddings: Record<string, unknown>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-provider-'));
+  fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ embeddings }), 'utf8');
+  return dir;
+}
+
+function jsonResponse(data: unknown, status = 200): unknown {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  };
+}
+
+function errorResponse(status: number, body: string): unknown {
+  return { ok: false, status, json: async () => ({}), text: async () => body };
+}
+
+function l2norm(v: number[]): number {
+  return Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+}
+
+const ENV_KEYS = ['OPENAI_API_KEY', 'VOYAGE_API_KEY', 'COHERE_API_KEY'];
+const savedEnv: Record<string, string | undefined> = {};
+
+describe('EmbeddingProvider', () => {
+  beforeEach(() => {
+    // Embedding-API hosts are egress-blocked in the build sandbox, so every test
+    // here uses a mocked fetch; a real integration test is Workstream C.
+    for (const k of ENV_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    vi.unstubAllGlobals();
+  });
+
+  describe('identity', () => {
+    it('local provider id is the bare model (back-compat with stored embedding_model)', () => {
+      const root = mkRoot({ provider: 'local', model: 'Xenova/all-MiniLM-L6-v2' });
+      expect(resolveEmbeddingIdentity(root)).toBe('Xenova/all-MiniLM-L6-v2');
+      expect(resolveEmbeddingProvider(root).kind).toBe('local');
+    });
+
+    it('api provider id is `${kind}:${model}`', () => {
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      expect(resolveEmbeddingIdentity(root)).toBe('openai:text-embedding-3-large');
+    });
+
+    it('defaults to the local provider when none is configured', () => {
+      const root = mkRoot({ model: 'Xenova/all-MiniLM-L6-v2' });
+      expect(resolveEmbeddingProvider(root).kind).toBe('local');
+    });
+
+    it('uses the provider flagship model when an api provider is set but no model', () => {
+      const root = mkRoot({ provider: 'openai' });
+      const p = resolveEmbeddingProvider(root);
+      expect(p.model).toBe('text-embedding-3-large');
+      expect(p.id).toBe('openai:text-embedding-3-large');
+    });
+  });
+
+  describe('backwards compatibility (no forced reindex on upgrade)', () => {
+    it('an existing MiniLM index is NOT stale for the local provider', () => {
+      const root = mkRoot({ provider: 'local', model: 'Xenova/all-MiniLM-L6-v2' });
+      // Legacy store: index present, model defaults to MiniLM (the historical default).
+      saveEmbeddingIndex(root, { mem_legacy: [0.1, 0.2, 0.3] });
+      const identity = resolveEmbeddingIdentity(root);
+      expect(embeddingModelRequiresReindex(root, identity)).toBe(false);
+    });
+
+    it('switching to an api provider flips the identity and triggers a reindex', () => {
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      saveEmbeddingIndex(root, { mem_legacy: [0.1, 0.2, 0.3] });
+      const identity = resolveEmbeddingIdentity(root);
+      expect(embeddingModelRequiresReindex(root, identity)).toBe(true);
+    });
+  });
+
+  describe('availability + missing key', () => {
+    it('resolveEmbeddingProvider never throws for a missing key', () => {
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      expect(() => resolveEmbeddingProvider(root)).not.toThrow();
+      expect(resolveEmbeddingProvider(root).isAvailable()).toBe(false);
+    });
+
+    it('embed() throws a clear, key-naming error when the key is missing', async () => {
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      await expect(resolveEmbeddingProvider(root).embed(['hi'], 'passage')).rejects.toThrow(
+        /OPENAI_API_KEY/,
+      );
+    });
+
+    it('is available once the key is present', () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      expect(resolveEmbeddingProvider(root).isAvailable()).toBe(true);
+    });
+
+    it('throws on an unknown provider value (no silent local fallback)', () => {
+      const root = mkRoot({ provider: 'opneai', model: 'text-embedding-3-large' });
+      expect(() => resolveEmbeddingProvider(root)).toThrow(/Unknown embeddings.provider/);
+      expect(isEmbeddingConfigured(root)).toBe(false);
+    });
+
+    it('honors embeddings.enabled=false even when the api key is present (no paid calls)', () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large', enabled: false });
+      expect(resolveEmbeddingProvider(root).isAvailable()).toBe(false);
+    });
+  });
+
+  describe('request contract + normalization (openai)', () => {
+    it('posts to /embeddings with bearer auth and a batched body, and L2-normalizes the result', async () => {
+      process.env.OPENAI_API_KEY = 'sk-secret-123';
+      const root = mkRoot({ provider: 'openai', model: 'text-embedding-3-large' });
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({ data: [{ embedding: [3, 0, 4] }, { embedding: [0, 6, 8] }] }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const vecs = await resolveEmbeddingProvider(root).embed(['a', 'b'], 'passage');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const call = fetchMock.mock.calls[0] as unknown as [string, { headers: Record<string, string>; body: string }];
+      expect(String(call[0])).toMatch(/\/embeddings$/);
+      expect(call[1].headers.authorization).toBe('Bearer sk-secret-123');
+      const body = JSON.parse(call[1].body) as { model: string; input: string[] };
+      expect(body.model).toBe('text-embedding-3-large');
+      expect(body.input).toEqual(['a', 'b']);
+      // [3,0,4] -> /5 ; [0,6,8] -> /10
+      expect(l2norm(vecs[0])).toBeCloseTo(1, 6);
+      expect(l2norm(vecs[1])).toBeCloseTo(1, 6);
+      expect(vecs[0][0]).toBeCloseTo(0.6, 6);
+    });
+
+    it('chunks requests by batchSize', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const root = mkRoot({ provider: 'openai', model: 'm', batchSize: 1 });
+      const fetchMock = vi.fn(async () => jsonResponse({ data: [{ embedding: [1, 0] }] }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await resolveEmbeddingProvider(root).embed(['a', 'b', 'c'], 'passage');
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('ignores a fractional batchSize and falls back to the default (no chunk explosion)', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const root = mkRoot({ provider: 'openai', model: 'm', batchSize: 0.5 });
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({ data: [{ embedding: [1, 0] }, { embedding: [1, 0] }, { embedding: [1, 0] }] }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await resolveEmbeddingProvider(root).embed(['a', 'b', 'c'], 'passage');
+      // 0.5 is rejected -> default batch (64) -> one request for all 3 inputs.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('role -> input_type mapping', () => {
+    it('voyage maps query/passage to query/document', async () => {
+      process.env.VOYAGE_API_KEY = 'k';
+      const root = mkRoot({ provider: 'voyage', model: 'voyage-3' });
+      const bodies: Array<Record<string, unknown>> = [];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: { body: string }) => {
+          bodies.push(JSON.parse(init.body));
+          return jsonResponse({ data: [{ embedding: [1] }] });
+        }),
+      );
+      const p = resolveEmbeddingProvider(root);
+      await p.embed(['x'], 'query');
+      await p.embed(['x'], 'passage');
+      expect(bodies[0].input_type).toBe('query');
+      expect(bodies[1].input_type).toBe('document');
+    });
+
+    it('cohere maps query/passage to search_query/search_document and posts to /embed', async () => {
+      process.env.COHERE_API_KEY = 'k';
+      const root = mkRoot({ provider: 'cohere', model: 'embed-v4.0' });
+      const bodies: Array<Record<string, unknown>> = [];
+      const urls: string[] = [];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string, init: { body: string }) => {
+          urls.push(String(url));
+          bodies.push(JSON.parse(init.body));
+          return jsonResponse({ embeddings: { float: [[1]] } });
+        }),
+      );
+      const p = resolveEmbeddingProvider(root);
+      await p.embed(['x'], 'query');
+      await p.embed(['x'], 'passage');
+      // Cohere v2 serves embeddings at /v2/embed, not /embeddings.
+      expect(urls[0]).toMatch(/\/embed$/);
+      expect(bodies[0].input_type).toBe('search_query');
+      expect(bodies[1].input_type).toBe('search_document');
+    });
+
+    it('openai sends no input_type', async () => {
+      process.env.OPENAI_API_KEY = 'k';
+      const root = mkRoot({ provider: 'openai', model: 'm' });
+      let body: Record<string, unknown> = {};
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_url: string, init: { body: string }) => {
+          body = JSON.parse(init.body);
+          return jsonResponse({ data: [{ embedding: [1] }] });
+        }),
+      );
+      await resolveEmbeddingProvider(root).embed(['x'], 'query');
+      expect(body.input_type).toBeUndefined();
+    });
+  });
+
+  describe('key redaction + hard-failure semantics', () => {
+    it('never leaks the key in an error when the API echoes it back', async () => {
+      const key = 'sk-supersecret-DEADBEEF';
+      process.env.OPENAI_API_KEY = key;
+      const root = mkRoot({ provider: 'openai', model: 'm' });
+      vi.stubGlobal('fetch', vi.fn(async () => errorResponse(401, `Invalid key ${key} for org`)));
+
+      const err = (await resolveEmbeddingProvider(root)
+        .embed(['x'])
+        .catch((e) => e)) as Error;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).not.toContain(key);
+    });
+
+    it('throws on a non-2xx response (so a reindex aborts atomically)', async () => {
+      process.env.OPENAI_API_KEY = 'k';
+      const root = mkRoot({ provider: 'openai', model: 'm' });
+      vi.stubGlobal('fetch', vi.fn(async () => errorResponse(500, 'server error')));
+      await expect(resolveEmbeddingProvider(root).embed(['x'])).rejects.toThrow(/500/);
+    });
+
+    it('throws when a 200 returns fewer vectors than inputs (contract violation, not silent misses)', async () => {
+      process.env.OPENAI_API_KEY = 'sk-test';
+      const root = mkRoot({ provider: 'openai', model: 'm' });
+      // 200 OK but only one vector for two inputs.
+      vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ data: [{ embedding: [1, 0] }] })));
+      await expect(resolveEmbeddingProvider(root).embed(['a', 'b'], 'passage')).rejects.toThrow(
+        /vectors for/,
+      );
+    });
+  });
+
+  describe('apiBaseUrl validation (https only, localhost exempt)', () => {
+    it('rejects a plaintext http base url', () => {
+      const root = mkRoot({ provider: 'openai', model: 'm', apiBaseUrl: 'http://evil.example.com/v1' });
+      expect(() => resolveEmbeddingProvider(root)).toThrow(/https/i);
+    });
+
+    it('accepts an https base url', () => {
+      const root = mkRoot({ provider: 'openai', model: 'm', apiBaseUrl: 'https://proxy.example.com/v1' });
+      expect(() => resolveEmbeddingProvider(root)).not.toThrow();
+    });
+
+    it('allows http for localhost', () => {
+      const root = mkRoot({ provider: 'openai', model: 'm', apiBaseUrl: 'http://localhost:1234/v1' });
+      expect(() => resolveEmbeddingProvider(root)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Workstream B: pluggable embedding providers

Lets a user bring a frontier API embedder (OpenAI / Voyage / Cohere, e.g. `text-embedding-3-large`) for frontier-class retrieval, while the out-of-box default stays the zero-dependency local `@xenova/transformers` path. API providers use the native `fetch` (Node 22.5+), so there are no new runtime dependencies and the default needs no API keys.

### What's in it
- `src/embedding-provider.ts`: `EmbeddingProvider` interface + local/openai/voyage/cohere providers; `resolveEmbeddingProvider` / `resolveEmbeddingIdentity` / `isEmbeddingConfigured`.
- Provider-aware availability (local: dependency installed; API: key present) at every embedding gate; identity-based reindex (local keeps the bare-model identity, so existing stores are NOT force-reindexed on upgrade; API providers use `provider:model`).
- Safety: `embeddings.enabled=false` hard-disables embedding (prevents unwanted paid calls); best-effort add path; atomic reindex; per-chunk checkpointed backfill that surfaces hard failures; strict API response validation; 30s request timeout; https-only `apiBaseUrl`; API key redaction in all error paths.
- New config keys: `embeddings.provider`, `embeddings.apiBaseUrl`, `embeddings.batchSize`.
- Provider-aware `hippo status` (provider, model, key-present, dimension, reindex hint).

### Review
Plan reviewed by a senior-code-reviewer agent (2 blocking seam findings fixed before any code), then 10 rounds of `codex review` on the diff with every finding fixed: Cohere `/embed` endpoint, missing fetch timeout, paid-call guards (disabled flag, no-cached-vector, unembedded store), reindex atomicity, best-effort vs explicit failure semantics, truncated-response handling, and more.

### Test plan
- [x] `npm run build` clean
- [x] full `vitest run`: 2525 pass (1 known `server-concurrency` flake under parallel load, passes in isolation)
- [x] 23 new provider unit tests (request contract, L2-norm, key redaction, batch chunking, role to input_type mapping, https validation, back-compat identity, enabled-disable, unknown-provider, response contract-violation)
- [x] manifest version check + `PACKAGE_VERSION` alignment test
- [ ] Real API integration: Workstream C (`docs/FRONTIER_EMBEDDER_BENCHMARK.md`), needs API egress + a key (blocked in CI / build sandbox)

### Follow-up
- Workstream C: run the frontier-embedder LongMemEval benchmark and publish dual numbers (zero-dep local floor + frontier), on a host with API egress + key.
- Workstream A (RRF-as-default + chunk-per-turn ingestion port) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
