### PR TITLE
fix: reject fractional drill depths

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1491,8 +1491,8 @@ export function drillDown(
 ): DrillDownOutcome {
   const limit = opts.limit ?? 50;
   // v0.30 / E5: depth defaults 1 (backward compat); hard cap 10 levels
-  // prevents pathological deep trees. CLI/HTTP/MCP layers also clamp.
-  const depth = Math.max(1, Math.min(opts.depth ?? 1, 10));
+  // prevents pathological deep trees. CLI/HTTP/MCP reject invalid values.
+  const depth = Math.max(1, Math.min(Math.trunc(opts.depth ?? 1), 10));
   const summary = readEntry(ctx.hippoRoot, summaryId, ctx.tenantId);
   // No unscoped cross-tenant probe here — readEntry's null return covers
   // both "doesn't exist" and "exists in another tenant" by design.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6736,7 +6736,7 @@ function cmdDrillDown(hippoRoot: string, summaryId: string, flags: Record<string
   const rawDepth = typeof flags['depth'] === 'string' ? Number(flags['depth']) : undefined;
   let depth: number | undefined;
   if (rawDepth !== undefined) {
-    if (!Number.isFinite(rawDepth) || rawDepth < 1 || rawDepth > 10) {
+    if (!Number.isInteger(rawDepth) || rawDepth < 1 || rawDepth > 10) {
       console.error(`--depth must be an integer between 1 and 10 (got ${flags['depth']})`);
       process.exit(2);
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -274,7 +274,7 @@ const TOOLS = [
           description: 'Max total token cost (~ chars/4) of returned children. Truncates chronologically.',
         },
         depth: {
-          type: 'number',
+          type: 'integer',
           minimum: 1,
           maximum: 10,
           description: 'v0.30 / E5: walk N levels down (default 1 = direct children only). Higher values include children of children. Token budget remains GLOBAL across levels. Hard cap 10.',
@@ -857,7 +857,7 @@ async function executeTool(
       let depth: number | undefined;
       if (args.depth !== undefined) {
         const depthRaw = Number(args.depth);
-        if (!Number.isFinite(depthRaw) || depthRaw < 1 || depthRaw > 10) {
+        if (!Number.isInteger(depthRaw) || depthRaw < 1 || depthRaw > 10) {
           return `depth must be an integer between 1 and 10 (got ${args.depth})`;
         }
         depth = depthRaw;

--- a/src/server.ts
+++ b/src/server.ts
@@ -918,7 +918,7 @@ async function handleRequest(
     if (depthRaw !== null) {
       const parsed = Number(depthRaw);
       // L4 fold: reject out-of-range explicitly (no silent clamp).
-      if (!Number.isFinite(parsed) || parsed < 1 || parsed > 10) {
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > 10) {
         throw new HttpError(400, 'depth must be a positive integer between 1 and 10');
       }
       depth = parsed;

--- a/tests/cli-drill.test.ts
+++ b/tests/cli-drill.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { initStore } from '../src/store.js';
+
+const CLI = resolve(__dirname, '..', 'bin', 'hippo.js');
+
+describe('hippo drill CLI', () => {
+  it('rejects fractional depth', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-cli-drill-'));
+    initStore(join(home, '.hippo'));
+
+    try {
+      execFileSync('node', [CLI, 'drill', 'missing', '--depth', '1.5'], {
+        cwd: home,
+        encoding: 'utf8',
+        env: { ...process.env, HIPPO_HOME: join(home, '.hippo-global') },
+      });
+      throw new Error('expected hippo drill to reject fractional depth');
+    } catch (error) {
+      const failure = error as { status?: number; stderr?: string | Buffer };
+      expect(failure.status).toBe(2);
+      expect(String(failure.stderr)).toContain('--depth must be an integer between 1 and 10');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/dag-e5-entity-profiles.test.ts
+++ b/tests/dag-e5-entity-profiles.test.ts
@@ -290,6 +290,17 @@ describe('v0.30 / E5 — level-3 entity profiles + drillDown depth', () => {
     expect(r.totalChildren).toBe(2);
   });
 
+  it('normalizes a fractional API depth before walking the DAG', () => {
+    const l3 = makeL3Profile('fractional depth profile', 'alice');
+    writeEntry(hippoRoot, l3);
+    const l2 = makeL2Summary('fractional depth topic', 'alice', l3.id);
+    writeEntry(hippoRoot, l2);
+    writeEntry(hippoRoot, makeL1Fact(l2.id, 'fractional depth leaf'));
+
+    const r = drillDown(defaultCtx(hippoRoot), l3.id, { depth: 1.5 }) as DrillDownResult;
+    expect(r.children.map((child) => child.id)).toEqual([l2.id]);
+  });
+
   it('test #8: drillDown depth=2 from L3 returns L2s + L1s with dedup + totalChildren=8', () => {
     const l3 = makeL3Profile('alice profile for depth test', 'alice');
     l3.descendant_count = 2; // stored direct-child count (2 L2 kids)

--- a/tests/http-drill.test.ts
+++ b/tests/http-drill.test.ts
@@ -105,6 +105,11 @@ describe('GET /v1/recall/drill/:id', () => {
     expect(res.status).toBe(400);
   });
 
+  it('400 on fractional depth', async () => {
+    const res = await fetch(`${handle.url}/v1/recall/drill/m_does_not_exist?depth=1.5`);
+    expect(res.status).toBe(400);
+  });
+
   it('budget truncates and sets truncated=true', async () => {
     const summary: MemoryEntry = createMemory('topic budget', {
       layer: Layer.Semantic, dag_level: 2, confidence: 'inferred',

--- a/tests/mcp-drill.test.ts
+++ b/tests/mcp-drill.test.ts
@@ -145,4 +145,13 @@ describe('mcp hippo_drill', () => {
     const text = extractText(res);
     expect(text.toLowerCase()).toContain('no summary_id');
   });
+
+  it('rejects fractional depth', async () => {
+    const res = await callTool(6, 'hippo_drill', { summary_id: 'missing', depth: 1.5 }, {
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: { subject: 'mcp', role: 'admin' },
+    });
+    expect(extractText(res)).toContain('depth must be an integer');
+  });
 });


### PR DESCRIPTION
## Summary
- reject fractional `depth` values at the CLI, HTTP, and MCP boundaries
- declare MCP `hippo_drill.depth` as an integer in the tool schema
- defensively truncate direct API depth before applying the existing 1–10 clamp
- add regression coverage for API, CLI, HTTP, and MCP behavior

## Why
Every surface describes drill depth as an integer, but the validators only checked finiteness and range. A value such as `1.5` therefore passed validation, and the BFS loop (`level < depth`) walked two levels instead of one.

## Verification
- `npm run build`
- 37 focused drill/DAG tests passed
- built CLI exits 2 for `hippo drill ... --depth 1.5` with the documented integer-range message
- `git diff --check`

Docker is not required for this change.