### PR TITLE
feat(website): SEO/AEO tier 2 - benchmarks, quickstart, vs-mem0

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -2,12 +2,17 @@
 import { site } from '../content/site';
 import Logo from './Logo.astro';
 
+const siteLinks = [
+  { label: 'Benchmarks', href: '/benchmarks/' },
+  { label: 'Quickstart', href: '/quickstart/' },
+  { label: 'hippo vs mem0', href: '/vs/mem0/' },
+];
+
 const footerLinks = [
   { label: 'GitHub', href: site.links.repo },
   { label: 'npm', href: site.links.npm },
   { label: 'Docs', href: site.links.docs },
   { label: 'Changelog', href: site.links.changelog },
-  { label: 'Benchmarks', href: site.links.benchmarks },
   { label: 'License (MIT)', href: site.links.license },
 ];
 ---
@@ -23,13 +28,22 @@ const footerLinks = [
           remembering more. It's knowing what to forget.
         </p>
       </div>
-      <nav class="flex flex-wrap gap-x-8 gap-y-3 text-sm">
-        {footerLinks.map((l) => (
-          <a href={l.href} target="_blank" rel="noopener noreferrer" class="text-zinc-400 transition hover:text-zinc-100">
-            {l.label}
-          </a>
-        ))}
-      </nav>
+      <div class="flex flex-wrap gap-x-12 gap-y-6">
+        <nav class="flex flex-col gap-y-2 text-sm">
+          {siteLinks.map((l) => (
+            <a href={l.href} class="text-zinc-400 transition hover:text-zinc-100">
+              {l.label}
+            </a>
+          ))}
+        </nav>
+        <nav class="flex flex-col gap-y-2 text-sm">
+          {footerLinks.map((l) => (
+            <a href={l.href} target="_blank" rel="noopener noreferrer" class="text-zinc-400 transition hover:text-zinc-100">
+              {l.label}
+            </a>
+          ))}
+        </nav>
+      </div>
     </div>
     <p class="mt-10 font-mono text-xs text-zinc-400">
       hippo-memory v{site.version} · MIT · built by kitfunso

--- a/website/src/content/site.ts
+++ b/website/src/content/site.ts
@@ -30,9 +30,10 @@ export const site = {
 } as const;
 
 export const nav = [
-  { label: 'How it works', href: '#how' },
-  { label: 'Receipts', href: '#receipts' },
-  { label: 'Compare', href: '#compare' },
+  { label: 'How it works', href: '/#how' },
+  { label: 'Benchmarks', href: '/benchmarks/' },
+  { label: 'Quickstart', href: '/quickstart/' },
+  { label: 'Compare', href: '/#compare' },
   { label: 'Docs', href: site.links.docs },
 ] as const;
 

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -35,6 +35,10 @@ const jsonLd = {
     'AI agent memory, LLM memory, agent memory layer, MCP memory server, memory lifecycle, decay, retrieval strengthening, consolidation, open source, local-first',
 };
 
+// The FAQPage schema describes the homepage FAQ, so only emit it on the homepage.
+// Sub-pages carry their own page-appropriate structured data.
+const isHome = Astro.url.pathname === '/';
+
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -88,7 +92,7 @@ const beaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN ?? 'dca34bc57a3946d08
     <meta name="twitter:image" content={ogImage} />
 
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+    {isHome && <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
   </head>
   <body class="min-h-screen antialiased">
     <a

--- a/website/src/pages/benchmarks.astro
+++ b/website/src/pages/benchmarks.astro
@@ -1,0 +1,147 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import { site } from '../content/site';
+
+const title = 'hippo benchmarks: LongMemEval retrieval (R@5 98.6 / 99.8)';
+const description =
+  "hippo's retrieval on the public LongMemEval benchmark, with the harness and data to reproduce it. 98.6% R@5 with the zero-dependency default, 99.8% with an opt-in frontier embedder.";
+
+// Verified against README.md + docs/evals/2026-06-09-longmemeval-per-haystack-dual.md.
+const perHaystack = [
+  { embedder: 'MiniLM-L6 (zero-dep default)', r1: '89.6', r5: '98.6', r10: '99.4' },
+  { embedder: 'voyage-3-large (opt-in)', r1: '94.6', r5: '99.8', r10: '99.8' },
+];
+const globalPool = [
+  { embedder: 'MiniLM-L6 (zero-dep default)', r5: '47.2' },
+  { embedder: 'voyage-3-large (opt-in)', r5: '56.4' },
+];
+
+const benchUrl = `${site.links.longmemeval}`;
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'hippo on LongMemEval: per-haystack retrieval R@5 98.6 (default) / 99.8 (voyage-3-large)',
+  description,
+  about: 'LongMemEval retrieval benchmark for the hippo-memory AI agent memory system',
+  author: { '@type': 'Organization', name: 'kitfunso', url: site.links.repo },
+  url: 'https://hippo-memory.pages.dev/benchmarks/',
+  isPartOf: { '@type': 'WebSite', name: site.name, url: 'https://hippo-memory.pages.dev/' },
+};
+---
+
+<Base title={title} description={description}>
+  <Nav />
+  <main id="main">
+    <!-- Header -->
+    <section class="relative scroll-mt-20">
+      <div class="mx-auto max-w-6xl px-5 pb-12 pt-28 sm:pt-32">
+        <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Benchmarks</p>
+        <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
+          Numbers, with the <span class="text-gradient">methodology</span>.
+        </h1>
+        <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
+          hippo's retrieval, measured on <a class="text-zinc-200 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href="https://arxiv.org/abs/2410.10813" target="_blank" rel="noopener noreferrer">LongMemEval</a> (ICLR 2025), the public 500-question memory benchmark. The harness, the data hash, and the per-question results are in the repo so you can rerun them.
+        </p>
+      </div>
+    </section>
+
+    <!-- Standard per-haystack -->
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+      <div class="mx-auto max-w-6xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Standard task: per-question haystack</h2>
+        <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
+          Each question ships its own haystack of about 48 conversation sessions, and the job is to retrieve the session that holds the answer. This is the standard LongMemEval-S setup, the same one published systems report. Recall at 5, on the <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-sm text-zinc-300">_s</code> split:
+        </p>
+        <div class="mt-8 overflow-hidden rounded-2xl border border-white/8">
+          <table class="w-full text-left text-sm">
+            <thead class="bg-white/[0.03] font-mono text-xs uppercase tracking-wider text-zinc-400">
+              <tr>
+                <th class="px-5 py-3 font-medium">Embedder</th>
+                <th class="px-5 py-3 font-medium">R@1</th>
+                <th class="px-5 py-3 font-medium">R@5</th>
+                <th class="px-5 py-3 font-medium">R@10</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/5">
+              {perHaystack.map((row) => (
+                <tr class="text-zinc-300">
+                  <td class="px-5 py-3.5">{row.embedder}</td>
+                  <td class="px-5 py-3.5 font-mono">{row.r1}</td>
+                  <td class="px-5 py-3.5 font-mono font-semibold text-gradient">{row.r5}</td>
+                  <td class="px-5 py-3.5 font-mono">{row.r10}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
+          For reference, gbrain reports 97.6% R@5 on this split with a paid frontier embedder. hippo's free, local, zero-dependency default reaches 98.6%. On the standard task, retrieval recall is effectively saturated, so the embedder is a swappable part, not the differentiator.
+        </p>
+      </div>
+    </section>
+
+    <!-- Large-store / global pool -->
+    <section class="relative scroll-mt-20 border-t border-white/5">
+      <div class="mx-auto max-w-6xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Large store: one unified memory</h2>
+        <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
+          Point retrieval at a single store of all 19,195 sessions, with no pre-scoped haystack, closer to how an agent's memory actually accumulates. Recall stops being free:
+        </p>
+        <div class="mt-8 grid max-w-2xl grid-cols-2 gap-4">
+          {globalPool.map((row) => (
+            <div class="glass rounded-2xl p-6">
+              <span class="font-mono text-4xl font-semibold tracking-tight text-zinc-200">{row.r5}</span>
+              <span class="mt-3 block text-sm text-zinc-400">R@5 &middot; {row.embedder}</span>
+            </div>
+          ))}
+        </div>
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
+          A stronger embedder helps here (47 to 56) but neither is usable on its own: the answer drowns among thousands of distractors. This is where the memory lifecycle earns its keep, by decaying, consolidating, and superseding so the effective store stays small. Measuring that is the next benchmark on the roadmap.
+        </p>
+      </div>
+    </section>
+
+    <!-- Other receipts -->
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+      <div class="mx-auto max-w-6xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Tested, and local by default</h2>
+        <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div class="glass rounded-2xl p-6">
+            <span class="font-mono text-4xl font-semibold tracking-tight text-gradient">74%</span>
+            <span class="mt-3 block text-sm font-medium text-zinc-200">R@5, BM25 only</span>
+            <span class="mt-2 block text-xs leading-relaxed text-zinc-400">Zero dependencies, no embeddings required at runtime.</span>
+          </div>
+          <div class="glass rounded-2xl p-6">
+            <span class="font-mono text-4xl font-semibold tracking-tight text-gradient">926</span>
+            <span class="mt-3 block text-sm font-medium text-zinc-200">tests, real database</span>
+            <span class="mt-2 block text-xs leading-relaxed text-zinc-400">Zero mocks. Project rule: no mocked dependencies.</span>
+          </div>
+          <div class="glass rounded-2xl p-6">
+            <span class="font-mono text-4xl font-semibold tracking-tight text-gradient">0</span>
+            <span class="mt-3 block text-sm font-medium text-zinc-200">outbound HTTP</span>
+            <span class="mt-2 block text-xs leading-relaxed text-zinc-400">Local SQLite, proven by a fetch spy on the ingestion smoke.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Methodology + reproduce -->
+    <section class="relative scroll-mt-20 border-t border-white/5">
+      <div class="mx-auto max-w-6xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Reproduce it</h2>
+        <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
+          The data is <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-sm text-zinc-300">longmemeval_s_cleaned.json</code> (SHA-256 <code class="font-mono text-xs text-zinc-500">d6f21ea9...</code>), 500 questions over 19,195 sessions. Retrieval is turn-level dense plus BM25, fused with reciprocal rank fusion and max-pooled to session. Embeddings are L2-normalized; the default is local MiniLM, with an opt-in pluggable provider for frontier embedders.
+        </p>
+        <div class="mt-7 flex flex-wrap gap-3">
+          <a href={benchUrl} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Benchmark harness &amp; data</a>
+          <a href={site.links.repo} target="_blank" rel="noopener noreferrer" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">Repository</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+</Base>

--- a/website/src/pages/quickstart.astro
+++ b/website/src/pages/quickstart.astro
@@ -1,0 +1,104 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import { site } from '../content/site';
+
+const title = 'hippo quickstart: persistent memory for Claude Code, Cursor, and MCP';
+const description =
+  'Install hippo and give your AI agents persistent, local memory in two commands. Auto-hooks for Claude Code, Codex, Cursor, OpenClaw, OpenCode, plus an MCP server for any MCP client.';
+
+const integrations = [
+  { name: 'Claude Code', note: 'Auto-installs a recall hook on session start and a sleep hook on exit.' },
+  { name: 'Cursor', note: 'Hook on task start plus the MCP server for in-editor recall.' },
+  { name: 'Codex', note: 'Auto-installed hook via hippo init.' },
+  { name: 'OpenClaw', note: 'Skill that injects recall on start and runs sleep on session end.' },
+  { name: 'OpenCode', note: 'Hook installed by hippo init.' },
+  { name: 'Any MCP client', note: 'MCP server for Cursor, Windsurf, Cline, and Claude Desktop.' },
+];
+
+const loop = [
+  { cmd: 'hippo remember "deploy failed: forgot migrations" --error', note: 'Store a memory. Errors get a longer half-life and stick.' },
+  { cmd: 'hippo recall "why did the deploy break" --budget 2000', note: 'Retrieve within a token budget, ranked by relevance and strength.' },
+  { cmd: 'hippo outcome --good', note: 'Tell hippo the recall helped. Useful memories decay slower.' },
+  { cmd: 'hippo sleep', note: 'Consolidate repeats into patterns, decay the unused, flag conflicts.' },
+];
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Add persistent memory to an AI agent with hippo',
+  description,
+  url: 'https://hippo-memory.pages.dev/quickstart/',
+  step: [
+    { '@type': 'HowToStep', name: 'Install', text: 'npm install -g hippo-memory' },
+    { '@type': 'HowToStep', name: 'Initialize', text: 'hippo init --scan ~ wires hooks into your agents and scans existing repos.' },
+    { '@type': 'HowToStep', name: 'Use', text: 'remember, recall, outcome, and sleep form the memory loop.' },
+  ],
+};
+---
+
+<Base title={title} description={description}>
+  <Nav />
+  <main id="main">
+    <section class="relative scroll-mt-20">
+      <div class="mx-auto max-w-5xl px-5 pb-12 pt-28 sm:pt-32">
+        <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Quickstart</p>
+        <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
+          Add memory in <span class="text-gradient">two commands</span>.
+        </h1>
+        <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
+          hippo is an MIT-licensed npm package with zero runtime dependencies. Install it, point it at your home directory, and it wires itself into the agents you already use.
+        </p>
+      </div>
+    </section>
+
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+      <div class="mx-auto max-w-5xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Install</h2>
+        <pre class="mt-6 overflow-x-auto rounded-2xl border border-white/8 bg-term-bg p-5 font-mono text-sm leading-relaxed text-term-fg"><code><span class="text-term-prompt">$</span> {site.installCmd}
+<span class="text-term-prompt">$</span> {site.initCmd}</code></pre>
+        <p class="mt-4 max-w-2xl text-sm leading-relaxed text-zinc-500">
+          <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-zinc-300">init --scan ~</code> detects your agents, installs their hooks, and gives you memory across every git repo under your home directory. Everything lives in a local SQLite store with markdown mirrors. No cloud, no account, no telemetry.
+        </p>
+      </div>
+    </section>
+
+    <section class="relative scroll-mt-20 border-t border-white/5">
+      <div class="mx-auto max-w-5xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Works with your agents</h2>
+        <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {integrations.map((i) => (
+            <div class="glass rounded-2xl p-5">
+              <span class="text-sm font-medium text-zinc-200">{i.name}</span>
+              <span class="mt-2 block text-xs leading-relaxed text-zinc-400">{i.note}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+      <div class="mx-auto max-w-5xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">The memory loop</h2>
+        <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
+          Four commands. Memories decay on a half-life unless something keeps them alive: a retrieval, a good outcome, an error tag, or consolidation during sleep.
+        </p>
+        <div class="mt-8 space-y-3">
+          {loop.map((step) => (
+            <div class="rounded-2xl border border-white/8 p-5">
+              <code class="block overflow-x-auto font-mono text-sm text-zinc-200"><span class="text-term-prompt">$</span> {step.cmd}</code>
+              <span class="mt-2 block text-xs leading-relaxed text-zinc-400">{step.note}</span>
+            </div>
+          ))}
+        </div>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a href={site.links.docs} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Full docs</a>
+          <a href="/benchmarks/" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">See the benchmarks</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+</Base>

--- a/website/src/pages/vs/mem0.astro
+++ b/website/src/pages/vs/mem0.astro
@@ -1,0 +1,114 @@
+---
+import Base from '../../layouts/Base.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import { site } from '../../content/site';
+
+const title = 'hippo vs mem0: AI agent memory compared';
+const description =
+  'hippo and mem0 are both open-source memory for AI agents, with different philosophies. mem0 saves and searches; hippo runs a memory lifecycle that forgets by default and earns persistence through use. Feature comparison and when to pick which.';
+
+const rows = [
+  { feature: 'Core model', hippo: 'Memory lifecycle: forget by default', mem0: 'Save everything, search later' },
+  { feature: 'Decay by default', hippo: 'Yes', mem0: 'No' },
+  { feature: 'Retrieval strengthening', hippo: 'Yes', mem0: 'No' },
+  { feature: 'Reward-proportional decay', hippo: 'Yes', mem0: 'No' },
+  { feature: 'Conflict detection + resolution', hippo: 'Yes', mem0: 'No' },
+  { feature: 'Search', hippo: 'BM25 + optional embeddings', mem0: 'Embeddings only' },
+  { feature: 'Zero runtime dependencies', hippo: 'Yes', mem0: 'No' },
+  { feature: 'Storage', hippo: 'Local SQLite + markdown', mem0: 'Vector store' },
+  { feature: 'MCP server', hippo: 'Yes', mem0: 'No' },
+  { feature: 'License', hippo: 'MIT', mem0: 'Apache-2.0' },
+];
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Is hippo a mem0 alternative?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. Both are open-source memory layers for AI agents. mem0 extracts and stores facts and retrieves them by similarity. hippo adds a memory lifecycle on top: memories decay on a half-life, retrieval strengthens them, errors stick, conflicts are flagged, and a sleep cycle consolidates repeats. hippo runs locally with zero runtime dependencies.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'When should I choose hippo over mem0?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Choose hippo when you want the store to stay small and current over time (decay, consolidation, supersession), local-first storage with no cloud or account, or zero runtime dependencies. mem0 is a fit when you mainly want to save and search facts. The two are not mutually exclusive philosophies, but hippo optimizes what to forget, not just what to retrieve.',
+      },
+    },
+  ],
+};
+---
+
+<Base title={title} description={description}>
+  <Nav />
+  <main id="main">
+    <section class="relative scroll-mt-20">
+      <div class="mx-auto max-w-5xl px-5 pb-12 pt-28 sm:pt-32">
+        <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Comparison</p>
+        <h1 class="mt-4 font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
+          hippo <span class="text-zinc-500">vs</span> <span class="text-gradient">mem0</span>
+        </h1>
+        <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
+          Both are open-source memory for AI agents. The difference is philosophy. mem0 saves and searches: it extracts facts and retrieves them by similarity. hippo runs a memory lifecycle: it forgets by default and earns persistence through use, so the store stays small and current instead of growing without bound.
+        </p>
+      </div>
+    </section>
+
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+      <div class="mx-auto max-w-5xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">Feature comparison</h2>
+        <div class="mt-8 overflow-hidden rounded-2xl border border-white/8">
+          <table class="w-full text-left text-sm">
+            <thead class="bg-white/[0.03] font-mono text-xs uppercase tracking-wider text-zinc-400">
+              <tr>
+                <th class="px-5 py-3 font-medium">Feature</th>
+                <th class="px-5 py-3 font-medium text-zinc-200">hippo</th>
+                <th class="px-5 py-3 font-medium">mem0</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/5">
+              {rows.map((r) => (
+                <tr class="text-zinc-300">
+                  <td class="px-5 py-3.5 text-zinc-400">{r.feature}</td>
+                  <td class="px-5 py-3.5 font-medium text-zinc-100">{r.hippo}</td>
+                  <td class="px-5 py-3.5">{r.mem0}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
+          Feature rows are from hippo's <a class="text-zinc-300 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href={`${site.links.repo}#comparison`} target="_blank" rel="noopener noreferrer">comparison table</a>. mem0 reports its own LongMemEval figures under its own conditions; hippo's per-haystack results are on the <a class="text-zinc-300 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href="/benchmarks/">benchmarks page</a>.
+        </p>
+      </div>
+    </section>
+
+    <section class="relative scroll-mt-20 border-t border-white/5">
+      <div class="mx-auto max-w-5xl px-5 py-20">
+        <h2 class="text-2xl leading-tight sm:text-3xl">When to choose which</h2>
+        <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div class="glass rounded-2xl p-6">
+            <span class="text-sm font-medium text-zinc-100">Choose hippo</span>
+            <span class="mt-2 block text-sm leading-relaxed text-zinc-400">You want the store to stay small and current over time, local-first with no cloud or account, zero runtime dependencies, and a memory that forgets the noise and keeps what gets used.</span>
+          </div>
+          <div class="glass rounded-2xl p-6">
+            <span class="text-sm font-medium text-zinc-100">Choose mem0</span>
+            <span class="mt-2 block text-sm leading-relaxed text-zinc-400">You mainly want to extract, store, and search facts, and a hosted or vector-store-backed setup fits your stack.</span>
+          </div>
+        </div>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a href="/quickstart/" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Get started with hippo</a>
+          <a href="/benchmarks/" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">Benchmarks</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+  <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />
+</Base>


### PR DESCRIPTION
## SEO/AEO Tier 2 (indexable content pages)

Adds three content pages so the site ranks for distinct high-intent queries and gives answer engines citable, structured pages, instead of a single landing page that ranks for almost nothing. Matches the existing dark/violet design and the plain factual voice; no homepage redesign.

### New pages
- **`/benchmarks`** — LongMemEval methodology + the per-haystack (98.6 / 99.8) and large-store results, the 74% / 926 / 0 receipts, and a reproduce section with the data hash. `TechArticle` JSON-LD. Targets "LongMemEval", "AI memory benchmark".
- **`/quickstart`** — install + per-agent integrations (Claude Code, Cursor, Codex, OpenClaw, OpenCode, MCP) + the remember/recall/outcome/sleep loop. `HowTo` JSON-LD. Targets "how to add memory to Claude/Cursor", "MCP memory server".
- **`/vs/mem0`** — focused comparison grounded in the verified README rows, with a page-scoped `FAQPage` ("Is hippo a mem0 alternative?", "when to choose which"). Targets "mem0 alternative".

### Supporting
- `Base.astro`: scope the homepage `FAQPage` schema to `/` so sub-pages carry only their own page-appropriate structured data.
- Nav: site-wide anchors (`/#how`, `/#compare`) so they resolve from sub-pages; add Benchmarks + Quickstart.
- Footer: internal links to the new pages (so `/vs/mem0` has an inbound link).

### Verification
- Builds clean (5 pages). All four indexable routes in the sitemap.
- FAQ schema gating confirmed: homepage 1, `/benchmarks` 0, `/vs/mem0` its own. `HowTo` on `/quickstart`. README<->site drift guard green.

### Not in this PR
- Custom domain (Tier 0, biggest lever).
- Visible homepage title/copy keyword tuning (voice pass).
- The `website` deploy script still needs `--project-name` (worked around).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
