### PR TITLE
chore: add homepage field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "type": "git",
     "url": "git+https://github.com/kitfunso/hippo-memory.git"
   },
+  "homepage": "https://hippo-memory.pages.dev",
   "engines": {
     "node": ">=22.5.0"
   },


### PR DESCRIPTION
Adds a `homepage` field so the npmjs.com package page carries a canonical link to the landing site, a high-authority backlink for search discovery. Takes effect at the next npm publish. Switch to the custom domain when hippo-memory.com goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)