### PR TITLE
feat(website): design-audit rebuild, 38 fixes + synapse background

### DIFF
--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -1,0 +1,93 @@
+---
+name: hippo-memory.com
+direction: dark-premium, receipts-led developer marketing
+updated: 2026-06-10
+source_of_truth: true
+tokens:
+  font:
+    display: "Bricolage Grotesque Variable"   # h1-h3 only
+    sans: "Hanken Grotesk Variable"           # body
+    mono: "JetBrains Mono Variable"           # code, numbers, eyebrows, stats
+  color:
+    bg: "#08080b"
+    accent_violet: "#a78bfa"
+    accent_cyan: "#22d3ee"
+    gradient: "linear-gradient(110deg, #a78bfa 0%, #22d3ee 100%)"  # surgical: one headline keyword, CTA ring, decay curve. Never a background fill.
+    gradient_fallback: "#c4b5fd"
+    text_body: "zinc-100"
+    text_muted: "zinc-400"          # FLOOR for any prose on bg (7.8:1). zinc-500 is decoration only, never sentences.
+    term_bg: "#0c0c12"
+    term_ok: "#4ade80"
+    confidence_emerald: "emerald-400"
+    error_rose: "rgba(251,113,133,0.6)"  # rose-400/60 minimum; /40 fails the 3:1 non-text floor
+  layout:
+    container: "72rem"              # max-w-6xl. ONE container token sitewide: nav, footer, every section. No max-w-5xl wrappers.
+    section_padding_y: "6rem"       # py-24 rhythm on all pages
+    prose_measure: "65-75ch"        # cap footnotes/summaries at max-w-2xl
+  type_scale:
+    floor: "0.75rem"                # 12px. No text-[10px]/[11px] anywhere
+    h1_leading: "1.03"              # one display leading token
+    h2: "text-3xl sm:text-4xl"      # one h2 pair sitewide; h1 always a clear step above; no h2 may match another page's h1
+  links:
+    color: "#22d3ee"
+    underline: "decoration >=40% opacity at rest"   # one treatment sitewide
+  touch_targets: "44px minimum on nav pills, chips, copy buttons"
+  glass:
+    surface: "rgba(255,255,255,0.035) + 1px rgba(255,255,255,0.08) border + backdrop blur(14px) saturate(140%)"
+    header_fallback: "rgba(10,10,15,0.85)"  # header only; verify built dist CSS retains the standard backdrop-filter property
+  motion:
+    reveal: "child elements only, never whole sections; fail-open (force-visible timeout) so full-page render/print/previews never blank"
+    background: "fixed canvas at z-index -1, alpha <=8%, static frame under prefers-reduced-motion"
+---
+
+# hippo-memory.com design system
+
+Codified from the shipped site plus the 2026-06-10 design audit
+(C:/Users/skf_s/design-audits/hippo-memory-2026-06-10/REPORT.md). The audit's
+confirmed findings are the deltas; the strengths it verified are the rules.
+
+## Identity
+
+Developer tool, receipts-led. The site argues with numbers (98.6% R@5, 926
+tests, 0 deps) and publishes its own bad results. Every page sequences:
+claim, methodology, trust, reproduce. Dark-premium surface; the violet-cyan
+gradient is a scalpel, not a wash.
+
+## Hierarchy grammar
+
+Mono uppercase eyebrow, display h2, muted body. Gradient marks exactly one
+keyword per h1, always on the brand side of a comparison (hippo, never the
+competitor). Primary CTA above the fold is adoption ("Get started" ->
+/quickstart/), never vanity (GitHub stars live in the nav badge). One proof
+line under the hero subhead.
+
+## Copy rules
+
+Numbers over adjectives. No em dashes in UI strings. No "not X, it's Y"
+contrast constructions (one earned exception: "Numbers, not adjectives.").
+No rhetorical scaffolding, no market-speak hedging. Footer tagline: "Good
+memory is knowing what to forget."
+
+## Accessibility floor
+
+AA 4.5:1 for all prose (zinc-400 minimum on bg), 3:1 for non-text glyphs.
+Skip link, landmarks (labeled when repeated), one h1 per page, no skipped
+heading levels, scope attrs on all comparison tables, aria-current on the
+active nav item, logo links home, visible focus (cyan outline), full
+prefers-reduced-motion handling, 44px touch targets.
+
+## Comparison surfaces
+
+Homepage matrix shows 5-6 differentiator rows against 3-4 named competitors,
+links to the full matrix on GitHub. Scroll containers get a right-edge fade
+plus caption cue on mobile. Every comparison page ships at least one number
+(the receipts strip pattern).
+
+## Background layer
+
+A fixed full-viewport canvas sits behind all content (z-index -1) replacing
+flat #08080b: the synapse-network field (variant A) - drifting neuron dots
+with depth parallax, faint links, pulses fired by scroll velocity. Luminance
+stays under 8% alpha so the AA floor holds. Static single frame under
+prefers-reduced-motion. Opaque section backgrounds (FAQ band) become
+translucent so the field reads site-long.

--- a/website/src/components/BackgroundFx.astro
+++ b/website/src/components/BackgroundFx.astro
@@ -1,0 +1,215 @@
+---
+// Synapse-network background (DESIGN.md "Background layer"): a fixed canvas at
+// z-index -1 behind every page. Drifting neuron dots with depth parallax, faint
+// links between close pairs, pulses fired by scroll velocity. Link alpha stays
+// <= 9% so the AA contrast floor holds on top of it. Base styles live in
+// global.css (#bg-fx); prefers-reduced-motion gets a single static frame.
+---
+
+<canvas id="bg-fx" aria-hidden="true"></canvas>
+
+<script>
+  function initBackgroundFx() {
+    const canvas = document.getElementById('bg-fx');
+    if (!(canvas instanceof HTMLCanvasElement)) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const CYAN = '34,211,238';
+    const VIOLET = '167,139,250';
+    const LINK = 120; // px: pairs closer than this get a connecting line
+    const MAX_PULSES = 10;
+
+    interface SynapseNode {
+      x: number;
+      y: number;
+      z: number; // depth 0.35-1.0: drives parallax, size, and alpha
+      vx: number;
+      vy: number;
+      color: string;
+      twinkle: number;
+    }
+
+    let nodes: SynapseNode[] = [];
+    let pulses: Array<{ i: number; j: number; progress: number }> = [];
+    let width = 0;
+    let height = 0;
+    let scrollOffset = window.scrollY;
+    let lastScroll = scrollOffset;
+    let velocity = 0;
+    let rafId = 0;
+    let running = false;
+
+    const wrap = (value: number, max: number) => ((value % max) + max) % max;
+
+    // Density scales with viewport area, capped so the O(n^2) link pass stays cheap.
+    const seedNodes = () => {
+      const count = Math.min(110, Math.max(48, Math.floor((width * height) / 16000)));
+      nodes = [];
+      for (let i = 0; i < count; i++) {
+        nodes.push({
+          x: Math.random() * width,
+          y: Math.random() * (height + 80),
+          z: 0.35 + Math.random() * 0.65,
+          vx: (Math.random() - 0.5) * 0.12,
+          vy: (Math.random() - 0.5) * 0.12,
+          color: Math.random() < 0.72 ? CYAN : VIOLET,
+          twinkle: Math.random() * Math.PI * 2,
+        });
+      }
+      pulses = []; // pulse endpoint indexes are invalid after a re-seed
+    };
+
+    const drawFrame = () => {
+      ctx.clearRect(0, 0, width, height);
+      velocity = velocity * 0.9 + Math.abs(scrollOffset - lastScroll) * 0.1;
+      lastScroll = scrollOffset;
+
+      // project nodes: slow drift + depth parallax against scroll
+      const pts: Array<[number, number, SynapseNode]> = [];
+      for (const node of nodes) {
+        node.x += node.vx;
+        node.y += node.vy;
+        node.twinkle += 0.012;
+        const px = wrap(node.x, width);
+        const py = wrap(node.y - scrollOffset * 0.08 * node.z, height + 80) - 40;
+        pts.push([px, py, node]);
+      }
+
+      // links between close pairs; O(n^2) is fine at n <= 110
+      ctx.lineWidth = 1;
+      for (let i = 0; i < pts.length; i++) {
+        for (let j = i + 1; j < pts.length; j++) {
+          const dx = pts[i][0] - pts[j][0];
+          const dy = pts[i][1] - pts[j][1];
+          const d2 = dx * dx + dy * dy;
+          if (d2 < LINK * LINK) {
+            const alpha = (1 - Math.sqrt(d2) / LINK) * 0.09;
+            ctx.strokeStyle = `rgba(120,160,210,${alpha.toFixed(3)})`;
+            ctx.beginPath();
+            ctx.moveTo(pts[i][0], pts[i][1]);
+            ctx.lineTo(pts[j][0], pts[j][1]);
+            ctx.stroke();
+          }
+        }
+      }
+
+      for (const [px, py, node] of pts) {
+        const alpha = 0.16 + 0.22 * node.z + 0.1 * Math.sin(node.twinkle);
+        ctx.fillStyle = `rgba(${node.color},${Math.max(0.05, alpha).toFixed(3)})`;
+        ctx.beginPath();
+        ctx.arc(px, py, 0.8 + 1.2 * node.z, 0, 6.2832);
+        ctx.fill();
+      }
+
+      // scroll velocity fires pulses; a rare ambient fire keeps the field alive
+      // at rest. Guarded on `running` so the reduced-motion static frame is calm.
+      if (running) {
+        const want = velocity > 2 ? 2 : Math.random() < 0.012 ? 1 : 0;
+        for (let k = 0; k < want && pulses.length < MAX_PULSES; k++) {
+          const i = (Math.random() * pts.length) | 0;
+          let best = -1;
+          let bestD2 = LINK * LINK;
+          for (let j = 0; j < pts.length; j++) {
+            if (j === i) continue;
+            const dx = pts[i][0] - pts[j][0];
+            const dy = pts[i][1] - pts[j][1];
+            const d2 = dx * dx + dy * dy;
+            if (d2 < bestD2) {
+              bestD2 = d2;
+              best = j;
+            }
+          }
+          if (best >= 0) pulses.push({ i, j: best, progress: 0 });
+        }
+      }
+
+      for (let k = pulses.length - 1; k >= 0; k--) {
+        const pulse = pulses[k];
+        pulse.progress += 0.035;
+        if (pulse.progress >= 1 || pulse.i >= pts.length || pulse.j >= pts.length) {
+          pulses.splice(k, 1);
+          continue;
+        }
+        const [ax, ay] = pts[pulse.i];
+        const [bx, by] = pts[pulse.j];
+        // endpoints wrapped to opposite edges: kill the pulse instead of streaking
+        if (Math.abs(ax - bx) > LINK * 1.5 || Math.abs(ay - by) > LINK * 1.5) {
+          pulses.splice(k, 1);
+          continue;
+        }
+        const x = ax + (bx - ax) * pulse.progress;
+        const y = ay + (by - ay) * pulse.progress;
+        const fade = Math.sin(pulse.progress * Math.PI);
+        const glow = ctx.createRadialGradient(x, y, 0, x, y, 7);
+        glow.addColorStop(0, `rgba(103,232,249,${(0.5 * fade).toFixed(3)})`);
+        glow.addColorStop(1, 'rgba(103,232,249,0)');
+        ctx.fillStyle = glow;
+        ctx.beginPath();
+        ctx.arc(x, y, 7, 0, 6.2832);
+        ctx.fill();
+      }
+    };
+
+    const frame = () => {
+      drawFrame();
+      if (running) rafId = requestAnimationFrame(frame);
+    };
+
+    const start = () => {
+      if (running) return;
+      running = true;
+      lastScroll = scrollOffset; // no velocity spike from a stale delta
+      rafId = requestAnimationFrame(frame);
+    };
+
+    const stop = () => {
+      if (!running) return;
+      running = false;
+      cancelAnimationFrame(rafId);
+    };
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    // Reduced motion: one static frame, no rAF loop. Re-applied when the
+    // preference changes at runtime, and on visibilitychange below.
+    const applyMotionPreference = () => {
+      if (motionQuery.matches) {
+        stop();
+        drawFrame();
+      } else if (!document.hidden) {
+        start();
+      }
+    };
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seedNodes(); // density is area-dependent: redistribute, don't stretch
+      if (!running) drawFrame(); // keep the static frame fresh under reduced motion
+    };
+
+    window.addEventListener(
+      'scroll',
+      () => {
+        scrollOffset = window.scrollY;
+      },
+      { passive: true }
+    );
+    window.addEventListener('resize', resize, { passive: true });
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) stop();
+      else applyMotionPreference();
+    });
+    motionQuery.addEventListener('change', applyMotionPreference);
+
+    resize(); // seeds + paints the first frame
+    applyMotionPreference();
+  }
+
+  initBackgroundFx();
+</script>

--- a/website/src/components/Compare.astro
+++ b/website/src/components/Compare.astro
@@ -9,78 +9,108 @@ function cellTone(v: string): string {
   if (v === '?' || v.startsWith('N/A')) return 'text-zinc-400';
   return 'text-zinc-300';
 }
+
+// Home shows a trimmed view: 6 differentiator rows x (Feature + hippo + 3 strongest
+// competitors). The FULL 10-tool data stays in `comparison` (README-verbatim,
+// build-gate-checked); the GitHub link below carries readers to it. Cells render
+// the short `display` verdict where one exists, else the verbatim cell.
+const homeSystems = ['Hippo', 'Mem0', 'gbrain', 'Zep'];
+const homeFeatures = [
+  'Decay by default',
+  'Retrieval strengthening',
+  'Cross-tool import (ChatGPT/Claude/Cursor)',
+  'Auto-hook install',
+  'Zero runtime deps',
+  'LongMemEval (best published)',
+];
+const systems = homeSystems.map((n) => comparison.systems.find((s) => s.name === n)!);
+const sysIdx = homeSystems.map((n) => comparison.systems.findIndex((s) => s.name === n));
+const rows = homeFeatures.map((f) => {
+  const row = comparison.rows.find((r) => r.feature === f)!;
+  const all: readonly string[] = 'display' in row ? row.display : row.cells;
+  return { feature: row.feature, cells: sysIdx.map((i) => all[i]) };
+});
 ---
 
 <section id="compare" class="relative scroll-mt-20 border-t border-white/5">
   <div class="mx-auto max-w-6xl px-5 py-24">
-    <div class="max-w-2xl" data-reveal>
+    <div class="max-w-2xl">
       <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Compare</p>
       <h2 class="mt-4 text-3xl leading-tight sm:text-4xl">
         <span class="text-gradient">{compare.heading}</span>
       </h2>
-      <p class="mt-5 text-lg leading-relaxed text-zinc-400">{compare.body}</p>
+      <p class="mt-5 text-lg leading-relaxed text-zinc-400" data-reveal>{compare.body}</p>
     </div>
 
-    <!-- full matrix; horizontal scroll is CONTAINED to this wrapper (never the page) -->
-    <div class="mt-10 overflow-x-auto rounded-2xl glass">
-      <table class="w-full min-w-[940px] border-collapse text-left text-sm">
-        <thead>
-          <tr class="border-b border-white/10">
-            <th
-              scope="col"
-              class="sticky left-0 z-20 w-40 border-r border-white/10 bg-[#0c0c11] px-4 py-3 font-mono text-xs uppercase tracking-wider text-zinc-400"
-            >
-              Feature
-            </th>
-            {comparison.systems.map((s) => (
-              <th scope="col" class="px-2 py-3 text-center align-bottom font-display text-[13px] font-semibold">
-                <a
-                  href={s.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class:list={[
-                    'underline-offset-4 transition hover:underline',
-                    s.self ? 'text-gradient' : 'text-zinc-300 hover:text-zinc-100',
-                  ]}
-                >{s.name}</a>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {comparison.rows.map((row, i) => (
-            <tr class:list={['border-b border-white/5', i % 2 === 1 ? 'bg-white/[0.015]' : '']}>
+    <!-- trimmed matrix; horizontal scroll is CONTAINED to this wrapper (never the page) -->
+    <div class="relative mt-10">
+      <div class="overflow-x-auto rounded-2xl glass">
+        <table class="w-full min-w-[560px] border-collapse text-left text-sm">
+          <thead>
+            <tr class="border-b border-white/10">
               <th
-                scope="row"
-                class="sticky left-0 z-10 w-40 border-r border-white/10 bg-[#0c0c11] px-4 py-3 text-left font-normal text-zinc-200"
+                scope="col"
+                class="sticky left-0 z-20 w-40 border-r border-white/10 bg-[#0c0c11] px-4 py-3 font-mono text-xs uppercase tracking-wider text-zinc-400"
               >
-                {row.feature}
+                Feature
               </th>
-              {row.cells.map((c, ci) => (
-                <td
-                  class:list={[
-                    'px-2 py-2.5 text-center align-top text-xs leading-snug',
-                    cellTone(c),
-                    ci === 0 ? 'bg-acc-violet/5 font-medium' : '',
-                  ]}
-                >{c}</td>
+              {systems.map((s) => (
+                <th scope="col" class="px-2 py-3 text-center align-bottom font-sans text-[13px] font-semibold">
+                  <a
+                    href={s.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class:list={[
+                      'underline-offset-4 transition hover:underline',
+                      s.self ? 'text-gradient' : 'text-zinc-300 hover:text-zinc-100',
+                    ]}
+                  >{s.name}</a>
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr class:list={['border-b border-white/5', i % 2 === 1 ? 'bg-white/[0.015]' : '']}>
+                <th
+                  scope="row"
+                  class="sticky left-0 z-10 w-40 border-r border-white/10 bg-[#0c0c11] px-4 py-3 text-left font-normal text-zinc-200"
+                >
+                  {row.feature}
+                </th>
+                {row.cells.map((c, ci) => (
+                  <td
+                    class:list={[
+                      'whitespace-nowrap px-2 py-2.5 text-center align-top text-[13px] leading-snug',
+                      cellTone(c),
+                      ci === 0 ? 'bg-acc-violet/5 font-medium' : '',
+                    ]}
+                  >{c}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <!-- mobile scroll cue: right-edge fade over the scroll container -->
+      <div
+        class="pointer-events-none absolute inset-y-0 right-0 w-14 rounded-r-2xl bg-gradient-to-l from-[#08080b]/90 to-transparent sm:hidden"
+        aria-hidden="true"
+      ></div>
     </div>
+    <p class="mt-2.5 font-mono text-xs text-zinc-400 sm:hidden">{compare.scrollCue} →</p>
 
-    <div class="mt-4 space-y-1.5">
-      {comparison.footnotes.map((f) => <p class="max-w-3xl text-xs leading-relaxed text-zinc-400">{f}</p>)}
-    </div>
-
-    <p class="mt-6 max-w-3xl text-sm leading-relaxed text-zinc-400">{comparison.closing}</p>
-
-    <p class="mt-5 text-sm text-zinc-400">
-      <a href={compare.sourceHref} target="_blank" rel="noopener noreferrer" class="text-acc-cyan underline underline-offset-4">
-        Source: the full comparison in the README
+    <p class="mt-5 text-sm">
+      <a href={compare.sourceHref} target="_blank" rel="noopener noreferrer" class="link">
+        {compare.sourceLabel} →
       </a>
     </p>
+
+    <div class="mt-4 space-y-1.5" data-reveal>
+      {comparison.footnotes.map((f) => <p class="max-w-2xl text-sm leading-relaxed text-zinc-400">{f}</p>)}
+      <p class="max-w-2xl text-sm leading-relaxed text-zinc-400">{compare.qualifierNote}</p>
+    </div>
+
+    <p class="mt-6 max-w-2xl text-sm leading-relaxed text-zinc-400" data-reveal>{comparison.closing}</p>
   </div>
 </section>

--- a/website/src/components/CopyCommand.astro
+++ b/website/src/components/CopyCommand.astro
@@ -14,7 +14,7 @@ const pad = size === 'lg' ? 'px-5 py-4 text-base' : 'px-4 py-3 text-sm';
     type="button"
     data-copy={command}
     aria-label={`Copy command: ${command}`}
-    class="shrink-0 rounded-md border border-white/10 px-3 py-1.5 text-xs text-zinc-400 transition hover:border-acc-violet/50 hover:text-zinc-100 focus-visible:text-zinc-100"
+    class="relative shrink-0 rounded-md border border-white/10 px-3 py-1.5 text-xs text-zinc-400 transition after:absolute after:-inset-2 after:content-[''] hover:border-acc-violet/50 hover:text-zinc-100 focus-visible:text-zinc-100"
   >
     <span data-copy-label>Copy</span>
   </button>

--- a/website/src/components/DecayCurve.tsx
+++ b/website/src/components/DecayCurve.tsx
@@ -78,8 +78,8 @@ export default function DecayCurve() {
       {/* axes */}
       <line x1="24" y1="184" x2="464" y2="184" stroke="rgba(255,255,255,0.12)" stroke-width="1" />
       <line x1="24" y1="20" x2="24" y2="184" stroke="rgba(255,255,255,0.12)" stroke-width="1" />
-      <text x="8" y="30" fill="#52525b" font-size="9" font-family="monospace" transform="rotate(-90 8 30)" style="transform-box: fill-box;">strength</text>
-      <text x="430" y="200" fill="#52525b" font-size="9" font-family="monospace">time</text>
+      <text x="8" y="30" fill="#a1a1aa" font-size="9" font-family="monospace" transform="rotate(-90 8 30)" style="transform-box: fill-box;">strength</text>
+      <text x="430" y="200" fill="#a1a1aa" font-size="9" font-family="monospace">time</text>
 
       {/* area fill under curve */}
       <path

--- a/website/src/components/Faq.astro
+++ b/website/src/components/Faq.astro
@@ -2,9 +2,9 @@
 import { faq } from '../content/site';
 ---
 
-<section id="faq" class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+<section id="faq" class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
   <div class="mx-auto max-w-3xl px-5 py-24">
-    <div data-reveal>
+    <div>
       <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">FAQ</p>
       <h2 class="mt-4 text-3xl leading-tight sm:text-4xl">Questions, answered.</h2>
     </div>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -24,19 +24,19 @@ const footerLinks = [
       <div class="max-w-sm">
         <Logo gid="ft" />
         <p class="mt-3 text-sm leading-relaxed text-zinc-400">
-          A memory layer for AI agents, modeled on the hippocampus. The secret to good memory isn't
-          remembering more. It's knowing what to forget.
+          A memory layer for AI agents, modeled on the hippocampus. Good memory is knowing what
+          to forget.
         </p>
       </div>
       <div class="flex flex-wrap gap-x-12 gap-y-6">
-        <nav class="flex flex-col gap-y-2 text-sm">
+        <nav aria-label="Site pages" class="flex flex-col gap-y-2 text-sm">
           {siteLinks.map((l) => (
             <a href={l.href} class="text-zinc-400 transition hover:text-zinc-100">
               {l.label}
             </a>
           ))}
         </nav>
-        <nav class="flex flex-col gap-y-2 text-sm">
+        <nav aria-label="Resources" class="flex flex-col gap-y-2 text-sm">
           {footerLinks.map((l) => (
             <a href={l.href} target="_blank" rel="noopener noreferrer" class="text-zinc-400 transition hover:text-zinc-100">
               {l.label}

--- a/website/src/components/GetStarted.astro
+++ b/website/src/components/GetStarted.astro
@@ -3,15 +3,15 @@ import { getStarted } from '../content/site';
 import CopyCommand from './CopyCommand.astro';
 ---
 
-<section id="get-started" class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+<section id="get-started" class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
   <div class="mx-auto max-w-6xl px-5 py-24">
     <div class="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:gap-16">
-      <div data-reveal>
+      <div>
         <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">{getStarted.kicker}</p>
         <h2 class="mt-4 text-3xl leading-tight sm:text-4xl">{getStarted.heading}</h2>
         <p class="mt-5 max-w-md text-lg leading-relaxed text-zinc-400">{getStarted.body}</p>
 
-        <div class="mt-8 rounded-2xl glass p-5">
+        <div class="mt-8 rounded-2xl glass p-5" data-reveal>
           <p class="text-sm font-medium text-zinc-200">{getStarted.autoInstall.heading}</p>
           <ul class="mt-3 flex flex-wrap gap-2">
             {getStarted.autoInstall.frameworks.map((f) => (

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -12,13 +12,13 @@ const stats = await getStats(); // build-time social proof (cached + fallback)
   <div class="pointer-events-none absolute inset-0 -z-10 dot-grid opacity-70"></div>
 
   <div class="mx-auto grid max-w-6xl items-center gap-12 px-5 py-20 lg:grid-cols-2 lg:gap-10 lg:py-28">
-    <div>
+    <div class="min-w-0">
       <span
         class="reveal inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 font-mono text-xs text-zinc-400"
         style="animation-delay: 0ms"
       >
         <span class="h-1.5 w-1.5 rounded-full bg-acc-cyan"></span>
-        npm i -g hippo-memory · v{site.version} · MIT
+        v{site.version} · MIT
       </span>
 
       <h1
@@ -35,18 +35,20 @@ const stats = await getStats(); // build-time social proof (cached + fallback)
         {site.description}
       </p>
 
+      <p class="reveal mt-4 max-w-md text-sm leading-relaxed text-zinc-400" style="animation-delay: 170ms">
+        <span class="font-medium text-zinc-200 tabular-nums">{site.proof.stat}</span> {site.proof.text}
+      </p>
+
       <div class="reveal mt-8 max-w-md" style="animation-delay: 210ms">
         <CopyCommand command={site.installCmd} size="lg" />
       </div>
 
       <div class="reveal mt-5 flex flex-wrap items-center gap-3" style="animation-delay: 280ms">
         <a
-          href={site.links.repo}
-          target="_blank"
-          rel="noopener noreferrer"
+          href="/quickstart/"
           class="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-acc-violet to-acc-cyan px-5 py-3 text-sm font-semibold text-zinc-950 transition hover:opacity-90"
         >
-          Star on GitHub
+          Get started
         </a>
         <a
           href={site.links.docs}
@@ -71,7 +73,7 @@ const stats = await getStats(); // build-time social proof (cached + fallback)
 
       <div class="reveal mt-9" style="animation-delay: 340ms">
         <p class="mb-2 font-mono text-xs uppercase tracking-wider text-zinc-400">Works with</p>
-        <div class="works-marquee relative overflow-hidden" aria-label={`Works with ${worksWith.join(', ')}`}>
+        <div class="works-marquee relative w-full overflow-hidden" aria-label={`Works with ${worksWith.join(', ')}`}>
           <div class="works-track flex w-max">
             <ul class="works-group flex shrink-0 list-none p-0 text-sm text-zinc-400">
               {worksWith.map((tool) => (
@@ -92,7 +94,7 @@ const stats = await getStats(); // build-time social proof (cached + fallback)
       </div>
     </div>
 
-    <div class="reveal lg:pl-4" style="animation-delay: 220ms">
+    <div class="reveal min-w-0 lg:pl-4" style="animation-delay: 220ms">
       <Terminal />
       <p class="mt-3 text-center font-mono text-xs text-zinc-400">an example session</p>
     </div>

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -11,8 +11,7 @@ import DecayCurve from './DecayCurve.tsx';
         Memories decay. Retrieval makes them <span class="text-gradient">stronger.</span>
       </h2>
       <p class="mt-5 text-lg leading-relaxed text-zinc-400">
-        The thing brains have been getting right for 500 million years. Hard lessons stick because
-        you used them. Trivia fades because you didn't.
+        Hard lessons stick because you used them. Trivia fades because you didn't.
       </p>
     </div>
 
@@ -22,12 +21,12 @@ import DecayCurve from './DecayCurve.tsx';
         <span class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Buffer</span>
         <p class="mt-2 text-sm leading-relaxed text-zinc-400">New information lands here. Session-only, no decay.</p>
       </div>
-      <div class="flex items-center justify-center font-mono text-xs text-zinc-500" aria-hidden="true">encode</div>
+      <div class="flex items-center justify-center font-mono text-xs text-zinc-400" aria-hidden="true">encode</div>
       <div class="glass flex flex-col rounded-2xl p-5">
         <span class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Episodic</span>
         <p class="mt-2 text-sm leading-relaxed text-zinc-400">Timestamped, decays by default. Retrieval strengthens it; errors stick.</p>
       </div>
-      <div class="flex items-center justify-center font-mono text-xs text-zinc-500" aria-hidden="true">sleep</div>
+      <div class="flex items-center justify-center font-mono text-xs text-zinc-400" aria-hidden="true">sleep</div>
       <div class="glass flex flex-col rounded-2xl p-5">
         <span class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Semantic</span>
         <p class="mt-2 text-sm leading-relaxed text-zinc-400">Repeated episodes compress into stable patterns. The originals decay.</p>

--- a/website/src/components/InstallCta.astro
+++ b/website/src/components/InstallCta.astro
@@ -3,22 +3,22 @@ import { site } from '../content/site';
 import CopyCommand from './CopyCommand.astro';
 ---
 
-<section class="relative overflow-hidden border-t border-white/5 bg-[#0a0a0f]">
+<section class="relative overflow-hidden border-t border-white/5 bg-white/[0.02]">
   <div class="pointer-events-none absolute inset-0 -z-10 hero-glow opacity-60"></div>
-  <div class="mx-auto max-w-3xl px-5 py-28 text-center" data-reveal>
-    <h2 class="text-4xl leading-tight sm:text-5xl">
+  <div class="mx-auto max-w-3xl px-5 py-28 text-center">
+    <h2 class="text-3xl leading-tight sm:text-4xl">
       One command. <span class="text-gradient">Every repo gets memory.</span>
     </h2>
     <p class="mx-auto mt-5 max-w-lg text-lg leading-relaxed text-zinc-400">
       Zero config. SQLite under the hood, zero runtime deps, works with every CLI agent you have.
     </p>
 
-    <div class="mx-auto mt-9 max-w-lg space-y-3 text-left">
+    <div class="mx-auto mt-9 max-w-lg space-y-3 text-left" data-reveal>
       <CopyCommand command={site.installCmd} size="lg" />
       <CopyCommand command={site.initCmd} size="lg" />
     </div>
 
-    <div class="mt-7 flex flex-wrap justify-center gap-3">
+    <div class="mt-7 flex flex-wrap justify-center gap-3" data-reveal>
       <a
         href={site.links.repo}
         target="_blank"

--- a/website/src/components/LocalFirst.astro
+++ b/website/src/components/LocalFirst.astro
@@ -4,7 +4,7 @@ import { localFirst, importsFrom } from '../content/site';
 
 <section id="local-first" class="relative scroll-mt-20 border-t border-white/5">
   <div class="mx-auto max-w-6xl px-5 py-24">
-    <div class="max-w-2xl" data-reveal>
+    <div class="max-w-2xl">
       <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">{localFirst.kicker}</p>
       <h2 class="mt-4 text-3xl leading-tight sm:text-4xl">
         Your memory never leaves your <span class="text-gradient">machine.</span>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -5,49 +5,88 @@ import { getStats } from '../lib/stats';
 
 const stats = await getStats(); // build-time; cached + fallback (see lib/stats.ts)
 
-// Mobile jump targets - includes Receipts so proof stays reachable on mobile.
-const mobileNav = [
-  { label: 'How', href: '#how' },
-  { label: 'Get started', href: '#get-started' },
-  { label: 'Receipts', href: '#receipts' },
-  { label: 'Compare', href: '#compare' },
-  { label: 'FAQ', href: '#faq' },
+// "/benchmarks/" -> "/benchmarks", "/" -> "/"
+const normalizePath = (path: string) => path.replace(/\/+$/, '') || '/';
+const currentPath = normalizePath(Astro.url.pathname);
+const isHome = currentPath === '/';
+// Hash and external links never mark a page; styling hook lives in global.css.
+const isCurrent = (href: string) =>
+  href.startsWith('/') && !href.includes('#') && normalizePath(href) === currentPath;
+
+// Mobile chips. Home: section jump targets (root-relative so they survive reuse),
+// includes Receipts so proof stays reachable on mobile. Subpages: page-aware
+// links, because the section ids only exist on the homepage.
+const sectionChips = [
+  { label: 'How', href: '/#how' },
+  { label: 'Get started', href: '/#get-started' },
+  { label: 'Receipts', href: '/#receipts' },
+  { label: 'Compare', href: '/#compare' },
+  { label: 'FAQ', href: '/#faq' },
 ];
+const pageChips = [
+  { label: 'Home', href: '/' },
+  { label: 'Benchmarks', href: '/benchmarks/' },
+  { label: 'Quickstart', href: '/quickstart/' },
+  { label: 'vs mem0', href: '/vs/mem0/' },
+];
+const mobileNav = isHome ? sectionChips : pageChips;
 ---
 
 <header class="sticky top-0 z-40 border-b border-white/8 glass">
-  <nav class="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
-    <a href="#main" aria-label="hippo, back to top"><Logo gid="nav" /></a>
+  <nav aria-label="Primary" class="mx-auto flex h-16 max-w-6xl items-center justify-between px-5">
+    <a href="/" aria-label="hippo, home"><Logo gid="nav" /></a>
 
     <ul class="hidden items-center gap-7 text-sm text-zinc-400 md:flex">
       {nav.map((item) => (
-        <li><a class="transition hover:text-zinc-100" href={item.href}>{item.label}</a></li>
-      ))}
-    </ul>
-
-    <a
-      href={site.links.repo}
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={`Star hippo on GitHub (${stats.stars} stars)`}
-      class="ring-grad inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-zinc-100 transition hover:bg-white/5"
-    >
-      <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
-      </svg>
-      <span aria-hidden="true" class="text-amber-300">★</span>
-      <span class="tabular-nums">{stats.starsLabel}</span>
-    </a>
-  </nav>
-
-  <!-- mobile section nav: contained horizontal-scroll chips, < md only -->
-  <div class="border-t border-white/5 md:hidden">
-    <ul class="flex gap-2 overflow-x-auto px-5 py-2 text-xs text-zinc-400 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      {mobileNav.map((item) => (
-        <li class="shrink-0">
-          <a href={item.href} class="inline-block rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 transition hover:text-zinc-100">{item.label}</a>
+        <li>
+          <a
+            class="transition hover:text-zinc-100"
+            href={item.href}
+            aria-current={isCurrent(item.href) ? 'page' : undefined}
+          >{item.label}</a>
         </li>
       ))}
     </ul>
-  </div>
+
+    <div class="flex items-center gap-1">
+      <a
+        href={site.links.repo}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Star hippo on GitHub (${stats.stars} stars)`}
+        class="ring-grad inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-zinc-100 transition hover:bg-white/5"
+      >
+        <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+        </svg>
+        <span aria-hidden="true" class="text-amber-300">★</span>
+        <span class="tabular-nums">{stats.starsLabel}</span>
+      </a>
+      <!-- back-to-top keeps the affordance the logo used to carry (logo now links home) -->
+      <a
+        href="#main"
+        aria-label="Back to top"
+        class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-zinc-400 transition hover:bg-white/5 hover:text-zinc-100"
+      >
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+          <path d="M8 3.5 13.5 9l-1.06 1.06-3.69-3.69V13h-1.5V6.37l-3.69 3.69L2.5 9 8 3.5Z"></path>
+        </svg>
+      </a>
+    </div>
+  </nav>
+
+  <!-- mobile nav: contained horizontal-scroll chips, < md only. 44px tap height. -->
+  <nav aria-label={isHome ? 'Page sections' : 'Pages'} class="border-t border-white/5 md:hidden">
+    <ul class="flex gap-2 overflow-x-auto px-5 py-1.5 text-xs text-zinc-400 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      {mobileNav.map((item) => (
+        <li class="shrink-0">
+          <a
+            href={item.href}
+            aria-current={isCurrent(item.href) ? 'page' : undefined}
+            class="inline-flex min-h-11 items-center rounded-full border border-white/10 bg-white/[0.03] px-4 transition hover:text-zinc-100"
+          >{item.label}</a>
+        </li>
+      ))}
+    </ul>
+  </nav>
 </header>

--- a/website/src/components/Problem.astro
+++ b/website/src/components/Problem.astro
@@ -2,9 +2,9 @@
 import { problem } from '../content/site';
 ---
 
-<section class="relative border-t border-white/5 bg-[#0a0a0f]">
+<section class="relative border-t border-white/5 bg-white/[0.02]">
   <div class="mx-auto max-w-6xl px-5 py-24">
-    <div class="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:gap-16" data-reveal>
+    <div class="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:gap-16">
       <div>
         <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">{problem.kicker}</p>
         <h2 class="mt-4 max-w-xl text-3xl leading-tight sm:text-4xl">
@@ -16,11 +16,11 @@ import { problem } from '../content/site';
       </div>
 
       <!-- the "saw it four times" motif: repeated faded failures, one finally remembered -->
-      <div class="flex min-w-0 items-center">
+      <div class="flex min-w-0 items-center" data-reveal>
         <div class="w-full min-w-0 space-y-2.5 font-mono text-sm" aria-hidden="true">
           {[1, 2, 3].map((n) => (
             <div class="flex items-center gap-3 rounded-lg border border-white/5 bg-white/[0.015] px-4 py-3 text-zinc-400">
-              <span class="text-rose-400/40">✗</span>
+              <span class="text-rose-400/60">✗</span>
               <span class="min-w-0 flex-1 truncate">deploy failed: forgot migrations</span>
               <span class="text-zinc-400">run #{n}</span>
             </div>
@@ -28,7 +28,7 @@ import { problem } from '../content/site';
           <div class="ring-grad flex items-center gap-3 rounded-lg bg-white/[0.03] px-4 py-3 text-zinc-200">
             <span class="text-emerald-400">✓</span>
             <span class="min-w-0 flex-1 truncate">remembered · surfaced before run #4</span>
-            <span class="rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] text-emerald-300">[verified]</span>
+            <span class="rounded bg-emerald-500/15 px-1.5 py-0.5 text-xs text-emerald-300">[verified]</span>
           </div>
         </div>
       </div>

--- a/website/src/components/Receipts.astro
+++ b/website/src/components/Receipts.astro
@@ -2,9 +2,9 @@
 import { receipts, importsFrom } from '../content/site';
 ---
 
-<section id="receipts" class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
+<section id="receipts" class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
   <div class="mx-auto max-w-6xl px-5 py-24">
-    <div class="flex flex-wrap items-end justify-between gap-4" data-reveal>
+    <div class="flex flex-wrap items-end justify-between gap-4">
       <div class="max-w-xl">
         <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Receipts</p>
         <h2 class="mt-4 text-3xl leading-tight sm:text-4xl">Numbers, not adjectives.</h2>
@@ -19,18 +19,19 @@ import { receipts, importsFrom } from '../content/site';
           target="_blank"
           rel="noopener noreferrer"
           class="glass glass-hover group flex flex-col rounded-2xl p-6"
+          data-reveal
         >
-          <span class="font-mono text-5xl font-semibold tracking-tight text-gradient">{r.stat}</span>
+          <span class="font-mono text-[clamp(1.75rem,8vw,3rem)] font-semibold tracking-tight text-gradient">{r.stat}</span>
           <span class="mt-3 text-sm font-medium text-zinc-200">{r.label}</span>
           <span class="mt-2 text-xs leading-relaxed text-zinc-400">{r.note}</span>
-          <span class="mt-4 inline-flex items-center gap-1 font-mono text-[11px] text-zinc-400 transition group-hover:text-acc-cyan">
+          <span class="mt-4 inline-flex items-center gap-1 font-mono text-xs text-zinc-400 transition group-hover:text-acc-cyan">
             source ↗
           </span>
         </a>
       ))}
     </div>
 
-    <div class="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-sm text-zinc-400">
+    <div class="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-sm text-zinc-400" data-reveal>
       <span class="text-zinc-400">imports from</span>
       {importsFrom.map((src) => (
         <span class="rounded border border-white/8 bg-white/[0.02] px-2 py-0.5 text-zinc-400">{src}</span>

--- a/website/src/components/Terminal.astro
+++ b/website/src/components/Terminal.astro
@@ -13,7 +13,7 @@ import { terminal } from '../content/site';
     <span class="ml-3 font-mono text-xs text-zinc-400">hippo · ~/projects</span>
   </div>
 
-  <div class="space-y-1.5 p-4 font-mono text-[13px] leading-relaxed text-term-fg sm:p-5" data-term-body>
+  <div class="space-y-1.5 overflow-x-auto p-4 font-mono text-[13px] leading-relaxed text-term-fg sm:p-5" data-term-body>
     {terminal.map((line) => (
       <div class="term-line flex items-start gap-2" data-kind={line.kind}>
         {line.kind === 'cmd' && <span class="select-none text-acc-cyan">$</span>}
@@ -23,7 +23,7 @@ import { terminal } from '../content/site';
         {line.chip && (
           <span
             class:list={[
-              'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium',
+              'shrink-0 rounded px-1.5 py-0.5 text-xs font-medium',
               line.chip === 'verified' ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500/15 text-sky-300',
             ]}
           >[{line.chip}]</span>

--- a/website/src/content/site.ts
+++ b/website/src/content/site.ts
@@ -5,17 +5,21 @@
  * (README v1.7.9) and is deliberately ABSENT. Edit copy here, not in components.
  */
 
+import pkg from '../../../package.json';
+
 export const REPO = 'https://github.com/kitfunso/hippo-memory';
 
 export const site = {
   name: 'hippo',
   pkg: 'hippo-memory',
-  version: '1.23.0', // package.json
+  version: pkg.version, // npm-published hippo-memory version, imported at build time from the repo-root package.json
   // README headline tagline, split for gradient emphasis on the verb.
   tagline: { lead: 'Know what to', accent: 'forget.' },
   // README line 12 (verbatim intent).
   description:
     'A memory layer for AI agents, modeled on the hippocampus. Decay by default, strength through use, provenance on every memory.',
+  // One proof line under the hero subhead (audit: lead with capability proof, not adjectives).
+  proof: { stat: '98.6% R@5', text: 'on LongMemEval with the zero-dependency default.' },
   installCmd: 'npm install -g hippo-memory',
   initCmd: 'hippo init --scan ~',
   links: {
@@ -64,12 +68,12 @@ export const mechanics = [
   {
     title: 'Decay by default',
     metric: '7d half-life',
-    body: 'Every memory fades on a 7-day half-life. Persistence is earned, not assumed.',
+    body: 'Every memory fades on a 7-day half-life. Persistence is earned through use.',
   },
   {
     title: 'Retrieval strengthens',
     metric: '+2d / recall',
-    body: 'Use it or lose it. Each recall extends the half-life. Memories you reach for learn to survive.',
+    body: 'Use it or lose it. Each recall extends the half-life. Memories you reach for survive.',
   },
   {
     title: 'Errors stick',
@@ -115,13 +119,20 @@ export const importsFrom = ['ChatGPT', 'CLAUDE.md', '.cursorrules', 'Slack', 'ma
 
 export const compare = {
   heading: 'Forget by default. Earn persistence through use.',
-  body: "The AI-memory category matured fast in 2026. Hippo's take - bio-decay, strengthen-on-use, outcome-weighted half-lives - is one stance among several. The matrix below is a feature snapshot, not a verdict.",
+  body: 'How hippo compares to the strongest tools in the category, on the features that define a memory lifecycle.',
   sourceHref: `${REPO}#comparison`,
+  sourceLabel: 'Full 10-tool matrix on GitHub',
+  scrollCue: 'scroll for more tools',
+  qualifierNote:
+    'Verdicts are shortened for scanning; the qualifier behind each Yes/No/Partial is in the full matrix.',
 } as const;
 
-/** Full comparison matrix, reproduced VERBATIM from README.md (#comparison),
- *  including the asterisked "not directly comparable" benchmark caveats + footnotes.
- *  cells[] align to systems[] order (Hippo first). Edit the README + here together. */
+/** Full comparison matrix. cells[] are reproduced VERBATIM from README.md (#comparison),
+ *  including the asterisked "not directly comparable" benchmark caveats + footnotes,
+ *  and are asserted against the README by scripts/check-readme-sync.mjs - NEVER edit a
+ *  cells literal without editing the README. display[] (optional) is a render-only short
+ *  verdict per cell that the checker ignores; the home matrix renders display ?? cells.
+ *  cells[]/display[] align to systems[] order (Hippo first). */
 export const comparison = {
   systems: [
     { name: 'Hippo', href: REPO, self: true },
@@ -137,7 +148,7 @@ export const comparison = {
   ],
   rows: [
     { feature: 'Decay by default', cells: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No'] },
-    { feature: 'Retrieval strengthening', cells: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'Partial (recall tuning)', 'No', 'Partial (Skill Memory distills patterns)'] },
+    { feature: 'Retrieval strengthening', cells: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'Partial (recall tuning)', 'No', 'Partial (Skill Memory distills patterns)'], display: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'Partial', 'No', 'Partial'] },
     { feature: 'Reward-proportional decay', cells: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No'] },
     { feature: 'Hybrid search (BM25 + embeddings)', cells: ['Yes', 'Embeddings + spatial', 'Embeddings only', 'No', 'Yes (vec + rerank + graph)', 'Yes (graph + vec)', '?', 'Yes (GraphRAG)', 'Yes (vector + full-text)', 'Yes (mRAG, multi-modal)'] },
     { feature: 'Schema acceleration / knowledge graph', cells: ['Yes (schema)', 'No', 'No', 'No', 'Yes (typed KG, self-wiring)', 'Yes (temporal KG)', 'No', 'Yes (auto-ontologies)', 'No (typed claims)', 'Yes (hierarchical: user/group/agent)'] },
@@ -148,11 +159,11 @@ export const comparison = {
     { feature: 'Confidence tiers', cells: ['Yes', 'No', 'No', 'No', 'No (typed facts)', 'No', 'No', 'No', 'No', 'No'] },
     { feature: 'Spatial organization', cells: ['No', 'Yes (wings/halls/rooms)', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No'] },
     { feature: 'Lossless compression', cells: ['No', 'Yes (AAAK, 30x)', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No'] },
-    { feature: 'Cross-tool import (ChatGPT/Claude/Cursor)', cells: ['Yes', 'No', 'No', 'No', 'Partial (data sources)', '?', 'No', 'Partial (28 data sources)', 'No (Git ops)', 'Partial (mRAG: PDFs/images/URLs)'] },
+    { feature: 'Cross-tool import (ChatGPT/Claude/Cursor)', cells: ['Yes', 'No', 'No', 'No', 'Partial (data sources)', '?', 'No', 'Partial (28 data sources)', 'No (Git ops)', 'Partial (mRAG: PDFs/images/URLs)'], display: ['Yes', 'No', 'No', 'No', 'Partial', '?', 'No', 'Partial', 'No', 'Partial'] },
     { feature: 'Auto-hook install', cells: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'No'] },
     { feature: 'MCP server', cells: ['Yes', 'Yes', 'No', 'No', 'Yes (stdio + HTTP/OAuth)', 'Partial (managed)', 'Yes (via Letta Code)', 'Yes (first-party Claude/LangGraph)', 'Yes', '?'] },
-    { feature: 'Zero runtime deps', cells: ['Yes', 'No (ChromaDB)', 'No', 'No', 'No (PGLite or PG+pgvector)', 'No (managed service)', 'No (Python deps)', 'No (Python deps)', 'Yes (single Rust binary)', 'No (managed + OSS)'] },
-    { feature: 'LongMemEval (best published)', cells: ['98.6% default / 99.8% voyage R@5 (s_cleaned, per-haystack)*', '96.6% raw / 100% reranked R@5', '~49-85% R@5', 'N/A', '97.6-97.9% R@5 (s_cleaned*)', 'N/A (LoCoMo 80.3%)', 'N/A', 'N/A', '88.78% overall accuracy w/ reader**', '83.00% overall** (LoCoMo 93.05%, HaluMem 93.04%)'] },
+    { feature: 'Zero runtime deps', cells: ['Yes', 'No (ChromaDB)', 'No', 'No', 'No (PGLite or PG+pgvector)', 'No (managed service)', 'No (Python deps)', 'No (Python deps)', 'Yes (single Rust binary)', 'No (managed + OSS)'], display: ['Yes', 'No', 'No', 'No', 'No', 'No', 'No', 'No', 'Yes', 'No'] },
+    { feature: 'LongMemEval (best published)', cells: ['98.6% default / 99.8% voyage R@5 (s_cleaned, per-haystack)*', '96.6% raw / 100% reranked R@5', '~49-85% R@5', 'N/A', '97.6-97.9% R@5 (s_cleaned*)', 'N/A (LoCoMo 80.3%)', 'N/A', 'N/A', '88.78% overall accuracy w/ reader**', '83.00% overall** (LoCoMo 93.05%, HaluMem 93.04%)'], display: ['98.6% R@5*', '96.6% R@5', '~49-85% R@5', 'N/A', '97.6% R@5*', 'N/A', 'N/A', 'N/A', '88.78%**', '83.00%**'] },
     { feature: 'Git-friendly', cells: ['Yes', 'No', 'No', 'Yes', 'Yes', 'No', 'No', 'No', 'Yes (Git is the model)', '?'] },
     { feature: 'Framework agnostic', cells: ['Yes', 'Yes', 'Partial', 'Yes', 'Yes', 'Yes', 'Yes', 'Yes', 'Yes', 'Yes'] },
     { feature: 'License', cells: ['MIT', '(open)', 'Apache-2.0', '(open)', 'MIT', 'Apache-2.0 (community)', 'Apache-2.0', 'MIT (core)', 'Apache-2.0', 'Apache-2.0 (OSS) + cloud'] },
@@ -162,7 +173,7 @@ export const comparison = {
     "** Different metric: Memoria's 88.78% and EverMind's 83% are reported as overall accuracy with a reader LLM, not retrieval R@5. Higher denominator + LLM helps. Not directly comparable to retrieval-only R@5 numbers above.",
   ],
   closing:
-    'Different tools answer different questions. Mem0 and Basic Memory implement "save everything, search later." MemPalace organizes spatially. gbrain, Zep, and Cognee extract typed entities into a knowledge graph. Letta lets the agent edit its own memory blocks. Memoria is Git-style version control over memory. EverMind is self-evolving Skill Memory. Hippo implements "forget by default, earn persistence through use." Complementary takes, not a single-axis ranking.',
+    'Different tools answer different questions. Mem0 and Basic Memory implement "save everything, search later." MemPalace organizes spatially. gbrain, Zep, and Cognee extract typed entities into a knowledge graph. Letta lets the agent edit its own memory blocks. Memoria is Git-style version control over memory. EverMind is self-evolving Skill Memory. Hippo implements "forget by default, earn persistence through use."',
 } as const;
 
 /** Get started = quickstart + the zero-config auto-install differentiator (README L97/L621). */
@@ -200,6 +211,6 @@ export const faq = [
   { q: 'Does it need embeddings?', a: 'No. Recall runs on BM25 out of the box (74% R@5 on LongMemEval, BM25 only). Embeddings are an optional dependency for hybrid scoring; nothing is required at runtime.' },
   { q: 'Where does my data go?', a: 'Nowhere. Everything is a local SQLite store with markdown mirrors: 0 outbound HTTP on the ingestion smoke, proven by a fetch spy. No cloud, no account, no telemetry.' },
   { q: 'Which agents does it work with?', a: 'hippo init auto-installs hooks for Claude Code, Codex, Cursor, OpenClaw, and OpenCode, and exposes an MCP server for any MCP client (Cursor, Windsurf, Cline, Claude Desktop).' },
-  { q: 'How is hippo different from mem0, Letta, or Zep?', a: 'hippo optimizes the memory lifecycle, not just storage or retrieval. mem0 and similar tools save and search; Zep and Cognee extract entities into a knowledge graph; Letta has the agent edit its own memory blocks. hippo forgets by default and earns persistence through use, with reward-weighted decay, conflict detection, and sleep consolidation, and it runs locally with zero runtime dependencies.' },
-  { q: 'Is it production-ready?', a: 'It is MIT-licensed at v1.23.0, with 926 tests against a real database and zero mocks. Multi-tenant isolation is proven by a negative test.' },
+  { q: 'How is hippo different from mem0, Letta, or Zep?', a: 'hippo optimizes the full memory lifecycle. mem0 and similar tools save and search; Zep and Cognee extract entities into a knowledge graph; Letta has the agent edit its own memory blocks. hippo forgets by default and earns persistence through use, with reward-weighted decay, conflict detection, and sleep consolidation, and it runs locally with zero runtime dependencies.' },
+  { q: 'Is it production-ready?', a: `It is MIT-licensed at v${pkg.version}, with 926 tests against a real database and zero mocks. Multi-tenant isolation is proven by a negative test.` },
 ] as const;

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import { site, faq } from '../content/site';
+import BackgroundFx from '../components/BackgroundFx.astro';
 
 interface Props {
   title?: string;
@@ -101,6 +102,7 @@ const beaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN ?? 'dca34bc57a3946d08
     >
       Skip to content
     </a>
+    <BackgroundFx />
     <slot />
     {beaconToken && (
       <script

--- a/website/src/pages/benchmarks.astro
+++ b/website/src/pages/benchmarks.astro
@@ -20,6 +20,13 @@ const globalPool = [
 
 const benchUrl = `${site.links.longmemeval}`;
 
+// Hero chip group: reuses the page's own receipts (no new claims).
+const heroChips = [
+  { num: '98.6%', label: 'R@5, zero-dep default' },
+  { num: '926', label: 'tests, real database' },
+  { num: '0', label: 'outbound HTTP' },
+];
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
@@ -37,21 +44,32 @@ const jsonLd = {
   <main id="main">
     <!-- Header -->
     <section class="relative scroll-mt-20">
-      <div class="mx-auto max-w-6xl px-5 pb-12 pt-28 sm:pt-32">
-        <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Benchmarks</p>
-        <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
-          Numbers, with the <span class="text-gradient">methodology</span>.
-        </h1>
-        <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
-          hippo's retrieval, measured on <a class="text-zinc-200 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href="https://arxiv.org/abs/2410.10813" target="_blank" rel="noopener noreferrer">LongMemEval</a> (ICLR 2025), the public 500-question memory benchmark. The harness, the data hash, and the per-question results are in the repo so you can rerun them.
-        </p>
+      <div class="mx-auto flex max-w-6xl items-end justify-between gap-10 px-5 pb-12 pt-28 sm:pt-32">
+        <div>
+          <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Benchmarks</p>
+          <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.03] tracking-tight sm:text-5xl">
+            Numbers, with the <span class="text-gradient">methodology</span>.
+          </h1>
+          <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
+            hippo's retrieval, measured on <a class="link" href="https://arxiv.org/abs/2410.10813" target="_blank" rel="noopener noreferrer">LongMemEval<span class="sr-only"> (opens in new tab)</span></a> (ICLR 2025), the public 500-question memory benchmark. The harness, the data hash, and the per-question results are in the repo so you can rerun them.
+          </p>
+        </div>
+        <!-- Metric chips fill the hero's right side on wide viewports; duplicates on-page data. -->
+        <div class="hidden w-60 shrink-0 flex-col gap-3 lg:flex" aria-hidden="true">
+          {heroChips.map((chip) => (
+            <div class="glass flex items-baseline justify-between gap-3 rounded-2xl px-4 py-3">
+              <span class="whitespace-nowrap font-mono text-xl font-semibold tracking-tight text-gradient">{chip.num}</span>
+              <span class="text-right text-xs leading-snug text-zinc-400">{chip.label}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
 
     <!-- Standard per-haystack -->
-    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
-      <div class="mx-auto max-w-6xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Standard task: per-question haystack</h2>
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-balance text-3xl leading-tight sm:text-4xl">Standard task: per-question&nbsp;haystack</h2>
         <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
           Each question ships its own haystack of about 48 conversation sessions, and the job is to retrieve the session that holds the answer. This is the standard LongMemEval-S setup, the same one published systems report. Recall at 5, on the <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-sm text-zinc-300">_s</code> split:
         </p>
@@ -59,16 +77,16 @@ const jsonLd = {
           <table class="w-full text-left text-sm">
             <thead class="bg-white/[0.03] font-mono text-xs uppercase tracking-wider text-zinc-400">
               <tr>
-                <th class="px-5 py-3 font-medium">Embedder</th>
-                <th class="px-5 py-3 font-medium">R@1</th>
-                <th class="px-5 py-3 font-medium">R@5</th>
-                <th class="px-5 py-3 font-medium">R@10</th>
+                <th scope="col" class="px-5 py-3 font-medium">Embedder</th>
+                <th scope="col" class="px-5 py-3 font-medium">R@1</th>
+                <th scope="col" class="px-5 py-3 font-medium">R@5</th>
+                <th scope="col" class="px-5 py-3 font-medium">R@10</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-white/5">
               {perHaystack.map((row) => (
                 <tr class="text-zinc-300">
-                  <td class="px-5 py-3.5">{row.embedder}</td>
+                  <th scope="row" class="px-5 py-3.5 text-left font-normal">{row.embedder}</th>
                   <td class="px-5 py-3.5 font-mono">{row.r1}</td>
                   <td class="px-5 py-3.5 font-mono font-semibold text-gradient">{row.r5}</td>
                   <td class="px-5 py-3.5 font-mono">{row.r10}</td>
@@ -77,7 +95,7 @@ const jsonLd = {
             </tbody>
           </table>
         </div>
-        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-400">
           For reference, gbrain reports 97.6% R@5 on this split with a paid frontier embedder. hippo's free, local, zero-dependency default reaches 98.6%. On the standard task, retrieval recall is effectively saturated, so the embedder is a swappable part, not the differentiator.
         </p>
       </div>
@@ -85,12 +103,12 @@ const jsonLd = {
 
     <!-- Large-store / global pool -->
     <section class="relative scroll-mt-20 border-t border-white/5">
-      <div class="mx-auto max-w-6xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Large store: one unified memory</h2>
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-balance text-3xl leading-tight sm:text-4xl">Large store: one unified memory</h2>
         <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
           Point retrieval at a single store of all 19,195 sessions, with no pre-scoped haystack, closer to how an agent's memory actually accumulates. Recall stops being free:
         </p>
-        <div class="mt-8 grid max-w-2xl grid-cols-2 gap-4">
+        <div class="mt-8 grid grid-cols-2 gap-4">
           {globalPool.map((row) => (
             <div class="glass rounded-2xl p-6">
               <span class="font-mono text-4xl font-semibold tracking-tight text-zinc-200">{row.r5}</span>
@@ -98,16 +116,16 @@ const jsonLd = {
             </div>
           ))}
         </div>
-        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-400">
           A stronger embedder helps here (47 to 56) but neither is usable on its own: the answer drowns among thousands of distractors. This is where the memory lifecycle earns its keep, by decaying, consolidating, and superseding so the effective store stays small. Measuring that is the next benchmark on the roadmap.
         </p>
       </div>
     </section>
 
     <!-- Other receipts -->
-    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
-      <div class="mx-auto max-w-6xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Tested, and local by default</h2>
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-balance text-3xl leading-tight sm:text-4xl">Tested, and local by default</h2>
         <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
           <div class="glass rounded-2xl p-6">
             <span class="font-mono text-4xl font-semibold tracking-tight text-gradient">74%</span>
@@ -130,14 +148,14 @@ const jsonLd = {
 
     <!-- Methodology + reproduce -->
     <section class="relative scroll-mt-20 border-t border-white/5">
-      <div class="mx-auto max-w-6xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Reproduce it</h2>
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-balance text-3xl leading-tight sm:text-4xl">Reproduce it</h2>
         <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
-          The data is <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-sm text-zinc-300">longmemeval_s_cleaned.json</code> (SHA-256 <code class="font-mono text-xs text-zinc-500">d6f21ea9...</code>), 500 questions over 19,195 sessions. Retrieval is turn-level dense plus BM25, fused with reciprocal rank fusion and max-pooled to session. Embeddings are L2-normalized; the default is local MiniLM, with an opt-in pluggable provider for frontier embedders.
+          The data is <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-sm text-zinc-300">longmemeval_s_cleaned.json</code> (SHA-256 <code class="font-mono text-xs text-zinc-400">d6f21ea9...</code>), 500 questions over 19,195 sessions. Retrieval is turn-level dense plus BM25, fused with reciprocal rank fusion and max-pooled to session. Embeddings are L2-normalized; the default is local MiniLM, with an opt-in pluggable provider for frontier embedders.
         </p>
         <div class="mt-7 flex flex-wrap gap-3">
-          <a href={benchUrl} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Benchmark harness &amp; data</a>
-          <a href={site.links.repo} target="_blank" rel="noopener noreferrer" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">Repository</a>
+          <a href={benchUrl} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Benchmark harness &amp; data<span class="sr-only"> (opens in new tab)</span></a>
+          <a href={site.links.repo} target="_blank" rel="noopener noreferrer" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">Repository<span class="sr-only"> (opens in new tab)</span></a>
         </div>
       </div>
     </section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -57,9 +57,14 @@ const metaDescription =
       });
 
       // scroll-reveal: reveal [data-reveal] blocks as they enter view (.js gate hides
-      // them first; no-JS / no-IO shows everything).
+      // them first; no-JS / no-IO shows everything). Reveals are applied to INNER
+      // blocks only (never section roots or h2 wrappers), and the fail-open below
+      // force-shows anything still hidden so print/screenshot/preview never blanks.
       var reveals = document.querySelectorAll('[data-reveal]');
       if (!reveals.length) return;
+      setTimeout(function () {
+        reveals.forEach(function (el) { el.classList.add('is-visible'); });
+      }, 1500);
       if (!('IntersectionObserver' in window)) {
         reveals.forEach(function (el) { el.classList.add('is-visible'); });
         return;

--- a/website/src/pages/quickstart.astro
+++ b/website/src/pages/quickstart.astro
@@ -17,6 +17,13 @@ const integrations = [
   { name: 'Any MCP client', note: 'MCP server for Cursor, Windsurf, Cline, and Claude Desktop.' },
 ];
 
+// Hero "at a glance" card: mirrors the page's real steps (and the HowTo JSON-LD below).
+const heroSteps = [
+  { n: '01', label: 'Install', cmd: site.installCmd, prompt: true },
+  { n: '02', label: 'Initialize', cmd: site.initCmd, prompt: true },
+  { n: '03', label: 'Use the loop', cmd: 'remember · recall · outcome · sleep', prompt: false },
+];
+
 const loop = [
   { cmd: 'hippo remember "deploy failed: forgot migrations" --error', note: 'Store a memory. Errors get a longer half-life and stick.' },
   { cmd: 'hippo recall "why did the deploy break" --budget 2000', note: 'Retrieve within a token budget, ranked by relevance and strength.' },
@@ -42,31 +49,46 @@ const jsonLd = {
   <Nav />
   <main id="main">
     <section class="relative scroll-mt-20">
-      <div class="mx-auto max-w-5xl px-5 pb-12 pt-28 sm:pt-32">
-        <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Quickstart</p>
-        <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
-          Add memory in <span class="text-gradient">two commands</span>.
-        </h1>
-        <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
-          hippo is an MIT-licensed npm package with zero runtime dependencies. Install it, point it at your home directory, and it wires itself into the agents you already use.
-        </p>
+      <div class="mx-auto flex max-w-6xl items-start justify-between gap-10 px-5 pb-12 pt-28 sm:pt-32">
+        <div>
+          <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Quickstart</p>
+          <h1 class="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[1.03] tracking-tight sm:text-5xl">
+            Add memory in <span class="text-gradient">two commands</span>.
+          </h1>
+          <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
+            hippo is an MIT-licensed npm package with zero runtime dependencies. Install it, point it at your home directory, and it wires itself into the agents you already use.
+          </p>
+        </div>
+        <!-- Setup-at-a-glance card fills the hero's right side on wide viewports. -->
+        <aside class="hidden w-[19rem] shrink-0 rounded-2xl border border-white/8 bg-term-bg p-5 lg:block" aria-label="Setup at a glance: 3 steps, about 2 minutes">
+          <p class="border-b border-white/5 pb-3 font-mono text-xs uppercase tracking-wider text-acc-cyan">3 steps &middot; ~2 minutes</p>
+          <ol class="mt-4 space-y-3.5">
+            {heroSteps.map((step) => (
+              <li class="grid grid-cols-[1.5rem_1fr] gap-x-2">
+                <span class="font-mono text-xs leading-6 text-acc-cyan" aria-hidden="true">{step.n}</span>
+                <span class="text-sm font-medium text-zinc-200">{step.label}</span>
+                <code class="col-start-2 mt-0.5 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-xs text-zinc-400">{step.prompt ? <><span class="text-term-prompt">$</span> {step.cmd}</> : step.cmd}</code>
+              </li>
+            ))}
+          </ol>
+        </aside>
       </div>
     </section>
 
-    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
-      <div class="mx-auto max-w-5xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Install</h2>
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-3xl leading-tight sm:text-4xl">Install</h2>
         <pre class="mt-6 overflow-x-auto rounded-2xl border border-white/8 bg-term-bg p-5 font-mono text-sm leading-relaxed text-term-fg"><code><span class="text-term-prompt">$</span> {site.installCmd}
 <span class="text-term-prompt">$</span> {site.initCmd}</code></pre>
-        <p class="mt-4 max-w-2xl text-sm leading-relaxed text-zinc-500">
+        <p class="mt-4 max-w-2xl text-sm leading-relaxed text-zinc-400">
           <code class="rounded bg-white/[0.04] px-1.5 py-0.5 font-mono text-zinc-300">init --scan ~</code> detects your agents, installs their hooks, and gives you memory across every git repo under your home directory. Everything lives in a local SQLite store with markdown mirrors. No cloud, no account, no telemetry.
         </p>
       </div>
     </section>
 
     <section class="relative scroll-mt-20 border-t border-white/5">
-      <div class="mx-auto max-w-5xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Works with your agents</h2>
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-3xl leading-tight sm:text-4xl">Works with your agents</h2>
         <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {integrations.map((i) => (
             <div class="glass rounded-2xl p-5">
@@ -78,9 +100,9 @@ const jsonLd = {
       </div>
     </section>
 
-    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
-      <div class="mx-auto max-w-5xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">The memory loop</h2>
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-3xl leading-tight sm:text-4xl">The memory loop</h2>
         <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
           Four commands. Memories decay on a half-life unless something keeps them alive: a retrieval, a good outcome, an error tag, or consolidation during sleep.
         </p>
@@ -93,7 +115,7 @@ const jsonLd = {
           ))}
         </div>
         <div class="mt-8 flex flex-wrap gap-3">
-          <a href={site.links.docs} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Full docs</a>
+          <a href={site.links.docs} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Full docs<span class="sr-only"> (opens in new tab)</span></a>
           <a href="/benchmarks/" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">See the benchmarks</a>
         </div>
       </div>

--- a/website/src/pages/vs/mem0.astro
+++ b/website/src/pages/vs/mem0.astro
@@ -21,6 +21,13 @@ const rows = [
   { feature: 'License', hippo: 'MIT', mem0: 'Apache-2.0' },
 ];
 
+// Receipts strip: figures reproduced from the comparison matrix in ../../content/site.ts
+// ("LongMemEval (best published)" row: Hippo 98.6% R@5, Mem0 ~49-85% R@5). Do not invent numbers.
+const receipts = {
+  hippo: { num: '98.6%', sub: 'per-question haystack, local MiniLM default' },
+  mem0: { num: '~49-85%', sub: 'self-reported, own conditions' },
+};
+
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -49,33 +56,55 @@ const faqJsonLd = {
   <Nav />
   <main id="main">
     <section class="relative scroll-mt-20">
-      <div class="mx-auto max-w-5xl px-5 pb-12 pt-28 sm:pt-32">
+      <div class="mx-auto max-w-6xl px-5 pb-12 pt-28 sm:pt-32">
         <p class="font-mono text-xs uppercase tracking-wider text-acc-cyan">Comparison</p>
-        <h1 class="mt-4 font-display text-4xl font-semibold leading-[1.05] tracking-tight sm:text-5xl">
-          hippo <span class="text-zinc-500">vs</span> <span class="text-gradient">mem0</span>
+        <h1 class="mt-4 font-display text-4xl font-semibold leading-[1.03] tracking-tight sm:text-5xl">
+          <span class="text-gradient">hippo</span> <span class="text-zinc-500">vs</span> mem0
         </h1>
         <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
           Both are open-source memory for AI agents. The difference is philosophy. mem0 saves and searches: it extracts facts and retrieves them by similarity. hippo runs a memory lifecycle: it forgets by default and earns persistence through use, so the store stays small and current instead of growing without bound.
         </p>
+        <!-- Receipts strip: the one number this page owes its reader. -->
+        <div class="mt-10">
+          <div class="glass rounded-2xl px-7 py-6">
+            <div class="flex flex-wrap items-center gap-x-10 gap-y-4">
+              <span class="font-mono text-xs uppercase leading-relaxed tracking-wider text-acc-cyan">LongMemEval<br />R@5</span>
+              <div class="flex flex-col gap-1">
+                <span class="font-mono text-xs uppercase tracking-wider text-zinc-200">hippo</span>
+                <span class="whitespace-nowrap font-mono text-3xl font-semibold tracking-tight text-gradient sm:text-4xl">{receipts.hippo.num}</span>
+                <span class="max-w-64 text-xs leading-relaxed text-zinc-400">{receipts.hippo.sub}</span>
+              </div>
+              <span class="hidden font-mono text-xs uppercase tracking-wider text-zinc-500 sm:inline" aria-hidden="true">vs</span>
+              <div class="flex flex-col gap-1">
+                <span class="font-mono text-xs uppercase tracking-wider text-zinc-400">mem0</span>
+                <span class="whitespace-nowrap font-mono text-3xl font-semibold tracking-tight text-zinc-300 sm:text-4xl">{receipts.mem0.num}</span>
+                <span class="max-w-64 text-xs leading-relaxed text-zinc-400">{receipts.mem0.sub}</span>
+              </div>
+            </div>
+          </div>
+          <p class="mt-3.5 max-w-2xl text-xs leading-relaxed text-zinc-400">
+            hippo measured 2026-06-09 on longmemeval_s_cleaned. mem0 reports its own LongMemEval figures under its own conditions, so this is not a controlled head-to-head. Full methodology and per-haystack results are on the <a class="link" href="/benchmarks/">benchmarks page</a>.
+          </p>
+        </div>
       </div>
     </section>
 
-    <section class="relative scroll-mt-20 border-t border-white/5 bg-[#0a0a0f]">
-      <div class="mx-auto max-w-5xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">Feature comparison</h2>
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-3xl leading-tight sm:text-4xl">Feature comparison</h2>
         <div class="mt-8 overflow-hidden rounded-2xl border border-white/8">
           <table class="w-full text-left text-sm">
             <thead class="bg-white/[0.03] font-mono text-xs uppercase tracking-wider text-zinc-400">
               <tr>
-                <th class="px-5 py-3 font-medium">Feature</th>
-                <th class="px-5 py-3 font-medium text-zinc-200">hippo</th>
-                <th class="px-5 py-3 font-medium">mem0</th>
+                <th scope="col" class="px-5 py-3 font-medium">Feature</th>
+                <th scope="col" class="px-5 py-3 font-medium text-zinc-200">hippo</th>
+                <th scope="col" class="px-5 py-3 font-medium">mem0</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-white/5">
               {rows.map((r) => (
                 <tr class="text-zinc-300">
-                  <td class="px-5 py-3.5 text-zinc-400">{r.feature}</td>
+                  <th scope="row" class="px-5 py-3.5 text-left font-normal text-zinc-400">{r.feature}</th>
                   <td class="px-5 py-3.5 font-medium text-zinc-100">{r.hippo}</td>
                   <td class="px-5 py-3.5">{r.mem0}</td>
                 </tr>
@@ -83,15 +112,15 @@ const faqJsonLd = {
             </tbody>
           </table>
         </div>
-        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-500">
-          Feature rows are from hippo's <a class="text-zinc-300 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href={`${site.links.repo}#comparison`} target="_blank" rel="noopener noreferrer">comparison table</a>. mem0 reports its own LongMemEval figures under its own conditions; hippo's per-haystack results are on the <a class="text-zinc-300 underline decoration-white/20 underline-offset-4 hover:decoration-acc-cyan" href="/benchmarks/">benchmarks page</a>.
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-400">
+          Feature rows are from hippo's <a class="link" href={`${site.links.repo}#comparison`} target="_blank" rel="noopener noreferrer">comparison table<span class="sr-only"> (opens in new tab)</span></a>; the qualifier behind each Yes/No is in the full matrix. Benchmark figures and the comparability caveat are in the strip above.
         </p>
       </div>
     </section>
 
     <section class="relative scroll-mt-20 border-t border-white/5">
-      <div class="mx-auto max-w-5xl px-5 py-20">
-        <h2 class="text-2xl leading-tight sm:text-3xl">When to choose which</h2>
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-3xl leading-tight sm:text-4xl">When to choose which</h2>
         <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div class="glass rounded-2xl p-6">
             <span class="text-sm font-medium text-zinc-100">Choose hippo</span>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -34,11 +34,14 @@
   }
 
   html {
+    /* bg lives on html and body stays transparent, so the fixed z-index -1
+       background canvas (BackgroundFx.astro) reads through site-long. */
+    background-color: var(--bg);
     scroll-behavior: smooth;
   }
 
   body {
-    background-color: var(--bg);
+    background-color: transparent;
     color: theme(--color-zinc-100);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
@@ -77,12 +80,19 @@
   }
 }
 
-/* ---- glass surface ---- */
+/* ---- glass surface ----
+   Standard property only: prefixing is the build toolchain's job. A hand-written
+   -webkit- duplicate made LightningCSS collapse the pair and ship a build whose
+   .glass had no standard backdrop-filter at all (audit 2026-06-10, high). */
 .glass {
   background: rgba(255, 255, 255, 0.035);
   border: 1px solid rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
+}
+/* Sticky header only: dark fallback so page text never reads through where
+   backdrop-filter is unsupported. The ~40 .glass content cards keep the light fill. */
+header.glass {
+  background: rgba(10, 10, 15, 0.85);
 }
 .glass-hover {
   transition: border-color 0.25s ease, background 0.25s ease, transform 0.25s ease;
@@ -92,7 +102,43 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
+/* ---- prose links (DESIGN.md links token) ----
+   One treatment sitewide: cyan with a 45% underline at rest, full on hover/focus.
+   Applied per-link via this class - deliberately NOT a blanket `a` rule, so nav
+   pills, CTAs, and card links keep their own treatments. */
+.link {
+  color: var(--color-acc-cyan);
+  text-decoration-line: underline;
+  text-decoration-color: rgba(34, 211, 238, 0.45);
+  text-underline-offset: 4px;
+}
+.link:hover,
+.link:focus-visible {
+  text-decoration-color: var(--color-acc-cyan);
+}
+
+/* ---- current-page nav markers (aria-current set in Nav.astro) ---- */
+header a[aria-current='page'] {
+  color: var(--color-acc-cyan);
+}
+/* the mobile chip rail additionally gets a cyan border + faint fill */
+nav[aria-label='Pages'] a[aria-current='page'] {
+  border-color: rgba(34, 211, 238, 0.55);
+  background: rgba(34, 211, 238, 0.08);
+}
+
 /* ---- decorative backgrounds ---- */
+/* fixed background canvas (BackgroundFx.astro): behind everything, never
+   intercepts input. width/height are explicit because inset alone doesn't
+   stretch a replaced element. */
+#bg-fx {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
 .dot-grid {
   background-image: radial-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px);
   background-size: 22px 22px;


### PR DESCRIPTION
## Summary

Rebuilds the website per the 2026-06-10 design audit (38 adversarially verified findings, 7 high) and adds a scroll-reactive synapse-network background. Design system codified in `website/DESIGN.md` (new source of truth).

Root-cause fix worth noting: the deployed CSS was losing the standard `backdrop-filter` property because LightningCSS collapsed the hand-written `-webkit-` duplicate in `global.css`. The duplicate is removed so the toolchain owns prefixing; the built dist now ships both properties (verified by anchored regex + computed-style check). This was the sticky-header text-bleed bug on every page.

High-severity fixes: mobile hero clip (min-w-0 grid children), header glass fallback, primary CTA now "Get started" -> /quickstart/, page-aware mobile chip nav, zinc-400 AA floor on methodology prose, reveal fail-open (full-page renders no longer blank 40-57% of home), vs/mem0 receipts strip with real numbers.

New `BackgroundFx.astro`: depth-parallax neuron field with scroll-fired pulses at <=9% alpha behind all content; static frame under prefers-reduced-motion; pauses when the tab is hidden; reseeds on resize; DPR capped at 1.5.

Guardrails respected: readme-sync gate passes with `cells:` literals untouched (visual trim uses parallel `display` fields); FAQ copy edited in `site.ts` so FAQPage JSON-LD stays in sync; `llms.txt` already matched final copy; version no longer hand-pinned (build-time import from root package.json).

## Test plan

- [x] `npm run build` green, including the readme-sync gate (55 cells + 10 systems match)
- [x] Dist CSS ships unprefixed `backdrop-filter` (anchored regex + `getComputedStyle` on the preview server)
- [x] 390px: `scrollWidth === 390` on all 4 pages (hero clip fixed); 98.6% stat no longer clips
- [x] Reveal fail-open: full-page screenshot immediately after load shows zero blank sections
- [x] Nav: logo -> `/`, one `aria-current` per nav, chips link to real pages on subpages
- [x] vs/mem0: receipts strip renders 98.6% vs ~49-85% with caveat; gradient on "hippo" not "mem0"
- [x] AA spot-check: methodology caveats compute to zinc-400
- [x] Visual QA vs approved mockup composites at 1440/390: no divergence (11 screenshots in audit dir)
- [x] Console: zero site-code errors (only the Cloudflare RUM beacon CORS-failing on localhost preview)
- [ ] Lighthouse on preview deployment
- [ ] Production deploy after sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
