### PR TITLE
feat: memory scope isolation (origin partition + secret veto, v39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+- **Memory scope isolation (fixes cross-project context bleed).** Ambient context - the Claude Code UserPromptSubmit hook, `hippo context`, `GET /v1/context`, and MCP `hippo_context` - no longer injects memories owned by OTHER projects into the active session. Every memory now carries an `origin_project` (a project name = owned by that project, '' = user-global and injectable everywhere, NULL = legacy pre-v39 row, treated as other-project). Origin is stamped automatically from the store's location at write time; migration v39 backfills existing rows from store location and `shared:<project>:` sources. Escape hatches: `hippo context --cross-project` (rendered under a demarcated "Other-project memory" section), `cross_project=1` on `/v1/context`, and config `contextProjectIsolation: false`.
+- **Secret hard veto.** New content/tag secret detection (provider-bounded patterns + `secret`/`api-key`/`token`/... tags). Secrets are never auto-shared or explicitly shared to the global store (`hippo share` refuses, `hippo sleep` skips), never synced down by `hippo sync`, and never ambient-injected outside their owning project - not even with `--cross-project` or isolation disabled. Origin-less secrets never ambient-inject at all. Explicit `hippo recall` still returns them: recalling a secret is a deliberate act.
+- **Context assembly now applies the same envelope default-deny as recall.** Private scopes (`*:private:*`) and quarantine buckets never inject into ambient context (previously only `hippo recall`/MCP recall enforced this).
+- `hippo sync --cross-project` re-includes other-project rows when syncing global memories down; the default now skips them (secrets always skipped). `syncGlobalToLocal` preserves `origin_project` on copies.
+
+### Changed
+- **Behavior change for existing installed hooks (intended):** the UserPromptSubmit hook command is unchanged and keeps working, but its injected content is now project-scoped. If you relied on seeing other projects' memories everywhere, set `contextProjectIsolation: false` in `config.json` or use `--cross-project` explicitly.
+- `ContextResult` entries gain `origin` and `category` (`project` | `user-global` | `cross-project`); the CLI JSON format exposes both.
+- `shareMemory` stamps the canonical `origin_project` on global copies (derived from the entry's own write-time stamp, not the local path basename).
+- Migration v39 (schema 38 -> 39): adds `memories.origin_project` + evidence-based backfill. Additive and idempotent; no data is removed.
+
 ## 1.23.0 (2026-06-08): pluggable embedding providers (bring a frontier embedder)
 
 ### Added

--- a/docs/plans/2026-07-01-memory-scope-isolation.md
+++ b/docs/plans/2026-07-01-memory-scope-isolation.md
@@ -1,0 +1,106 @@
+# Memory scope isolation (ROADMAP.md Part I [Committed], added c7c7fdf)
+
+2026-07-01, v2 after codex plan review (REJECT on v1; 5 P1 + 13 P2 findings applied; see "Review deltas" at bottom). Target: next minor (v1.24.0). Branch: `feat/memory-scope-isolation` (worktree `hippo-wt-scope-isolation`).
+
+## Problem
+
+The every-turn UserPromptSubmit hook (`hippo context --pinned-only --include-recent 5 --format additional-context`, src/hooks.ts:118) injects memories from other projects into the active session. Reproduced 2026-07-01 from `C:\Users\skf_s\shiny` (own `.hippo` store): 19/19 injected entries were `[global]`-store rows about other projects. Observed 2026-06-30: a production API key stored as a memory in the live context of unrelated sessions; a wrong-project infra recommendation traced to the same bleed.
+
+## Root cause
+
+1. **`getContext` (src/api.ts:2118) bypasses the scope-isolation machinery `api.recall` enforces** (`passesScopeFilterForRecall` api.ts:182-198, `RECALL_DEFAULT_DENY_SCOPES` store.ts:227 via `loadRecallSearchEntries`). Its loads (`loadAllEntries` api.ts:2143-2144; pinned mode api.ts:2176+) apply no scope predicate.
+2. **No project-origin partition anywhere.** Global rows (`~/.hippo`) merge into every session (searchBoth shared.ts:88-143, searchBothHybrid shared.ts:170-227); origin is recorded only lossily (`source: shared:<project>:<ts>`, from a path basename, shared.ts:278-305) and never consulted. `autoShare` (shared.ts:373-411) only down-weights `api-key`-tagged rows (PROJECT_SPECIFIC_TAGS -0.15), never vetoes.
+3. **No secret detection on memory content** (only provider-error redaction and sleep metadata redaction).
+4. Path identity is a weak rank-boost only (`pathOverlapScore` path-context.ts:29-37 divides by the memory's tag count; bare `path:skf_s` scores 1.0 everywhere under home) - but path tuning is DEFERRED (see Non-goals) because it lives in generic search code.
+
+## Design pillars
+
+### Origin model (three-valued, default-deny for unknowns)
+
+New column `memories.origin_project TEXT NULL`:
+- `'<name>'` - owned by that project (lowercased project-root basename from `resolveProjectIdentity`).
+- `''` - explicitly user-global (written at/under home or in a markerless dir; injectable everywhere).
+- `NULL` - legacy/unknown - **treated as OTHER-PROJECT (deny) by ambient context**, never as trusted. (codex P1-1: NULL-injects would invert default-deny.)
+
+Write sites always stamp `''` or a name going forward; NULL only exists pre-migration.
+
+**Backfill (migration, evidence-based only - codex P2-7; no path-tag guessing):**
+- Rows in a PROJECT-local store: origin = that store's project name (`resolveProjectIdentity(storeRoot)`) - store location is authoritative.
+- Rows in the global/home store with parseable `source: shared:<project>:<ts>`: origin = `<project>`.
+- Remaining global/home-store rows (written at home): origin = `''` (user-global). Rationale: home-store rows ARE the user's global working set; the secret veto (below) backstops keys among them. This is store-location evidence, not a guess.
+- Anything else stays NULL (deny).
+
+### Surface policy matrix (codex P2-9)
+
+| Surface | Origin partition | Secret veto |
+|---|---|---|
+| `getContext` all 3 modes (pinned / `*` / query) - feeds CLI `hippo context`, hook inject | ON (default) | ON (always) |
+| CLI context render + ambient-state summary (cli.ts:5463-5474 recomputes from raw loads - must use filtered set, codex P2-13) | ON | ON |
+| MCP `hippo_context` (does NOT call getContext today, mcp/server.ts:974-1004 - route through `api.getContext` or apply identical policy, codex P2-12) | ON | ON |
+| HTTP `GET /v1/context` (server.ts:1032-1077) | ON (opt-out via `cross_project=true` param) | ON |
+| `api.recall` / MCP `hippo_recall` / HTTP recall / CLI `hippo recall` | OFF - recall is a deliberate act | OFF (recallable explicitly) |
+| `autoShare` / `shareMemory` (to global) | n/a | **hard veto pre-transferScore** |
+| `syncGlobalToLocal` (shared.ts:418-436) | ON - only same-project + `''` rows copy down; preserves origin_project on the copy | ON (secret rows never sync) |
+
+Escape hatches: `ContextOpts.crossProject` -> CLI `hippo context --cross-project` -> HTTP `cross_project` param; config `contextProjectIsolation: false` restores legacy behavior wholesale (threaded through config.ts defaults; codex P2-10/P2-11).
+
+Known residue (tracked in TODOS.md, NOT this PR): CLI `hippo recall` direct path (cli.ts:901-902 via searchBoth) predates api.recall's private-scope SQL default-deny; unchanged here (codex P1-3 resolved as documented follow-up since recall is deliberate by policy).
+
+## Slices
+
+### S1. Project identity + origin persistence
+
+- `src/project-identity.ts` (DONE, cycle-free leaf module): `resolveProjectIdentity(cwd)` -> `{root, name, isHome}`; nearest `.hippo` else `.git` (dir or worktree file); home is never a project (its `.hippo` is the global store); markerless => user-global (`name: ''`); realpath/junction-safe; cached. `deriveOriginProject(cwd)` -> `'<name>' | ''`.
+- Persistence threading (codex P1-5, ALL sites): `MemoryEntry.origin_project` (memory.ts), `MemoryRow` + `MEMORY_SELECT_COLUMNS` + `rowToEntry` + upsert/writeEntry (store.ts), markdown-mirror `serializeEntry`/`deserializeEntry` frontmatter, createMemory/remember write sites (cli.ts ~12 sites via one helper), `shareMemory` stamps canonical origin via `resolveProjectIdentity` not path basename (codex P2-17). FTS projection untouched (origin is not searchable text). Migration = next schema version, additive column + backfill above; per-version migration test with real pre-migration rows. (ROADMAP "Iron rule" concerns NEW TABLES; this is an additive column - risk framing is projection coverage, codex P2-6.)
+
+### S2. Envelope-filter parity inside getContext ONLY
+
+Apply `passesScopeFilterForRecall` + `RECALL_DEFAULT_DENY_SCOPES` as a post-load filter on getContext's candidate sets (all 3 modes), leaving `loadAllEntries`/`searchBoth*` untouched so `hippo recall`'s public behavior cannot shift (codex P1-2). `--scope` callers keep recall-parity semantics.
+
+### S3. Origin partition + crossProject threading
+
+- Partition in getContext per the matrix; `ContextResultEntry` gains `origin: string | null` + `category: 'project' | 'user-global' | 'cross-project'` so the renderer and tests can see why an entry appeared (codex P2-15).
+- CLI: `--cross-project` flag; excluded-by-default entries render under `## Other-project memory (explicitly requested)` only when requested; snapshot tests updated.
+- HTTP `/v1/context`: `cross_project` query param, documented, default off.
+- MCP `hippo_context`: route through `api.getContext` (preferred; fall back to identical inline policy if routing is structurally hard - decide at implementation with a note).
+- Ambient-state summary computed from the FILTERED entry set.
+- `syncGlobalToLocal`: origin-gated, preserves origin, skips secrets.
+
+### S4. Secret hard rule (producer + consumer)
+
+`src/secret-detect.ts`: `detectSecret(entry) -> { flagged: boolean, reason: string | null }` combining:
+- Tag veto: `secret`, `api-key`, `credential`, `token`, `password`.
+- Provider-bounded content patterns ONLY (codex P2-8, no bare `sk-` prose trap): `AKIA[0-9A-Z]{16}`, `ghp_[A-Za-z0-9]{36}` / `gho_` / `github_pat_`, `xox[baprs]-[A-Za-z0-9-]{10,}`, `sk-[A-Za-z0-9]{20,}` bounded by non-word delimiters AND co-occurring with key-ish nouns (key|token|secret|api) within the same line, `sk_(live|test)_[A-Za-z0-9]{16,}`, `AIza[0-9A-Za-z_-]{35}`, `-----BEGIN [A-Z ]*PRIVATE KEY-----`, generic assignment `(api[_-]?key|secret|token|password)\s*[:=]\s*[^\s'"]{12,}`.
+- Producer: `autoShare`/`shareMemory` hard-veto flagged rows BEFORE transferScore; skip count in SleepResult + sleep output line.
+- Consumer: ambient surfaces (matrix) never emit flagged rows outside their owning project; flagged rows with origin `''`/NULL never ambient-inject anywhere. Explicit recall unaffected.
+- Tests include benign-prose negatives ("the ghp_ prefix identifies GitHub tokens", "risk-free rate", markdown code fences) and true-positive fixtures.
+
+## Non-goals
+
+- **S5 path-overlap tuning - DEFERRED** to a follow-up under a fuller retrieval eval (codex P2-16/P3-20): the boost lives in generic search code shared with recall; isolate + measure separately.
+- A4 full lifecycle compliance (write-time scrubbing, PII, right-to-be-forgotten).
+- A5 sub-2 L9 background-pipeline tenant scoping.
+- CLI `hippo recall` private-scope residue (TODOS.md follow-up).
+- Changing the hook command or any consumer integration. NOTE for CHANGELOG (codex P2-18): installed hooks keep working unchanged; their injected content just gets project-scoped - call this out prominently as intended behavior change with the `contextProjectIsolation: false` opt-out.
+
+## Tests (real SQLite, no mocks)
+
+- S1: project-identity unit tests (DONE, 14 cases incl. junction + home/.hippo-global trap); migration up test on real pre-migration rows covering all four backfill buckets; mirror round-trip preserves origin.
+- S2: private-scope + `unknown:legacy` rows excluded from all 3 getContext modes for a no-scope caller.
+- S3: **the leak test the current suite cannot catch (codex P2-14)**: two project stores + an INITIALIZED global store under a test `HIPPO_HOME`; project-B-origin rows (incl. pinned) absent from project-A context in pinned/recent/query/`*` modes; present under `--cross-project` with the demarcated header; `''`-origin rows present everywhere; NULL-origin rows absent by default; full-legacy parity with `contextProjectIsolation: false`. Same assertions through HTTP `/v1/context` and MCP `hippo_context`. syncGlobalToLocal gating tests.
+- S4: producer (sleep never shares flagged rows; SleepResult count) + consumer (flagged row never ambient-injects outside owner; explicit recall still returns it) + benign-prose negatives.
+- CLI snapshot tests updated; ambient-summary test asserts it reflects the filtered set.
+
+## Risks
+
+- Legacy NULL-deny may hide a wanted memory until re-written/confirmed -> escape hatches + backfill buckets minimize; secret veto backstops the home bucket.
+- Migration threading breadth (P1-5) -> single helper for write sites; per-site grep audit at review (from-import, sys.path-style dynamic surfaces).
+- Concurrent multi-agent repo activity -> dedicated worktree (done), `git branch --show-current` before every commit, check origin/master before version bump.
+
+## Process
+
+Implement S1 -> S4 in order, tests green per slice -> codex gating review per commit (`codex review`, Windows: `-c "mcp_servers={}"`, stdin closed, cwd-pinned) -> PR -> squash merge -> `npm run build:all` -> v1.24.0.
+
+## Review deltas (v1 -> v2, codex 2026-07-01)
+
+P1-1 NULL=deny origin model; P1-2 filter inside getContext, no shared-loader swap; P1-3 CLI-recall surface documented as deliberate + TODOS residue; P1-4 syncGlobalToLocal gated; P1-5 full persistence threading enumerated; P2-6 Iron-rule framing fixed; P2-7 evidence-only backfill; P2-8 bounded secret patterns + negatives; P2-9 policy matrix; P2-10/11 crossProject threaded CLI/HTTP/config; P2-12 MCP context routed; P2-13 ambient summary filtered; P2-14 HIPPO_HOME leak tests; P2-15 ContextResultEntry origin/category; P2-16+P3-20 S5 deferred; P2-17 shareMemory canonical origin; P2-18 hook back-compat CHANGELOG note; P3-19 citations refreshed.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.23.0",
+  "version": "1.24.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -2354,24 +2354,32 @@ export async function getContext(
     // Real query: hybrid search (global + local) or physics+hybrid (local only).
     let results: ContextResultEntry[];
     if (hasGlobal) {
+      // searchBothHybrid loads from the store roots itself, so the ambient
+      // filter above never saw its candidates - re-apply it after the search
+      // (post-filter only; the shared loaders stay untouched so hippo
+      // recall's public behavior cannot shift). Over-fetch 3x then greedy
+      // re-fill to the caller's budget so an excluded high-scoring row
+      // cannot starve admitted lower-scoring rows out of the budget
+      // (codex gating review P2).
       const merged = await searchBothHybrid(query, ctx.hippoRoot, globalRoot, {
-        budget,
+        budget: budget * 3,
         scope: activeScope,
         tenantId: ctx.tenantId,
       });
       const localIndex = loadIndex(ctx.hippoRoot);
-      // searchBothHybrid loads from the store roots itself, so the ambient
-      // filter above never saw its candidates - re-apply it here (post-filter
-      // only; the shared loaders stay untouched so hippo recall's public
-      // behavior cannot shift).
-      results = merged
-        .filter((r) => ambientAdmit(r.entry))
-        .map((r) => ({
+      results = [];
+      let usedQueryTokens = 0;
+      for (const r of merged) {
+        if (!ambientAdmit(r.entry)) continue;
+        if (usedQueryTokens + r.tokens > budget) continue;
+        results.push({
           entry: r.entry,
           score: r.score,
           tokens: r.tokens,
           isGlobal: !localIndex.entries[r.entry.id],
-        }));
+        });
+        usedQueryTokens += r.tokens;
+      }
     } else {
       const ctxConfig = loadConfig(ctx.hippoRoot);
       const usePhysicsCtx = ctxConfig.physics?.enabled !== false;

--- a/src/api.ts
+++ b/src/api.ts
@@ -2355,33 +2355,25 @@ export async function getContext(
     let results: ContextResultEntry[];
     if (hasGlobal) {
       // searchBothHybrid loads from the store roots itself, so the ambient
-      // filter above never saw its candidates - re-apply it after the search
-      // (post-filter only; the shared loaders stay untouched so hippo
-      // recall's public behavior cannot shift). Budgeting is deferred until
-      // AFTER admission: fetch the full ranked candidate set (unbounded
-      // token budget), filter, then greedy-fill to the caller's budget -
-      // otherwise excluded high-scoring rows could saturate any fixed
-      // over-fetch and starve admissible rows out entirely (codex gating
-      // rounds 1+3).
+      // filter above never saw its candidates. Admission runs INSIDE the
+      // search via the opt-in entryFilter, BEFORE ranking, cross-store
+      // content-dedupe, and budgeting - a post-filter instead would let an
+      // excluded row saturate the budget (codex rounds 1+3) or shadow its
+      // admitted duplicate in the dedupe pass (codex round 4). Recall paths
+      // never set entryFilter, so their behavior is unchanged.
       const merged = await searchBothHybrid(query, ctx.hippoRoot, globalRoot, {
-        budget: Number.MAX_SAFE_INTEGER,
+        budget,
         scope: activeScope,
         tenantId: ctx.tenantId,
+        entryFilter: ambientAdmit,
       });
       const localIndex = loadIndex(ctx.hippoRoot);
-      results = [];
-      let usedQueryTokens = 0;
-      for (const r of merged) {
-        if (!ambientAdmit(r.entry)) continue;
-        if (usedQueryTokens + r.tokens > budget) continue;
-        results.push({
-          entry: r.entry,
-          score: r.score,
-          tokens: r.tokens,
-          isGlobal: !localIndex.entries[r.entry.id],
-        });
-        usedQueryTokens += r.tokens;
-      }
+      results = merged.map((r) => ({
+        entry: r.entry,
+        score: r.score,
+        tokens: r.tokens,
+        isGlobal: !localIndex.entries[r.entry.id],
+      }));
     } else {
       const ctxConfig = loadConfig(ctx.hippoRoot);
       const usePhysicsCtx = ctxConfig.physics?.enabled !== false;

--- a/src/api.ts
+++ b/src/api.ts
@@ -12,6 +12,7 @@ import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import {
   writeEntry,
   writeEntryDbOnly,
+  stampOriginProject,
   writeEntryMirrors,
   readEntry,
   deleteEntry,
@@ -1757,7 +1758,7 @@ export function supersede(
       // 2. Write new memory inside same tx via writeEntryDbOnly (DB-only
       //    path). This emits its OWN 'remember' audit row for the new
       //    memory inside the SAVEPOINT — atomic with the row INSERT.
-      writeEntryDbOnly(db, newEntry, { actor: ctx.actor.subject });
+      writeEntryDbOnly(db, stampOriginProject(ctx.hippoRoot, newEntry), { actor: ctx.actor.subject });
       // 3. User-facing 'supersede' audit row inside the same tx so the
       //    chain pointer + audit trail commit atomically.
       appendAuditEvent(db, {

--- a/src/api.ts
+++ b/src/api.ts
@@ -2357,12 +2357,14 @@ export async function getContext(
       // searchBothHybrid loads from the store roots itself, so the ambient
       // filter above never saw its candidates - re-apply it after the search
       // (post-filter only; the shared loaders stay untouched so hippo
-      // recall's public behavior cannot shift). Over-fetch 3x then greedy
-      // re-fill to the caller's budget so an excluded high-scoring row
-      // cannot starve admitted lower-scoring rows out of the budget
-      // (codex gating review P2).
+      // recall's public behavior cannot shift). Budgeting is deferred until
+      // AFTER admission: fetch the full ranked candidate set (unbounded
+      // token budget), filter, then greedy-fill to the caller's budget -
+      // otherwise excluded high-scoring rows could saturate any fixed
+      // over-fetch and starve admissible rows out entirely (codex gating
+      // rounds 1+3).
       const merged = await searchBothHybrid(query, ctx.hippoRoot, globalRoot, {
-        budget: budget * 3,
+        budget: Number.MAX_SAFE_INTEGER,
         scope: activeScope,
         tenantId: ctx.tenantId,
       });

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,7 +68,8 @@ import { markRetrieved, estimateTokens, hybridSearch, physicsSearch, type Rerank
 import { scopeMatch } from './scope.js';
 import { consolidate } from './consolidate.js';
 import { loadConfig } from './config.js';
-import { resolveProjectIdentity } from './project-identity.js';
+import { resolveProjectIdentity, classifyOriginProject } from './project-identity.js';
+import { detectSecret } from './secret-detect.js';
 import { deduplicateStore } from './dedupe.js';
 import { computeAmbientState, type AmbientState } from './ambient.js';
 import { loadPendingExtractionTenants, markPendingProcessedUpTo } from './graph.js';
@@ -203,23 +204,10 @@ export function isPrivateScope(scope: string | null | undefined): boolean {
   return typeof scope === 'string' && PRIVATE_SCOPE_RE.test(scope);
 }
 
-/**
- * v39 memory scope isolation: classify a memory's origin_project against the
- * active project. `currentName === ''` means the session is not in a project
- * (home dir or markerless cwd) - everything is in scope there, matching
- * pre-isolation behavior. NULL/undefined origin is a legacy pre-v39 row and
- * is treated as cross-project (deny by default) - the safe direction for a
- * security partition.
- */
-export function classifyOriginProject(
-  origin: string | null | undefined,
-  currentName: string,
-): 'project' | 'user-global' | 'cross-project' {
-  if (currentName === '') return 'project';
-  if (origin === undefined || origin === null) return 'cross-project';
-  if (origin === '') return 'user-global';
-  return origin === currentName ? 'project' : 'cross-project';
-}
+// v39: classifyOriginProject lives in project-identity.ts (leaf) so
+// shared.ts can use it without an api.ts import cycle. Re-exported here for
+// callers that already import the api surface.
+export { classifyOriginProject } from './project-identity.js';
 
 export interface RememberOpts {
   content: string;
@@ -2194,6 +2182,16 @@ export async function getContext(
     opts.currentProject ?? resolveProjectIdentity(process.cwd()).name;
   const includeCrossProject = opts.crossProject === true || !isolationEnabled;
   const ambientAdmit = (e: MemoryEntry): boolean => {
+    // S4 secret veto - UNCONDITIONAL for ambient surfaces: neither
+    // crossProject nor contextProjectIsolation:false re-includes secrets.
+    // A flagged row only injects inside its owning project; flagged rows
+    // with no project origin (''/null) never ambient-inject at all.
+    // Explicit recall still returns them - recalling is a deliberate act.
+    if (detectSecret(e).flagged) {
+      const origin = e.origin_project;
+      if (origin === undefined || origin === null || origin === '') return false;
+      if (origin !== currentProjectName) return false;
+    }
     if (!passesScopeFilterForRecall(e.scope ?? null, undefined)) return false;
     if (includeCrossProject) return true;
     return classifyOriginProject(e.origin_project, currentProjectName) !== 'cross-project';

--- a/src/api.ts
+++ b/src/api.ts
@@ -209,6 +209,43 @@ export function isPrivateScope(scope: string | null | undefined): boolean {
 // callers that already import the api surface.
 export { classifyOriginProject } from './project-identity.js';
 
+/**
+ * v39: the single ambient-injection admission policy, shared by getContext
+ * and the CLI-side ambient-state summary so the two cannot drift.
+ *
+ * - S4 secret veto is UNCONDITIONAL: neither crossProject nor
+ *   contextProjectIsolation:false re-includes secrets. A flagged row only
+ *   injects inside its owning project; flagged rows with no project origin
+ *   (''/null) never ambient-inject at all. Explicit recall is unaffected -
+ *   recalling a secret is a deliberate act.
+ * - S2 envelope parity: private scopes + quarantine buckets never inject.
+ * - S3 origin partition: other-project rows are excluded unless
+ *   `includeCrossProject`.
+ */
+export function ambientAdmitEntry(
+  e: MemoryEntry,
+  currentProjectName: string,
+  includeCrossProject: boolean,
+): boolean {
+  if (!ambientSecretAdmit(e, currentProjectName)) return false;
+  if (!passesScopeFilterForRecall(e.scope ?? null, undefined)) return false;
+  if (includeCrossProject) return true;
+  return classifyOriginProject(e.origin_project, currentProjectName) !== 'cross-project';
+}
+
+/**
+ * v39 S4: the secret half of the ambient policy on its own, for surfaces
+ * with their own scope semantics (MCP hippo_context's explicit-scope
+ * exact-match). A flagged row is only admitted inside its owning project;
+ * flagged rows with no project origin never ambient-inject.
+ */
+export function ambientSecretAdmit(e: MemoryEntry, currentProjectName: string): boolean {
+  if (!detectSecret(e).flagged) return true;
+  const origin = e.origin_project;
+  if (origin === undefined || origin === null || origin === '') return false;
+  return origin === currentProjectName;
+}
+
 export interface RememberOpts {
   content: string;
   kind?: MemoryKind;
@@ -2181,21 +2218,8 @@ export async function getContext(
   const currentProjectName =
     opts.currentProject ?? resolveProjectIdentity(process.cwd()).name;
   const includeCrossProject = opts.crossProject === true || !isolationEnabled;
-  const ambientAdmit = (e: MemoryEntry): boolean => {
-    // S4 secret veto - UNCONDITIONAL for ambient surfaces: neither
-    // crossProject nor contextProjectIsolation:false re-includes secrets.
-    // A flagged row only injects inside its owning project; flagged rows
-    // with no project origin (''/null) never ambient-inject at all.
-    // Explicit recall still returns them - recalling is a deliberate act.
-    if (detectSecret(e).flagged) {
-      const origin = e.origin_project;
-      if (origin === undefined || origin === null || origin === '') return false;
-      if (origin !== currentProjectName) return false;
-    }
-    if (!passesScopeFilterForRecall(e.scope ?? null, undefined)) return false;
-    if (includeCrossProject) return true;
-    return classifyOriginProject(e.origin_project, currentProjectName) !== 'cross-project';
-  };
+  const ambientAdmit = (e: MemoryEntry): boolean =>
+    ambientAdmitEntry(e, currentProjectName, includeCrossProject);
   localEntries = localEntries.filter(ambientAdmit);
   globalEntries = globalEntries.filter(ambientAdmit);
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,6 +68,7 @@ import { markRetrieved, estimateTokens, hybridSearch, physicsSearch, type Rerank
 import { scopeMatch } from './scope.js';
 import { consolidate } from './consolidate.js';
 import { loadConfig } from './config.js';
+import { resolveProjectIdentity } from './project-identity.js';
 import { deduplicateStore } from './dedupe.js';
 import { computeAmbientState, type AmbientState } from './ambient.js';
 import { loadPendingExtractionTenants, markPendingProcessedUpTo } from './graph.js';
@@ -200,6 +201,24 @@ export function passesScopeFilterForRecall(
 
 export function isPrivateScope(scope: string | null | undefined): boolean {
   return typeof scope === 'string' && PRIVATE_SCOPE_RE.test(scope);
+}
+
+/**
+ * v39 memory scope isolation: classify a memory's origin_project against the
+ * active project. `currentName === ''` means the session is not in a project
+ * (home dir or markerless cwd) - everything is in scope there, matching
+ * pre-isolation behavior. NULL/undefined origin is a legacy pre-v39 row and
+ * is treated as cross-project (deny by default) - the safe direction for a
+ * security partition.
+ */
+export function classifyOriginProject(
+  origin: string | null | undefined,
+  currentName: string,
+): 'project' | 'user-global' | 'cross-project' {
+  if (currentName === '') return 'project';
+  if (origin === undefined || origin === null) return 'cross-project';
+  if (origin === '') return 'user-global';
+  return origin === currentName ? 'project' : 'cross-project';
 }
 
 export interface RememberOpts {
@@ -2081,6 +2100,15 @@ export interface ContextOpts {
   pinnedOnly?: boolean;
   scope?: string;
   includeRecent?: number;
+  /** v39 memory scope isolation: re-include other-project memories that the
+   *  origin partition excludes by default. They come back tagged
+   *  `category: 'cross-project'` so renderers can demarcate them. */
+  crossProject?: boolean;
+  /** The active project name for the origin partition ('' = not in a
+   *  project). Defaults to `resolveProjectIdentity(process.cwd()).name`;
+   *  surfaces whose process cwd is not the caller's project (HTTP server)
+   *  should pass it explicitly. */
+  currentProject?: string;
 }
 
 export interface ContextResultEntry {
@@ -2089,6 +2117,12 @@ export interface ContextResultEntry {
   tokens: number;
   isGlobal?: boolean;
   isFreshTail?: boolean;
+  /** v39: the entry's owning project ('' = user-global, null = legacy row). */
+  origin?: string | null;
+  /** v39: how the origin relates to the active project. 'cross-project'
+   *  entries only appear when ContextOpts.crossProject was set (or isolation
+   *  is disabled). */
+  category?: 'project' | 'user-global' | 'cross-project';
 }
 
 export interface ContextResult {
@@ -2147,6 +2181,25 @@ export async function getContext(
   // Filter superseded — context never includes superseded rows.
   localEntries = localEntries.filter((e) => !e.superseded_by);
   globalEntries = globalEntries.filter((e) => !e.superseded_by);
+
+  // v39 memory scope isolation (docs/plans/2026-07-01-memory-scope-isolation.md).
+  // S2: envelope-filter parity with api.recall for AMBIENT context - private
+  // scopes and quarantine buckets never inject. `requested` is deliberately
+  // undefined: opts.scope is the scope-TAG boost input here, not an
+  // envelope-scope request (api.recall's exact-match semantics don't apply).
+  // S3: origin partition - other-project memories are excluded unless the
+  // caller explicitly asks for them (crossProject) or isolation is disabled.
+  const isolationEnabled = loadConfig(ctx.hippoRoot).contextProjectIsolation !== false;
+  const currentProjectName =
+    opts.currentProject ?? resolveProjectIdentity(process.cwd()).name;
+  const includeCrossProject = opts.crossProject === true || !isolationEnabled;
+  const ambientAdmit = (e: MemoryEntry): boolean => {
+    if (!passesScopeFilterForRecall(e.scope ?? null, undefined)) return false;
+    if (includeCrossProject) return true;
+    return classifyOriginProject(e.origin_project, currentProjectName) !== 'cross-project';
+  };
+  localEntries = localEntries.filter(ambientAdmit);
+  globalEntries = globalEntries.filter(ambientAdmit);
 
   const activeSnapshot = hasLocal
     ? loadActiveTaskSnapshot(ctx.hippoRoot, ctx.tenantId)
@@ -2285,12 +2338,18 @@ export async function getContext(
         tenantId: ctx.tenantId,
       });
       const localIndex = loadIndex(ctx.hippoRoot);
-      results = merged.map((r) => ({
-        entry: r.entry,
-        score: r.score,
-        tokens: r.tokens,
-        isGlobal: !localIndex.entries[r.entry.id],
-      }));
+      // searchBothHybrid loads from the store roots itself, so the ambient
+      // filter above never saw its candidates - re-apply it here (post-filter
+      // only; the shared loaders stay untouched so hippo recall's public
+      // behavior cannot shift).
+      results = merged
+        .filter((r) => ambientAdmit(r.entry))
+        .map((r) => ({
+          entry: r.entry,
+          score: r.score,
+          tokens: r.tokens,
+          isGlobal: !localIndex.entries[r.entry.id],
+        }));
     } else {
       const ctxConfig = loadConfig(ctx.hippoRoot);
       const usePhysicsCtx = ctxConfig.physics?.enabled !== false;
@@ -2357,6 +2416,14 @@ export async function getContext(
     selectedItems = selectedItems.slice(0, limit);
     totalTokens = selectedItems.reduce((sum, r) => sum + r.tokens, 0);
   }
+
+  // v39: annotate every returned entry with its origin and how it relates to
+  // the active project, so renderers can demarcate cross-project inclusions.
+  selectedItems = selectedItems.map((r) => ({
+    ...r,
+    origin: r.entry.origin_project ?? null,
+    category: classifyOriginProject(r.entry.origin_project, currentProjectName),
+  }));
 
   if (
     selectedItems.length === 0 &&

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,7 @@ import {
   MemoryEntry,
   ConfidenceLevel,
 } from './memory.js';
+import { resolveProjectIdentity } from './project-identity.js';
 import {
   getHippoRoot,
   isInitialized,
@@ -5367,6 +5368,9 @@ async function cmdContext(
     tenantId: resolveTenantId({}),
     actor: api.adminActor('cli'),
   };
+  // v39 memory scope isolation: --cross-project re-includes other-project
+  // memories (rendered under a demarcated section below).
+  const crossProject = flags['cross-project'] === true;
   const opts: api.ContextOpts = {
     q: query,
     budget,
@@ -5374,6 +5378,7 @@ async function cmdContext(
     pinnedOnly,
     scope: ctxActiveScope ?? undefined,
     includeRecent: parseCountFlag(flags['include-recent']),
+    crossProject,
   };
 
   const result = await api.getContext(ctx, opts);
@@ -5390,8 +5395,13 @@ async function cmdContext(
   const format = String(flags['format'] ?? 'markdown');
   const framing = String(flags['framing'] ?? 'observe');
 
-  // Adapter: ContextResultEntry -> the print-helper input shape.
-  const renderItems = result.entries.map((r) => ({
+  // Adapter: ContextResultEntry -> the print-helper input shape. v39:
+  // cross-project inclusions (only present under --cross-project or with
+  // isolation disabled via crossProject) render in their own demarcated
+  // section so they can never masquerade as project memory.
+  const mainEntries = result.entries.filter((r) => r.category !== 'cross-project');
+  const crossEntries = result.entries.filter((r) => r.category === 'cross-project');
+  const renderItems = mainEntries.map((r) => ({
     entry: r.entry,
     score: r.score,
     tokens: r.tokens,
@@ -5407,6 +5417,8 @@ async function cmdContext(
       confidence: r.entry.confidence,
       content: r.entry.content,
       global: r.isGlobal ?? false,
+      origin: r.origin ?? null,
+      category: r.category ?? null,
     }));
     console.log(JSON.stringify({
       query: query || '*',
@@ -5431,6 +5443,7 @@ async function cmdContext(
       if (renderItems.length > 0) {
         printContextMarkdown(renderItems, result.tokens, framing);
       }
+      printCrossProjectSection(crossEntries);
     } finally {
       console.log = realLog;
     }
@@ -5457,6 +5470,7 @@ async function cmdContext(
     if (renderItems.length > 0) {
       printContextMarkdown(renderItems, result.tokens, framing);
     }
+    printCrossProjectSection(crossEntries);
 
     // Ambient state summary (CLI-side: api.getContext doesn't load all entries
     // post-selection, so we re-load here for the landscape summary).
@@ -5465,11 +5479,18 @@ async function cmdContext(
       const tenantId = ctx.tenantId;
       const globalRoot = getGlobalRoot();
       const hasGlobalForAmbient = isInitialized(globalRoot);
+      // v39: the landscape summary must reflect the same admission policy as
+      // the injected entries - otherwise excluded rows leak back in as
+      // aggregate signal (codex P2-13).
+      const isolationOff = ambientConfig.contextProjectIsolation === false;
+      const ambientCurrentName = resolveProjectIdentity(process.cwd()).name;
+      const ambientAdmit = (e: MemoryEntry) =>
+        api.ambientAdmitEntry(e, ambientCurrentName, crossProject || isolationOff);
       const localForAmbient = isInitialized(hippoRoot)
-        ? loadAllEntries(hippoRoot, tenantId).filter(e => !e.superseded_by)
+        ? loadAllEntries(hippoRoot, tenantId).filter(e => !e.superseded_by).filter(ambientAdmit)
         : [];
       const globalForAmbient = hasGlobalForAmbient
-        ? loadAllEntries(globalRoot, tenantId).filter(e => !e.superseded_by)
+        ? loadAllEntries(globalRoot, tenantId).filter(e => !e.superseded_by).filter(ambientAdmit)
         : [];
       const allForAmbient = [...localForAmbient, ...globalForAmbient];
       if (allForAmbient.length > 0) {
@@ -5477,6 +5498,21 @@ async function cmdContext(
         console.log(`\n${renderAmbientSummary(ambientState)}`);
       }
     }
+  }
+}
+
+/**
+ * v39: render cross-project inclusions under an explicit header so agents
+ * (and humans) can tell borrowed context from project memory. Only ever
+ * non-empty when the caller passed --cross-project or disabled isolation.
+ */
+function printCrossProjectSection(items: api.ContextResultEntry[]): void {
+  if (items.length === 0) return;
+  console.log(`\n## Other-project memory (explicitly requested, ${items.length} entries)\n`);
+  for (const item of items) {
+    const originLabel = item.origin === null || item.origin === '' ? 'unknown-origin' : item.origin;
+    const tagStr = item.entry.tags.length > 0 ? ` [${item.entry.tags.join(', ')}]` : '';
+    console.log(`- **[${originLabel}]** ${item.entry.content}${tagStr}`);
   }
 }
 
@@ -5982,7 +6018,7 @@ function cmdPromote(hippoRoot: string, id: string): void {
 // Sync command
 // ---------------------------------------------------------------------------
 
-function cmdSync(hippoRoot: string): void {
+function cmdSync(hippoRoot: string, flags: Record<string, string | boolean | string[]> = {}): void {
   requireInit(hippoRoot);
 
   const globalRoot = getGlobalRoot();
@@ -5991,8 +6027,10 @@ function cmdSync(hippoRoot: string): void {
     return;
   }
 
-  const count = syncGlobalToLocal(hippoRoot, globalRoot);
-  console.log(`Synced ${count} global memories into local project.`);
+  // v39: other-project rows are skipped by default; secrets always are.
+  const includeCrossProject = flags['cross-project'] === true;
+  const count = syncGlobalToLocal(hippoRoot, globalRoot, { includeCrossProject });
+  console.log(`Synced ${count} global memories into local project.${includeCrossProject ? '' : ' (other-project rows skipped; use --cross-project to include them)'}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -8407,7 +8445,7 @@ async function main(): Promise<void> {
     }
 
     case 'sync':
-      cmdSync(hippoRoot);
+      cmdSync(hippoRoot, flags);
       break;
 
     case 'share': {

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,12 @@ export interface HippoConfig {
     enabled: boolean;
     budget: number;
   };
+  /** Memory scope isolation (v39): when true (default), ambient context
+   *  (`hippo context`, the UserPromptSubmit hook, /v1/context, MCP
+   *  hippo_context) excludes memories owned by OTHER projects; explicit
+   *  recall is unaffected. Set false to restore pre-v39 behavior. See
+   *  docs/plans/2026-07-01-memory-scope-isolation.md. */
+  contextProjectIsolation: boolean;
   extraction: {
     enabled: boolean | 'auto';
     model: string;
@@ -128,6 +134,7 @@ const DEFAULT_CONFIG: HippoConfig = {
     enabled: true,
     budget: 1500,
   },
+  contextProjectIsolation: true,
   extraction: {
     enabled: 'auto',
     model: 'claude-sonnet-4-6',
@@ -172,6 +179,7 @@ export function loadConfig(hippoRoot: string): HippoConfig {
       autoTraceCapture: raw.autoTraceCapture ?? DEFAULT_CONFIG.autoTraceCapture,
       autoTraceWindowDays: raw.autoTraceWindowDays ?? DEFAULT_CONFIG.autoTraceWindowDays,
       pinnedInject: { ...DEFAULT_CONFIG.pinnedInject, ...(raw.pinnedInject ?? {}) },
+      contextProjectIsolation: raw.contextProjectIsolation ?? DEFAULT_CONFIG.contextProjectIsolation,
       extraction: { ...DEFAULT_CONFIG.extraction, ...(raw.extraction ?? {}) },
       multihop: { ...DEFAULT_CONFIG.multihop, ...(raw.multihop ?? {}) },
       salience: { ...DEFAULT_CONFIG.salience, ...(raw.salience ?? {}) },

--- a/src/db.ts
+++ b/src/db.ts
@@ -2174,6 +2174,20 @@ const MIGRATIONS: Migration[] = [
           const name = match[1].toLowerCase();
           setOrigin.run(name === homeName ? '' : name, row.id);
         }
+        // Rows promoted from a project store carry source 'promoted:<localRoot>'
+        // where <localRoot> is `<project>/.hippo` - the parent basename is the
+        // project (same parse listPeers uses). Pure string logic; the recorded
+        // path may no longer exist on disk (codex gating review P1).
+        const promotedRows = db.prepare(
+          `SELECT id, source FROM memories WHERE origin_project IS NULL AND source LIKE 'promoted:%'`,
+        ).all() as Array<{ id: string; source: string }>;
+        for (const row of promotedRows) {
+          const promotedPath = row.source.slice('promoted:'.length).trim();
+          if (!promotedPath) continue;
+          const name = path.basename(path.resolve(promotedPath, '..')).toLowerCase();
+          if (!name) continue;
+          setOrigin.run(name === homeName ? '' : name, row.id);
+        }
         const storeOrigin = deriveOriginProject(path.dirname(hippoRoot));
         db.prepare(`UPDATE memories SET origin_project = ? WHERE origin_project IS NULL`).run(storeOrigin);
       }

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'module';
 import { createPhysicsTable } from './physics-state.js';
 import { cleanupArchivedMirrors } from './raw-archive-mirror-cleanup.js';
 import { PACKAGE_VERSION, compareSemver } from './version.js';
-import { deriveOriginProject } from './project-identity.js';
+import { deriveOriginProject, originFromSource } from './project-identity.js';
 
 const require = createRequire(import.meta.url);
 
@@ -2163,33 +2163,29 @@ const MIGRATIONS: Migration[] = [
       // Rows stay NULL only when no hippoRoot was provided.
       const hippoRoot = ctx?.hippoRoot;
       if (hippoRoot) {
+        // Provenance-source evidence first (shared:<project>: / promoted:<localRoot>,
+        // parsed by the same helper the markdown-import stamp uses), then the
+        // store's own location for everything else.
         const homeName = path.basename(os.homedir()).toLowerCase();
-        const sharedRows = db.prepare(
-          `SELECT id, source FROM memories WHERE origin_project IS NULL AND source LIKE 'shared:%'`,
+        const sourcedRows = db.prepare(
+          `SELECT id, source FROM memories WHERE origin_project IS NULL AND (source LIKE 'shared:%' OR source LIKE 'promoted:%')`,
         ).all() as Array<{ id: string; source: string }>;
         const setOrigin = db.prepare(`UPDATE memories SET origin_project = ? WHERE id = ?`);
-        for (const row of sharedRows) {
-          const match = /^shared:([^:]+):/.exec(row.source);
-          if (!match) continue;
-          const name = match[1].toLowerCase();
-          setOrigin.run(name === homeName ? '' : name, row.id);
-        }
-        // Rows promoted from a project store carry source 'promoted:<localRoot>'
-        // where <localRoot> is `<project>/.hippo` - the parent basename is the
-        // project (same parse listPeers uses). Pure string logic; the recorded
-        // path may no longer exist on disk (codex gating review P1).
-        const promotedRows = db.prepare(
-          `SELECT id, source FROM memories WHERE origin_project IS NULL AND source LIKE 'promoted:%'`,
-        ).all() as Array<{ id: string; source: string }>;
-        for (const row of promotedRows) {
-          const promotedPath = row.source.slice('promoted:'.length).trim();
-          if (!promotedPath) continue;
-          const name = path.basename(path.resolve(promotedPath, '..')).toLowerCase();
-          if (!name) continue;
-          setOrigin.run(name === homeName ? '' : name, row.id);
+        for (const row of sourcedRows) {
+          const origin = originFromSource(row.source, homeName);
+          if (origin === null) continue;
+          setOrigin.run(origin, row.id);
         }
         const storeOrigin = deriveOriginProject(path.dirname(hippoRoot));
         db.prepare(`UPDATE memories SET origin_project = ? WHERE origin_project IS NULL`).run(storeOrigin);
+      }
+      // Rollback-safety guard (v24 precedent): a pre-isolation binary opening
+      // this DB would ignore origin_project and the secret veto and resume
+      // injecting cross-project rows. 1.24.0 is the first version with the
+      // isolation behavior. Forward-only - never lower an existing minimum.
+      const existingMin = (db.prepare(`SELECT value FROM meta WHERE key = 'min_compatible_binary'`).get() as { value?: string } | undefined)?.value;
+      if (!existingMin || compareSemver('1.24.0', existingMin) > 0) {
+        db.prepare(`INSERT INTO meta(key, value) VALUES('min_compatible_binary', ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value`).run('1.24.0');
       }
     },
   },

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,9 +1,11 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { createRequire } from 'module';
 import { createPhysicsTable } from './physics-state.js';
 import { cleanupArchivedMirrors } from './raw-archive-mirror-cleanup.js';
 import { PACKAGE_VERSION, compareSemver } from './version.js';
+import { deriveOriginProject } from './project-identity.js';
 
 const require = createRequire(import.meta.url);
 
@@ -23,11 +25,18 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 38;
+const CURRENT_SCHEMA_VERSION = 39;
+
+/**
+ * Context passed to migrations that need to know WHERE the store lives.
+ * hippoRoot is the store directory (e.g. `<project>/.hippo`); undefined only
+ * for callers that open a DB without a filesystem store notion (none today).
+ */
+type MigrationContext = { hippoRoot?: string };
 
 type Migration = {
   version: number;
-  up: (db: DatabaseSyncLike) => void;
+  up: (db: DatabaseSyncLike, ctx?: MigrationContext) => void;
 };
 
 const MIGRATIONS: Migration[] = [
@@ -2135,6 +2144,41 @@ const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    version: 39,
+    up: (db, ctx) => {
+      // Memory scope isolation (docs/plans/2026-07-01-memory-scope-isolation.md).
+      // origin_project: '<name>' = owned by that project, '' = user-global,
+      // NULL = legacy/unknown (ambient context treats NULL as deny).
+      if (!tableHasColumn(db, 'memories', 'origin_project')) {
+        db.exec(`ALTER TABLE memories ADD COLUMN origin_project TEXT`);
+      }
+      // Backfill on store-location evidence only (no path-tag guessing):
+      // 1. Rows shared from a project carry source 'shared:<project>:<ts>' -
+      //    take <project>; a share whose <project> is the home dir basename
+      //    maps to '' (user-global).
+      // 2. Every other row was written into THIS store, so it takes the
+      //    store's own origin: `<project>/.hippo` -> '<project>', the
+      //    home/global store -> '' (user-global).
+      // Rows stay NULL only when no hippoRoot was provided.
+      const hippoRoot = ctx?.hippoRoot;
+      if (hippoRoot) {
+        const homeName = path.basename(os.homedir()).toLowerCase();
+        const sharedRows = db.prepare(
+          `SELECT id, source FROM memories WHERE origin_project IS NULL AND source LIKE 'shared:%'`,
+        ).all() as Array<{ id: string; source: string }>;
+        const setOrigin = db.prepare(`UPDATE memories SET origin_project = ? WHERE id = ?`);
+        for (const row of sharedRows) {
+          const match = /^shared:([^:]+):/.exec(row.source);
+          if (!match) continue;
+          const name = match[1].toLowerCase();
+          setOrigin.run(name === homeName ? '' : name, row.id);
+        }
+        const storeOrigin = deriveOriginProject(path.dirname(hippoRoot));
+        db.prepare(`UPDATE memories SET origin_project = ? WHERE origin_project IS NULL`).run(storeOrigin);
+      }
+    },
+  },
 ];
 
 function tableHasColumn(db: DatabaseSyncLike, tableName: string, columnName: string): boolean {
@@ -2178,7 +2222,7 @@ export function openHippoDb(hippoRoot: string): DatabaseSyncLike {
     db.exec('PRAGMA synchronous = NORMAL');
     db.exec('PRAGMA wal_autocheckpoint = 100');
     db.exec('PRAGMA foreign_keys = ON');
-    runMigrations(db);
+    runMigrations(db, hippoRoot);
     // Path A backfill: delete any orphan markdown mirrors for already-archived
     // raw_archive rows. Idempotent via per-row raw_archive.mirror_cleaned_at
     // (v21). Wrapped in try/catch — a filesystem failure must not prevent DB open.
@@ -2198,7 +2242,7 @@ export function openHippoDb(hippoRoot: string): DatabaseSyncLike {
   }
 }
 
-function runMigrations(db: DatabaseSyncLike): void {
+function runMigrations(db: DatabaseSyncLike, hippoRoot?: string): void {
   ensureMetaTable(db);
 
   // v1.3.1 rollback-safety guard. Schema v24 stamped meta.min_compatible_binary;
@@ -2221,7 +2265,7 @@ function runMigrations(db: DatabaseSyncLike): void {
 
     db.exec('BEGIN');
     try {
-      migration.up(db);
+      migration.up(db, { hippoRoot });
       setSchemaVersion(db, migration.version);
       db.exec('COMMIT');
       currentVersion = migration.version;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1007,13 +1007,20 @@ async function executeTool(
       // but synced-down or legacy rows can still carry another project's
       // origin, and secrets must never ambient-inject outside their owner.
       // Same policy as api.getContext; the scope filter above keeps this
-      // surface's own explicit-scope exact-match semantics. Identity comes
-      // from the MCP server's launch cwd, NOT the store path: when store
-      // resolution falls back to the global store (git repo without a local
-      // .hippo), dirname(store) would be home ('' = admit everything) and
-      // the leak would return (codex round 4 P1). Stdio MCP servers launch
-      // in the project they serve, so cwd is the right identity.
-      const mcpProjectName = resolveProjectIdentity(process.cwd()).name;
+      // surface's own explicit-scope exact-match semantics.
+      //
+      // Identity resolution handles both transports (codex rounds 4+5):
+      // - The SERVED store is authoritative when it is a project store -
+      //   an HTTP /mcp daemon launched from anywhere still isolates the
+      //   project it serves.
+      // - When the served store is the global root (stdio in a git repo
+      //   with no local .hippo falls back to it), dirname(store) is home
+      //   ('' would admit everything), so fall back to the launch cwd -
+      //   stdio servers launch in the project they serve.
+      const mcpStoreIdentity = resolveProjectIdentity(path.dirname(path.resolve(hippoRoot)));
+      const mcpProjectName = mcpStoreIdentity.name !== ''
+        ? mcpStoreIdentity.name
+        : resolveProjectIdentity(process.cwd()).name;
       const isolationOff = config.contextProjectIsolation === false;
       const entries = allEntries.filter((e) => {
         if (!passesScopeFilter(e.scope ?? null)) return false;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1007,8 +1007,13 @@ async function executeTool(
       // but synced-down or legacy rows can still carry another project's
       // origin, and secrets must never ambient-inject outside their owner.
       // Same policy as api.getContext; the scope filter above keeps this
-      // surface's own explicit-scope exact-match semantics.
-      const mcpProjectName = resolveProjectIdentity(path.dirname(path.resolve(hippoRoot))).name;
+      // surface's own explicit-scope exact-match semantics. Identity comes
+      // from the MCP server's launch cwd, NOT the store path: when store
+      // resolution falls back to the global store (git repo without a local
+      // .hippo), dirname(store) would be home ('' = admit everything) and
+      // the leak would return (codex round 4 P1). Stdio MCP servers launch
+      // in the project they serve, so cwd is the right identity.
+      const mcpProjectName = resolveProjectIdentity(process.cwd()).name;
       const isolationOff = config.contextProjectIsolation === false;
       const entries = allEntries.filter((e) => {
         if (!passesScopeFilter(e.scope ?? null)) return false;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,7 +27,8 @@ import { fetchGitLog, extractLessons, deduplicateLesson, isGitRepo } from '../au
 import { loadConfig } from '../config.js';
 import { resolveConfidence } from '../memory.js';
 import { resolveTenantId } from '../tenant.js';
-import { recall as apiRecall, remember as apiRemember, outcome as apiOutcome, drillDown as apiDrillDown, assemble as apiAssemble, isPrivateScope, adminActor, buildSuppressionSummary, type Context as ApiContext } from '../api.js';
+import { recall as apiRecall, remember as apiRemember, outcome as apiOutcome, drillDown as apiDrillDown, assemble as apiAssemble, isPrivateScope, adminActor, buildSuppressionSummary, ambientSecretAdmit, type Context as ApiContext } from '../api.js';
+import { resolveProjectIdentity, classifyOriginProject } from '../project-identity.js';
 import { computePredictionBaserate } from '../predictions.js';
 import { appendAuditEvent } from '../audit.js';
 import { createHash } from 'node:crypto';
@@ -1002,7 +1003,19 @@ async function executeTool(
         return true;
       };
       const allEntries = loadAllEntries(hippoRoot, tenantId);
-      const entries = allEntries.filter((e) => passesScopeFilter(e.scope ?? null));
+      // v39 memory scope isolation: this surface reads the LOCAL store only,
+      // but synced-down or legacy rows can still carry another project's
+      // origin, and secrets must never ambient-inject outside their owner.
+      // Same policy as api.getContext; the scope filter above keeps this
+      // surface's own explicit-scope exact-match semantics.
+      const mcpProjectName = resolveProjectIdentity(path.dirname(path.resolve(hippoRoot))).name;
+      const isolationOff = config.contextProjectIsolation === false;
+      const entries = allEntries.filter((e) => {
+        if (!passesScopeFilter(e.scope ?? null)) return false;
+        if (!ambientSecretAdmit(e, mcpProjectName)) return false;
+        if (isolationOff) return true;
+        return classifyOriginProject(e.origin_project, mcpProjectName) !== 'cross-project';
+      });
       const usePhysicsCtx = config.physics?.enabled !== false;
       const results = usePhysicsCtx
         ? await physicsSearch(query, entries, { budget, hippoRoot, physicsConfig: config.physics })

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -106,6 +106,15 @@ export interface MemoryEntry {
   // A5 stub auth (schema v16)
   tenantId: string;             // 'default' for single-tenant deployments
   /**
+   * Memory scope isolation (schema v39): owning project for ambient-context
+   * partitioning. A lowercased project name, '' for user-global (injectable
+   * everywhere), or null for legacy pre-v39 rows - ambient context treats
+   * null as other-project (deny). Stamped from the store's location at write
+   * time (store.ts stampOriginProject); undefined only on entries not yet
+   * written. See docs/plans/2026-07-01-memory-scope-isolation.md.
+   */
+  origin_project?: string | null;
+  /**
    * F1 (v1.7.0): raw SQLite FTS5 bm25() score from the FTS path of
    * `loadSearchEntries`.
    *

--- a/src/project-identity.ts
+++ b/src/project-identity.ts
@@ -1,0 +1,151 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Project identity resolution for memory scope isolation (ROADMAP.md Part I
+ * [Committed] "Memory scope isolation"; plan docs/plans/2026-07-01-memory-scope-isolation.md S1).
+ *
+ * Resolution rules:
+ * - The nearest ancestor of cwd (including cwd itself) containing a `.hippo`
+ *   directory is the project root; if none exists, the nearest ancestor
+ *   containing `.git` (directory or worktree file).
+ * - The user home directory is NEVER a project, even though it contains the
+ *   global store at `~/.hippo`. Reaching home ends the walk.
+ * - A directory with no marker anywhere up the walk is NOT a project: it
+ *   resolves to the user-global identity (empty name), so memories written
+ *   there stay injectable everywhere (matches pre-isolation behavior).
+ *
+ * NOTE: this module must stay free of imports from shared.ts / store.ts /
+ * api.ts so any of them can import it without creating a cycle.
+ */
+
+/** The project a working directory belongs to. */
+export interface ProjectIdentity {
+  /** Realpath-resolved root directory of the project (the start dir when not in a project). */
+  root: string;
+  /** Lowercased basename of the project root; empty string when not in a project. */
+  name: string;
+  /** True when the directory resolves to the user home working set. */
+  isHome: boolean;
+}
+
+/**
+ * Options for resolveProjectIdentity. Both fields are test seams; results are
+ * not cached when either is set. stopDir bounds the upward walk so tests in a
+ * temp sandbox never escape it and hit the host machine's real markers.
+ */
+export interface ResolveProjectIdentityOpts {
+  homeDir?: string;
+  stopDir?: string;
+}
+
+const MAX_WALK_DEPTH = 64;
+
+const identityCache = new Map<string, ProjectIdentity>();
+
+/** Clear the per-process identity cache (test seam). */
+export function clearProjectIdentityCache(): void {
+  identityCache.clear();
+}
+
+/**
+ * Canonicalize a path via realpath, falling back to path.resolve when the
+ * path does not exist or realpath fails (mirrors importers.ts).
+ */
+function realpathOrResolve(p: string): string {
+  try {
+    return fs.realpathSync.native(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/** Compare two canonical paths, case-insensitively on Windows. */
+function samePath(a: string, b: string): boolean {
+  if (process.platform === 'win32') return a.toLowerCase() === b.toLowerCase();
+  return a === b;
+}
+
+function isUnder(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  const under = rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  if (under) return true;
+  if (process.platform === 'win32') {
+    const relLower = path.relative(parent.toLowerCase(), child.toLowerCase());
+    return relLower === '' || (!relLower.startsWith('..') && !path.isAbsolute(relLower));
+  }
+  return false;
+}
+
+/**
+ * Resolve the project identity for a working directory.
+ * Defaults to process.cwd(). Results are cached per resolved input path.
+ */
+export function resolveProjectIdentity(
+  cwd?: string,
+  opts?: ResolveProjectIdentityOpts,
+): ProjectIdentity {
+  const startInput = path.resolve(cwd ?? process.cwd());
+  const cacheable = !opts?.homeDir && !opts?.stopDir;
+  if (cacheable) {
+    const cached = identityCache.get(startInput);
+    if (cached) return cached;
+  }
+
+  const home = realpathOrResolve(opts?.homeDir ?? os.homedir());
+  const stopDir = opts?.stopDir ? realpathOrResolve(opts.stopDir) : null;
+  const start = realpathOrResolve(startInput);
+
+  let hippoRoot: string | null = null;
+  let gitRoot: string | null = null;
+  let reachedHome = false;
+
+  let dir = start;
+  for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+    if (samePath(dir, home)) {
+      reachedHome = true;
+      break;
+    }
+    if (stopDir !== null && samePath(dir, stopDir)) break;
+    if (hippoRoot === null && fs.existsSync(path.join(dir, '.hippo'))) {
+      hippoRoot = dir;
+    }
+    if (gitRoot === null && fs.existsSync(path.join(dir, '.git'))) {
+      gitRoot = dir;
+    }
+    const parent = path.dirname(dir);
+    if (samePath(parent, dir)) break; // filesystem root
+    dir = parent;
+  }
+
+  let identity: ProjectIdentity;
+  const root = hippoRoot ?? gitRoot;
+  if (root !== null) {
+    identity = { root, name: path.basename(root).toLowerCase(), isHome: false };
+  } else if (reachedHome || isUnder(start, home)) {
+    identity = { root: home, name: '', isHome: true };
+  } else {
+    // No markers anywhere: not a project. Empty name keeps these memories
+    // user-global rather than fabricating an origin from a basename.
+    identity = { root: start, name: '', isHome: false };
+  }
+
+  if (cacheable) identityCache.set(startInput, identity);
+  return identity;
+}
+
+/**
+ * The origin project to stamp on a memory written from cwd.
+ * Returns the project name, or '' for user-global (written at/under home or
+ * in a markerless directory) - injectable everywhere. Write sites must always
+ * persist this value; a NULL origin_project column is reserved for legacy
+ * pre-migration rows, which ambient context treats as deny (see plan
+ * docs/plans/2026-07-01-memory-scope-isolation.md "Origin model").
+ */
+export function deriveOriginProject(
+  cwd?: string,
+  opts?: ResolveProjectIdentityOpts,
+): string {
+  return resolveProjectIdentity(cwd, opts).name;
+}

--- a/src/project-identity.ts
+++ b/src/project-identity.ts
@@ -136,6 +136,24 @@ export function resolveProjectIdentity(
 }
 
 /**
+ * v39 memory scope isolation: classify a memory's origin_project against the
+ * active project. `currentName === ''` means the session is not in a project
+ * (home dir or markerless cwd) - everything is in scope there, matching
+ * pre-isolation behavior. NULL/undefined origin is a legacy pre-v39 row and
+ * is treated as cross-project (deny by default) - the safe direction for a
+ * security partition.
+ */
+export function classifyOriginProject(
+  origin: string | null | undefined,
+  currentName: string,
+): 'project' | 'user-global' | 'cross-project' {
+  if (currentName === '') return 'project';
+  if (origin === undefined || origin === null) return 'cross-project';
+  if (origin === '') return 'user-global';
+  return origin === currentName ? 'project' : 'cross-project';
+}
+
+/**
  * The origin project to stamp on a memory written from cwd.
  * Returns the project name, or '' for user-global (written at/under home or
  * in a markerless directory) - injectable everywhere. Write sites must always

--- a/src/project-identity.ts
+++ b/src/project-identity.ts
@@ -154,6 +154,34 @@ export function classifyOriginProject(
 }
 
 /**
+ * Parse a memory's origin from its provenance `source` string, mirroring the
+ * v39 migration's evidence rules: `shared:<project>:<ts>` and
+ * `promoted:<localRoot>` identify the owning project; the user home dir's
+ * basename maps to '' (user-global). Returns null when the source carries no
+ * origin evidence. Pure string logic - recorded paths may no longer exist.
+ */
+export function originFromSource(
+  source: string | null | undefined,
+  homeName?: string,
+): string | null {
+  if (!source) return null;
+  const home = (homeName ?? path.basename(os.homedir())).toLowerCase();
+  const shared = /^shared:([^:]+):/.exec(source);
+  if (shared) {
+    const name = shared[1].toLowerCase();
+    return name === home ? '' : name;
+  }
+  if (source.startsWith('promoted:')) {
+    const promotedPath = source.slice('promoted:'.length).trim();
+    if (!promotedPath) return null;
+    const name = path.basename(path.resolve(promotedPath, '..')).toLowerCase();
+    if (!name) return null;
+    return name === home ? '' : name;
+  }
+  return null;
+}
+
+/**
  * The origin project to stamp on a memory written from cwd.
  * Returns the project name, or '' for user-global (written at/under home or
  * in a markerless directory) - injectable everywhere. Write sites must always

--- a/src/secret-detect.ts
+++ b/src/secret-detect.ts
@@ -1,0 +1,71 @@
+/**
+ * Secret detection for memory content (v39 memory scope isolation, S4;
+ * docs/plans/2026-07-01-memory-scope-isolation.md).
+ *
+ * Conservative, provider-bounded patterns only - a bare `sk-` in prose must
+ * NOT flag. Detection gates two surfaces:
+ *  - producer: shareMemory/autoShare never promote flagged rows to the
+ *    global store;
+ *  - consumer: ambient context (getContext) never injects a flagged row
+ *    outside its owning project, and never anywhere when the row has no
+ *    project origin. Explicit recall is unaffected - recalling a secret is
+ *    a deliberate act.
+ *
+ * This is deliberately a thin slice of the A4 lifecycle-compliance item
+ * (no write-time scrubbing, no PII detection).
+ *
+ * Leaf module: keep free of imports from store/api/shared so all of them
+ * can import it without cycles.
+ */
+
+/** Result of scanning one memory. `reason` names the tag or pattern that fired. */
+export interface SecretDetection {
+  flagged: boolean;
+  reason: string | null;
+}
+
+const SECRET_TAGS = new Set([
+  'secret', 'api-key', 'apikey', 'credential', 'credentials',
+  'token', 'password', 'private-key',
+]);
+
+const SECRET_PATTERNS: ReadonlyArray<{ name: string; re: RegExp }> = [
+  { name: 'aws-access-key', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'github-token', re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b/ },
+  { name: 'github-fine-grained-pat', re: /\bgithub_pat_[A-Za-z0-9_]{22,}\b/ },
+  { name: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { name: 'stripe-key', re: /\b[sr]k_(?:live|test)_[A-Za-z0-9]{16,}\b/ },
+  { name: 'google-api-key', re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { name: 'private-key-block', re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  // sk-... (OpenAI/Anthropic style) and sk_<vendor>_... shapes. Both require
+  // a key-ish noun somewhere in the content (co-occurrence guard) so prose
+  // like "the sk- prefix identifies API keys" without an actual long token
+  // does not flag, but a stored key ("2chain prod API key sk_keith_...")
+  // does.
+  { name: 'sk-style-key', re: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+  { name: 'sk-underscore-key', re: /\bsk_[A-Za-z0-9]+_[A-Za-z0-9_]{6,}\b/ },
+  // Generic assignment: api_key=..., password: ..., token = "..." with a
+  // 12+ char opaque value.
+  { name: 'secret-assignment', re: /\b(?:api[_-]?key|secret|token|password)\s*[:=]\s*['"]?[^\s'"]{12,}/i },
+];
+
+const KEYISH_CONTEXT_RE = /key|token|secret|credential|bearer|auth|password/i;
+const CO_OCCURRENCE_GUARDED = new Set(['sk-style-key', 'sk-underscore-key']);
+
+/**
+ * Scan a memory's tags + content for secret material.
+ * Pure and deterministic; no filesystem or store access.
+ */
+export function detectSecret(entry: { content: string; tags: string[] }): SecretDetection {
+  for (const tag of entry.tags) {
+    if (SECRET_TAGS.has(tag.toLowerCase())) {
+      return { flagged: true, reason: `tag:${tag.toLowerCase()}` };
+    }
+  }
+  for (const { name, re } of SECRET_PATTERNS) {
+    if (!re.test(entry.content)) continue;
+    if (CO_OCCURRENCE_GUARDED.has(name) && !KEYISH_CONTEXT_RE.test(entry.content)) continue;
+    return { flagged: true, reason: `pattern:${name}` };
+  }
+  return { flagged: false, reason: null };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import { createHash } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { resolveProjectIdentity } from './project-identity.js';
 import { detectServer, writePidfile, removePidfileIfOwned } from './server-detect.js';
 import { resolveTenantId } from './tenant.js';
 import { openHippoDb, closeHippoDb } from './db.js';
@@ -1073,6 +1075,13 @@ async function handleRequest(
         throw new HttpError(400, 'include_recent must be a non-negative number');
       }
     }
+    // v39 memory scope isolation: cross_project=1|true re-includes
+    // other-project rows (tagged category 'cross-project' in the response).
+    // The partition identity comes from the SERVED STORE's location, not the
+    // daemon's process cwd - a daemon started from anywhere still isolates
+    // the project it serves.
+    const crossProjectRaw = query.get('cross_project');
+    const crossProject = crossProjectRaw === '1' || crossProjectRaw === 'true';
     const ctx = buildContextWithAuth(req, opts.hippoRoot);
     const result = await getContext(ctx, {
       q,
@@ -1081,6 +1090,8 @@ async function handleRequest(
       pinnedOnly,
       scope,
       includeRecent,
+      crossProject,
+      currentProject: resolveProjectIdentity(dirname(resolve(opts.hippoRoot))).name,
     });
     sendJson(res, 200, result);
     return;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -19,6 +19,8 @@ import {
 } from './store.js';
 import { search, hybridSearch, SearchResult } from './search.js';
 import { evalNow } from './ablation.js';
+import { deriveOriginProject, classifyOriginProject } from './project-identity.js';
+import { detectSecret } from './secret-detect.js';
 
 /**
  * Returns the path to the global Hippo store.
@@ -288,17 +290,33 @@ export function shareMemory(
   const entry = readEntry(localRoot, id, options.tenantId);
   if (!entry) throw new Error(`Memory not found: ${id}`);
 
+  // v39 S4 producer veto: secrets never go to the global store, not even
+  // with --force. Explicit and loud - a silent null would read as "low
+  // transfer score" and invite retries.
+  const secret = detectSecret(entry);
+  if (secret.flagged) {
+    throw new Error(
+      `Refusing to share ${id} to the global store: content matches secret material (${secret.reason}). ` +
+      `Secrets stay in their owning project's store.`,
+    );
+  }
+
   const score = transferScore(entry);
   if (score < 0.3 && !options.force) return null;
 
   initGlobal();
   const globalRoot = getGlobalRoot();
 
-  const projectName = path.basename(path.resolve(localRoot, '..'));
+  // v39: canonical origin comes from the entry's own stamp (write-time,
+  // store-location-derived); the localRoot parent basename is only a
+  // fallback for pre-v39 rows and keeps the legacy source format intact.
+  const fallbackName = path.basename(path.resolve(localRoot, '..'));
+  const originName = entry.origin_project ?? deriveOriginProject(path.dirname(path.resolve(localRoot)));
   const globalEntry: MemoryEntry = {
     ...entry,
     id: generateId('g'),
-    source: `shared:${projectName}:${new Date().toISOString()}`,
+    source: `shared:${originName === '' ? fallbackName : originName}:${new Date().toISOString()}`,
+    origin_project: originName,
   };
 
   writeEntry(globalRoot, globalEntry);
@@ -389,6 +407,11 @@ export function autoShare(
   );
 
   const candidates = localEntries.filter((entry) => {
+    // v39 S4 producer veto: secret rows never auto-share, regardless of
+    // transfer score. (shareMemory would throw; filtering here keeps the
+    // sleep pipeline fail-safe.)
+    if (detectSecret(entry).flagged) return false;
+
     const score = transferScore(entry);
     if (score < minScore) return false;
 
@@ -415,7 +438,11 @@ export function autoShare(
  * Skips entries that already exist locally (by ID or by near-identical content).
  * Returns the count of newly copied entries.
  */
-export function syncGlobalToLocal(localRoot: string, globalRoot: string): number {
+export function syncGlobalToLocal(
+  localRoot: string,
+  globalRoot: string,
+  opts: { includeCrossProject?: boolean } = {},
+): number {
   if (!fs.existsSync(globalRoot)) return 0;
 
   // L9: host-wide read. syncGlobalToLocal copies the global union into a
@@ -423,11 +450,22 @@ export function syncGlobalToLocal(localRoot: string, globalRoot: string): number
   // the local-root context provides one.
   const globalEntries = loadAllEntries(globalRoot);
   const localIndex = loadIndex(localRoot);
+
+  // v39 (codex P1-4): syncing down must not re-import what ambient context
+  // excludes - other-project rows are skipped by default and secret rows
+  // are never copied. origin_project is preserved on the copy (writeEntry
+  // only stamps when the field is missing).
+  const currentName = deriveOriginProject(path.dirname(path.resolve(localRoot)));
   let count = 0;
 
   for (const entry of globalEntries) {
     // Skip if already present by ID
     if (localIndex.entries[entry.id]) continue;
+    if (detectSecret(entry).flagged) continue;
+    if (
+      !opts.includeCrossProject &&
+      classifyOriginProject(entry.origin_project, currentName) === 'cross-project'
+    ) continue;
 
     writeEntry(localRoot, entry);
     count++;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -176,6 +176,12 @@ export interface HybridSearchOptions extends SearchOptions {
   summaryDeboost?: number;
   /** v0.30 / E4 — propagated. Default true (1.05 boost if rebuilt within 7d). */
   summaryFreshness?: boolean;
+  /** v39 memory scope isolation: optional admission predicate applied to the
+   *  loaded candidate entries of BOTH stores BEFORE ranking, cross-store
+   *  content-dedupe, and budgeting. Without it, an excluded row can shadow
+   *  its admitted duplicate in the dedupe pass, or saturate the budget.
+   *  Default undefined = unchanged behavior (recall paths never set it). */
+  entryFilter?: (entry: MemoryEntry) => boolean;
 }
 
 /**
@@ -188,10 +194,14 @@ export async function searchBothHybrid(
   globalRoot: string,
   options: HybridSearchOptions = {}
 ): Promise<SearchResult[]> {
-  const { budget = 4000, now = evalNow(), embeddingWeight, explain, mmr, mmrLambda, localBump = 1.2, minResults, scope, includeSuperseded, asOf, tenantId, summaryDeboost, summaryFreshness } = options;
+  const { budget = 4000, now = evalNow(), embeddingWeight, explain, mmr, mmrLambda, localBump = 1.2, minResults, scope, includeSuperseded, asOf, tenantId, summaryDeboost, summaryFreshness, entryFilter } = options;
 
-  const localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, undefined, tenantId) : [];
-  const globalEntries = fs.existsSync(globalRoot) ? loadSearchEntries(globalRoot, query, undefined, tenantId) : [];
+  let localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, undefined, tenantId) : [];
+  let globalEntries = fs.existsSync(globalRoot) ? loadSearchEntries(globalRoot, query, undefined, tenantId) : [];
+  if (entryFilter) {
+    localEntries = localEntries.filter(entryFilter);
+    globalEntries = globalEntries.filter(entryFilter);
+  }
 
   if (localEntries.length === 0 && globalEntries.length === 0) return [];
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -196,8 +196,15 @@ export async function searchBothHybrid(
 ): Promise<SearchResult[]> {
   const { budget = 4000, now = evalNow(), embeddingWeight, explain, mmr, mmrLambda, localBump = 1.2, minResults, scope, includeSuperseded, asOf, tenantId, summaryDeboost, summaryFreshness, entryFilter } = options;
 
-  let localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, undefined, tenantId) : [];
-  let globalEntries = fs.existsSync(globalRoot) ? loadSearchEntries(globalRoot, query, undefined, tenantId) : [];
+  // When an admission filter is active, lift the per-store candidate cap
+  // (default 200): excluded rows matching the query could otherwise fill the
+  // window before any admitted row is even loaded (codex gating round 6).
+  // Only ambient-context query mode sets entryFilter, and that path is
+  // interactive - never the per-turn pinned-only hook - so ranking the full
+  // match set is acceptable.
+  const searchWindow = entryFilter ? Number.MAX_SAFE_INTEGER : undefined;
+  let localEntries = fs.existsSync(localRoot) ? loadSearchEntries(localRoot, query, searchWindow, tenantId) : [];
+  let globalEntries = fs.existsSync(globalRoot) ? loadSearchEntries(globalRoot, query, searchWindow, tenantId) : [];
   if (entryFilter) {
     localEntries = localEntries.filter(entryFilter);
     globalEntries = globalEntries.filter(entryFilter);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -60,14 +60,27 @@ export function promoteToGlobal(
   const entry = readEntry(localRoot, id, opts?.tenantId);
   if (!entry) throw new Error(`Memory not found: ${id}`);
 
+  // v39 S4 producer veto: promote is a producer path to the global store
+  // exactly like shareMemory - same hard rule (codex gating review P2).
+  const promoteSecret = detectSecret(entry);
+  if (promoteSecret.flagged) {
+    throw new Error(
+      `Refusing to promote ${id} to the global store: content matches secret material (${promoteSecret.reason}). ` +
+      `Secrets stay in their owning project's store.`,
+    );
+  }
+
   initGlobal();
   const globalRoot = getGlobalRoot();
 
-  // Mint a new ID for the global store
+  // Mint a new ID for the global store. origin_project rides along from the
+  // local entry's write-time stamp via the spread; back-stop it for pre-v39
+  // local rows so a promoted copy never lands NULL in the global store.
   const globalEntry: MemoryEntry = {
     ...entry,
     id: generateId('g'),
     source: `promoted:${localRoot}`,
+    origin_project: entry.origin_project ?? deriveOriginProject(path.dirname(path.resolve(localRoot))),
   };
 
   writeEntry(globalRoot, globalEntry, { actor: opts?.actor });

--- a/src/store.ts
+++ b/src/store.ts
@@ -842,7 +842,9 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
   db.exec('BEGIN');
   try {
     for (const entry of legacyEntries) {
-      upsertEntryRow(db, entry);
+      // v39: legacy markdown carries no origin_project; stamp from the store
+      // location so bootstrapped rows stay visible to ambient context.
+      upsertEntryRow(db, stampOriginProject(hippoRoot, entry));
     }
 
     const legacyIndex = loadLegacyIndexFile(hippoRoot);
@@ -1576,7 +1578,12 @@ export function batchWriteAndDelete(
         }
       }
     }
-    for (const entry of toWrite) {
+    // v39: consolidate's new semantic rows (and any other batch writer)
+    // bypass writeEntry, so stamp store-derived origins here too - a NULL
+    // origin would make freshly consolidated memories vanish from ambient
+    // context (codex gating review P1).
+    const stampedWrites = toWrite.map((e) => stampOriginProject(hippoRoot, e));
+    for (const entry of stampedWrites) {
       upsertEntryRow(db, entry);
       // Hook for writes: child upserted under a level-2 summary marks parent dirty.
       if (entry.dag_parent_id) {
@@ -1596,7 +1603,7 @@ export function batchWriteAndDelete(
     db.exec('COMMIT');
 
     // Sync mirrors once after all DB writes
-    for (const entry of toWrite) {
+    for (const entry of stampedWrites) {
       writeMarkdownMirror(hippoRoot, entry);
     }
     for (const id of toDeleteIds) {
@@ -1708,7 +1715,8 @@ export function rebuildIndex(hippoRoot: string): HippoIndex {
       db.exec('BEGIN');
       try {
         for (const entry of legacyEntries) {
-          upsertEntryRow(db, entry);
+          // v39: same store-derived origin stamp as bootstrapLegacyStore.
+          upsertEntryRow(db, stampOriginProject(hippoRoot, entry));
         }
         db.exec('COMMIT');
       } catch (err) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,7 +23,7 @@ import { SessionHandoff, SessionHandoffRow, rowToSessionHandoff } from './handof
 import { tokenize } from './search.js';
 import { appendAuditEvent, type AuditOp } from './audit.js';
 import { resolveTenantId } from './tenant.js';
-import { deriveOriginProject } from './project-identity.js';
+import { deriveOriginProject, originFromSource } from './project-identity.js';
 
 /**
  * Emit an audit event for a mutation against `db`. Wrapped so a broken audit
@@ -1184,14 +1184,21 @@ export function stampOriginProject(hippoRoot: string, entry: MemoryEntry): Memor
 }
 
 /**
- * Import-time variant that ALSO stamps null: used only where the store's
- * location genuinely is the evidence for rows that predate the origin
- * column - the legacy-markdown bootstrap and rebuildIndex import, which are
- * the markdown-store equivalent of the v39 SQL backfill.
+ * Import-time variant that ALSO stamps null: used only where evidence exists
+ * for rows that predate the origin column - the legacy-markdown bootstrap and
+ * rebuildIndex import, which are the markdown-store equivalent of the v39 SQL
+ * backfill. Same evidence order as the migration: the provenance source
+ * (`shared:<project>:` / `promoted:<localRoot>`) wins over the destination
+ * store's location, so a shared row imported into the global store keeps its
+ * owning project instead of becoming user-global (codex gating round 3 P1).
  */
 function stampOriginProjectForImport(hippoRoot: string, entry: MemoryEntry): MemoryEntry {
   if (entry.origin_project !== undefined && entry.origin_project !== null) return entry;
-  return { ...entry, origin_project: deriveOriginProject(path.dirname(hippoRoot)) };
+  const fromSource = originFromSource(entry.source);
+  return {
+    ...entry,
+    origin_project: fromSource ?? deriveOriginProject(path.dirname(hippoRoot)),
+  };
 }
 
 export function writeEntry(

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,6 +23,7 @@ import { SessionHandoff, SessionHandoffRow, rowToSessionHandoff } from './handof
 import { tokenize } from './search.js';
 import { appendAuditEvent, type AuditOp } from './audit.js';
 import { resolveTenantId } from './tenant.js';
+import { deriveOriginProject } from './project-identity.js';
 
 /**
  * Emit an audit event for a mutation against `db`. Wrapped so a broken audit
@@ -101,6 +102,8 @@ interface MemoryRow {
   owner: string | null;
   artifact_ref: string | null;
   tenant_id: string | null;
+  // Memory scope isolation (schema v39).
+  origin_project: string | null;
   descendant_count: number | null;
   earliest_at: string | null;
   latest_at: string | null;
@@ -196,13 +199,13 @@ export interface SessionEvent {
 }
 
 const INDEX_VERSION = 3;
-const MEMORY_SELECT_COLUMNS = `id, created, last_retrieved, retrieval_count, strength, half_life_days, layer, tags_json, emotional_valence, schema_fit, source, outcome_score, outcome_positive, outcome_negative, conflicts_with_json, pinned, confidence, content, parents_json, starred, trace_outcome, source_session_id, valid_from, superseded_by, extracted_from, dag_level, dag_parent_id, kind, scope, owner, artifact_ref, tenant_id, descendant_count, earliest_at, latest_at, summary_dirty, last_rebuilt_at, rebuild_count, dag_level_3_built_at`;
+const MEMORY_SELECT_COLUMNS = `id, created, last_retrieved, retrieval_count, strength, half_life_days, layer, tags_json, emotional_valence, schema_fit, source, outcome_score, outcome_positive, outcome_negative, conflicts_with_json, pinned, confidence, content, parents_json, starred, trace_outcome, source_session_id, valid_from, superseded_by, extracted_from, dag_level, dag_parent_id, kind, scope, owner, artifact_ref, tenant_id, origin_project, descendant_count, earliest_at, latest_at, summary_dirty, last_rebuilt_at, rebuild_count, dag_level_3_built_at`;
 // F1 (v1.7.0): qualified-and-aliased columns for the FTS join in
 // loadSearchRows. Every column is `m.<col> AS <col>` so rowToEntry's
 // unqualified field reads keep working unchanged. The trailing
 // bm25(memories_fts) AS bm25_score adds the FTS rank as a result column.
 // Only used inside the FTS path; non-FTS paths keep MEMORY_SELECT_COLUMNS.
-const MEMORY_SEARCH_COLUMNS = `m.id AS id, m.created AS created, m.last_retrieved AS last_retrieved, m.retrieval_count AS retrieval_count, m.strength AS strength, m.half_life_days AS half_life_days, m.layer AS layer, m.tags_json AS tags_json, m.emotional_valence AS emotional_valence, m.schema_fit AS schema_fit, m.source AS source, m.outcome_score AS outcome_score, m.outcome_positive AS outcome_positive, m.outcome_negative AS outcome_negative, m.conflicts_with_json AS conflicts_with_json, m.pinned AS pinned, m.confidence AS confidence, m.content AS content, m.parents_json AS parents_json, m.starred AS starred, m.trace_outcome AS trace_outcome, m.source_session_id AS source_session_id, m.valid_from AS valid_from, m.superseded_by AS superseded_by, m.extracted_from AS extracted_from, m.dag_level AS dag_level, m.dag_parent_id AS dag_parent_id, m.kind AS kind, m.scope AS scope, m.owner AS owner, m.artifact_ref AS artifact_ref, m.tenant_id AS tenant_id, m.descendant_count AS descendant_count, m.earliest_at AS earliest_at, m.latest_at AS latest_at, m.summary_dirty AS summary_dirty, m.last_rebuilt_at AS last_rebuilt_at, m.rebuild_count AS rebuild_count, m.dag_level_3_built_at AS dag_level_3_built_at, bm25(memories_fts) AS bm25_score`;
+const MEMORY_SEARCH_COLUMNS = `m.id AS id, m.created AS created, m.last_retrieved AS last_retrieved, m.retrieval_count AS retrieval_count, m.strength AS strength, m.half_life_days AS half_life_days, m.layer AS layer, m.tags_json AS tags_json, m.emotional_valence AS emotional_valence, m.schema_fit AS schema_fit, m.source AS source, m.outcome_score AS outcome_score, m.outcome_positive AS outcome_positive, m.outcome_negative AS outcome_negative, m.conflicts_with_json AS conflicts_with_json, m.pinned AS pinned, m.confidence AS confidence, m.content AS content, m.parents_json AS parents_json, m.starred AS starred, m.trace_outcome AS trace_outcome, m.source_session_id AS source_session_id, m.valid_from AS valid_from, m.superseded_by AS superseded_by, m.extracted_from AS extracted_from, m.dag_level AS dag_level, m.dag_parent_id AS dag_parent_id, m.kind AS kind, m.scope AS scope, m.owner AS owner, m.artifact_ref AS artifact_ref, m.tenant_id AS tenant_id, m.origin_project AS origin_project, m.descendant_count AS descendant_count, m.earliest_at AS earliest_at, m.latest_at AS latest_at, m.summary_dirty AS summary_dirty, m.last_rebuilt_at AS last_rebuilt_at, m.rebuild_count AS rebuild_count, m.dag_level_3_built_at AS dag_level_3_built_at, bm25(memories_fts) AS bm25_score`;
 /**
  * Default candidate-pool size for `loadSearchEntries` when called with
  * `limit === undefined`. Single source of truth; `api.recall` imports
@@ -328,6 +331,11 @@ export function serializeEntry(entry: MemoryEntry): string {
   if (tenantId !== 'default') {
     frontmatter['tenant_id'] = tenantId;
   }
+  // v39: origin_project '' (user-global) is meaningful and must round-trip;
+  // only undefined/null (legacy/unstamped) is omitted.
+  if (entry.origin_project !== undefined && entry.origin_project !== null) {
+    frontmatter['origin_project'] = entry.origin_project;
+  }
   const fm = dumpFrontmatter(frontmatter);
   return `${fm}\n\n${entry.content}\n`;
 }
@@ -377,6 +385,7 @@ export function deserializeEntry(raw: string): MemoryEntry | null {
     owner: data['owner'] === null || data['owner'] === undefined ? null : String(data['owner']),
     artifact_ref: data['artifact_ref'] === null || data['artifact_ref'] === undefined ? null : String(data['artifact_ref']),
     tenantId: data['tenant_id'] === null || data['tenant_id'] === undefined ? 'default' : String(data['tenant_id']),
+    origin_project: data['origin_project'] === null || data['origin_project'] === undefined ? null : String(data['origin_project']),
   };
 }
 
@@ -419,6 +428,7 @@ function rowToEntry(row: MemoryRow): MemoryEntry {
     owner: row.owner ?? null,
     artifact_ref: row.artifact_ref ?? null,
     tenantId: row.tenant_id ?? 'default',
+    origin_project: row.origin_project ?? null,
     descendant_count: Number(row.descendant_count ?? 0),
     earliest_at: row.earliest_at ?? null,
     latest_at: row.latest_at ?? null,
@@ -929,11 +939,11 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
       extracted_from,
       dag_level, dag_parent_id,
       kind, scope, owner, artifact_ref,
-      tenant_id,
+      tenant_id, origin_project,
       descendant_count, earliest_at, latest_at,
       dag_level_3_built_at,
       updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT(id) DO UPDATE SET
       created = excluded.created,
       last_retrieved = excluded.last_retrieved,
@@ -966,6 +976,7 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
       owner = excluded.owner,
       artifact_ref = excluded.artifact_ref,
       tenant_id = excluded.tenant_id,
+      origin_project = excluded.origin_project,
       descendant_count = excluded.descendant_count,
       earliest_at = excluded.earliest_at,
       latest_at = excluded.latest_at,
@@ -1004,6 +1015,7 @@ function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry):
     entry.owner ?? null,
     entry.artifact_ref ?? null,
     entry.tenantId ?? 'default',
+    entry.origin_project ?? null,
     entry.descendant_count ?? 0,
     entry.earliest_at ?? null,
     entry.latest_at ?? null,
@@ -1150,6 +1162,19 @@ export function saveIndex(hippoRoot: string, index: HippoIndex): void {
  * filesystem mirrors / audit emit never run. Used by E1.3+ connectors to
  * stamp idempotency rows atomically with the memory write.
  */
+/**
+ * Stamp origin_project from the store's own location when the entry does not
+ * already carry one (v39 memory scope isolation). The store dir is
+ * `<project>/.hippo`, so its parent resolves to the owning project; the
+ * home/global store resolves to '' (user-global). Callers that know a better
+ * origin (shareMemory, syncGlobalToLocal) set entry.origin_project before
+ * writing and this is a no-op. Returns a stamped copy; never mutates.
+ */
+export function stampOriginProject(hippoRoot: string, entry: MemoryEntry): MemoryEntry {
+  if (entry.origin_project !== undefined && entry.origin_project !== null) return entry;
+  return { ...entry, origin_project: deriveOriginProject(path.dirname(hippoRoot)) };
+}
+
 export function writeEntry(
   hippoRoot: string,
   entry: MemoryEntry,
@@ -1165,11 +1190,12 @@ export function writeEntry(
   },
 ): void {
   initStore(hippoRoot);
+  const stamped = stampOriginProject(hippoRoot, entry);
   const db = openHippoDb(hippoRoot);
   try {
-    writeEntryDbOnly(db, entry, opts);
+    writeEntryDbOnly(db, stamped, opts);
     opts?.afterCommit?.();
-    writeEntryMirrors(hippoRoot, db, entry);
+    writeEntryMirrors(hippoRoot, db, stamped);
   } finally {
     closeHippoDb(db);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -844,7 +844,7 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
     for (const entry of legacyEntries) {
       // v39: legacy markdown carries no origin_project; stamp from the store
       // location so bootstrapped rows stay visible to ambient context.
-      upsertEntryRow(db, stampOriginProject(hippoRoot, entry));
+      upsertEntryRow(db, stampOriginProjectForImport(hippoRoot, entry));
     }
 
     const legacyIndex = loadLegacyIndexFile(hippoRoot);
@@ -1165,14 +1165,31 @@ export function saveIndex(hippoRoot: string, index: HippoIndex): void {
  * stamp idempotency rows atomically with the memory write.
  */
 /**
- * Stamp origin_project from the store's own location when the entry does not
- * already carry one (v39 memory scope isolation). The store dir is
+ * Stamp origin_project from the store's own location when the entry has
+ * never been stamped (v39 memory scope isolation). The store dir is
  * `<project>/.hippo`, so its parent resolves to the owning project; the
  * home/global store resolves to '' (user-global). Callers that know a better
  * origin (shareMemory, syncGlobalToLocal) set entry.origin_project before
  * writing and this is a no-op. Returns a stamped copy; never mutates.
+ *
+ * NULL is deliberately PRESERVED, not re-stamped: null means "legacy row the
+ * v39 migration found no evidence for" and is deny-by-default in ambient
+ * context. A writeback (e.g. markRetrieved on a crossProject-included row)
+ * must not launder it into an injectable origin - the migration is the only
+ * evidence-based NULL converter (codex gating round 2 P1).
  */
 export function stampOriginProject(hippoRoot: string, entry: MemoryEntry): MemoryEntry {
+  if (entry.origin_project !== undefined) return entry;
+  return { ...entry, origin_project: deriveOriginProject(path.dirname(hippoRoot)) };
+}
+
+/**
+ * Import-time variant that ALSO stamps null: used only where the store's
+ * location genuinely is the evidence for rows that predate the origin
+ * column - the legacy-markdown bootstrap and rebuildIndex import, which are
+ * the markdown-store equivalent of the v39 SQL backfill.
+ */
+function stampOriginProjectForImport(hippoRoot: string, entry: MemoryEntry): MemoryEntry {
   if (entry.origin_project !== undefined && entry.origin_project !== null) return entry;
   return { ...entry, origin_project: deriveOriginProject(path.dirname(hippoRoot)) };
 }
@@ -1716,7 +1733,7 @@ export function rebuildIndex(hippoRoot: string): HippoIndex {
       try {
         for (const entry of legacyEntries) {
           // v39: same store-derived origin stamp as bootstrapLegacyStore.
-          upsertEntryRow(db, stampOriginProject(hippoRoot, entry));
+          upsertEntryRow(db, stampOriginProjectForImport(hippoRoot, entry));
         }
         db.exec('COMMIT');
       } catch (err) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.23.0';
+export const PACKAGE_VERSION = '1.24.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(38);
+    expect(getSchemaVersion(db)).toBe(39);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
-      expect(getCurrentSchemaVersion()).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
+      expect(getCurrentSchemaVersion()).toBe(39);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
-      expect(getCurrentSchemaVersion()).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
+      expect(getCurrentSchemaVersion()).toBe(39);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/context-scope-isolation.test.ts
+++ b/tests/context-scope-isolation.test.ts
@@ -1,0 +1,146 @@
+/**
+ * v39 memory scope isolation - the cross-project leak tests (plan S2/S3,
+ * docs/plans/2026-07-01-memory-scope-isolation.md).
+ *
+ * Reproduces the 2026-07-01 bug shape: a project-A session whose global
+ * store carries rows owned by OTHER projects. Before v39, every mode of
+ * getContext injected them; the existing api-context tests could not catch
+ * this because they isolate the global store away entirely.
+ *
+ * Real-DB per project convention.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initStore, writeEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createMemory } from '../src/memory.js';
+import { getContext, type Context } from '../src/api.js';
+import { clearProjectIdentityCache } from '../src/project-identity.js';
+
+let tmpRoot: string;
+let projA: string;
+let globalStore: string;
+let origHippoHome: string | undefined;
+let ctx: Context;
+
+const ALPHA = 'ALPHA-RULE deploykey rotation happens on fridays';
+const GLOBAL_PREF = 'GLOBAL-PREF deploykey answers stay under three lines';
+const BRAVO = 'BRAVO-FACT deploykey for project bravo lives in vault slot 7';
+const LEGACY = 'LEGACY-ROW deploykey note from before origin tracking';
+
+function contents(entries: Array<{ entry: { content: string } }>): string[] {
+  return entries.map((r) => r.entry.content);
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-ctx-iso-'));
+  projA = path.join(tmpRoot, 'proj-a', '.hippo');
+  fs.mkdirSync(projA, { recursive: true });
+  initStore(projA);
+  globalStore = path.join(tmpRoot, 'globalstore');
+  initStore(globalStore);
+  origHippoHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = globalStore;
+  clearProjectIdentityCache();
+
+  writeEntry(projA, createMemory(ALPHA, { pinned: true }));
+  writeEntry(globalStore, { ...createMemory(GLOBAL_PREF, { pinned: true }), origin_project: '' });
+  writeEntry(globalStore, { ...createMemory(BRAVO, { pinned: true }), origin_project: 'proj-b' });
+  writeEntry(globalStore, { ...createMemory(LEGACY, { pinned: true }), origin_project: 'placeholder' });
+  const db = openHippoDb(globalStore);
+  try {
+    db.prepare(`UPDATE memories SET origin_project = NULL WHERE content = ?`).run(LEGACY);
+  } finally {
+    closeHippoDb(db);
+  }
+
+  ctx = { hippoRoot: projA, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+});
+
+afterEach(() => {
+  if (origHippoHome !== undefined) {
+    process.env.HIPPO_HOME = origHippoHome;
+  } else {
+    delete process.env.HIPPO_HOME;
+  }
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('getContext origin partition (project A session)', () => {
+  const base = { currentProject: 'proj-a' };
+
+  it('pinned mode: other-project and legacy rows never inject; own + user-global do', async () => {
+    const result = await getContext(ctx, { ...base, pinnedOnly: true });
+    const got = contents(result.entries);
+    expect(got).toContain(ALPHA);
+    expect(got).toContain(GLOBAL_PREF);
+    expect(got).not.toContain(BRAVO);
+    expect(got).not.toContain(LEGACY);
+  });
+
+  it("'*' fallback mode applies the same partition", async () => {
+    const result = await getContext(ctx, { ...base });
+    const got = contents(result.entries);
+    expect(got).toContain(ALPHA);
+    expect(got).toContain(GLOBAL_PREF);
+    expect(got).not.toContain(BRAVO);
+    expect(got).not.toContain(LEGACY);
+  });
+
+  it('query mode applies the same partition to searchBothHybrid results', async () => {
+    const result = await getContext(ctx, { ...base, q: 'deploykey' });
+    const got = contents(result.entries);
+    expect(got).not.toContain(BRAVO);
+    expect(got).not.toContain(LEGACY);
+    expect(got.length).toBeGreaterThan(0);
+  });
+
+  it('annotates returned entries with origin and category', async () => {
+    const result = await getContext(ctx, { ...base, pinnedOnly: true });
+    const alpha = result.entries.find((r) => r.entry.content === ALPHA);
+    const pref = result.entries.find((r) => r.entry.content === GLOBAL_PREF);
+    expect(alpha?.origin).toBe('proj-a');
+    expect(alpha?.category).toBe('project');
+    expect(pref?.origin).toBe('');
+    expect(pref?.category).toBe('user-global');
+  });
+
+  it('crossProject: true re-includes excluded rows tagged cross-project', async () => {
+    const result = await getContext(ctx, { ...base, pinnedOnly: true, crossProject: true });
+    const got = contents(result.entries);
+    expect(got).toContain(BRAVO);
+    expect(got).toContain(LEGACY);
+    const bravo = result.entries.find((r) => r.entry.content === BRAVO);
+    expect(bravo?.category).toBe('cross-project');
+  });
+
+  it('contextProjectIsolation: false restores legacy behavior wholesale', async () => {
+    fs.writeFileSync(
+      path.join(projA, 'config.json'),
+      JSON.stringify({ contextProjectIsolation: false }),
+    );
+    const result = await getContext(ctx, { ...base, pinnedOnly: true });
+    const got = contents(result.entries);
+    expect(got).toContain(BRAVO);
+    expect(got).toContain(LEGACY);
+  });
+
+  it('a non-project session (currentProject "") sees everything, matching pre-v39 behavior', async () => {
+    const result = await getContext(ctx, { currentProject: '', pinnedOnly: true });
+    const got = contents(result.entries);
+    expect(got).toContain(ALPHA);
+    expect(got).toContain(GLOBAL_PREF);
+    expect(got).toContain(BRAVO);
+    expect(got).toContain(LEGACY);
+  });
+
+  it('private-scope rows never ambient-inject even from the local store (S2 parity)', async () => {
+    const secret = 'PRIVATE-SCOPED deploykey row that must not inject';
+    writeEntry(projA, { ...createMemory(secret, { pinned: true, scope: 'github:private:repo-x' }) });
+    const result = await getContext(ctx, { ...base, pinnedOnly: true });
+    expect(contents(result.entries)).not.toContain(secret);
+  });
+});

--- a/tests/context-scope-isolation.test.ts
+++ b/tests/context-scope-isolation.test.ts
@@ -150,6 +150,14 @@ describe('getContext origin partition (project A session)', () => {
     expect(got.join('\n')).not.toContain('filler text for bulk');
   });
 
+  it('an excluded duplicate cannot shadow its admitted copy in query mode (admission runs before dedupe)', async () => {
+    const DUP = 'deploykey duplicated fact shared to global';
+    writeEntry(projA, { ...createMemory(DUP, { scope: 'github:private:x' }) }); // excluded (private scope)
+    writeEntry(globalStore, { ...createMemory(DUP), origin_project: '' });      // admitted (user-global)
+    const result = await getContext(ctx, { currentProject: 'proj-a', q: 'deploykey duplicated' });
+    expect(contents(result.entries)).toContain(DUP);
+  });
+
   it('private-scope rows never ambient-inject even from the local store (S2 parity)', async () => {
     const secret = 'PRIVATE-SCOPED deploykey row that must not inject';
     writeEntry(projA, { ...createMemory(secret, { pinned: true, scope: 'github:private:repo-x' }) });

--- a/tests/context-scope-isolation.test.ts
+++ b/tests/context-scope-isolation.test.ts
@@ -137,6 +137,19 @@ describe('getContext origin partition (project A session)', () => {
     expect(got).toContain(LEGACY);
   });
 
+  it('query mode: an excluded high-token cross-project row cannot starve admitted rows out of the budget', async () => {
+    // A large cross-project row that matches the query strongly; the small
+    // in-scope rows must still fill the (tiny) budget after it is excluded.
+    writeEntry(globalStore, {
+      ...createMemory('deploykey deploykey deploykey ' + 'filler text for bulk '.repeat(40)),
+      origin_project: 'proj-b',
+    });
+    const result = await getContext(ctx, { currentProject: 'proj-a', q: 'deploykey', budget: 60 });
+    const got = contents(result.entries);
+    expect(got.length).toBeGreaterThan(0);
+    expect(got.join('\n')).not.toContain('filler text for bulk');
+  });
+
   it('private-scope rows never ambient-inject even from the local store (S2 parity)', async () => {
     const secret = 'PRIVATE-SCOPED deploykey row that must not inject';
     writeEntry(projA, { ...createMemory(secret, { pinned: true, scope: 'github:private:repo-x' }) });

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -74,7 +74,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db, 'schema_version')).toBe('38');
+      expect(getMeta(db, 'schema_version')).toBe('39');
     } finally {
       closeHippoDb(db);
     }
@@ -134,7 +134,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db2);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db2, 'schema_version')).toBe('38');
+      expect(getMeta(db2, 'schema_version')).toBe('39');
     } finally {
       closeHippoDb(db2);
     }

--- a/tests/github-schema.test.ts
+++ b/tests/github-schema.test.ts
@@ -109,11 +109,11 @@ describe('schema v24 — github connector tables', () => {
     } finally { closeHippoDb(db); }
   });
 
-  it('writes min_compatible_binary = 1.2.1 to meta', () => {
+  it('writes min_compatible_binary to meta (v24 stamped 1.2.1; v39 forward-bumps to 1.24.0)', () => {
     const db = openHippoDb(root);
     try {
       const v = getMeta(db, 'min_compatible_binary', '');
-      expect(v).toBe('1.2.1');
+      expect(v).toBe('1.24.0');
     } finally { closeHippoDb(db); }
   });
 

--- a/tests/graph-schema.test.ts
+++ b/tests/graph-schema.test.ts
@@ -25,7 +25,7 @@ describe('graph schema v37 (E3.3)', () => {
   afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
 
   it('CURRENT_SCHEMA_VERSION is 38', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
   });
 
   it('creates entities + relations + graph_extraction_queue tables', () => {

--- a/tests/l9-tenant-scoping.test.ts
+++ b/tests/l9-tenant-scoping.test.ts
@@ -430,7 +430,7 @@ describe('L9: host-wide back-compat parity (current behaviour preserved)', () =>
     expect(peerNames).toContain('project-bar');
   });
 
-  it('case 13: syncGlobalToLocal copies all global entries to local (host-wide global read)', () => {
+  it('case 13: syncGlobalToLocal host-wide TENANT read survives the v39 origin gate', () => {
     // syncGlobalToLocal doesn't call initGlobal() (caller provides the
     // globalRoot directly), so HIPPO_HOME isolation isn't strictly required
     // here — but kept consistent for defence-in-depth.
@@ -439,12 +439,19 @@ describe('L9: host-wide back-compat parity (current behaviour preserved)', () =>
       // Set up two separate roots to simulate global → local sync
       const { tmpDir: globalTmp, hippoRoot: globalRoot } = newRoot('hippo-l9-global-');
       try {
-        // Seed global with two tenants' worth of entries
+        // Seed global with two tenants' worth of entries. Under v39 they
+        // are stamped with the seed store's own (different) project origin,
+        // so the default sync gates them as cross-project...
         seedFor(globalRoot, 'tenant-a', 'global memory from tenant-a', {});
         seedFor(globalRoot, 'tenant-b', 'global memory from tenant-b', {});
 
-        const copied = syncGlobalToLocal(hippoRoot, globalRoot);
-        expect(copied).toBe(2); // both tenants' global entries copied to local
+        expect(syncGlobalToLocal(hippoRoot, globalRoot)).toBe(0);
+
+        // ...but this case's original guarantee - the global read is
+        // host-wide across TENANTS - still holds once the origin gate is
+        // explicitly lifted: both tenants' rows copy.
+        const copied = syncGlobalToLocal(hippoRoot, globalRoot, { includeCrossProject: true });
+        expect(copied).toBe(2);
       } finally {
         rmSync(globalTmp, { recursive: true, force: true });
       }

--- a/tests/origin-project-persistence.test.ts
+++ b/tests/origin-project-persistence.test.ts
@@ -65,6 +65,24 @@ describe('writeEntry origin stamping (v39)', () => {
     expect(entry.origin_project).toBe('proj-a');
   });
 
+  it('a legacy NULL origin is sticky across writebacks (never laundered to an injectable origin)', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    writeEntry(storeRoot, createMemory('a legacy row that must stay denied'));
+    const db = openHippoDb(storeRoot);
+    try {
+      db.exec(`UPDATE memories SET origin_project = NULL`);
+    } finally {
+      closeHippoDb(db);
+    }
+    const [legacy] = loadAllEntries(storeRoot);
+    expect(legacy.origin_project).toBeNull();
+    // Simulate the markRetrieved writeback: writeEntry on the loaded row.
+    writeEntry(storeRoot, legacy);
+    expect(loadAllEntries(storeRoot)[0].origin_project).toBeNull();
+    // The pure helper preserves null too.
+    expect(stampOriginProject(storeRoot, { ...legacy, origin_project: null }).origin_project).toBeNull();
+  });
+
   it('stampOriginProject never mutates the input entry', () => {
     const storeRoot = makeProjectStore('proj-a');
     const entry = createMemory('immutability check');

--- a/tests/origin-project-persistence.test.ts
+++ b/tests/origin-project-persistence.test.ts
@@ -162,6 +162,36 @@ describe('v39 migration backfill', () => {
     expect(entry.origin_project).toBe('proj-b');
   });
 
+  it('legacy markdown bootstrap honors source evidence over the destination store origin', () => {
+    // A pre-v39 markdown-only store: a shared:proj-b row imported into a
+    // proj-a store must keep proj-b, not become proj-a (codex round 3 P1).
+    const projectDir = path.join(tmpRoot, 'proj-a');
+    const storeRoot = path.join(projectDir, '.hippo');
+    fs.mkdirSync(path.join(storeRoot, 'episodic'), { recursive: true });
+    const sharedRow = { ...createMemory('markdown row shared from proj b', { source: 'shared:Proj-B:2026-01-01T00:00:00Z' }), origin_project: null };
+    const plainRow = { ...createMemory('markdown row written here long ago'), origin_project: null };
+    fs.writeFileSync(path.join(storeRoot, 'episodic', `${sharedRow.id}.md`), serializeEntry(sharedRow));
+    fs.writeFileSync(path.join(storeRoot, 'episodic', `${plainRow.id}.md`), serializeEntry(plainRow));
+
+    initStore(storeRoot); // bootstrapLegacyStore imports the markdown
+    const entries = loadAllEntries(storeRoot);
+    const shared = entries.find((e) => e.source.startsWith('shared:'));
+    const plain = entries.find((e) => !e.source.startsWith('shared:'));
+    expect(shared?.origin_project).toBe('proj-b');
+    expect(plain?.origin_project).toBe('proj-a');
+  });
+
+  it('stamps min_compatible_binary 1.24.0 so pre-isolation binaries refuse the DB', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const db = openHippoDb(storeRoot);
+    try {
+      const row = db.prepare(`SELECT value FROM meta WHERE key = 'min_compatible_binary'`).get() as { value?: string };
+      expect(row?.value).toBe('1.24.0');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
   it('is idempotent: a second migration pass changes nothing', () => {
     const storeRoot = makeProjectStore('proj-a');
     writeEntry(storeRoot, createMemory('row for idempotency check'));

--- a/tests/origin-project-persistence.test.ts
+++ b/tests/origin-project-persistence.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createMemory } from '../src/memory.js';
+import {
+  initStore,
+  writeEntry,
+  loadAllEntries,
+  serializeEntry,
+  deserializeEntry,
+  stampOriginProject,
+} from '../src/store.js';
+import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
+import { clearProjectIdentityCache } from '../src/project-identity.js';
+
+let tmpRoot: string;
+
+function makeProjectStore(projectName: string): string {
+  const projectDir = path.join(tmpRoot, projectName);
+  const storeRoot = path.join(projectDir, '.hippo');
+  fs.mkdirSync(storeRoot, { recursive: true });
+  initStore(storeRoot);
+  return storeRoot;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-origin-'));
+  clearProjectIdentityCache();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('writeEntry origin stamping (v39)', () => {
+  it('stamps the store-derived project origin when the entry has none', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    writeEntry(storeRoot, createMemory('remember this fact about proj a'));
+    const [entry] = loadAllEntries(storeRoot);
+    expect(entry.origin_project).toBe('proj-a');
+  });
+
+  it('preserves an explicitly set origin', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const entry = { ...createMemory('a row shared from elsewhere'), origin_project: 'proj-b' };
+    writeEntry(storeRoot, entry);
+    const [loaded] = loadAllEntries(storeRoot);
+    expect(loaded.origin_project).toBe('proj-b');
+  });
+
+  it("preserves an explicit '' (user-global) origin", () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const entry = { ...createMemory('a user-global preference'), origin_project: '' };
+    writeEntry(storeRoot, entry);
+    const [loaded] = loadAllEntries(storeRoot);
+    expect(loaded.origin_project).toBe('');
+  });
+
+  it('stampOriginProject never mutates the input entry', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const entry = createMemory('immutability check');
+    const stamped = stampOriginProject(storeRoot, entry);
+    expect(entry.origin_project).toBeUndefined();
+    expect(stamped.origin_project).toBe('proj-a');
+  });
+});
+
+describe('markdown mirror round-trip', () => {
+  it("round-trips a project origin and the meaningful ''", () => {
+    const base = createMemory('round trip content here');
+    for (const origin of ['proj-a', '']) {
+      const raw = serializeEntry({ ...base, origin_project: origin });
+      const back = deserializeEntry(raw);
+      expect(back?.origin_project).toBe(origin);
+    }
+  });
+
+  it('omits legacy null/undefined origin and deserializes it back to null', () => {
+    const base = createMemory('legacy row content here');
+    const raw = serializeEntry({ ...base, origin_project: null });
+    expect(raw).not.toContain('origin_project');
+    expect(deserializeEntry(raw)?.origin_project).toBeNull();
+  });
+});
+
+describe('v39 migration backfill', () => {
+  function regressStoreToV38(storeRoot: string): void {
+    const db = openHippoDb(storeRoot);
+    try {
+      db.exec(`UPDATE memories SET origin_project = NULL`);
+      db.prepare(`UPDATE meta SET value = '38' WHERE key = 'schema_version'`).run();
+    } finally {
+      closeHippoDb(db);
+    }
+  }
+
+  it('backfills project-store rows with the store-derived origin', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    writeEntry(storeRoot, createMemory('an old row written before v39'));
+    regressStoreToV38(storeRoot);
+
+    const db = openHippoDb(storeRoot); // reopening runs the v39 migration
+    try {
+      expect(getSchemaVersion(db)).toBeGreaterThanOrEqual(39);
+    } finally {
+      closeHippoDb(db);
+    }
+    const [entry] = loadAllEntries(storeRoot);
+    expect(entry.origin_project).toBe('proj-a');
+  });
+
+  it('backfills shared:<project>: rows from their source, mapping the home basename to user-global', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const homeName = path.basename(os.homedir()).toLowerCase();
+    writeEntry(storeRoot, createMemory('shared from proj b long ago', { source: 'shared:Proj-B:2026-01-01T00:00:00Z' }));
+    writeEntry(storeRoot, createMemory('shared from a home session', { source: `shared:${homeName}:2026-01-01T00:00:00Z` }));
+    regressStoreToV38(storeRoot);
+
+    closeHippoDb(openHippoDb(storeRoot)); // migrate
+    const entries = loadAllEntries(storeRoot);
+    const fromB = entries.find((e) => e.source.startsWith('shared:Proj-B'));
+    const fromHome = entries.find((e) => e.source.startsWith(`shared:${homeName}`));
+    expect(fromB?.origin_project).toBe('proj-b');
+    expect(fromHome?.origin_project).toBe('');
+  });
+
+  it('is idempotent: a second migration pass changes nothing', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    writeEntry(storeRoot, createMemory('row for idempotency check'));
+    regressStoreToV38(storeRoot);
+    closeHippoDb(openHippoDb(storeRoot));
+    const first = loadAllEntries(storeRoot).map((e) => [e.id, e.origin_project]);
+    closeHippoDb(openHippoDb(storeRoot));
+    const second = loadAllEntries(storeRoot).map((e) => [e.id, e.origin_project]);
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/origin-project-persistence.test.ts
+++ b/tests/origin-project-persistence.test.ts
@@ -10,6 +10,7 @@ import {
   serializeEntry,
   deserializeEntry,
   stampOriginProject,
+  batchWriteAndDelete,
 } from '../src/store.js';
 import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
 import { clearProjectIdentityCache } from '../src/project-identity.js';
@@ -55,6 +56,13 @@ describe('writeEntry origin stamping (v39)', () => {
     writeEntry(storeRoot, entry);
     const [loaded] = loadAllEntries(storeRoot);
     expect(loaded.origin_project).toBe('');
+  });
+
+  it('stamps origins on the batch write path too (consolidate bypasses writeEntry)', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    batchWriteAndDelete(storeRoot, [createMemory('a consolidated semantic summary row')], []);
+    const [entry] = loadAllEntries(storeRoot);
+    expect(entry.origin_project).toBe('proj-a');
   });
 
   it('stampOriginProject never mutates the input entry', () => {
@@ -123,6 +131,17 @@ describe('v39 migration backfill', () => {
     const fromHome = entries.find((e) => e.source.startsWith(`shared:${homeName}`));
     expect(fromB?.origin_project).toBe('proj-b');
     expect(fromHome?.origin_project).toBe('');
+  });
+
+  it('backfills promoted:<localRoot> rows with the promoting project', () => {
+    const storeRoot = makeProjectStore('proj-a');
+    const promotedFrom = path.join(tmpRoot, 'Proj-B', '.hippo');
+    writeEntry(storeRoot, createMemory('promoted from project b long ago', { source: `promoted:${promotedFrom}` }));
+    regressStoreToV38(storeRoot);
+
+    closeHippoDb(openHippoDb(storeRoot)); // migrate
+    const [entry] = loadAllEntries(storeRoot);
+    expect(entry.origin_project).toBe('proj-b');
   });
 
   it('is idempotent: a second migration pass changes nothing', () => {

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
-      expect(getCurrentSchemaVersion()).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
+      expect(getCurrentSchemaVersion()).toBe(39);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/project-identity.test.ts
+++ b/tests/project-identity.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  resolveProjectIdentity,
+  deriveOriginProject,
+  clearProjectIdentityCache,
+} from '../src/project-identity.js';
+
+let tmpRoot: string;
+let home: string;
+
+function mkdirs(...segments: string[]): string {
+  const p = path.join(tmpRoot, ...segments);
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-pid-'));
+  home = mkdirs('home');
+  // The global store lives in the home dir, like ~/.hippo on a real machine.
+  fs.mkdirSync(path.join(home, '.hippo'), { recursive: true });
+  clearProjectIdentityCache();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveProjectIdentity', () => {
+  it('resolves a project by its .hippo directory', () => {
+    const proj = mkdirs('home', 'my-app');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    const id = resolveProjectIdentity(proj, { homeDir: home });
+    expect(id).toEqual({ root: fs.realpathSync.native(proj), name: 'my-app', isHome: false });
+  });
+
+  it('resolves from a nested subdirectory to the nearest .hippo ancestor', () => {
+    const proj = mkdirs('home', 'my-app');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    const nested = mkdirs('home', 'my-app', 'src', 'deep');
+    const id = resolveProjectIdentity(nested, { homeDir: home });
+    expect(id.name).toBe('my-app');
+    expect(id.isHome).toBe(false);
+  });
+
+  it('falls back to the git root when no .hippo exists', () => {
+    const proj = mkdirs('home', 'git-only');
+    fs.mkdirSync(path.join(proj, '.git'));
+    const nested = mkdirs('home', 'git-only', 'src');
+    const id = resolveProjectIdentity(nested, { homeDir: home });
+    expect(id.name).toBe('git-only');
+    expect(id.isHome).toBe(false);
+  });
+
+  it('prefers .hippo over a nearer .git', () => {
+    const outer = mkdirs('home', 'mono');
+    fs.mkdirSync(path.join(outer, '.hippo'));
+    const inner = mkdirs('home', 'mono', 'vendored');
+    fs.mkdirSync(path.join(inner, '.git'));
+    const id = resolveProjectIdentity(inner, { homeDir: home });
+    expect(id.name).toBe('mono');
+  });
+
+  it('treats a .git worktree FILE as a git marker', () => {
+    const proj = mkdirs('home', 'wt');
+    fs.writeFileSync(path.join(proj, '.git'), 'gitdir: elsewhere\n');
+    const id = resolveProjectIdentity(proj, { homeDir: home });
+    expect(id.name).toBe('wt');
+  });
+
+  it('home itself is never a project despite containing .hippo (the global store)', () => {
+    const id = resolveProjectIdentity(home, { homeDir: home });
+    expect(id.isHome).toBe(true);
+    expect(id.name).toBe('');
+  });
+
+  it('a markerless directory under home resolves to the home identity', () => {
+    const misc = mkdirs('home', 'documents', 'notes');
+    const id = resolveProjectIdentity(misc, { homeDir: home });
+    expect(id.isHome).toBe(true);
+    expect(id.name).toBe('');
+  });
+
+  it('the walk from a child project does not treat home/.hippo as a project marker', () => {
+    // No .hippo/.git in the project dir itself; home/.hippo must not win.
+    const bare = mkdirs('home', 'bare-project');
+    const id = resolveProjectIdentity(bare, { homeDir: home });
+    expect(id.isHome).toBe(true);
+  });
+
+  it('a markerless directory outside home is not a project (user-global, empty name)', () => {
+    const outside = mkdirs('elsewhere', 'scratch');
+    const id = resolveProjectIdentity(outside, { homeDir: home, stopDir: tmpRoot });
+    expect(id.isHome).toBe(false);
+    expect(id.name).toBe('');
+    expect(id.root).toBe(fs.realpathSync.native(outside));
+  });
+
+  it('lowercases the project name', () => {
+    const proj = mkdirs('home', 'MyApp');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    const id = resolveProjectIdentity(proj, { homeDir: home });
+    expect(id.name).toBe('myapp');
+  });
+
+  it('caches by input path only when no test homeDir is injected', () => {
+    const proj = mkdirs('home', 'cached-app');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    const first = resolveProjectIdentity(proj, { homeDir: home });
+    // Remove the marker; an uncached resolve must now differ.
+    fs.rmdirSync(path.join(proj, '.hippo'));
+    const second = resolveProjectIdentity(proj, { homeDir: home });
+    expect(first.name).toBe('cached-app');
+    expect(second.isHome).toBe(true);
+  });
+
+  const junctionIt = process.platform === 'win32' ? it : it.skip;
+  junctionIt('resolves a junction alias to the same identity as the real path', () => {
+    const proj = mkdirs('home', 'real-app');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    const alias = path.join(tmpRoot, 'alias-app');
+    fs.symlinkSync(proj, alias, 'junction');
+    const viaAlias = resolveProjectIdentity(alias, { homeDir: home });
+    const viaReal = resolveProjectIdentity(proj, { homeDir: home });
+    expect(viaAlias.root).toBe(viaReal.root);
+    expect(viaAlias.name).toBe('real-app');
+  });
+});
+
+describe('deriveOriginProject', () => {
+  it('returns the project name inside a project', () => {
+    const proj = mkdirs('home', 'origin-app');
+    fs.mkdirSync(path.join(proj, '.hippo'));
+    expect(deriveOriginProject(proj, { homeDir: home })).toBe('origin-app');
+  });
+
+  it('returns the empty string (user-global) at or under home with no markers', () => {
+    expect(deriveOriginProject(home, { homeDir: home })).toBe('');
+    const misc = mkdirs('home', 'downloads');
+    expect(deriveOriginProject(misc, { homeDir: home })).toBe('');
+  });
+});

--- a/tests/secret-detect.test.ts
+++ b/tests/secret-detect.test.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { detectSecret } from '../src/secret-detect.js';
 import { initStore, writeEntry, loadAllEntries } from '../src/store.js';
 import { createMemory } from '../src/memory.js';
-import { shareMemory, autoShare, syncGlobalToLocal, getGlobalRoot } from '../src/shared.js';
+import { shareMemory, autoShare, syncGlobalToLocal, promoteToGlobal, getGlobalRoot } from '../src/shared.js';
 import { getContext, type Context } from '../src/api.js';
 import { clearProjectIdentityCache } from '../src/project-identity.js';
 
@@ -88,6 +88,18 @@ describe('producer + sync vetoes (real stores)', () => {
     writeEntry(projA, createMemory(CLEAN_ROW, { pinned: true, tags: ['error', 'gotcha'] }));
     const shared = autoShare(projA, { minScore: 0.6 });
     expect(shared.map((e) => e.content)).toEqual([CLEAN_ROW]);
+  });
+
+  it('promoteToGlobal refuses a secret row and stamps origin on clean promotes', () => {
+    writeEntry(projA, createMemory(SECRET_ROW, { pinned: true }));
+    writeEntry(projA, createMemory(CLEAN_ROW, { pinned: true }));
+    const rows = loadAllEntries(projA);
+    const secretRow = rows.find((e) => e.content === SECRET_ROW)!;
+    const cleanRow = rows.find((e) => e.content === CLEAN_ROW)!;
+    expect(() => promoteToGlobal(projA, secretRow.id)).toThrow(/secret/i);
+    const promoted = promoteToGlobal(projA, cleanRow.id);
+    expect(promoted.origin_project).toBe('proj-a');
+    expect(loadAllEntries(getGlobalRoot()).map((e) => e.content)).toEqual([CLEAN_ROW]);
   });
 
   it('shareMemory stamps the canonical origin on the global copy', () => {

--- a/tests/secret-detect.test.ts
+++ b/tests/secret-detect.test.ts
@@ -1,0 +1,137 @@
+/**
+ * v39 S4 secret detection + producer/consumer vetoes
+ * (docs/plans/2026-07-01-memory-scope-isolation.md).
+ * Real-DB per project convention for the store-level tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { detectSecret } from '../src/secret-detect.js';
+import { initStore, writeEntry, loadAllEntries } from '../src/store.js';
+import { createMemory } from '../src/memory.js';
+import { shareMemory, autoShare, syncGlobalToLocal, getGlobalRoot } from '../src/shared.js';
+import { getContext, type Context } from '../src/api.js';
+import { clearProjectIdentityCache } from '../src/project-identity.js';
+
+describe('detectSecret patterns', () => {
+  const flagged = (content: string, tags: string[] = []) => detectSecret({ content, tags }).flagged;
+
+  it('flags real key shapes', () => {
+    expect(flagged('aws creds AKIAIOSFODNN7EXAMPLE for the deploy user')).toBe(true);
+    expect(flagged('gh token ghp_abcdefghijklmnopqrstuvwxyz0123456789')).toBe(true);
+    expect(flagged('slack bot xoxb-123456789012-abcdefghij')).toBe(true);
+    expect(flagged('stripe sk_live_abcdefghijklmnop1234')).toBe(true);
+    expect(flagged('-----BEGIN RSA PRIVATE KEY-----')).toBe(true);
+    expect(flagged('the prod API key is sk-abcdefghij0123456789xyz')).toBe(true);
+    // The exact leaked shape from the 2026-06-30 incident.
+    expect(flagged('2chain prod API key for keith-personal: sk_keith_kit_8c4f2e91')).toBe(true);
+    expect(flagged('config sets api_key=9f8e7d6c5b4a3210ffff')).toBe(true);
+  });
+
+  it('flags by tag regardless of content', () => {
+    expect(flagged('rotate quarterly', ['api-key'])).toBe(true);
+    expect(flagged('rotate quarterly', ['SECRET'])).toBe(true);
+  });
+
+  it('does not flag benign prose', () => {
+    expect(flagged('the ghp_ prefix identifies GitHub personal access tokens')).toBe(false);
+    expect(flagged('use sklearn for the regression baseline')).toBe(false);
+    expect(flagged('the risk-free rate assumption is 4.2 percent')).toBe(false);
+    expect(flagged('prefer parameterized queries; never concatenate SQL')).toBe(false);
+    expect(flagged('password rotation policy: every 90 days, no reuse')).toBe(false);
+    expect(flagged('sk-hyphenated-words-in-prose read fine in plain writing')).toBe(false);
+  });
+});
+
+describe('producer + sync vetoes (real stores)', () => {
+  let tmpRoot: string;
+  let projA: string;
+  let globalStore: string;
+  let origHippoHome: string | undefined;
+
+  const SECRET_ROW = 'service api key sk_vendor_deadbeef123456 for the ingest worker';
+  const CLEAN_ROW = 'gotcha: powershell 5.1 has no pipeline chain operators, use if blocks';
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-secret-'));
+    projA = path.join(tmpRoot, 'proj-a', '.hippo');
+    fs.mkdirSync(projA, { recursive: true });
+    initStore(projA);
+    globalStore = path.join(tmpRoot, 'globalstore');
+    initStore(globalStore);
+    origHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalStore;
+    clearProjectIdentityCache();
+  });
+
+  afterEach(() => {
+    if (origHippoHome !== undefined) {
+      process.env.HIPPO_HOME = origHippoHome;
+    } else {
+      delete process.env.HIPPO_HOME;
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('shareMemory refuses a secret row even with force', () => {
+    writeEntry(projA, createMemory(SECRET_ROW, { pinned: true }));
+    const [row] = loadAllEntries(projA);
+    expect(() => shareMemory(projA, row.id, { force: true })).toThrow(/secret/i);
+    expect(loadAllEntries(getGlobalRoot())).toHaveLength(0);
+  });
+
+  it('autoShare silently skips secret rows and still shares clean ones', () => {
+    // error tag + pin push transferScore over the 0.6 bar for both rows.
+    writeEntry(projA, createMemory(SECRET_ROW, { pinned: true, tags: ['error', 'gotcha'] }));
+    writeEntry(projA, createMemory(CLEAN_ROW, { pinned: true, tags: ['error', 'gotcha'] }));
+    const shared = autoShare(projA, { minScore: 0.6 });
+    expect(shared.map((e) => e.content)).toEqual([CLEAN_ROW]);
+  });
+
+  it('shareMemory stamps the canonical origin on the global copy', () => {
+    writeEntry(projA, createMemory(CLEAN_ROW, { pinned: true }));
+    const [row] = loadAllEntries(projA);
+    const globalCopy = shareMemory(projA, row.id, { force: true });
+    expect(globalCopy?.origin_project).toBe('proj-a');
+    expect(globalCopy?.source).toMatch(/^shared:proj-a:/);
+  });
+
+  it('syncGlobalToLocal skips secrets and other-project rows, preserves origin on copies', () => {
+    writeEntry(globalStore, { ...createMemory(CLEAN_ROW), origin_project: '' });
+    writeEntry(globalStore, { ...createMemory('project b routing table quirk'), origin_project: 'proj-b' });
+    writeEntry(globalStore, { ...createMemory(SECRET_ROW), origin_project: '' });
+
+    const count = syncGlobalToLocal(projA, globalStore);
+    expect(count).toBe(1);
+    const local = loadAllEntries(projA);
+    expect(local.map((e) => e.content)).toEqual([CLEAN_ROW]);
+    expect(local[0].origin_project).toBe('');
+
+    const withCross = syncGlobalToLocal(projA, globalStore, { includeCrossProject: true });
+    expect(withCross).toBe(1); // proj-b row now copies; the secret still never does
+    expect(loadAllEntries(projA).map((e) => e.content)).not.toContain(SECRET_ROW);
+  });
+
+  it('ambient context never injects a secret outside its owning project, even cross-project or with isolation off', async () => {
+    writeEntry(globalStore, { ...createMemory(SECRET_ROW, { pinned: true }), origin_project: 'proj-b' });
+    writeEntry(globalStore, { ...createMemory('a user-global secret sk_vendor_cafe0123456', { pinned: true }), origin_project: '' });
+    const ctx: Context = { hippoRoot: projA, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+
+    const base = await getContext(ctx, { pinnedOnly: true, currentProject: 'proj-a' });
+    expect(base.entries).toHaveLength(0);
+
+    const cross = await getContext(ctx, { pinnedOnly: true, currentProject: 'proj-a', crossProject: true });
+    expect(cross.entries).toHaveLength(0);
+
+    fs.writeFileSync(path.join(projA, 'config.json'), JSON.stringify({ contextProjectIsolation: false }));
+    const legacyMode = await getContext(ctx, { pinnedOnly: true, currentProject: 'proj-a' });
+    expect(legacyMode.entries).toHaveLength(0);
+
+    // Inside the owning project the project-owned secret is ambient again;
+    // the origin-less one stays out everywhere.
+    const owner = await getContext(ctx, { pinnedOnly: true, currentProject: 'proj-b' });
+    expect(owner.entries.map((r) => r.entry.content)).toEqual([SECRET_ROW]);
+  });
+});

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(38);
+      expect(getSchemaVersion(db2)).toBe(39);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(38);
+      expect(getSchemaVersion(db2)).toBe(39);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(38);
+    expect(getCurrentSchemaVersion()).toBe(39);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(38);
+      expect(getSchemaVersion(db)).toBe(39);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
Fixes the cross-project context bleed (ROADMAP.md Part I [Committed], added in c7c7fdf): the every-turn UserPromptSubmit hook injected other-project memories, including a production API key, into unrelated sessions. Reproduced live from `shiny` before the fix: 19/19 injected entries were other projects' global-store rows.

## Root cause

1. `getContext` (the hook path) was the one reader bypassing the private-scope/default-deny filtering `api.recall` enforces.
2. Global-store rows merged into every session with no project-origin partition; `autoShare` only down-weighted `api-key`-tagged rows.
3. No secret detection existed on memory content anywhere.

## What this does

- **Origin model (schema v39):** every memory carries `origin_project` (project name / `''` user-global / NULL legacy = deny). Stamped from store location at write time via one choke point (`stampOriginProject`); migration backfills from store location + `shared:`/`promoted:` source evidence; NULL is sticky across writebacks (never laundered). Migration forward-bumps `min_compatible_binary` to 1.24.0 so pre-isolation binaries refuse migrated DBs.
- **Ambient partition:** `getContext` (all 3 modes), CLI render + ambient summary, MCP `hippo_context`, HTTP `/v1/context` exclude other-project rows by default. Escape hatches: `--cross-project` (demarcated render section), `cross_project=1`, config `contextProjectIsolation: false`. Explicit recall is untouched by design.
- **Secret hard veto:** new `src/secret-detect.ts` (tag veto + provider-bounded patterns, benign-prose tested). Secrets never share/promote/auto-share to global, never sync down, never ambient-inject outside their owning project (unconditional - no escape hatch re-includes them). Explicit recall still returns them.
- **Envelope parity:** private scopes + quarantine buckets never ambient-inject.
- `syncGlobalToLocal` origin-gated + secret-skipping; `shareMemory`/`promoteToGlobal` stamp canonical origins.

## Review process

Plan: codex plan review (REJECT, 18 findings) -> plan v2 applied all. Implementation: 6 codex gating rounds (4 P1 + 4 P2 + 3 + 2 + 1 + 1 findings), every finding fixed with a regression test; round 6 had no P1s. Plan + deltas in `docs/plans/2026-07-01-memory-scope-isolation.md`.

## Test plan

- [x] 14 project-identity unit tests (junction/realpath, home/.hippo-global trap, markerless dirs)
- [x] 14 origin-persistence tests (write stamping, batch/bootstrap paths, mirror round-trip, v39 backfill buckets incl. shared/promoted sources, NULL stickiness, idempotency, min-binary stamp)
- [x] 10 cross-project leak tests (two stores + initialized HIPPO_HOME: all 3 getContext modes, crossProject escape, config off-switch, non-project parity, dedupe-shadow, budget starvation, S2 parity)
- [x] 9 secret tests (detector positives incl. the leaked-key shape, benign-prose negatives, share/promote/autoShare vetoes, sync gating, 4-mode ambient consumer veto)
- [x] Full suite green: 2650 passed / 4 skipped (tests/server-concurrency.test.ts is a pre-existing flake under full parallel load on this machine; passes standalone repeatedly)
- [ ] Post-merge: `npm run build:all` + release as v1.24.0 (version manifests already bumped; CHANGELOG Unreleased entry included)
- [ ] Post-merge operational follow-up: one-time secret audit of the existing `~/.hippo` global store (producer veto stops recurrence; residue cleanup by id via store API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
