### PR TITLE
seo(website): enrich homepage meta description (open-source, local-first)

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -11,9 +11,15 @@ import Compare from '../components/Compare.astro';
 import Faq from '../components/Faq.astro';
 import InstallCta from '../components/InstallCta.astro';
 import Footer from '../components/Footer.astro';
+
+// Homepage-only meta + OG description, enriched with the high-search modifiers
+// "open-source" and "local-first". The canonical site.description (JSON-LD and
+// every other page) and the visible hero copy are intentionally left unchanged.
+const metaDescription =
+  'Open-source, local-first memory for AI agents, modeled on the hippocampus. Decay by default, strength through use, provenance on every memory.';
 ---
 
-<Base>
+<Base description={metaDescription}>
   <Nav />
   <main id="main">
     <Hero />


### PR DESCRIPTION
Homepage-only `<meta description>` + `og:description` override, adding the high-search modifiers **open-source** and **local-first**.

The `Know what to forget` H1, the README-sourced `site.description` (used in JSON-LD and on every other page), and all visible hero copy are unchanged. Sub-pages keep their own descriptions.

Verified live (deploy 6d5d2696): homepage meta + og:description show the new text; `/vs/mem0/` still serves its own description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)