### PR TITLE
fix(mcp): honor zero context budget

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -323,7 +323,7 @@ const TOOLS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
-        budget: { type: 'number', description: 'Max tokens (default: 1500)' },
+        budget: { type: 'number', minimum: 0, description: 'Max tokens (default: 1500)' },
         scope: {
           type: 'string',
           description: 'Restrict memories and snapshot to this scope exactly. When omitted, default-deny applies to ANY <source>:private:* (slack, github, ...) and unknown-legacy rows.',
@@ -973,7 +973,11 @@ async function executeTool(
     }
 
     case 'hippo_context': {
-      const budget = Number(args.budget) || config.defaultContextBudget;
+      const budget = args.budget === undefined
+        ? config.defaultContextBudget
+        : Number(args.budget);
+      if (!Number.isFinite(budget) || budget < 0) return 'budget must be a non-negative number.';
+      if (budget === 0) return '';
       const explicitScope = typeof args.scope === 'string' && args.scope.length > 0
         ? String(args.scope)
         : undefined;

--- a/tests/mcp-context-scope.test.ts
+++ b/tests/mcp-context-scope.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { initStore, saveActiveTaskSnapshot, writeEntry } from '../src/store.js';
+import { initStore, readEntry, saveActiveTaskSnapshot, writeEntry } from '../src/store.js';
 import { createMemory } from '../src/memory.js';
 import { handleMcpRequest } from '../src/mcp/server.js';
 
@@ -44,6 +44,27 @@ describe('mcp hippo_context scope filter', () => {
 
   afterEach(() => {
     rmSync(home, { recursive: true, force: true });
+  });
+
+  it('budget=0 returns no context without marking memories retrieved', async () => {
+    const memory = createMemory('zero budget canary memory');
+    writeEntry(home, memory);
+    saveActiveTaskSnapshot(home, 'default', {
+      task: 'Zero budget snapshot',
+      summary: 'Must not be returned',
+      next_step: 'Stay hidden',
+      session_id: 'sess-zero-budget',
+      source: 'test',
+    });
+
+    const res = await callTool(0, 'hippo_context', { budget: 0 }, {
+      hippoRoot: home,
+      tenantId: 'default',
+      actor: { subject: 'mcp', role: 'admin' },
+    });
+
+    expect(extractText(res)).toBe('Done.');
+    expect(readEntry(home, memory.id)?.retrieval_count).toBe(0);
   });
 
   it('default-deny: no-scope caller does not see private-scope memories or snapshot', async () => {


### PR DESCRIPTION
## Problem

Calling `hippo_context` through MCP with `budget: 0` uses the configured default budget instead of returning no context. It can therefore return snapshots and memories—and mark matching memories retrieved—even though the caller requested a zero-token budget.

## Root cause

`Number(args.budget) || config.defaultContextBudget` treats the valid numeric value `0` as missing.

## Fix

- Default the budget only when the argument is omitted.
- Reject non-finite and negative values.
- Return before loading or mutating context when the budget is zero.
- Advertise the non-negative constraint in the MCP schema.

## Tests

- [x] Regression test verifies `budget: 0` returns no context and leaves `retrieval_count` unchanged.
- [x] `npx vitest run --no-file-parallelism --maxWorkers=1 tests/*mcp*.test.ts` — 57 passed.
- [x] Context/API/HTTP focused suite — 20 passed.
- [x] `npm run build`.