### PR TITLE
fix(cli): reject value-less --scope flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -913,6 +913,10 @@ async function cmdRecall(
   // FILTER input; recallActiveScope (which falls back to detectScope()) stays
   // boost-only — auto-detection must never become a filter input or
   // detected-project recalls would change shape.
+  if (flags['scope'] === true) {
+    console.error('--scope requires a value (e.g. --scope slack:private:C1).');
+    process.exit(1);
+  }
   const recallExplicitScope = flags['scope'] !== undefined ? String(flags['scope']).trim() : null;
   const requestedScopeForFilter = recallExplicitScope || undefined;
 
@@ -1951,6 +1955,10 @@ async function cmdExplain(
   // same unscoped loads, same fix, same semantics (explain explains what
   // recall would see). Flag hoisted above the loads; the note below keeps the
   // command honest for an operator debugging a hidden row.
+  if (flags['scope'] === true) {
+    console.error('--scope requires a value (e.g. --scope slack:private:C1).');
+    process.exit(1);
+  }
   const explainExplicitScope = flags['scope'] !== undefined ? String(flags['scope']).trim() : null;
   const explainRequestedScope = explainExplicitScope || undefined;
   let explainLocalEntries = loadRecallSearchEntries(hippoRoot, query, undefined, tenantId, explainRequestedScope, 'additive');

--- a/tests/cli-recall-scope-deny.test.ts
+++ b/tests/cli-recall-scope-deny.test.ts
@@ -80,6 +80,16 @@ describe('cli recall scope default-deny (v1.25.0)', () => {
     expect(out).not.toContain(LEGACY);
   });
 
+  it.each(['recall', 'explain'])('%s rejects a value-less --scope', (command) => {
+    const res = spawnSync('node', [HIPPO_BIN, command, 'deploykey', '--scope'], {
+      cwd: home,
+      env: { ...process.env, ...env },
+      encoding: 'utf-8',
+    });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('--scope requires a value');
+  });
+
   it('JSON output excludes denied rows pre-candidate (SQL predicate before the window)', () => {
     const raw = hippo(home, env, 'recall', 'deploykey', '--json', '--limit', '10');
     const parsed = JSON.parse(raw) as {


### PR DESCRIPTION
## Problem

A bare `--scope` on `hippo recall` or `hippo explain` is parsed as boolean `true`. Both commands then coerce it with `String(...)`, silently treating the malformed flag as the literal scope `"true"` and continuing successfully.

This addresses the v1.25.0 follow-up documented in `TODOS.md` as **Value-less `--scope` coercion polish**.

## Fix

Reject a boolean `--scope` before candidate loading in both affected commands and print an actionable example, matching the existing value-less `--hops` behavior.

Valid `--scope <value>` behavior is unchanged.

## Tests

- [x] Subprocess regressions verify both `recall` and `explain` exit 1 and report that `--scope` requires a value.
- [x] Focused CLI/scope suite: 15 passed.
- [x] New regressions isolated: 2 passed.
- [x] `npm run build`.

Full parallel suite on this machine: 2,638 passed and 29 timed out under load across unrelated heavy tests; the focused suites above pass in isolation.