### PR TITLE
fix(consolidate): demote merged sources via half_life, not strength

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5954,7 +5954,11 @@ const HOOKS: Record<string, { file: string; content: string; description: string
     content: `
 ## Project Memory (Hippo)
 
-Before starting work, load relevant context:
+Pinned rules and recent writes auto-inject at every prompt via the installed
+UserPromptSubmit hook; never re-run that part manually. At the START of a
+task (not per prompt), additionally load task-specific context: git-aware
+recall over the full store that per-prompt injection does not cover. Also
+run it if the hook is not installed:
 \`\`\`bash
 hippo context --auto --budget 1500
 \`\`\`

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -33,6 +33,12 @@ import { resolveTenantId } from './tenant.js';
 const DECAY_THRESHOLD = 0.05;
 const MERGE_OVERLAP_THRESHOLD = 0.35;  // Jaccard similarity for "related"
 const MERGE_MIN_CLUSTER = 2;            // minimum cluster size to merge
+// Half-life scale for merged source episodics. Demotion must go through
+// half_life_days: calculateStrength() recomputes live strength from
+// last_retrieved/half_life and never reads the stored strength field, so a
+// stored-strength write is inert for ranking and gets overwritten by the
+// next sleep's decay pass anyway.
+const MERGE_SOURCE_HALF_LIFE_FACTOR = 0.3;
 // Contradictions should be gated by content overlap, not shared tags. Tags like
 // `feedback` / `policy` are too coarse and can make unrelated rules look like
 // conflicts before the polarity heuristics run.
@@ -501,10 +507,21 @@ export async function consolidate(
       pendingWrites.push(semantic);
       result.semanticCreated++;
 
-      // Reduce strength of source episodics (they've been compressed into neocortex)
+      // Demote source episodics (they've been compressed into neocortex):
+      // scale half_life_days so they decay sooner while staying recoverable.
+      // Immediate ranking is deliberately unchanged: the 2026-06-10 DAG
+      // slice-1 eval measured that dropping children below a worse-retrieving
+      // summary regresses budget-bounded QA (docs/evals/). The stored
+      // strength is refreshed to the live value so inspect, replay sampling,
+      // and strength-sorted assembly see the truth instead of a fake 0.3.
+      // Mutate in place (not a copy): `cluster` holds the same object
+      // references as `survivors`, and the later detectConflicts(survivors)
+      // pass in this same run must see the post-demotion half-life, or it
+      // can persist conflicts for entries the just-written state excludes.
       for (const e of cluster) {
-        const weakened: MemoryEntry = { ...e, strength: e.strength * 0.3 };
-        pendingWrites.push(weakened);
+        e.half_life_days = Math.max(1, Math.floor(e.half_life_days * MERGE_SOURCE_HALF_LIFE_FACTOR));
+        e.strength = calculateStrength(e, now, decayOpts);
+        pendingWrites.push(e);
       }
     }
   }

--- a/tests/consolidate.test.ts
+++ b/tests/consolidate.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { consolidate } from '../src/consolidate.js';
 import { initStore, writeEntry, loadAllEntries, readEntry, listMemoryConflicts } from '../src/store.js';
-import { createMemory, Layer } from '../src/memory.js';
+import { createMemory, Layer, calculateStrength } from '../src/memory.js';
 
 let tmpDir: string;
 
@@ -193,6 +193,49 @@ describe('Merge pass', () => {
     const result = await consolidate(tmpDir, { now: new Date() });
     expect(result.merged).toBe(0);
     expect(result.semanticCreated).toBe(0);
+  });
+
+  it('demotes merged source episodics via half_life_days, not the inert stored-strength field', async () => {
+    initStore(tmpDir);
+
+    const e1 = createMemory('cache refresh failure data pipeline error', { layer: Layer.Episodic });
+    const e2 = createMemory('cache refresh failure data pipeline problem', { layer: Layer.Episodic });
+    writeEntry(tmpDir, e1);
+    writeEntry(tmpDir, e2);
+
+    const now = new Date();
+    const result = await consolidate(tmpDir, { now });
+    expect(result.merged).toBe(2);
+
+    const m1 = readEntry(tmpDir, e1.id);
+    const m2 = readEntry(tmpDir, e2.id);
+    expect(m1!.half_life_days).toBe(Math.max(1, Math.floor(e1.half_life_days * 0.3)));
+    expect(m2!.half_life_days).toBe(Math.max(1, Math.floor(e2.half_life_days * 0.3)));
+
+    // Stored strength is a cache of the LIVE value, not a fake 0.3: fresh
+    // entries keep ~full strength now (no immediate ranking cliff)...
+    expect(m1!.strength).toBeGreaterThan(0.9);
+
+    // ...but the demotion is real where ranking actually reads it: a few
+    // days out, the merged source decays below an unmerged peer written at
+    // the same time with the same default half-life.
+    const later = new Date(now.getTime() + 10 * 24 * 60 * 60 * 1000);
+    const unmergedPeer = { ...createMemory('completely unrelated standalone topic'), half_life_days: e1.half_life_days };
+    expect(calculateStrength(m1!, later)).toBeLessThan(calculateStrength(unmergedPeer, later));
+  });
+
+  it('half-life demotion floors at 1 day', async () => {
+    initStore(tmpDir);
+
+    const e1 = { ...createMemory('cache refresh failure data pipeline error', { layer: Layer.Episodic }), half_life_days: 2 };
+    const e2 = { ...createMemory('cache refresh failure data pipeline problem', { layer: Layer.Episodic }), half_life_days: 2 };
+    writeEntry(tmpDir, e1);
+    writeEntry(tmpDir, e2);
+
+    await consolidate(tmpDir, { now: new Date() });
+
+    expect(readEntry(tmpDir, e1.id)!.half_life_days).toBe(1);
+    expect(readEntry(tmpDir, e2.id)!.half_life_days).toBe(1);
   });
 
   it('detects overlapping contradictory memories and records open conflicts', async () => {


### PR DESCRIPTION
## Problem

Consolidation's merge pass "weakens" source episodics by writing `strength: e.strength * 0.3` (consolidate.ts:506). But `calculateStrength()` recomputes live strength from `last_retrieved`/`half_life_days` and never reads the stored field, so the demotion was:

- **inert** for ranking and physics mass (a merged source showed stored `0.3` while ranking at full strength), and
- **transient**: the next sleep's decay pass overwrote the stored value with the live one.

This is the source-verified root cause behind the 2026-06-09 lifecycle-stress finding ("summaries rank below the weakened originals" - the originals were never actually weakened), and the fake stored `0.3` also polluted everything that reads the stored field: `hippo inspect`, replay sampling weights, and the strength-sorted ambient assembly.

## Fix

- Demote via `half_life_days * 0.3` (floor 1 day, mirroring the invalidation idiom): merged sources decay sooner while staying recoverable (AGENTS.md: weaken, never delete).
- Refresh the stored strength cache to the live value so observability tells the truth.
- **Immediate ranking is deliberately unchanged**: the 2026-06-10 DAG slice-1 eval measured that demoting children below a worse-retrieving summary regresses budget-bounded QA (-6.3pp). This fix makes the demotion real where ranking actually reads it (decay over time), without repeating that mechanism.

Also fixes the claude-code CLAUDE.md hook template: it read as if manual `hippo context --auto` were the only memory loading, when the installer already auto-wires a UserPromptSubmit hook injecting pinned rules + recent writes every prompt. The new wording separates the two channels: never manually re-run the per-prompt injection; DO run `hippo context --auto` once at task start, because per-prompt pinned/recent injection is not task-specific recall. (codex/cursor templates untouched: those tools have no per-prompt hook.)

## Verification (lifecycle ruler, Cell-B binding config: 16 facts, B=300, 1x, 4 seeds)

| Path | master a36238a | this PR | delta |
|---|---|---|---|
| hippo-full, relevance | 53.1% | 53.1% | +0.0pp (rank-neutral, as designed) |
| hippo-full, strength-sorted ambient | 18.8% | 25.0% | **+6.2pp, now +0.0pp parity with no-lifecycle** |

The strength-sorted improvement closes the slice-1 result doc's open follow-up #3 (secondary-path regression): the fake stored 0.3 was its cause.

## Tests

- [x] 2 new real-DB merge-pass tests: half-life demotion math, 1-day floor, and a decays-sooner-than-unmerged-peer assertion at +10 days
- [x] Full suite: 2535 passed / 1 failed (`server-concurrency.test.ts` ECONNRESET - load-flake, passes in isolation, untouched by this diff)
- [x] `npm run build` clean (tsc + benchmarks tsconfig)

## Review trail

Codex review round 1: P2 (same-run `detectConflicts(survivors)` would see stale pre-demotion half-life) - FIXED by mutating cluster entries in place (they share references with `survivors`); P3 (untracked local draft files) - kept out of the change set. Round 2: consolidation change clean; P2 on the template wording ("skip context loading by default" would suppress the only task-specific lookup, since the hook injects pinned/recent, not task recall) - FIXED with the two-channel wording above. Verification re-run after each fix: eval identical, 67/67 consolidate-dependent tests green.

## Flags for review

1. **Re-merge compounding (pre-existing surface):** merged sources stay episodic, so the same cluster can re-merge on later sleeps - master already re-creates duplicate semantic summaries indefinitely. Under this PR the demotion compounds across re-merges (0.3 -> 0.09 -> floor 1), which closes that infinite-duplication loop over time (sources eventually decay out) but is a behavior worth knowing. A merge marker / idempotency guard for the default merge pass (mirroring the archived slice-1 R1 fix) is a sensible follow-up.
2. Existing installed CLAUDE.md blocks are not migrated (autoInstallHooks skips files that already contain a hippo block); only fresh installs get the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
