### PR TITLE
fix: default-deny private scopes in CLI recall

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -898,6 +898,12 @@ async function cmdRecall(
   // A5 stub auth: resolve the active tenant once and thread it through every
   // recall-time SELECT against `memories`. Cross-tenant rows must never surface.
   const tenantId = resolveTenantId({});
+  const recallExplicitScope =
+    typeof flags['scope'] === 'string' ? flags['scope'].trim() || null : null;
+  const recallEntryFilter = recallExplicitScope
+    ? undefined
+    : (entry: MemoryEntry): boolean =>
+        api.passesScopeFilterForRecall(entry.scope ?? null, undefined);
 
   let localEntries = loadSearchEntries(hippoRoot, query, undefined, tenantId);
   let globalEntries = isInitialized(globalRoot) ? loadSearchEntries(globalRoot, query, undefined, tenantId) : [];
@@ -909,6 +915,11 @@ async function cmdRecall(
   // are NOT counted in v1 — they are part of the rank step, not a filter.
   const totalCandidatesCountCmd = localEntries.length + globalEntries.length;
   let droppedPreRankCountCmd = 0;
+  if (recallEntryFilter) {
+    localEntries = localEntries.filter(recallEntryFilter);
+    globalEntries = globalEntries.filter(recallEntryFilter);
+    droppedPreRankCountCmd += totalCandidatesCountCmd - (localEntries.length + globalEntries.length);
+  }
 
   // Bi-temporal filtering for physics path (hybridSearch handles it internally)
   if (asOf) {
@@ -960,7 +971,6 @@ async function cmdRecall(
   const minResults = flags['min-results'] !== undefined
     ? parseInt(String(flags['min-results']), 10)
     : undefined;
-  const recallExplicitScope = flags['scope'] !== undefined ? String(flags['scope']).trim() : null;
   const recallActiveScope = recallExplicitScope || detectScope();
 
   const useMultihop = flags['multihop'] === true || config.multihop.enabled;
@@ -1040,7 +1050,7 @@ async function cmdRecall(
     // Use searchBothHybrid for merged results with embedding support
     results = await searchBothHybrid(query, hippoRoot, globalRoot, {
       budget, mmr: mmrEnabled, mmrLambda, localBump, minResults, scope: recallActiveScope, tenantId,
-      includeSuperseded, asOf,
+      includeSuperseded, asOf, entryFilter: recallEntryFilter,
     });
   } else {
     results = await hybridSearch(query, localEntries, {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -197,9 +197,9 @@ export async function searchBothHybrid(
   // When an admission filter is active, lift the per-store candidate cap
   // (default 200): excluded rows matching the query could otherwise fill the
   // window before any admitted row is even loaded (codex gating round 6).
-  // Only ambient-context query mode sets entryFilter, and that path is
-  // interactive - never the per-turn pinned-only hook - so ranking the full
-  // match set is acceptable.
+  // Ambient-context query mode and unscoped CLI recall set entryFilter. Both
+  // are interactive - never the per-turn pinned-only hook - so ranking the
+  // full match set is acceptable.
   // 5000 = 25x the default 200-row window: large enough that exclusion
   // crowding is a non-issue on real stores, bounded so a common query term
   // on a 100k-row store cannot stall an interactive call by ranking every

--- a/tests/cli-recall-scope-filter.test.ts
+++ b/tests/cli-recall-scope-filter.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createMemory } from '../src/memory.js';
+import { initStore, writeEntry } from '../src/store.js';
+
+const CLI_PATH = join(__dirname, '..', 'dist', 'cli.js');
+
+function recallContents(
+  project: string,
+  home: string,
+  globalRoot: string,
+  ...args: string[]
+): string[] {
+  const stdout = execFileSync(
+    process.execPath,
+    [CLI_PATH, 'recall', 'canary', '--classic', '--json', ...args],
+    {
+      cwd: project,
+      env: { ...process.env, HOME: home, USERPROFILE: home, HIPPO_HOME: globalRoot },
+      encoding: 'utf8',
+    },
+  );
+  return (JSON.parse(stdout) as { results: Array<{ content: string }> })
+    .results.map((result) => result.content);
+}
+
+describe('CLI recall scope filtering', () => {
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH) || !statSync(CLI_PATH).isFile()) {
+      throw new Error(`dist/cli.js not found at ${CLI_PATH}. Run \`npm run build\` first.`);
+    }
+  });
+
+  it('default-denies private and legacy rows from local and global stores', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-cli-recall-scope-'));
+    const project = join(home, 'project');
+    const localRoot = join(project, '.hippo');
+    const globalRoot = join(home, '.hippo-global');
+    mkdirSync(localRoot, { recursive: true });
+    initStore(localRoot);
+    initStore(globalRoot);
+
+    writeEntry(localRoot, createMemory('public local canary', { scope: 'github:public:acme/open' }));
+    writeEntry(localRoot, createMemory('private local canary', { scope: 'github:private:acme/secret' }));
+    writeEntry(globalRoot, createMemory('public global canary', { scope: 'slack:public:Cgeneral' }));
+    writeEntry(globalRoot, createMemory('private global canary', { scope: 'slack:private:Csecret' }));
+    writeEntry(globalRoot, createMemory('legacy global canary', { scope: 'unknown:legacy' }));
+
+    try {
+      const contents = recallContents(project, home, globalRoot);
+      expect(contents).toContain('public local canary');
+      expect(contents).toContain('public global canary');
+      expect(contents).not.toContain('private local canary');
+      expect(contents).not.toContain('private global canary');
+      expect(contents).not.toContain('legacy global canary');
+
+      const localOnly = recallContents(project, home, join(home, 'missing-global'));
+      expect(localOnly).toContain('public local canary');
+      expect(localOnly).not.toContain('private local canary');
+
+      const explicitPrivate = recallContents(
+        project,
+        home,
+        globalRoot,
+        '--scope',
+        'github:private:acme/secret',
+      );
+      expect(explicitPrivate).toContain('private local canary');
+
+      const valuelessScope = recallContents(project, home, globalRoot, '--scope');
+      expect(valuelessScope).not.toContain('private local canary');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- apply the shared recall scope predicate to unscoped CLI candidates from both local and global stores
- pass the predicate into merged hybrid search so excluded rows cannot affect ranking, deduplication, or budgeting
- treat empty and valueless `--scope` flags as unscoped while preserving deliberate access through a non-empty explicit scope
- add end-to-end CLI coverage for local, global, private, public, and legacy-quarantine rows

## Why
`api.recall`, HTTP, and MCP default-deny `<source>:private:*` and `unknown:legacy` rows, but direct `cmdRecall` loaded candidates with `loadSearchEntries` and could return them to an unscoped caller. This addresses the first v1.24 post-ship item in `TODOS.md`.

## Verification
- `npm run build`
- 94 relevant tests passed across CLI recall, local/global hybrid search, API/MCP/HTTP scope filtering, context isolation, multihop, and DAG recall
- `git diff --check`

Docker is not required for this change.