### PR TITLE
feat(website): SEO/AEO tier 1 (llms.txt, JSON-LD, 404, AI robots)

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,29 @@
+# hippo
+
+> A memory layer for AI agents, modeled on the hippocampus. hippo forgets by default and earns persistence through use: memories decay on a half-life, retrieval strengthens them, errors stick, and a sleep cycle consolidates repeats into patterns. Open source (MIT), zero runtime dependencies, runs locally.
+
+hippo (npm package `hippo-memory`) is an open-source memory system for AI agents and LLM applications. Unlike "save everything and search later" stores, hippo models the full memory lifecycle: decay by default, retrieval strengthening, outcome-weighted half-lives, error tagging, conflict detection, supersession, and sleep consolidation. It is local-first (SQLite source of truth with git-friendly markdown mirrors, zero outbound HTTP), framework-agnostic, and ships an MCP server plus auto-installed hooks for Claude Code, Codex, Cursor, OpenClaw, and OpenCode.
+
+## Key facts
+- License: MIT. Current version: 1.23.0. Runtime: Node.js 22.5+. Zero runtime dependencies (embeddings are optional).
+- Storage: local SQLite source of truth plus markdown mirrors. No cloud, no account, no telemetry.
+- Retrieval: BM25 out of the box; optional hybrid BM25 + embeddings via a pluggable provider (local MiniLM default, or opt-in OpenAI / Voyage / Cohere).
+- Mechanics: decay by default, retrieval strengthening, reward-proportional half-lives, error and emotional tagging, sleep consolidation, conflict detection, bi-temporal supersession.
+- Integrations: MCP server (Cursor, Windsurf, Cline, Claude Desktop) and hooks for Claude Code, Codex, Cursor, OpenClaw, OpenCode.
+
+## Benchmarks
+- LongMemEval-S, standard per-question haystack, recall@5: 98.6% with the zero-dependency local default (MiniLM), 99.8% with voyage-3-large (opt-in), at or above the published frontier (gbrain reports 97.6%). Zero-dependency BM25-only path: 74%.
+- 926 tests against a real database, zero mocks.
+
+## Links
+- Repository: https://github.com/kitfunso/hippo-memory
+- npm: https://www.npmjs.com/package/hippo-memory
+- Docs (README): https://github.com/kitfunso/hippo-memory#readme
+- Benchmarks: https://github.com/kitfunso/hippo-memory/tree/master/benchmarks
+- Changelog: https://github.com/kitfunso/hippo-memory/blob/master/CHANGELOG.md
+
+## Install
+```
+npm install -g hippo-memory
+hippo init --scan ~
+```

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,36 @@
+# https://hippo-memory.pages.dev
 User-agent: *
+Allow: /
+
+# AI answer engines and assistants are explicitly welcome (answer-engine optimization).
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
 Allow: /
 
 Sitemap: https://hippo-memory.pages.dev/sitemap-index.xml

--- a/website/src/content/site.ts
+++ b/website/src/content/site.ts
@@ -10,7 +10,7 @@ export const REPO = 'https://github.com/kitfunso/hippo-memory';
 export const site = {
   name: 'hippo',
   pkg: 'hippo-memory',
-  version: '1.15.0', // package.json
+  version: '1.23.0', // package.json
   // README headline tagline, split for gradient emphasis on the verb.
   tagline: { lead: 'Know what to', accent: 'forget.' },
   // README line 12 (verbatim intent).
@@ -199,5 +199,6 @@ export const faq = [
   { q: 'Does it need embeddings?', a: 'No. Recall runs on BM25 out of the box (74% R@5 on LongMemEval, BM25 only). Embeddings are an optional dependency for hybrid scoring; nothing is required at runtime.' },
   { q: 'Where does my data go?', a: 'Nowhere. Everything is a local SQLite store with markdown mirrors: 0 outbound HTTP on the ingestion smoke, proven by a fetch spy. No cloud, no account, no telemetry.' },
   { q: 'Which agents does it work with?', a: 'hippo init auto-installs hooks for Claude Code, Codex, Cursor, OpenClaw, and OpenCode, and exposes an MCP server for any MCP client (Cursor, Windsurf, Cline, Claude Desktop).' },
-  { q: 'Is it production-ready?', a: 'It is MIT-licensed at v1.15.0, with 926 tests against a real database and zero mocks. Multi-tenant isolation is proven by a negative test.' },
+  { q: 'How is hippo different from mem0, Letta, or Zep?', a: 'hippo optimizes the memory lifecycle, not just storage or retrieval. mem0 and similar tools save and search; Zep and Cognee extract entities into a knowledge graph; Letta has the agent edit its own memory blocks. hippo forgets by default and earns persistence through use, with reward-weighted decay, conflict detection, and sleep consolidation, and it runs locally with zero runtime dependencies.' },
+  { q: 'Is it production-ready?', a: 'It is MIT-licensed at v1.23.0, with 926 tests against a real database and zero mocks. Multi-tenant isolation is proven by a negative test.' },
 ] as const;

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -27,8 +27,12 @@ const jsonLd = {
   url: site.links.repo,
   softwareVersion: site.version,
   license: 'https://opensource.org/licenses/MIT',
-  author: { '@type': 'Organization', name: 'kitfunso' },
+  author: { '@type': 'Organization', name: 'kitfunso', url: site.links.repo },
   offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  sameAs: [site.links.repo, site.links.npm],
+  downloadUrl: site.links.npm,
+  keywords:
+    'AI agent memory, LLM memory, agent memory layer, MCP memory server, memory lifecycle, decay, retrieval strengthening, consolidation, open source, local-first',
 };
 
 const faqJsonLd = {

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -1,0 +1,29 @@
+---
+import Base from '../layouts/Base.astro';
+import { site } from '../content/site';
+---
+
+<Base
+  title={`Page not found - ${site.name}`}
+  description="That page does not exist. Head back to the hippo homepage."
+>
+  <main
+    id="main"
+    class="mx-auto flex min-h-screen max-w-xl flex-col items-center justify-center gap-6 px-6 text-center"
+  >
+    <p class="font-mono text-sm tracking-widest text-zinc-500">404</p>
+    <h1 class="font-display text-4xl font-semibold tracking-tight sm:text-5xl">
+      This memory decayed.
+    </h1>
+    <p class="max-w-md leading-relaxed text-zinc-400">
+      The page you are looking for does not exist, or it was forgotten. hippo forgets by
+      default, after all.
+    </p>
+    <a
+      href="/"
+      class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white"
+    >
+      Back to home
+    </a>
+  </main>
+</Base>


### PR DESCRIPTION
## SEO/AEO Tier 1 (on-page, machine-facing)

First pass at improving search + answer-engine optimization for hippo-memory.pages.dev. The site already had solid fundamentals (meta, OG/Twitter, JSON-LD with SoftwareApplication + FAQPage, sitemap, robots). This fills the real gaps. **No visible copy or design changes** (those need a separate voice pass).

### Changes
- **`public/llms.txt` (new)** - the core AEO artifact: a machine-readable summary of what hippo is, key facts, the LongMemEval numbers (98.6 / 99.8), integrations, links, and install. Was missing (the path soft-fell-back to the HTML page).
- **`src/pages/404.astro` (new)** - fixes the soft-404: unknown routes were served `index.html` with HTTP 200 (duplicate-content / soft-404 risk). Now a real `404.html`.
- **`Base.astro` JSON-LD** - enriched `SoftwareApplication`: `sameAs` (GitHub + npm), `downloadUrl`, `keywords`, author `url`.
- **`robots.txt`** - explicitly allow AI answer-engine crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, anthropic-ai, PerplexityBot, Google-Extended, Applebot-Extended, cohere-ai).
- **`site.ts`** - fix stale version `1.15.0 -> 1.23.0` (was wrong in JSON-LD + FAQ); add a "How is hippo different from mem0 / Letta / Zep?" FAQ (high-intent query, feeds the FAQPage schema).

### Verification
- Builds clean: 2 pages (index + 404), sitemap generated, README<->site drift guard green.
- dist confirmed to contain `llms.txt`, `404.html`, `robots.txt` (GPTBot allow), JSON-LD `sameAs`/`downloadUrl`, the comparison FAQ (visible + schema), version 1.23.0.

### Not in this PR (follow-ups)
- **Custom domain** (biggest SEO lever; `.pages.dev` is shared/low-authority) - needs a dashboard decision.
- **Tier 2 content depth**: `/vs/mem0`, `/benchmarks`, `/quickstart` indexable pages.
- **Visible copy/title keyword tuning** (voice pass).
- The repo `website` deploy script is missing `--project-name` (fails on wrangler 4.x) - worth a 1-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
