### PR TITLE
fix: reject malformed versions in rollback guard

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -36,13 +36,13 @@ export const PACKAGE_VERSION = '1.24.0';
  * pre-release semantics later, replace this with a real semver lib.
  */
 export function compareSemver(a: string, b: string): number {
-  const parse = (v: string): number[] =>
-    v.split('.').map((n) => {
-      if (!/^\d+$/.test(n)) {
-        throw new Error(`compareSemver: pre-release/build metadata not supported: ${v}`);
-      }
-      return Number(n);
-    });
+  const parse = (v: string): number[] => {
+    const parts = v.split('.');
+    if (parts.length !== 3 || parts.some((n) => !/^\d+$/.test(n))) {
+      throw new Error(`compareSemver: expected numeric x.y.z without pre-release/build metadata: ${v}`);
+    }
+    return parts.map(Number);
+  };
   const [a1, a2, a3] = parse(a);
   const [b1, b2, b3] = parse(b);
   if (a1 !== b1) return (a1 ?? 0) - (b1 ?? 0);

--- a/tests/github-v1.3.2-hotfix.test.ts
+++ b/tests/github-v1.3.2-hotfix.test.ts
@@ -84,8 +84,10 @@ describe('v1.3.2 P1: compareSemver throws on pre-release tags', () => {
     expect(() => compareSemver('1.3.2+build.42', '1.3.2')).toThrow(/pre-release/);
   });
 
-  it('throws on non-numeric segments', () => {
+  it('throws on malformed versions', () => {
     expect(() => compareSemver('one.two.three', '1.0.0')).toThrow(/pre-release/);
+    expect(() => compareSemver('1.3', '1.3.0')).toThrow(/expected numeric x\.y\.z/);
+    expect(() => compareSemver('1.3.0.1', '1.3.0')).toThrow(/expected numeric x\.y\.z/);
   });
 });
 


### PR DESCRIPTION
## Summary
- require `compareSemver` inputs to contain exactly three numeric components
- reject missing or extra components instead of silently treating them as zero/ignoring them
- add regression coverage for `1.3` and `1.3.0.1`

## Why
The rollback-safety guard promises strict `x.y.z` inputs, but the comparator previously treated `1.24` and `1.24.0.999` as equal to `1.24.0`. A malformed `min_compatible_binary` stamp could therefore pass without the documented loud failure.

## Verification
- `npm run build`
- `npx vitest run tests/github-v1.3.1-hotfix.test.ts tests/github-v1.3.2-hotfix.test.ts` (15 tests passed)
- verified `openHippoDb` rejects a database stamped with `1.24.0.999`
- `git diff --check`