### PR TITLE
feat(website): point canonical domain at hippo-memory.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm](https://img.shields.io/npm/v/hippo-memory)](https://npmjs.com/package/hippo-memory)
 [![license](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
-[![website](https://img.shields.io/badge/website-hippo--memory.pages.dev-7c3aed)](https://hippo-memory.pages.dev)
+[![website](https://img.shields.io/badge/website-hippo--memory.com-7c3aed)](https://hippo-memory.com)
 
 <p align="center">
   <img src="./assets/hippo-init.svg" alt="hippo init --scan ~ — initializing memory across all repos" width="720">

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "type": "git",
     "url": "git+https://github.com/kitfunso/hippo-memory.git"
   },
-  "homepage": "https://hippo-memory.pages.dev",
+  "homepage": "https://hippo-memory.com",
   "engines": {
     "node": ">=22.5.0"
   },

--- a/website/README.md
+++ b/website/README.md
@@ -18,8 +18,9 @@ npm run preview  # serve the built dist/
 npm run deploy   # build + wrangler pages deploy dist
 ```
 
-Production: https://hippo-memory.pages.dev (custom domain TBD; set it in the CF Pages
-dashboard and update `site` in `astro.config.mjs`).
+Production: https://hippo-memory.com (apex custom domain on Cloudflare Pages). The
+hippo-memory.pages.dev subdomain still serves the same deployment; canonical tags point
+to the apex.
 
 ## Notes
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,7 +8,7 @@ import tailwindcss from '@tailwindcss/vite';
 // No SSR adapter: `astro build` -> dist/ -> `wrangler pages deploy dist`.
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://hippo-memory.pages.dev',
+  site: 'https://hippo-memory.com',
   integrations: [preact(), sitemap()],
   vite: {
     plugins: [tailwindcss()],

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,4 @@
-# https://hippo-memory.pages.dev
+# https://hippo-memory.com
 User-agent: *
 Allow: /
 
@@ -33,4 +33,4 @@ Allow: /
 User-agent: cohere-ai
 Allow: /
 
-Sitemap: https://hippo-memory.pages.dev/sitemap-index.xml
+Sitemap: https://hippo-memory.com/sitemap-index.xml

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -13,7 +13,7 @@ const {
 } = Astro.props;
 
 // All URLs derive from astro.config `site` -> a later domain swap is one edit.
-const base = Astro.site ?? new URL('https://hippo-memory.pages.dev');
+const base = Astro.site ?? new URL('https://hippo-memory.com');
 const canonical = new URL(Astro.url.pathname, base).href;
 const ogImage = new URL('/og.png', base).href;
 

--- a/website/src/pages/benchmarks.astro
+++ b/website/src/pages/benchmarks.astro
@@ -27,8 +27,8 @@ const jsonLd = {
   description,
   about: 'LongMemEval retrieval benchmark for the hippo-memory AI agent memory system',
   author: { '@type': 'Organization', name: 'kitfunso', url: site.links.repo },
-  url: 'https://hippo-memory.pages.dev/benchmarks/',
-  isPartOf: { '@type': 'WebSite', name: site.name, url: 'https://hippo-memory.pages.dev/' },
+  url: new URL('/benchmarks/', Astro.site!).href,
+  isPartOf: { '@type': 'WebSite', name: site.name, url: Astro.site!.href },
 };
 ---
 

--- a/website/src/pages/quickstart.astro
+++ b/website/src/pages/quickstart.astro
@@ -29,7 +29,7 @@ const jsonLd = {
   '@type': 'HowTo',
   name: 'Add persistent memory to an AI agent with hippo',
   description,
-  url: 'https://hippo-memory.pages.dev/quickstart/',
+  url: new URL('/quickstart/', Astro.site!).href,
   step: [
     { '@type': 'HowToStep', name: 'Install', text: 'npm install -g hippo-memory' },
     { '@type': 'HowToStep', name: 'Initialize', text: 'hippo init --scan ~ wires hooks into your agents and scans existing repos.' },


### PR DESCRIPTION
Custom domain **hippo-memory.com** is attached to the Cloudflare Pages project and live with SSL. This migrates every canonical reference from the `pages.dev` subdomain to the apex.

**Domain strings updated:** astro.config `site` (drives canonical/OG/sitemap), robots.txt sitemap URL + comment, root README website badge, website README note, package.json `homepage`, Base.astro fallback origin.

**Root-cause fix:** the benchmarks/quickstart JSON-LD `url`/`isPartOf` were hardcoded to the domain. Switched them to derive from `Astro.site` so a future domain change is a single `astro.config` edit, not N hardcoded edits.

**Verified live on https://hippo-memory.com** (deploy b7ce6d53): canonical, og:url, sitemap (all 4 routes), robots sitemap line, and the derived JSON-LD all resolve to the apex. `pages.dev` still serves the deployment; canonical tags consolidate it to the apex. IndexNow re-submitted for the new host (202); GitHub repo website field set to hippo-memory.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)