### PR TITLE
feat(eval): lifecycle ablation flags + injectable clock (paper instrumentation)

### DIFF
--- a/src/ablation.ts
+++ b/src/ablation.ts
@@ -29,13 +29,19 @@
  *                              stamping (simulated-time protocols). Invalid
  *                              values are ignored (real clock used).
  *
- * Formula note (load-bearing for the experiments): with decay ablated,
- * calculateStrength's raw product is retrievalBoost * emotionalMultiplier,
- * which the [0,1] clamp caps at 1.0 - i.e. the recall-strengthening READ-side
- * boost can only offset decay, never exceed baseline. Ablating decay therefore
- * also flattens the read-side of strengthening (the write-side still runs).
- * This is a real property of the unified formula, not an implementation
- * accident; experiment analysis must account for it.
+ * Formula notes (load-bearing for the experiments) - ablating decay has TWO
+ * intrinsic co-effects, because the unified formula routes other mechanisms
+ * THROUGH the decay term. Both are real properties of the architecture, not
+ * implementation accidents; experiment analysis must attribute accordingly
+ * (the decay-off arm is "decay + its dependents off", see prereg amendment A1):
+ *   1. Read-side strengthening flattens: raw = retrievalBoost * emotionalMult
+ *      >= 1, and the [0,1] clamp caps it at 1.0 - the recall boost can only
+ *      offset decay, never exceed baseline. (Write-side still runs.)
+ *   2. Outcome-slow goes inert: rewardFactor only acts by scaling the
+ *      effective half-life INSIDE the decay exponent; with decay := 1 there
+ *      is no exponent for it to modulate. Outcome-slow is decay-rate
+ *      modulation BY DESIGN, so "no decay" necessarily means "no slow
+ *      channel" (the fast channel in hybridSearch is unaffected).
  *
  * Env caching follows the house pattern (see getLossAversionRatio in
  * memory.ts): read once per process, with a test-only reset helper. Tests
@@ -64,8 +70,15 @@ function readFlags(): AblationFlags {
   let fakeNowMs: number | null = null;
   const rawNow = process.env.HIPPO_FAKE_NOW;
   if (rawNow !== undefined && rawNow !== '') {
-    const parsed = Date.parse(rawNow);
-    fakeNowMs = Number.isFinite(parsed) ? parsed : null;
+    // STRICT canonical ISO-8601 UTC only (codex P2): Date.parse accepts junk
+    // like '1' or locale-dependent '06/11/2026', which would silently shift
+    // every simulated-time run. Anything non-canonical falls back to the real
+    // clock, exactly as documented.
+    const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+    if (ISO_UTC.test(rawNow)) {
+      const parsed = Date.parse(rawNow);
+      fakeNowMs = Number.isFinite(parsed) ? parsed : null;
+    }
   }
   _cache = {
     decay: isTruthy(process.env.HIPPO_ABLATE_DECAY),

--- a/src/ablation.ts
+++ b/src/ablation.ts
@@ -14,21 +14,33 @@
  *
  * Flags (set to '1' or 'true'):
  *   HIPPO_ABLATE_DECAY         time-decay term := 1 in calculateStrength.
- *   HIPPO_ABLATE_RECALL_BOOST  markRetrieved becomes a no-op (all three
- *                              sub-effects: clock reset, retrieval_count,
- *                              half_life increment), the retrieval-count READ
- *                              boost := 1, and decay anchors at `created`
- *                              instead of `last_retrieved` (so clock resets
- *                              persisted by PRIOR unflagged runs cannot leak
- *                              in). CAVEAT: half_life increments persisted by
- *                              prior runs are NOT reconstructed (consolidation
- *                              legitimately writes half_life too, so they are
- *                              not separable) - ablation arms must run on
- *                              FRESH stores, as the experiment protocol
- *                              mandates. NOTE: also neutralizes replay
- *                              rehearsal inside consolidation (same helper);
- *                              use config replay.count=0 to separate replay
- *                              from query-time strengthening.
+ *   HIPPO_ABLATE_RECALL_BOOST  full recall-strengthening ablation:
+ *                              - markRetrieved returns entries UNMUTATED (no
+ *                                clock reset / count / half-life increment);
+ *                                ids stay available so `hippo outcome`
+ *                                attribution keeps working in this arm;
+ *                              - persisting callers (CLI recall, api context,
+ *                                MCP recall/context, consolidation replay)
+ *                                skip their writeEntry loops (identical-row
+ *                                writes still refresh updated_at / mirrors /
+ *                                DAG dirty flags);
+ *                              - the retrieval-count READ boost := 1;
+ *                              - decay anchors at `created` instead of
+ *                                `last_retrieved` (prior-run clock resets
+ *                                cannot leak in);
+ *                              - physics: computeMass ignores the count, and
+ *                                physicsSearch recomputes loaded masses LIVE
+ *                                under ablated strength rules (persisted
+ *                                masses embed recall history in their frozen
+ *                                strength component);
+ *                              - replay rehearsal is silenced entirely (it IS
+ *                                strengthening; use config replay.count=0 to
+ *                                separate replay in unflagged arms).
+ *                              CAVEAT: half_life increments persisted by
+ *                              prior unflagged runs are NOT reconstructed
+ *                              (consolidation legitimately writes half_life
+ *                              too) - ablation arms run on FRESH stores, as
+ *                              the experiment protocol mandates.
  *   HIPPO_ABLATE_OUTCOME       both outcome channels := neutral
  *                              (= _SLOW + _FAST together). The slow side also
  *                              silences replay's outcome reward bias

--- a/src/ablation.ts
+++ b/src/ablation.ts
@@ -16,18 +16,31 @@
  *   HIPPO_ABLATE_DECAY         time-decay term := 1 in calculateStrength.
  *   HIPPO_ABLATE_RECALL_BOOST  markRetrieved becomes a no-op (all three
  *                              sub-effects: clock reset, retrieval_count,
- *                              half_life increment). NOTE: also neutralizes
- *                              replay rehearsal inside consolidation (same
- *                              helper); use config replay.count=0 to separate
- *                              replay from query-time strengthening.
+ *                              half_life increment), the retrieval-count READ
+ *                              boost := 1, and decay anchors at `created`
+ *                              instead of `last_retrieved` (so clock resets
+ *                              persisted by PRIOR unflagged runs cannot leak
+ *                              in). CAVEAT: half_life increments persisted by
+ *                              prior runs are NOT reconstructed (consolidation
+ *                              legitimately writes half_life too, so they are
+ *                              not separable) - ablation arms must run on
+ *                              FRESH stores, as the experiment protocol
+ *                              mandates. NOTE: also neutralizes replay
+ *                              rehearsal inside consolidation (same helper);
+ *                              use config replay.count=0 to separate replay
+ *                              from query-time strengthening.
  *   HIPPO_ABLATE_OUTCOME       both outcome channels := neutral
  *                              (= _SLOW + _FAST together).
  *   HIPPO_ABLATE_OUTCOME_SLOW  rewardFactor := 1 (no half-life modulation).
  *   HIPPO_ABLATE_OUTCOME_FAST  hybridSearch outcomeBoost := 1.
- *   HIPPO_FAKE_NOW             ISO timestamp injected as the default `now`
- *                              for strength computation and retrieval
- *                              stamping (simulated-time protocols). Invalid
- *                              values are ignored (real clock used).
+ *   HIPPO_FAKE_NOW             timestamp injected as the default `now` for
+ *                              strength computation and retrieval stamping
+ *                              (simulated-time protocols). MUST be the exact
+ *                              Date.toISOString() form
+ *                              (YYYY-MM-DDTHH:mm:ss.sssZ); validated by
+ *                              round-trip, so junk, locale dates, non-UTC
+ *                              offsets, and rolled-over dates (2026-02-31)
+ *                              all fall back to the real clock.
  *
  * Formula notes (load-bearing for the experiments) - ablating decay has TWO
  * intrinsic co-effects, because the unified formula routes other mechanisms
@@ -70,14 +83,16 @@ function readFlags(): AblationFlags {
   let fakeNowMs: number | null = null;
   const rawNow = process.env.HIPPO_FAKE_NOW;
   if (rawNow !== undefined && rawNow !== '') {
-    // STRICT canonical ISO-8601 UTC only (codex P2): Date.parse accepts junk
-    // like '1' or locale-dependent '06/11/2026', which would silently shift
-    // every simulated-time run. Anything non-canonical falls back to the real
+    // STRICT canonical form only: exactly what Date.prototype.toISOString
+    // emits (YYYY-MM-DDTHH:mm:ss.sssZ), verified by ROUND-TRIP equality.
+    // Two codex P2s drove this: (1) Date.parse accepts junk like '1' or
+    // locale-dependent '06/11/2026'; (2) a regex alone still admits
+    // rolled-over dates ('2026-02-31T...Z' silently becomes March 3). A
+    // value that does not round-trip byte-identical falls back to the real
     // clock, exactly as documented.
-    const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
-    if (ISO_UTC.test(rawNow)) {
-      const parsed = Date.parse(rawNow);
-      fakeNowMs = Number.isFinite(parsed) ? parsed : null;
+    const parsed = Date.parse(rawNow);
+    if (Number.isFinite(parsed) && new Date(parsed).toISOString() === rawNow) {
+      fakeNowMs = parsed;
     }
   }
   _cache = {

--- a/src/ablation.ts
+++ b/src/ablation.ts
@@ -30,7 +30,12 @@
  *                              use config replay.count=0 to separate replay
  *                              from query-time strengthening.
  *   HIPPO_ABLATE_OUTCOME       both outcome channels := neutral
- *                              (= _SLOW + _FAST together).
+ *                              (= _SLOW + _FAST together). The slow side also
+ *                              silences replay's outcome reward bias
+ *                              (replayPriority). NOT gated: the opt-in
+ *                              `recall --value-aware` rerank (an explicit CLI
+ *                              flag that also reads outcome counts) - ablated
+ *                              arms must not pass it.
  *   HIPPO_ABLATE_OUTCOME_SLOW  rewardFactor := 1 (no half-life modulation).
  *   HIPPO_ABLATE_OUTCOME_FAST  hybridSearch outcomeBoost := 1.
  *   HIPPO_FAKE_NOW             timestamp injected as the default `now` for

--- a/src/ablation.ts
+++ b/src/ablation.ts
@@ -1,0 +1,109 @@
+/**
+ * EVAL-ONLY lifecycle ablation switches.
+ *
+ * These env flags exist for controlled experiments on hippo's memory-lifecycle
+ * mechanisms (the "lifecycle, ablated" paper protocol): each switch neutralizes
+ * exactly ONE mechanism so its causal contribution can be measured in isolation.
+ *
+ * They are NOT a production configuration surface:
+ *   - no config-file equivalents, deliberately (config implies support);
+ *   - undocumented in user-facing help;
+ *   - semantics may change with the experiment design.
+ * Production behavior with all flags unset is byte-identical to before this
+ * module existed.
+ *
+ * Flags (set to '1' or 'true'):
+ *   HIPPO_ABLATE_DECAY         time-decay term := 1 in calculateStrength.
+ *   HIPPO_ABLATE_RECALL_BOOST  markRetrieved becomes a no-op (all three
+ *                              sub-effects: clock reset, retrieval_count,
+ *                              half_life increment). NOTE: also neutralizes
+ *                              replay rehearsal inside consolidation (same
+ *                              helper); use config replay.count=0 to separate
+ *                              replay from query-time strengthening.
+ *   HIPPO_ABLATE_OUTCOME       both outcome channels := neutral
+ *                              (= _SLOW + _FAST together).
+ *   HIPPO_ABLATE_OUTCOME_SLOW  rewardFactor := 1 (no half-life modulation).
+ *   HIPPO_ABLATE_OUTCOME_FAST  hybridSearch outcomeBoost := 1.
+ *   HIPPO_FAKE_NOW             ISO timestamp injected as the default `now`
+ *                              for strength computation and retrieval
+ *                              stamping (simulated-time protocols). Invalid
+ *                              values are ignored (real clock used).
+ *
+ * Formula note (load-bearing for the experiments): with decay ablated,
+ * calculateStrength's raw product is retrievalBoost * emotionalMultiplier,
+ * which the [0,1] clamp caps at 1.0 - i.e. the recall-strengthening READ-side
+ * boost can only offset decay, never exceed baseline. Ablating decay therefore
+ * also flattens the read-side of strengthening (the write-side still runs).
+ * This is a real property of the unified formula, not an implementation
+ * accident; experiment analysis must account for it.
+ *
+ * Env caching follows the house pattern (see getLossAversionRatio in
+ * memory.ts): read once per process, with a test-only reset helper. Tests
+ * that mutate these env vars MUST call _resetAblationCacheForTests() in BOTH
+ * beforeEach AND afterEach.
+ */
+
+interface AblationFlags {
+  decay: boolean;
+  recallBoost: boolean;
+  outcomeSlow: boolean;
+  outcomeFast: boolean;
+  /** Parsed HIPPO_FAKE_NOW epoch millis, or null when unset/invalid. */
+  fakeNowMs: number | null;
+}
+
+let _cache: AblationFlags | undefined;
+
+function isTruthy(value: string | undefined): boolean {
+  return value === '1' || value === 'true';
+}
+
+function readFlags(): AblationFlags {
+  if (_cache !== undefined) return _cache;
+  const outcomeBoth = isTruthy(process.env.HIPPO_ABLATE_OUTCOME);
+  let fakeNowMs: number | null = null;
+  const rawNow = process.env.HIPPO_FAKE_NOW;
+  if (rawNow !== undefined && rawNow !== '') {
+    const parsed = Date.parse(rawNow);
+    fakeNowMs = Number.isFinite(parsed) ? parsed : null;
+  }
+  _cache = {
+    decay: isTruthy(process.env.HIPPO_ABLATE_DECAY),
+    recallBoost: isTruthy(process.env.HIPPO_ABLATE_RECALL_BOOST),
+    outcomeSlow: outcomeBoth || isTruthy(process.env.HIPPO_ABLATE_OUTCOME_SLOW),
+    outcomeFast: outcomeBoth || isTruthy(process.env.HIPPO_ABLATE_OUTCOME_FAST),
+    fakeNowMs,
+  };
+  return _cache;
+}
+
+export function isDecayAblated(): boolean {
+  return readFlags().decay;
+}
+
+export function isRecallBoostAblated(): boolean {
+  return readFlags().recallBoost;
+}
+
+export function isOutcomeSlowAblated(): boolean {
+  return readFlags().outcomeSlow;
+}
+
+export function isOutcomeFastAblated(): boolean {
+  return readFlags().outcomeFast;
+}
+
+/**
+ * The default `now` for lifecycle computations: HIPPO_FAKE_NOW when set and
+ * parseable, else the real clock. Callers that already take an explicit `now`
+ * parameter are unaffected (explicit always wins).
+ */
+export function evalNow(): Date {
+  const ms = readFlags().fakeNowMs;
+  return ms === null ? new Date() : new Date(ms);
+}
+
+/** Test-only. See module JSDoc: call in BOTH beforeEach AND afterEach. */
+export function _resetAblationCacheForTests(): void {
+  _cache = undefined;
+}

--- a/src/ambient.ts
+++ b/src/ambient.ts
@@ -7,6 +7,7 @@
  * without retrieving specific memories.
  */
 
+import { evalNow } from './ablation.js';
 import type { MemoryEntry } from './memory.js';
 import { Layer } from './memory.js';
 import { calculateStrength } from './memory.js';
@@ -36,7 +37,7 @@ export function computeAmbientState(entries: MemoryEntry[], now?: Date): Ambient
     };
   }
 
-  const currentTime = now ?? new Date();
+  const currentTime = now ?? evalNow(); // honors HIPPO_FAKE_NOW (eval-only)
 
   const tagCounts = new Map<string, number>();
   let strengthSum = 0;

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,6 +54,7 @@ import {
   type AuditOp,
 } from './audit.js';
 import { promoteToGlobal, getGlobalRoot, autoShare, searchBothHybrid } from './shared.js';
+import { evalNow } from './ablation.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
   createApiKey,
@@ -2180,7 +2181,7 @@ export async function getContext(
     }
     // Effective budget: explicit opts.budget wins over config.
     const effBudget = opts.budget !== undefined ? budget : pinnedCfg.pinnedInject.budget;
-    const nowP = new Date();
+    const nowP = evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
     const selectedIds = new Set<string>();
     let usedP = 0;
 
@@ -2245,7 +2246,7 @@ export async function getContext(
     totalTokens = usedP;
   } else if (query === '*') {
     // No query: return strongest memories by strength, up to budget.
-    const now = new Date();
+    const now = evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
     const localRanked = localEntries
       .map((e) => ({
         entry: e,

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,7 @@ import {
   type AuditOp,
 } from './audit.js';
 import { promoteToGlobal, getGlobalRoot, autoShare, searchBothHybrid } from './shared.js';
-import { evalNow } from './ablation.js';
+import { evalNow, isRecallBoostAblated } from './ablation.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
   createApiKey,
@@ -2374,13 +2374,19 @@ export async function getContext(
     const updatedEntries = markRetrieved(toUpdate);
     const localIndex = loadIndex(ctx.hippoRoot);
 
-    for (const u of updatedEntries) {
-      const targetRoot = localIndex.entries[u.id]
-        ? ctx.hippoRoot
-        : hasGlobal
-          ? globalRoot
-          : ctx.hippoRoot;
-      writeEntry(targetRoot, u);
+    // EVAL-ONLY ablation (see ablation.ts): under the recall flag,
+    // markRetrieved returns unmutated entries (ids preserved for outcome
+    // attribution) and persistence is skipped (identical-row writes still
+    // refresh updated_at / mirrors / DAG dirty flags).
+    if (!isRecallBoostAblated()) {
+      for (const u of updatedEntries) {
+        const targetRoot = localIndex.entries[u.id]
+          ? ctx.hippoRoot
+          : hasGlobal
+            ? globalRoot
+            : ctx.hippoRoot;
+        writeEntry(targetRoot, u);
+      }
     }
 
     localIndex.last_retrieval_ids = updatedEntries.map((u) => u.id);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@
  *   hippo wm <push|read|clear|flush>
  */
 
-import { evalNow } from './ablation.js';
+import { evalNow, isRecallBoostAblated } from './ablation.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -1687,9 +1687,15 @@ async function cmdRecall(
   // Update retrieval metadata and persist
   const updated = markRetrieved(results.map((r) => r.entry));
   const localIndex = loadIndex(hippoRoot);
-  for (const u of updated) {
-    const targetRoot = localIndex.entries[u.id] ? hippoRoot : (isInitialized(globalRoot) ? globalRoot : hippoRoot);
-    writeEntry(targetRoot, u);
+  // EVAL-ONLY ablation (see ablation.ts): under the recall flag, markRetrieved
+  // returns unmutated entries (ids preserved for outcome attribution below)
+  // and persistence is skipped - writeEntry on identical rows still refreshes
+  // updated_at, rewrites mirrors, and marks DAG parents dirty.
+  if (!isRecallBoostAblated()) {
+    for (const u of updated) {
+      const targetRoot = localIndex.entries[u.id] ? hippoRoot : (isInitialized(globalRoot) ? globalRoot : hippoRoot);
+      writeEntry(targetRoot, u);
+    }
   }
 
   // Track last retrieval IDs for outcome command

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@
  *   hippo wm <push|read|clear|flush>
  */
 
+import { evalNow } from './ablation.js';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -2335,7 +2336,7 @@ function cmdTrace(
     process.exit(1);
   }
 
-  const now = new Date();
+  const now = evalNow();
   const strength = calculateStrength(entry, now);
   const halfLife = deriveHalfLife(7, entry);
   const rewardFactor = calculateRewardFactor(entry);
@@ -3021,7 +3022,7 @@ function cmdStatus(hippoRoot: string): void {
 
   const entries = loadAllEntries(hippoRoot);
   const stats = loadStats(hippoRoot);
-  const now = new Date();
+  const now = evalNow();
 
   const byLayer = {
     [Layer.Buffer]: 0,
@@ -3257,7 +3258,7 @@ function cmdInspect(hippoRoot: string, id: string): void {
     process.exit(1);
   }
 
-  const now = new Date();
+  const now = evalNow();
   const currentStrength = calculateStrength(entry, now);
   const lastRetrieved = new Date(entry.last_retrieved);
   const created = new Date(entry.created);
@@ -5479,7 +5480,7 @@ export function printContextMarkdown(
   totalTokens: number,
   framing: string = 'observe'
 ): void {
-  const now = new Date();
+  const now = evalNow();
   console.log(`## Project Memory (${items.length} entries, ${totalTokens} tokens)\n`);
   for (const item of items) {
     const e = item.entry;

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -7,7 +7,7 @@
  * 3. Stats tracking
  */
 
-import { evalNow } from './ablation.js';
+import { evalNow, isRecallBoostAblated } from './ablation.js';
 import { MemoryEntry, Layer, calculateStrength, createMemory, resolveConfidence, type DecayOptions } from './memory.js';
 import {
   loadAllEntries,
@@ -253,7 +253,11 @@ export async function consolidate(
   // it doesn't fade" pass.
   {
     const replayCount = config.replay?.count ?? REPLAY_COUNT_DEFAULT;
-    if (replayCount > 0 && survivors.length > 0) {
+    // EVAL-ONLY ablation (see ablation.ts): replay rehearsal IS recall
+    // strengthening (same markRetrieved dynamics), so the strengthen-off arm
+    // silences the whole pass - markRetrieved would return unmutated entries
+    // and persisting them anyway would still refresh updated_at / mirrors.
+    if (replayCount > 0 && survivors.length > 0 && !isRecallBoostAblated()) {
       const seed = Math.floor(now.getTime() / 1000) & 0xffffffff;
       const picked = sampleForReplay(survivors, replayCount, now, seed);
       if (picked.length > 0) {

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -7,6 +7,7 @@
  * 3. Stats tracking
  */
 
+import { evalNow } from './ablation.js';
 import { MemoryEntry, Layer, calculateStrength, createMemory, resolveConfidence, type DecayOptions } from './memory.js';
 import {
   loadAllEntries,
@@ -99,7 +100,7 @@ export async function consolidate(
   hippoRoot: string,
   options: { dryRun?: boolean; now?: Date } = {}
 ): Promise<ConsolidationResult> {
-  const now = options.now ?? new Date();
+  const now = options.now ?? evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
   const dryRun = options.dryRun ?? false;
 
   const result: ConsolidationResult = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,7 +18,7 @@ import {
   calculateStrength,
 } from '../memory.js';
 import { search, hybridSearch, physicsSearch, markRetrieved, estimateTokens } from '../search.js';
-import { isRecallBoostAblated } from '../ablation.js';
+import { isRecallBoostAblated, evalNow } from '../ablation.js';
 import { loadAllEntries, writeEntry, readEntry, initStore, loadActiveTaskSnapshot, listMemoryConflicts, resolveConflict, RECALL_DEFAULT_DENY_SCOPES } from '../store.js';
 import { shareMemory, listPeers, getGlobalRoot } from '../shared.js';
 import { consolidate } from '../consolidate.js';
@@ -1041,7 +1041,7 @@ async function executeTool(
 
     case 'hippo_status': {
       const entries = loadAllEntries(hippoRoot, tenantId);
-      const now = new Date();
+      const now = evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
       let atRisk = 0;
       let totalStrength = 0;
       for (const e of entries) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,6 +18,7 @@ import {
   calculateStrength,
 } from '../memory.js';
 import { search, hybridSearch, physicsSearch, markRetrieved, estimateTokens } from '../search.js';
+import { isRecallBoostAblated } from '../ablation.js';
 import { loadAllEntries, writeEntry, readEntry, initStore, loadActiveTaskSnapshot, listMemoryConflicts, resolveConflict, RECALL_DEFAULT_DENY_SCOPES } from '../store.js';
 import { shareMemory, listPeers, getGlobalRoot } from '../shared.js';
 import { consolidate } from '../consolidate.js';
@@ -582,7 +583,11 @@ async function executeTool(
 
       // Mark retrieved and persist
       const retrieved = markRetrieved(results.map((r) => r.entry));
-      for (const entry of retrieved) writeEntry(hippoRoot, entry);
+      // EVAL-ONLY ablation (see ablation.ts): skip persistence under the recall
+      // flag; ids below stay populated for outcome attribution.
+      if (!isRecallBoostAblated()) {
+        for (const entry of retrieved) writeEntry(hippoRoot, entry);
+      }
       lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
       // v0.33 / J1 — MCP per-pipeline anchoring detector. UNLIKE J3.2's
@@ -1003,7 +1008,11 @@ async function executeTool(
         ? await physicsSearch(query, entries, { budget, hippoRoot, physicsConfig: config.physics })
         : await hybridSearch(query, entries, { budget, hippoRoot });
       const retrieved = markRetrieved(results.map((r) => r.entry));
-      for (const entry of retrieved) writeEntry(hippoRoot, entry);
+      // EVAL-ONLY ablation (see ablation.ts): skip persistence under the recall
+      // flag; ids below stay populated for outcome attribution.
+      if (!isRecallBoostAblated()) {
+        for (const entry of retrieved) writeEntry(hippoRoot, entry);
+      }
       lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
       const rawSnapshot = loadActiveTaskSnapshot(hippoRoot, tenantId);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -306,7 +306,16 @@ export function calculateStrength(
 ): number {
   if (entry.pinned) return 1.0;
 
-  const lastRetrieved = new Date(entry.last_retrieved);
+  // EVAL-ONLY ablation (see ablation.ts): with recall-strengthening ablated,
+  // anchor decay at CREATION, not last_retrieved. A never-strengthened memory
+  // decays from when it was made; using last_retrieved would let clock resets
+  // persisted by PRIOR unflagged runs leak strengthening into an ablated
+  // arm's rankings (codex P2). Identity on fresh stores (created ==
+  // last_retrieved at write). Prior-run half_life increments are NOT
+  // reconstructed - see the ablation.ts caveat (fresh stores per arm).
+  const lastRetrieved = new Date(
+    isRecallBoostAblated() ? entry.created : entry.last_retrieved,
+  );
   const daysSince = (now.getTime() - lastRetrieved.getTime()) / (1000 * 60 * 60 * 24);
 
   // Reward-proportional half-life modulation

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -435,7 +435,7 @@ export function generateId(prefix: string = 'mem'): string {
  * If the entry has not been retrieved in 30+ days and is not 'verified',
  * returns 'stale'. Otherwise returns the stored confidence value.
  */
-export function resolveConfidence(entry: MemoryEntry, now: Date = new Date()): ConfidenceLevel {
+export function resolveConfidence(entry: MemoryEntry, now: Date = evalNow()): ConfidenceLevel {
   if (entry.pinned || entry.confidence === 'verified') return entry.confidence;
 
   const lastRetrieved = new Date(entry.last_retrieved);
@@ -482,7 +482,7 @@ export function createMemory(
     throw new Error(`Invalid trace_outcome: ${options.trace_outcome}. Must be 'success', 'failure', 'partial', or null.`);
   }
 
-  const now = new Date().toISOString();
+  const now = evalNow().toISOString(); // honors HIPPO_FAKE_NOW (eval-only)
   const layer = options.layer ?? Layer.Episodic;
   const tags = options.tags ?? [];
   const emotional_valence = options.emotional_valence ?? inferValence(tags);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4,7 +4,12 @@
  */
 
 import { randomUUID } from 'crypto';
-import { isDecayAblated, isOutcomeSlowAblated, evalNow } from './ablation.js';
+import {
+  isDecayAblated,
+  isOutcomeSlowAblated,
+  isRecallBoostAblated,
+  evalNow,
+} from './ablation.js';
 
 export enum Layer {
   Buffer = 'buffer',
@@ -338,7 +343,13 @@ export function calculateStrength(
   const decay = isDecayAblated() ? 1.0 : Math.pow(0.5, decayExponent);
 
   // Retrieval boost: 1 + 0.1 * log2(retrieval_count + 1)
-  const retrievalBoost = 1 + 0.1 * Math.log2(entry.retrieval_count + 1);
+  // EVAL-ONLY ablation (see ablation.ts): the recall-boost flag neutralizes
+  // the READ side too, so a store with PRIOR retrieval history (counts > 0
+  // written before the flag was set) does not leak strengthening into an
+  // ablated arm's rankings (codex P2).
+  const retrievalBoost = isRecallBoostAblated()
+    ? 1.0
+    : 1 + 0.1 * Math.log2(entry.retrieval_count + 1);
 
   // Emotional multiplier
   // v1.13.5 / J5: apply HIPPO_LOSS_AVERSION_RATIO to the negative multiplier

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { isDecayAblated, isOutcomeSlowAblated, evalNow } from './ablation.js';
 
 export enum Layer {
   Buffer = 'buffer',
@@ -257,6 +258,8 @@ function applyLossAversionRatio(
  * decay slower; consistent negative outcomes decay faster.
  */
 export function calculateRewardFactor(entry: MemoryEntry): number {
+  // EVAL-ONLY ablation (see ablation.ts): the slow outcome channel.
+  if (isOutcomeSlowAblated()) return 1.0;
   const pos = entry.outcome_positive ?? 0;
   const neg = entry.outcome_negative ?? 0;
   if (pos === 0 && neg === 0) return 1.0;
@@ -291,7 +294,9 @@ export interface DecayOptions {
  */
 export function calculateStrength(
   entry: MemoryEntry,
-  now: Date = new Date(),
+  // evalNow(): the real clock unless HIPPO_FAKE_NOW is set (eval-only,
+  // simulated-time protocols; see ablation.ts). Explicit `now` always wins.
+  now: Date = evalNow(),
   options: DecayOptions = {},
 ): number {
   if (entry.pinned) return 1.0;
@@ -327,7 +332,10 @@ export function calculateStrength(
     decayExponent = daysSince / effectiveHalfLife;
   }
 
-  const decay = Math.pow(0.5, decayExponent);
+  // EVAL-ONLY ablation (see ablation.ts): decay term := 1. NOTE the [0,1]
+  // clamp below then caps retrievalBoost at baseline - see ablation.ts
+  // formula note.
+  const decay = isDecayAblated() ? 1.0 : Math.pow(0.5, decayExponent);
 
   // Retrieval boost: 1 + 0.1 * log2(retrieval_count + 1)
   const retrievalBoost = 1 + 0.1 * Math.log2(entry.retrieval_count + 1);

--- a/src/physics-state.ts
+++ b/src/physics-state.ts
@@ -4,6 +4,7 @@
  * in SQLite using BLOB columns for 384-dim vectors.
  */
 
+import { evalNow } from './ablation.js';
 import type { DatabaseSyncLike } from './db.js';
 import type { MemoryEntry } from './memory.js';
 import type { PhysicsParticle } from './physics.js';
@@ -155,7 +156,7 @@ export function savePhysicsState(
 export function initializeParticle(
   entry: MemoryEntry,
   embedding: number[],
-  now: Date = new Date(),
+  now: Date = evalNow(),
 ): PhysicsParticle {
   const strength = calculateStrength(entry, now);
   const ageDays = (now.getTime() - new Date(entry.created).getTime()) / (1000 * 60 * 60 * 24);
@@ -186,7 +187,7 @@ export function resetAllPhysicsState(
   db: DatabaseSyncLike,
   entries: MemoryEntry[],
   embeddingIndex: Record<string, number[]>,
-  now: Date = new Date(),
+  now: Date = evalNow(),
 ): number {
   db.exec('DELETE FROM memory_physics');
 
@@ -211,7 +212,7 @@ export function resetAllPhysicsState(
 export function refreshParticleProperties(
   particles: PhysicsParticle[],
   entries: Map<string, MemoryEntry>,
-  now: Date = new Date(),
+  now: Date = evalNow(),
 ): void {
   for (const p of particles) {
     const entry = entries.get(p.memoryId);

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -130,19 +130,6 @@ export function computeMass(strength: number, retrievalCount: number): number {
   return Math.max(0.01, strength * (1 + 0.1 * Math.log2(effectiveCount + 1)));
 }
 
-/**
- * EVAL-ONLY (see ablation.ts): strip the retrieval-count boost baked into a
- * PERSISTED particle mass. memory_physics rows written before the recall
- * ablation was enabled carry mass = strength * (1 + 0.1*log2(rc+1)); under
- * the flag, query gravity must not rank by that history (codex P2). Exact
- * whenever rc has not changed since the mass was persisted - which holds for
- * any store where the flag has been on since the last sleep (the flag stops
- * rc from ever incrementing). No-op when rc = 0 (protocol-fresh stores).
- */
-export function stripRetrievalBoostFromMass(mass: number, retrievalCount: number): number {
-  return Math.max(0.01, mass / (1 + 0.1 * Math.log2(retrievalCount + 1)));
-}
-
 export function computeCharge(valence: EmotionalValence): number {
   return CHARGE_MAP[valence] ?? 0;
 }

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -10,6 +10,7 @@
  * amplify each other via constructive interference.
  */
 
+import { isRecallBoostAblated } from './ablation.js';
 import type { EmotionalValence } from './memory.js';
 import type { PhysicsConfig } from './physics-config.js';
 
@@ -120,7 +121,13 @@ const CHARGE_MAP: Record<EmotionalValence, number> = {
 };
 
 export function computeMass(strength: number, retrievalCount: number): number {
-  return Math.max(0.01, strength * (1 + 0.1 * Math.log2(retrievalCount + 1)));
+  // EVAL-ONLY ablation (see ablation.ts): under the recall-boost flag, particle
+  // mass must not scale with retrieval history either - query gravity ranks by
+  // mass, so prior retrieval counts would leak strengthening into the ablated
+  // arm's physics-pool rankings (codex P2). Covers both the init and refresh
+  // callers in physics-state.ts.
+  const effectiveCount = isRecallBoostAblated() ? 0 : retrievalCount;
+  return Math.max(0.01, strength * (1 + 0.1 * Math.log2(effectiveCount + 1)));
 }
 
 export function computeCharge(valence: EmotionalValence): number {

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -130,6 +130,19 @@ export function computeMass(strength: number, retrievalCount: number): number {
   return Math.max(0.01, strength * (1 + 0.1 * Math.log2(effectiveCount + 1)));
 }
 
+/**
+ * EVAL-ONLY (see ablation.ts): strip the retrieval-count boost baked into a
+ * PERSISTED particle mass. memory_physics rows written before the recall
+ * ablation was enabled carry mass = strength * (1 + 0.1*log2(rc+1)); under
+ * the flag, query gravity must not rank by that history (codex P2). Exact
+ * whenever rc has not changed since the mass was persisted - which holds for
+ * any store where the flag has been on since the last sleep (the flag stops
+ * rc from ever incrementing). No-op when rc = 0 (protocol-fresh stores).
+ */
+export function stripRetrievalBoostFromMass(mass: number, retrievalCount: number): number {
+  return Math.max(0.01, mass / (1 + 0.1 * Math.log2(retrievalCount + 1)));
+}
+
 export function computeCharge(valence: EmotionalValence): number {
   return CHARGE_MAP[valence] ?? 0;
 }

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -23,6 +23,7 @@
  *   - REPLAY: picks winners and rehearses them (this file)
  */
 
+import { isOutcomeSlowAblated } from './ablation.js';
 import type { MemoryEntry, EmotionalValence } from './memory.js';
 
 const VALENCE_WEIGHT: Record<EmotionalValence, number> = {
@@ -43,7 +44,9 @@ export function replayPriority(entry: MemoryEntry, now: Date): number {
   // negative-dominated memories floor at 0.1 (so they're still eligible, just
   // much less likely to be sampled than neutral peers). Clamp is required
   // because sampleForReplay depends on all weights being positive.
-  const rewardSignal = Math.max(0.1, 1 + pos * 0.5 + (pos - neg) * 0.25);
+  const rewardSignal = isOutcomeSlowAblated()
+    ? 1.0 // EVAL-ONLY ablation (see ablation.ts): outcome-off also silences replay's reward bias
+    : Math.max(0.1, 1 + pos * 0.5 + (pos - neg) * 0.25);
 
   const valence = VALENCE_WEIGHT[entry.emotional_valence] ?? 1.0;
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@
  */
 
 import { MemoryEntry, calculateStrength } from './memory.js';
+import { isOutcomeFastAblated, isRecallBoostAblated, evalNow } from './ablation.js';
 import { extractPathTags, pathOverlapScore } from './path-context.js';
 import { detectScope, scopeMatch } from './scope.js';
 import {
@@ -590,9 +591,10 @@ export async function hybridSearch(
 
     // Retrieval-time outcome personalization: nudge up/down from user feedback.
     // Distinct from reward-factor-via-strength (slow); this is immediate.
+    // EVAL-ONLY ablation (see ablation.ts): the fast outcome channel.
     const pos = entries[i].outcome_positive ?? 0;
     const neg = entries[i].outcome_negative ?? 0;
-    const outcomeBoost = pos === 0 && neg === 0
+    const outcomeBoost = isOutcomeFastAblated() || (pos === 0 && neg === 0)
       ? 1.0
       : Math.max(0.85, Math.min(1.15, 1 + 0.15 * Math.tanh((pos - neg) / 2)));
     compositeScore *= outcomeBoost;
@@ -1197,8 +1199,15 @@ export function search(
 /**
  * Update retrieval metadata on entries that were returned by a search.
  * Returns the mutated copies (caller must persist to disk).
+ *
+ * EVAL-ONLY ablation (see ablation.ts): with HIPPO_ABLATE_RECALL_BOOST set,
+ * this is a no-op returning the entries unchanged - neutralizing all three
+ * strengthening sub-effects (clock reset, retrieval_count, half-life
+ * increment) at the single shared write site. Callers persist identical rows.
+ * The default `now` honors HIPPO_FAKE_NOW (simulated-time protocols).
  */
-export function markRetrieved(entries: MemoryEntry[], now: Date = new Date()): MemoryEntry[] {
+export function markRetrieved(entries: MemoryEntry[], now: Date = evalNow()): MemoryEntry[] {
+  if (isRecallBoostAblated()) return entries;
   return entries.map((e) => {
     if (e.superseded_by) return e;
     const updated: MemoryEntry = {

--- a/src/search.ts
+++ b/src/search.ts
@@ -13,7 +13,7 @@ import {
   loadEmbeddingIndex,
 } from './embeddings.js';
 import { resolveEmbeddingProvider } from './embedding-provider.js';
-import { physicsScore as computePhysicsScores } from './physics.js';
+import { physicsScore as computePhysicsScores, stripRetrievalBoostFromMass } from './physics.js';
 import type { PhysicsParticle } from './physics.js';
 import type { PhysicsConfig } from './physics-config.js';
 import { DEFAULT_PHYSICS_CONFIG } from './physics-config.js';
@@ -934,7 +934,15 @@ export async function physicsSearch(
       && particle.velocity.length === queryVector.length
     ) {
       physicsEntries.push(entry);
-      physicsParticles.push(particle);
+      // EVAL-ONLY ablation (see ablation.ts): persisted masses carry the
+      // retrieval-count boost baked in at the last sleep; under the recall
+      // flag, strip it so query gravity cannot rank by retrieval history
+      // (codex P2). No-op for rc = 0.
+      physicsParticles.push(
+        isRecallBoostAblated()
+          ? { ...particle, mass: stripRetrievalBoostFromMass(particle.mass, entry.retrieval_count) }
+          : particle,
+      );
     } else {
       classicEntries.push(entry);
     }
@@ -1201,13 +1209,19 @@ export function search(
  * Returns the mutated copies (caller must persist to disk).
  *
  * EVAL-ONLY ablation (see ablation.ts): with HIPPO_ABLATE_RECALL_BOOST set,
- * this is a no-op returning the entries unchanged - neutralizing all three
- * strengthening sub-effects (clock reset, retrieval_count, half-life
- * increment) at the single shared write site. Callers persist identical rows.
+ * this returns an EMPTY array - neutralizing all three strengthening
+ * sub-effects (clock reset, retrieval_count, half-life increment) at the
+ * single shared write site AND signalling callers to persist nothing.
+ * Returning the entries themselves was not enough: every production caller
+ * writes the returned array back via writeEntry, which refreshes updated_at,
+ * rewrites mirrors, and marks DAG parents dirty even for identical rows
+ * (codex P2). All callers map-then-persist the return value; the one
+ * consumer that re-joins it into display results (api.assembleContext) uses
+ * a `?? original` fallback, so an empty return is safe everywhere.
  * The default `now` honors HIPPO_FAKE_NOW (simulated-time protocols).
  */
 export function markRetrieved(entries: MemoryEntry[], now: Date = evalNow()): MemoryEntry[] {
-  if (isRecallBoostAblated()) return entries;
+  if (isRecallBoostAblated()) return [];
   return entries.map((e) => {
     if (e.superseded_by) return e;
     const updated: MemoryEntry = {

--- a/src/search.ts
+++ b/src/search.ts
@@ -400,7 +400,7 @@ export async function hybridSearch(
     };
   } = {}
 ): Promise<SearchResult[]> {
-  const now = options.now ?? new Date();
+  const now = options.now ?? evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
   const budget = options.budget ?? 4000;
   const minResults = options.minResults ?? 1;
   const embeddingWeight = options.embeddingWeight ?? 0.6;
@@ -872,7 +872,7 @@ export async function physicsSearch(
     summaryFreshness?: boolean;
   } = {}
 ): Promise<SearchResult[]> {
-  const now = options.now ?? new Date();
+  const now = options.now ?? evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
   const budget = options.budget ?? 4000;
   const minResults = options.minResults ?? 1;
   const config = options.physicsConfig ?? DEFAULT_PHYSICS_CONFIG;
@@ -1061,7 +1061,7 @@ export function search(
   options: { budget?: number; now?: Date; hippoRoot?: string; minResults?: number; includeSuperseded?: boolean; asOf?: string } = {}
 ): SearchResult[] {
   // Synchronous path: BM25 only (no async hybrid)
-  const now = options.now ?? new Date();
+  const now = options.now ?? evalNow(); // honors HIPPO_FAKE_NOW (eval-only; see ablation.ts)
   const budget = options.budget ?? 4000;
   const minResults = options.minResults ?? 1;
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -13,7 +13,7 @@ import {
   loadEmbeddingIndex,
 } from './embeddings.js';
 import { resolveEmbeddingProvider } from './embedding-provider.js';
-import { physicsScore as computePhysicsScores, stripRetrievalBoostFromMass } from './physics.js';
+import { physicsScore as computePhysicsScores, computeMass } from './physics.js';
 import type { PhysicsParticle } from './physics.js';
 import type { PhysicsConfig } from './physics-config.js';
 import { DEFAULT_PHYSICS_CONFIG } from './physics-config.js';
@@ -934,13 +934,18 @@ export async function physicsSearch(
       && particle.velocity.length === queryVector.length
     ) {
       physicsEntries.push(entry);
-      // EVAL-ONLY ablation (see ablation.ts): persisted masses carry the
-      // retrieval-count boost baked in at the last sleep; under the recall
-      // flag, strip it so query gravity cannot rank by retrieval history
-      // (codex P2). No-op for rc = 0.
+      // EVAL-ONLY ablation (see ablation.ts): persisted masses embed recall
+      // history TWICE - the outer retrieval-count multiplier AND the frozen
+      // strength inside it (computed at sleep time from clock-reset
+      // last_retrieved + the read-side boost). Stripping the outer multiplier
+      // alone is not enough (codex round-7 P2); under the flag, recompute the
+      // mass LIVE from the current entry under ablated strength rules
+      // (created-anchored decay, no boost - both applied inside
+      // calculateStrength/computeMass by the same flag). The frozen-at-sleep
+      // semantics is unrecoverable for the ablated arm by definition.
       physicsParticles.push(
         isRecallBoostAblated()
-          ? { ...particle, mass: stripRetrievalBoostFromMass(particle.mass, entry.retrieval_count) }
+          ? { ...particle, mass: computeMass(calculateStrength(entry, now), entry.retrieval_count) }
           : particle,
       );
     } else {
@@ -1209,19 +1214,21 @@ export function search(
  * Returns the mutated copies (caller must persist to disk).
  *
  * EVAL-ONLY ablation (see ablation.ts): with HIPPO_ABLATE_RECALL_BOOST set,
- * this returns an EMPTY array - neutralizing all three strengthening
+ * this returns the entries UNMUTATED - neutralizing all three strengthening
  * sub-effects (clock reset, retrieval_count, half-life increment) at the
- * single shared write site AND signalling callers to persist nothing.
- * Returning the entries themselves was not enough: every production caller
- * writes the returned array back via writeEntry, which refreshes updated_at,
- * rewrites mirrors, and marks DAG parents dirty even for identical rows
- * (codex P2). All callers map-then-persist the return value; the one
- * consumer that re-joins it into display results (api.assembleContext) uses
- * a `?? original` fallback, so an empty return is safe everywhere.
+ * single shared write site. The entries (not an empty array) must be
+ * returned because callers derive `last_retrieval_ids` from the return
+ * value, and a later `hippo outcome --good/--bad` targets those ids - an
+ * empty return would silently co-ablate the outcome channel in the
+ * strengthen-off arm (codex round-7 P2). PERSISTENCE is gated separately at
+ * each persisting caller (CLI recall, api context, MCP recall/context,
+ * consolidation replay): writeEntry on identical rows still refreshes
+ * updated_at, rewrites mirrors, and marks DAG parents dirty (codex round-6
+ * P2), so those write loops skip under the flag.
  * The default `now` honors HIPPO_FAKE_NOW (simulated-time protocols).
  */
 export function markRetrieved(entries: MemoryEntry[], now: Date = evalNow()): MemoryEntry[] {
-  if (isRecallBoostAblated()) return [];
+  if (isRecallBoostAblated()) return entries;
   return entries.map((e) => {
     if (e.superseded_by) return e;
     const updated: MemoryEntry = {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -91,7 +91,7 @@ export function searchBoth(
   globalRoot: string,
   options: SearchOptions = {}
 ): SearchResult[] {
-  const { budget = 4000, now = new Date(), minResults, tenantId } = options;
+  const { budget = 4000, now = evalNow(), minResults, tenantId } = options;
   const effectiveMin = minResults ?? 1;
 
   const localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, undefined, tenantId) : [];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -18,6 +18,7 @@ import {
   readEntry,
 } from './store.js';
 import { search, hybridSearch, SearchResult } from './search.js';
+import { evalNow } from './ablation.js';
 
 /**
  * Returns the path to the global Hippo store.
@@ -172,7 +173,7 @@ export async function searchBothHybrid(
   globalRoot: string,
   options: HybridSearchOptions = {}
 ): Promise<SearchResult[]> {
-  const { budget = 4000, now = new Date(), embeddingWeight, explain, mmr, mmrLambda, localBump = 1.2, minResults, scope, includeSuperseded, asOf, tenantId, summaryDeboost, summaryFreshness } = options;
+  const { budget = 4000, now = evalNow(), embeddingWeight, explain, mmr, mmrLambda, localBump = 1.2, minResults, scope, includeSuperseded, asOf, tenantId, summaryDeboost, summaryFreshness } = options;
 
   const localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, undefined, tenantId) : [];
   const globalEntries = fs.existsSync(globalRoot) ? loadSearchEntries(globalRoot, query, undefined, tenantId) : [];

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -1,0 +1,245 @@
+/**
+ * EVAL-ONLY lifecycle ablation flags (src/ablation.ts).
+ *
+ * Pre-registered design rev #10 requirement: each flag must neutralize ONLY
+ * its intended mechanism. Every block therefore asserts BOTH the ablation
+ * (target mechanism off) AND the isolation (the other mechanisms intact).
+ *
+ * Env isolation pattern (canonical: tests/emotional-multipliers-j5.test.ts):
+ * beforeEach AND afterEach clear all ablation env vars + reset the module
+ * cache, so no test leaks flags into the next.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  calculateStrength,
+  calculateRewardFactor,
+  createMemory,
+  applyOutcome,
+  type MemoryEntry,
+} from '../src/memory.js';
+import { hybridSearch, markRetrieved } from '../src/search.js';
+import { evalNow, _resetAblationCacheForTests } from '../src/ablation.js';
+
+const ABLATION_ENV_VARS = [
+  'HIPPO_ABLATE_DECAY',
+  'HIPPO_ABLATE_RECALL_BOOST',
+  'HIPPO_ABLATE_OUTCOME',
+  'HIPPO_ABLATE_OUTCOME_SLOW',
+  'HIPPO_ABLATE_OUTCOME_FAST',
+  'HIPPO_FAKE_NOW',
+] as const;
+
+function clearAblationEnv(): void {
+  for (const v of ABLATION_ENV_VARS) delete process.env[v];
+  _resetAblationCacheForTests();
+}
+
+beforeEach(clearAblationEnv);
+afterEach(clearAblationEnv);
+
+/** A memory last retrieved `daysAgo` days before `NOW`, with a short half-life. */
+function agedMemory(daysAgo: number, content = 'aged memory content'): MemoryEntry {
+  const m = createMemory(content);
+  m.last_retrieved = new Date(NOW.getTime() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+  m.half_life_days = 7;
+  return m;
+}
+
+const NOW = new Date('2026-06-11T12:00:00.000Z');
+
+// ---------------------------------------------------------------------------
+// Defaults: all flags unset -> behavior identical to pre-ablation hippo
+// ---------------------------------------------------------------------------
+
+describe('defaults (no flags set)', () => {
+  it('decay, strengthening, and both outcome channels all run', async () => {
+    // Decay live: old memory weaker than fresh.
+    expect(calculateStrength(agedMemory(30), NOW)).toBeLessThan(
+      calculateStrength(agedMemory(0), NOW),
+    );
+    // Strengthening live: markRetrieved mutates.
+    const [marked] = markRetrieved([agedMemory(30)], NOW);
+    expect(marked.retrieval_count).toBe(1);
+    expect(marked.last_retrieved).toBe(NOW.toISOString());
+    expect(marked.half_life_days).toBe(9); // 7 + 2
+    // Slow outcome channel live.
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    expect(calculateRewardFactor(m)).toBeGreaterThan(1);
+    // Fast outcome channel live.
+    const results = await hybridSearch('outcome-laden', [m], { budget: 10000, explain: true });
+    expect(results[0].breakdown?.outcomeBoost).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIPPO_ABLATE_DECAY
+// ---------------------------------------------------------------------------
+
+describe('HIPPO_ABLATE_DECAY', () => {
+  beforeEach(() => {
+    process.env.HIPPO_ABLATE_DECAY = '1';
+    _resetAblationCacheForTests();
+  });
+
+  it('neutralizes decay: a 30-day-old memory equals a fresh one', () => {
+    expect(calculateStrength(agedMemory(30), NOW)).toBe(calculateStrength(agedMemory(0), NOW));
+  });
+
+  it('isolation: strengthening writes still run', () => {
+    const [marked] = markRetrieved([agedMemory(30)], NOW);
+    expect(marked.retrieval_count).toBe(1);
+    expect(marked.half_life_days).toBe(9);
+  });
+
+  it('isolation: slow outcome channel still runs', () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, false);
+    expect(calculateRewardFactor(m)).toBeLessThan(1);
+  });
+
+  it('documents the clamp interaction: read-side retrieval boost saturates at 1', () => {
+    // With decay := 1, raw = retrievalBoost * emotionalMult >= 1, clamped to 1.
+    // The strengthening READ-side therefore flattens when decay is off (the
+    // boost can only offset decay, never exceed baseline). See ablation.ts.
+    const m = agedMemory(0);
+    m.retrieval_count = 16;
+    expect(calculateStrength(m, NOW)).toBe(1.0);
+    expect(calculateStrength(agedMemory(0), NOW)).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIPPO_ABLATE_RECALL_BOOST
+// ---------------------------------------------------------------------------
+
+describe('HIPPO_ABLATE_RECALL_BOOST', () => {
+  beforeEach(() => {
+    process.env.HIPPO_ABLATE_RECALL_BOOST = '1';
+    _resetAblationCacheForTests();
+  });
+
+  it('neutralizes ALL THREE strengthening sub-effects (no-op markRetrieved)', () => {
+    const before = agedMemory(30);
+    before.confidence = 'stale';
+    const result = markRetrieved([before], NOW);
+    expect(result[0]).toBe(before); // identical object, untouched
+    expect(result[0].retrieval_count).toBe(0); // no count
+    expect(result[0].last_retrieved).not.toBe(NOW.toISOString()); // no clock reset
+    expect(result[0].half_life_days).toBe(7); // no +2
+    expect(result[0].confidence).toBe('stale'); // no stale->observed promotion
+  });
+
+  it('isolation: decay still runs', () => {
+    expect(calculateStrength(agedMemory(30), NOW)).toBeLessThan(
+      calculateStrength(agedMemory(0), NOW),
+    );
+  });
+
+  it('isolation: both outcome channels still run', async () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    expect(calculateRewardFactor(m)).toBeGreaterThan(1);
+    const results = await hybridSearch('outcome-laden', [m], { budget: 10000, explain: true });
+    expect(results[0].breakdown?.outcomeBoost).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIPPO_ABLATE_OUTCOME (both channels) / _SLOW / _FAST (decomposition)
+// ---------------------------------------------------------------------------
+
+describe('HIPPO_ABLATE_OUTCOME', () => {
+  beforeEach(() => {
+    process.env.HIPPO_ABLATE_OUTCOME = '1';
+    _resetAblationCacheForTests();
+  });
+
+  it('neutralizes the slow channel (rewardFactor = 1 despite outcomes)', () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    m = applyOutcome(m, true);
+    expect(calculateRewardFactor(m)).toBe(1.0);
+  });
+
+  it('neutralizes the fast channel (outcomeBoost = 1 despite outcomes)', async () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    m = applyOutcome(m, true);
+    const results = await hybridSearch('outcome-laden', [m], { budget: 10000, explain: true });
+    expect(results[0].breakdown?.outcomeBoost).toBe(1);
+  });
+
+  it('isolation: decay and strengthening still run', () => {
+    expect(calculateStrength(agedMemory(30), NOW)).toBeLessThan(
+      calculateStrength(agedMemory(0), NOW),
+    );
+    const [marked] = markRetrieved([agedMemory(30)], NOW);
+    expect(marked.retrieval_count).toBe(1);
+  });
+});
+
+describe('HIPPO_ABLATE_OUTCOME_SLOW (decomposition arm)', () => {
+  beforeEach(() => {
+    process.env.HIPPO_ABLATE_OUTCOME_SLOW = '1';
+    _resetAblationCacheForTests();
+  });
+
+  it('slow off, fast still live', async () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    expect(calculateRewardFactor(m)).toBe(1.0); // slow off
+    const results = await hybridSearch('outcome-laden', [m], { budget: 10000, explain: true });
+    expect(results[0].breakdown?.outcomeBoost).toBeGreaterThan(1); // fast on
+  });
+});
+
+describe('HIPPO_ABLATE_OUTCOME_FAST (decomposition arm)', () => {
+  beforeEach(() => {
+    process.env.HIPPO_ABLATE_OUTCOME_FAST = '1';
+    _resetAblationCacheForTests();
+  });
+
+  it('fast off, slow still live', async () => {
+    let m = createMemory('outcome-laden');
+    m = applyOutcome(m, true);
+    expect(calculateRewardFactor(m)).toBeGreaterThan(1); // slow on
+    const results = await hybridSearch('outcome-laden', [m], { budget: 10000, explain: true });
+    expect(results[0].breakdown?.outcomeBoost).toBe(1); // fast off
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HIPPO_FAKE_NOW (simulated time)
+// ---------------------------------------------------------------------------
+
+describe('HIPPO_FAKE_NOW', () => {
+  it('injects the fake clock as the default now', () => {
+    process.env.HIPPO_FAKE_NOW = '2030-01-01T00:00:00.000Z';
+    _resetAblationCacheForTests();
+    expect(evalNow().toISOString()).toBe('2030-01-01T00:00:00.000Z');
+    // Default-now path of calculateStrength uses the fake clock: a memory
+    // "fresh" relative to real time decays hard against the 2030 clock.
+    const realFresh = createMemory('fresh in 2026');
+    realFresh.half_life_days = 7;
+    expect(calculateStrength(realFresh)).toBeLessThan(0.01);
+    // markRetrieved default stamp = fake now.
+    const [marked] = markRetrieved([createMemory('stamp me')]);
+    expect(marked.last_retrieved).toBe('2030-01-01T00:00:00.000Z');
+  });
+
+  it('invalid value falls back to the real clock', () => {
+    process.env.HIPPO_FAKE_NOW = 'not-a-date';
+    _resetAblationCacheForTests();
+    const drift = Math.abs(evalNow().getTime() - Date.now());
+    expect(drift).toBeLessThan(5000);
+  });
+
+  it('explicit now parameter always wins over the fake clock', () => {
+    process.env.HIPPO_FAKE_NOW = '2030-01-01T00:00:00.000Z';
+    _resetAblationCacheForTests();
+    const m = agedMemory(0);
+    expect(calculateStrength(m, NOW)).toBe(1.0); // explicit NOW, not 2030
+  });
+});

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -170,6 +170,17 @@ describe('HIPPO_ABLATE_RECALL_BOOST', () => {
     expect(calculateStrength(withHistory, NOW)).toBe(calculateStrength(without, NOW));
   });
 
+  it('neutralizes physics particle mass too: retrieval history cannot leak via gravity (codex round-5 P2)', async () => {
+    // Query gravity ranks the physics pool by particle mass, which scales with
+    // retrieval_count; under the flag, mass must ignore retrieval history in
+    // both the init and refresh paths (computeMass is the single shared site).
+    const { computeMass } = await import('../src/physics.js');
+    expect(computeMass(0.8, 16)).toBe(computeMass(0.8, 0));
+    // Sanity: WITHOUT the flag, history raises mass.
+    clearAblationEnv();
+    expect(computeMass(0.8, 16)).toBeGreaterThan(computeMass(0.8, 0));
+  });
+
   it('anchors decay at created: prior clock resets cannot leak in (codex round-3 P2)', () => {
     // Both memories created 30 days ago; one was "retrieved" 1 day ago by a
     // PRIOR unflagged run (persisted last_retrieved reset). Under the flag,

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -41,10 +41,15 @@ function clearAblationEnv(): void {
 beforeEach(clearAblationEnv);
 afterEach(clearAblationEnv);
 
-/** A memory last retrieved `daysAgo` days before `NOW`, with a short half-life. */
+/** A memory created AND last retrieved `daysAgo` days before `NOW` (i.e. aged
+ *  and never strengthened since), with a short half-life. Both timestamps are
+ *  backdated so the helper means the same thing under both decay anchors
+ *  (last_retrieved normally, created under HIPPO_ABLATE_RECALL_BOOST). */
 function agedMemory(daysAgo: number, content = 'aged memory content'): MemoryEntry {
   const m = createMemory(content);
-  m.last_retrieved = new Date(NOW.getTime() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+  const then = new Date(NOW.getTime() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+  m.created = then;
+  m.last_retrieved = then;
   m.half_life_days = 7;
   return m;
 }
@@ -165,6 +170,25 @@ describe('HIPPO_ABLATE_RECALL_BOOST', () => {
     expect(calculateStrength(withHistory, NOW)).toBe(calculateStrength(without, NOW));
   });
 
+  it('anchors decay at created: prior clock resets cannot leak in (codex round-3 P2)', () => {
+    // Both memories created 30 days ago; one was "retrieved" 1 day ago by a
+    // PRIOR unflagged run (persisted last_retrieved reset). Under the flag,
+    // decay anchors at created, so both decay identically from creation.
+    const created = new Date(NOW.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const reset = createMemory('clock reset by a prior run');
+    reset.created = created;
+    reset.last_retrieved = new Date(NOW.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    reset.half_life_days = 7;
+    const untouched = createMemory('never retrieved');
+    untouched.created = created;
+    untouched.last_retrieved = created;
+    untouched.half_life_days = 7;
+    expect(calculateStrength(reset, NOW)).toBe(calculateStrength(untouched, NOW));
+    // Sanity: WITHOUT the flag these differ (the reset memory is stronger).
+    clearAblationEnv();
+    expect(calculateStrength(reset, NOW)).toBeGreaterThan(calculateStrength(untouched, NOW));
+  });
+
   it('isolation: both outcome channels still run', async () => {
     let m = createMemory('outcome-laden');
     m = applyOutcome(m, true);
@@ -280,8 +304,19 @@ describe('HIPPO_FAKE_NOW', () => {
   });
 
   it('rejects non-canonical formats Date.parse would accept (codex P2)', () => {
-    // '1', locale dates, and non-UTC ISO must NOT silently become a fake clock.
-    for (const junk of ['1', '06/11/2026', '2026-06-11', '2026-06-11T12:00:00', '2026-06-11T12:00:00+01:00']) {
+    // '1', locale dates, non-UTC ISO, millis-less forms, and ROLLED-OVER dates
+    // (2026-02-31 silently becomes March 3 under V8 Date.parse) must NOT
+    // become a fake clock - round-trip validation catches them all.
+    for (const junk of [
+      '1',
+      '06/11/2026',
+      '2026-06-11',
+      '2026-06-11T12:00:00',
+      '2026-06-11T12:00:00+01:00',
+      '2026-06-11T12:00:00Z', // millis required (exact toISOString form)
+      '2026-02-31T00:00:00.000Z', // rollover (codex round-3 P2)
+      '2026-13-01T00:00:00.000Z', // rollover month
+    ]) {
       process.env.HIPPO_FAKE_NOW = junk;
       _resetAblationCacheForTests();
       const drift = Math.abs(evalNow().getTime() - Date.now());

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -144,15 +144,30 @@ describe('HIPPO_ABLATE_RECALL_BOOST', () => {
     _resetAblationCacheForTests();
   });
 
-  it('neutralizes ALL THREE strengthening sub-effects (no-op markRetrieved)', () => {
+  it('neutralizes ALL THREE strengthening sub-effects AND persistence (markRetrieved returns [])', () => {
+    // Returns EMPTY so callers persist nothing: writeEntry on identical rows
+    // still refreshes updated_at, rewrites mirrors, and marks DAG parents
+    // dirty (codex round-6 P2). The source entry itself is untouched.
     const before = agedMemory(30);
     before.confidence = 'stale';
     const result = markRetrieved([before], NOW);
-    expect(result[0]).toBe(before); // identical object, untouched
-    expect(result[0].retrieval_count).toBe(0); // no count
-    expect(result[0].last_retrieved).not.toBe(NOW.toISOString()); // no clock reset
-    expect(result[0].half_life_days).toBe(7); // no +2
-    expect(result[0].confidence).toBe('stale'); // no stale->observed promotion
+    expect(result).toEqual([]); // nothing to persist
+    expect(before.retrieval_count).toBe(0); // no count
+    expect(before.last_retrieved).not.toBe(NOW.toISOString()); // no clock reset
+    expect(before.half_life_days).toBe(7); // no +2
+    expect(before.confidence).toBe('stale'); // no stale->observed promotion
+  });
+
+  it('strips retrieval boost from PERSISTED physics masses (codex round-6 P2)', async () => {
+    // memory_physics rows written before the flag carry the boost baked in;
+    // the loaded-mass path must strip it (exact when rc is unchanged since
+    // the mass was persisted; no-op for rc = 0).
+    const { computeMass, stripRetrievalBoostFromMass } = await import('../src/physics.js');
+    clearAblationEnv(); // compute a mass as an UNFLAGGED sleep would have persisted it
+    const baked = computeMass(0.8, 16);
+    expect(baked).toBeGreaterThan(0.8);
+    expect(stripRetrievalBoostFromMass(baked, 16)).toBeCloseTo(0.8, 10);
+    expect(stripRetrievalBoostFromMass(0.8, 0)).toBe(0.8); // rc=0 no-op
   });
 
   it('isolation: decay still runs', () => {

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -230,6 +230,28 @@ describe('HIPPO_ABLATE_OUTCOME', () => {
     const [marked] = markRetrieved([agedMemory(30)], NOW);
     expect(marked.retrieval_count).toBe(1);
   });
+
+  it('silences replay reward bias too: outcome counts no longer skew replay priority (codex P2)', async () => {
+    // Replay (a consolidation sub-pass) preferentially rehearses
+    // outcome-positive memories and then strengthens them via markRetrieved -
+    // an outcome-dependent lifecycle path that must also go quiet in the
+    // outcome-off arm.
+    const { replayPriority } = await import('../src/replay.js');
+    let rewarded = agedMemory(5, 'replay candidate');
+    rewarded = applyOutcome(applyOutcome(rewarded, true), true);
+    const plain = agedMemory(5, 'replay candidate');
+    // Recompute BOTH strength caches at the same instant: replayPriority also
+    // reads entry.strength, and applyOutcome's recompute-at-real-now would
+    // otherwise differ from plain's initial cache purely by fixture timing.
+    rewarded.strength = calculateStrength(rewarded, NOW);
+    plain.strength = calculateStrength(plain, NOW);
+    expect(replayPriority(rewarded, NOW)).toBe(replayPriority(plain, NOW));
+    // Sanity: WITHOUT the flag the rewarded memory is prioritized.
+    clearAblationEnv();
+    rewarded.strength = calculateStrength(rewarded, NOW);
+    plain.strength = calculateStrength(plain, NOW);
+    expect(replayPriority(rewarded, NOW)).toBeGreaterThan(replayPriority(plain, NOW));
+  });
 });
 
 describe('HIPPO_ABLATE_OUTCOME_SLOW (decomposition arm)', () => {
@@ -272,10 +294,15 @@ describe('HIPPO_FAKE_NOW', () => {
     _resetAblationCacheForTests();
     expect(evalNow().toISOString()).toBe('2030-01-01T00:00:00.000Z');
     // Default-now path of calculateStrength uses the fake clock: a memory
-    // "fresh" relative to real time decays hard against the 2030 clock.
+    // dated 2026 decays hard against the 2030 clock. (createMemory itself now
+    // stamps fake time under the flag, so the 2026 dates are set explicitly.)
     const realFresh = createMemory('fresh in 2026');
+    realFresh.created = '2026-06-11T00:00:00.000Z';
+    realFresh.last_retrieved = '2026-06-11T00:00:00.000Z';
     realFresh.half_life_days = 7;
     expect(calculateStrength(realFresh)).toBeLessThan(0.01);
+    // createMemory write-stamps honor the fake clock too (simulated sessions).
+    expect(createMemory('stamped in 2030').created).toBe('2030-01-01T00:00:00.000Z');
     // markRetrieved default stamp = fake now.
     const [marked] = markRetrieved([createMemory('stamp me')]);
     expect(marked.last_retrieved).toBe('2030-01-01T00:00:00.000Z');
@@ -287,7 +314,9 @@ describe('HIPPO_FAKE_NOW', () => {
     process.env.HIPPO_FAKE_NOW = '2030-01-01T00:00:00.000Z';
     _resetAblationCacheForTests();
     const m = createMemory('search scoring uses the fake clock');
-    m.half_life_days = 7; // fresh in real time, ancient against the 2030 clock
+    m.created = '2026-06-11T00:00:00.000Z'; // dated 2026, ancient against the 2030 clock
+    m.last_retrieved = '2026-06-11T00:00:00.000Z';
+    m.half_life_days = 7;
     const results = await hybridSearch('search scoring fake clock', [m], {
       budget: 10000,
       explain: true,
@@ -332,7 +361,9 @@ describe('HIPPO_FAKE_NOW', () => {
     _resetAblationCacheForTests();
     const { searchBothHybrid } = await import('../src/shared.js');
     const m = createMemory('wrapper clock consistency check');
-    m.half_life_days = 7; // fresh in real time, ancient against the 2030 clock
+    m.created = '2026-06-11T00:00:00.000Z'; // dated 2026, ancient against the 2030 clock
+    m.last_retrieved = '2026-06-11T00:00:00.000Z';
+    m.half_life_days = 7;
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-abl-'));
     try {
       // Local-only store via the wrapper (global root nonexistent path).

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -144,30 +144,40 @@ describe('HIPPO_ABLATE_RECALL_BOOST', () => {
     _resetAblationCacheForTests();
   });
 
-  it('neutralizes ALL THREE strengthening sub-effects AND persistence (markRetrieved returns [])', () => {
-    // Returns EMPTY so callers persist nothing: writeEntry on identical rows
-    // still refreshes updated_at, rewrites mirrors, and marks DAG parents
-    // dirty (codex round-6 P2). The source entry itself is untouched.
+  it('neutralizes ALL THREE strengthening sub-effects; entries returned unmutated', () => {
+    // Returns the UNMUTATED entries (not []): callers derive
+    // last_retrieval_ids from the return value, and `hippo outcome` targets
+    // those ids - an empty return would co-ablate the outcome channel in the
+    // strengthen-off arm (codex round-7 P2). Persistence is gated separately
+    // at each persisting caller (codex round-6 P2).
     const before = agedMemory(30);
     before.confidence = 'stale';
     const result = markRetrieved([before], NOW);
-    expect(result).toEqual([]); // nothing to persist
-    expect(before.retrieval_count).toBe(0); // no count
-    expect(before.last_retrieved).not.toBe(NOW.toISOString()); // no clock reset
-    expect(before.half_life_days).toBe(7); // no +2
-    expect(before.confidence).toBe('stale'); // no stale->observed promotion
+    expect(result.length).toBe(1); // ids preserved for outcome attribution
+    expect(result[0]).toBe(before); // identical object, untouched
+    expect(result[0].retrieval_count).toBe(0); // no count
+    expect(result[0].last_retrieved).not.toBe(NOW.toISOString()); // no clock reset
+    expect(result[0].half_life_days).toBe(7); // no +2
+    expect(result[0].confidence).toBe('stale'); // no stale->observed promotion
   });
 
-  it('strips retrieval boost from PERSISTED physics masses (codex round-6 P2)', async () => {
-    // memory_physics rows written before the flag carry the boost baked in;
-    // the loaded-mass path must strip it (exact when rc is unchanged since
-    // the mass was persisted; no-op for rc = 0).
-    const { computeMass, stripRetrievalBoostFromMass } = await import('../src/physics.js');
-    clearAblationEnv(); // compute a mass as an UNFLAGGED sleep would have persisted it
-    const baked = computeMass(0.8, 16);
-    expect(baked).toBeGreaterThan(0.8);
-    expect(stripRetrievalBoostFromMass(baked, 16)).toBeCloseTo(0.8, 10);
-    expect(stripRetrievalBoostFromMass(0.8, 0)).toBe(0.8); // rc=0 no-op
+  it('physics mass recomputed under ablated rules ignores ALL recall history (codex round-7 P2)', async () => {
+    // The physicsSearch join recomputes mass as
+    // computeMass(calculateStrength(entry, now), rc) under the flag; both
+    // functions apply ablated semantics internally, so a heavily-recalled
+    // entry and an untouched twin produce the SAME mass - no history leaks
+    // through either the count multiplier or the frozen-strength component.
+    const { computeMass } = await import('../src/physics.js');
+    const created = new Date(NOW.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const hot = agedMemory(10);
+    hot.created = created;
+    hot.retrieval_count = 16;
+    hot.last_retrieved = new Date(NOW.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString();
+    const cold = agedMemory(10);
+    cold.created = created;
+    expect(computeMass(calculateStrength(hot, NOW), hot.retrieval_count)).toBe(
+      computeMass(calculateStrength(cold, NOW), cold.retrieval_count),
+    );
   });
 
   it('isolation: decay still runs', () => {

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -137,6 +137,15 @@ describe('HIPPO_ABLATE_RECALL_BOOST', () => {
     );
   });
 
+  it('neutralizes the READ side too: prior retrieval_count > 0 gives no boost (codex P2)', () => {
+    // A store written BEFORE the flag was set can carry counts; the ablated
+    // arm must not let that history leak strengthening into rankings.
+    const withHistory = agedMemory(10);
+    withHistory.retrieval_count = 16;
+    const without = agedMemory(10);
+    expect(calculateStrength(withHistory, NOW)).toBe(calculateStrength(without, NOW));
+  });
+
   it('isolation: both outcome channels still run', async () => {
     let m = createMemory('outcome-laden');
     m = applyOutcome(m, true);
@@ -227,6 +236,21 @@ describe('HIPPO_FAKE_NOW', () => {
     // markRetrieved default stamp = fake now.
     const [marked] = markRetrieved([createMemory('stamp me')]);
     expect(marked.last_retrieved).toBe('2030-01-01T00:00:00.000Z');
+  });
+
+  it('flows through search scoring, not just retrieval stamping (codex P2)', async () => {
+    // Without the search-default wiring, scoring would use the REAL clock while
+    // markRetrieved stamps the fake one - inconsistent simulated time.
+    process.env.HIPPO_FAKE_NOW = '2030-01-01T00:00:00.000Z';
+    _resetAblationCacheForTests();
+    const m = createMemory('search scoring uses the fake clock');
+    m.half_life_days = 7; // fresh in real time, ancient against the 2030 clock
+    const results = await hybridSearch('search scoring fake clock', [m], {
+      budget: 10000,
+      explain: true,
+    });
+    // strengthMultiplier = 0.5 + 0.5 * strength; strength ~ 0 under the 2030 clock.
+    expect(results[0].breakdown?.strengthMultiplier).toBeLessThan(0.51);
   });
 
   it('invalid value falls back to the real clock', () => {

--- a/tests/ablation-flags.test.ts
+++ b/tests/ablation-flags.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   calculateStrength,
   calculateRewardFactor,
@@ -107,6 +110,22 @@ describe('HIPPO_ABLATE_DECAY', () => {
     m.retrieval_count = 16;
     expect(calculateStrength(m, NOW)).toBe(1.0);
     expect(calculateStrength(agedMemory(0), NOW)).toBe(1.0);
+  });
+
+  it('documents the co-ablation: outcome-slow is inert when decay is off (codex P2)', async () => {
+    // rewardFactor acts ONLY by scaling the effective half-life inside the
+    // decay exponent; with decay := 1 there is nothing to modulate. The
+    // decay-off arm is therefore "decay + outcome-slow off" BY CONSTRUCTION
+    // (prereg amendment A1). The fast channel is unaffected.
+    let bad = agedMemory(10, 'outcome laden memory');
+    bad = applyOutcome(applyOutcome(bad, false), false);
+    const plain = agedMemory(10, 'outcome laden memory');
+    expect(calculateStrength(bad, NOW)).toBe(calculateStrength(plain, NOW)); // slow inert
+    const results = await hybridSearch('outcome laden memory', [bad], {
+      budget: 10000,
+      explain: true,
+    });
+    expect(results[0].breakdown?.outcomeBoost).toBeLessThan(1); // fast still live
   });
 });
 
@@ -258,6 +277,42 @@ describe('HIPPO_FAKE_NOW', () => {
     _resetAblationCacheForTests();
     const drift = Math.abs(evalNow().getTime() - Date.now());
     expect(drift).toBeLessThan(5000);
+  });
+
+  it('rejects non-canonical formats Date.parse would accept (codex P2)', () => {
+    // '1', locale dates, and non-UTC ISO must NOT silently become a fake clock.
+    for (const junk of ['1', '06/11/2026', '2026-06-11', '2026-06-11T12:00:00', '2026-06-11T12:00:00+01:00']) {
+      process.env.HIPPO_FAKE_NOW = junk;
+      _resetAblationCacheForTests();
+      const drift = Math.abs(evalNow().getTime() - Date.now());
+      expect(drift, `format '${junk}' must fall back to real clock`).toBeLessThan(5000);
+    }
+  });
+
+  it('flows through the searchBothHybrid wrapper default too (codex P2)', async () => {
+    // The wrapper destructures its own `now` default and passes it explicitly
+    // into hybridSearch, so the inner fallback never runs - the wrapper default
+    // itself must honor the fake clock.
+    process.env.HIPPO_FAKE_NOW = '2030-01-01T00:00:00.000Z';
+    _resetAblationCacheForTests();
+    const { searchBothHybrid } = await import('../src/shared.js');
+    const m = createMemory('wrapper clock consistency check');
+    m.half_life_days = 7; // fresh in real time, ancient against the 2030 clock
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-abl-'));
+    try {
+      // Local-only store via the wrapper (global root nonexistent path).
+      const { initStore, writeEntry } = await import('../src/store.js');
+      initStore(tmp);
+      writeEntry(tmp, m);
+      const results = await searchBothHybrid('wrapper clock consistency check', tmp, path.join(tmp, 'no-global'), {
+        budget: 10000,
+        explain: true,
+      });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].breakdown?.strengthMultiplier).toBeLessThan(0.51);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('explicit now parameter always wins over the fake clock', () => {


### PR DESCRIPTION
## What

EVAL-ONLY env switches for the pre-registered memory-lifecycle paper experiments (prereg frozen at hippo-paper/PREREGISTERED-DESIGN.md v0.2). Each flag neutralizes exactly one lifecycle mechanism for causal ablation:

- `HIPPO_ABLATE_DECAY` - decay term := 1 in calculateStrength
- `HIPPO_ABLATE_RECALL_BOOST` - markRetrieved no-op (clock reset + retrieval_count + half-life increment, the single shared write site)
- `HIPPO_ABLATE_OUTCOME` / `_OUTCOME_SLOW` / `_OUTCOME_FAST` - outcome channels (slow = rewardFactor, fast = hybridSearch outcomeBoost), jointly or decomposed
- `HIPPO_FAKE_NOW` - injectable default clock for simulated-time protocols

New `src/ablation.ts` follows the house env-cache pattern (getLossAversionRatio) incl. `_resetForTests`. Deliberately NOT config-file options: no production surface.

## Why

The paper's frozen design requires per-mechanism ablation arms with unit-test proof that each flag neutralizes only its mechanism (codex design-review rev #10).

## Safety

With all flags unset, behavior is unchanged. Full suite: 2586 passed / 1 known server-concurrency ECONNRESET flake (passes in isolation). 16 new tests assert ablation + isolation per flag, the decay-clamp interaction, and fake-clock fallback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)