### PR TITLE
fix: locomo harness newline truncation + correct the published tag-loss attribution

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -22,7 +22,8 @@ Cross-referenced from `ROADMAP-RESEARCH.md` §"Next 90 days". The full execution
 Surfaced while publishing the v1.25.0 LoCoMo baseline refresh
 (`docs/plans/2026-07-05-f7-locomo-baseline-refresh.md`,
 `benchmarks/LOCOMO_INVESTIGATION.md`). Neither blocked the baseline
-publication; both are recall/write-path correctness items.
+publication. The first is a recall correctness item; the second was
+reattributed and resolved the same day (harness bug, not hippo).
 
 - **Deterministic tie-breaking in recall ranking.** Cross-store run-to-run
   rank variance among near-duplicate score plateaus: no RNG exists in the
@@ -32,27 +33,21 @@ publication; both are recall/write-path correctness items.
   conversation-1 repeats gave mean_score 0.3630, stdev 0.0175 (range
   0.3401-0.3820, n=197 QAs per run). Candidate fix: a stable secondary sort
   key (e.g. content hash) at score ties.
-- **Rare silent loss of user-supplied `--tag` values on `remember`.** In the
-  LoCoMo v1.25.0 run, 13 distinct memory rows were stored with only the auto
-  `path:*` tag — the `conv:`/`session:`/`speaker:`/`dia:` tags passed at
-  `remember` time are absent — and those 13 rows surface in 33 of the 9,930
-  retrieved top-5 slots (1,986 QAs x 5; one row recurs in 11 QAs' top-5,
-  occurrence distribution 11,4,3,3,2,2,2,1,1,1,1,1,1). Repro pointers (the
-  divergence-causing subset — tagless AND gold evidence, so
-  content-recoverable): `benchmarks/locomo/results/hippo-v1.25.0-evidence.json`,
-  conv-41 qa_index 79 `top_k_memories[1]`; conv-43 qa_index 15
-  `top_k_memories[0]`; conv-43 qa_index 58 `top_k_memories[3]`. Needs
-  root-cause in the remember/write path. Impact: metadata-dependent
-  consumers (scope filters, tag-based recall boosts) silently undercount for
-  the affected rows. Store-level spot check (fresh re-ingest of conv-41 +
-  conv-43) confirms this is a write-path issue, not retrieval-path: all
-  turns stored in both conversations (conv-41 `turns=663 rows=663`; conv-43
-  `turns=680 remember_ok=680 rows=680` — no dedupe/merge loss), but conv-41
-  lost tags on 10/663 rows (1.5%) and conv-43 on 2/680 rows (0.3%), combined
-  12/1,343 (0.9%) stored with only the auto `path:*` tag — the ground-truth
-  rate; the 13 retrieved-unique rows are a lower bound consistent with it.
-  Root-cause candidate: an intermittent failure in whatever code path
-  attaches `conv:`/`session:`/`speaker:`/`dia:` tags during `hippo remember`.
+- **RESOLVED 2026-07-05 (same day) — silent loss of user-supplied `--tag`
+  values was a harness bug, not a hippo write-path bug.** The rows this
+  bullet originally described (13 tagless rows in the LoCoMo v1.25.0 run)
+  were caused by `benchmarks/locomo/run.py`'s `run_hippo` using
+  `shell=(sys.platform == "win32")`: cmd.exe truncates the built command
+  line at the first embedded newline, dropping every `--tag` argument on
+  turns whose text ends with `"\n"`. Hippo's write path is exonerated (one
+  writer of `tags_json`, unreachable ON CONFLICT branch, both import paths
+  hard-gated, markdown mirror carries the same stripped tags). Fixed via
+  `benchmarks/locomo/hippo_subproc.py` (never sets `shell=True`), wired into
+  `run.py` and `audit_matched_stores.py`, with regression coverage in
+  `benchmarks/locomo/test_hippo_subproc.py`. Full root-cause writeup:
+  `benchmarks/LOCOMO_INVESTIGATION.md`, "Correction 2026-07-05". Published
+  numbers unaffected (content-recovery fallback already absorbed the
+  tag-less rows).
 
 ### E2/E3 graph track — SHIPPED v1.16.0 → v1.22.0 (2026-06-03)
 

--- a/benchmarks/LOCOMO_INVESTIGATION.md
+++ b/benchmarks/LOCOMO_INVESTIGATION.md
@@ -16,6 +16,79 @@ gold-evidence recall does not show a meaningful retrieval regression.
 Open for quality improvement: absolute LoCoMo evidence recall is still low.
 Do NOT carry any framing from the (now closed) LongMemEval thread.
 
+**Correction 2026-07-05 (same day): tag-loss root cause reattributed.**
+The "tag-loss finding" published earlier today (below, under "Update
+2026-07-05") attributed the loss to hippo's **write path**. That
+attribution is wrong. Root cause is the **harness**, not hippo:
+`benchmarks/locomo/run.py`'s `run_hippo` used
+`shell=(sys.platform == "win32")`. On Windows, `subprocess.run(shell=True)`
+builds a `cmd.exe /c <line>` command line, and cmd.exe truncates that line
+at the first embedded newline. Every LoCoMo turn whose source text ends
+with `"\n"` therefore lost its closing quote and every `--tag` argument
+after it -- exit code stayed 0, because the truncated line was still
+syntactically valid.
+
+Evidence:
+
+- All 10 conv-41 and both conv-43 tagless rows' SOURCE texts end with a
+  trailing newline; their stored content is newline-stripped; healthy rows
+  have no trailing newline.
+- Deterministic 2-row-store repro, identical content: `shell=True` produces
+  a row with only the auto `path:*` tag and a stripped trailing newline;
+  `shell=False` produces the full tag set and the newline intact.
+- Full-sequence replay: `shell=False` gives 0/663 tagless rows on conv-41;
+  `shell=True` (uncontended) reproduces the exact same 10/663 as the
+  original run.
+- **Hippo exoneration (write-path enumeration, complete).** Exactly one SQL
+  statement writes `memories.tags_json` -- `upsertEntryRow`,
+  `src/store.ts:992`. Its `ON CONFLICT` branch is unreachable across
+  distinct `remember` calls because ids are random 12-hex and collision is
+  not something a normal run hits. Both files-to-DB import paths are
+  hard-gated: `bootstrapLegacyStore` no-ops on a non-empty DB
+  (`store.ts:871-873`); `rebuildIndex` filters to ids not already in the DB
+  (`store.ts:1785-1788`). The markdown mirror of an affected row carries
+  the SAME stripped tags as the DB row, proving the loss predates
+  `writeEntry` entirely. `cli.ts`'s `parseArgs` is positional with no
+  content-conditional branching that could drop tags for some inputs and
+  not others.
+
+The **measured rates are kept as measurements of the harness bug**, not
+deleted: 13 distinct tagless rows / 33 of 9,930 top-5 slots at the
+retrieval-sample level, 12/1,343 (0.9%) at the store level (conv-41
+10/663, conv-43 2/680) -- see "Tag-loss finding" below, unedited. The
+canonical published number is **unaffected**: `score_evidence.py`'s
+content-recovery fallback (`content_to_dia`) absorbed tag-less rows in
+both the April and July runs, so evidence recall@5 = 0.363369 stands.
+The same `shell=True` truncation existed in every April locomo run too
+(same `run_hippo` code, same platform).
+
+Fix + regression test + this correction ship together in
+`docs/plans/2026-07-05-locomo-harness-newline-fix.md`: a new
+`benchmarks/locomo/hippo_subproc.py` helper that never sets `shell=True`
+(also refuses `.cmd`/`.bat` HIPPO_BIN shims outright, since batch files
+transit `cmd.exe` regardless of the `shell=` argument -- the BatBadBut /
+CVE-2024-24576 class -- rather than being individually escapable), wired
+into `locomo/run.py` and `locomo/audit_matched_stores.py`. The judge
+subprocess calls in `run.py` (`:406` claude judge, `:506` command judge)
+are untouched: they pass the prompt via stdin, not argv, so they were
+never exposed to this bug.
+
+**Exposure audit** (which scripts pass hippo-bound content via argv vs
+stdin vs direct SQLite -- the newline-truncation bug can only fire on the
+argv path):
+
+| Site | Content path | Exposed? | Action |
+|---|---|---|---|
+| `locomo/run.py` `run_hippo` (remember + recall) | content + tags via **argv** | YES (the proven bug) | fixed via `hippo_subproc.py` |
+| `locomo/audit_matched_stores.py` `run_hippo` / `remember_turn` | content via **argv**, multi-build `--hippo-cmd` | YES | fixed via `hippo_subproc.py` (explicit `command=` param) |
+| `locomo/run.py` judge calls (`:406` claude-cli, `:506` command) | prompt via **stdin** (`input=`), not a hippo call | no | out of scope, documented |
+| `longmemeval/ingest.py` (`remember -` content) | content via **stdin** | no | UNEXPOSED, documented only |
+| `longmemeval/ingest_direct.py`, `ingest_enriched.py` | direct SQLite `INSERT`, no subprocess for content | no | UNEXPOSED, documented only |
+| `longmemeval/retrieve.py` (`recall <query>` argv) | query via argv, but queries are single-line question strings, never turn text | not exposed in practice | documented only, no code change |
+
+No LongMemEval script passes turn content through argv to a shelled-out
+hippo call, so no LongMemEval taint follow-up is filed.
+
 Update 2026-07-05: v1.25.0 baseline refresh (F7). ROADMAP F7 said "Never run
 before" — that was stale. `benchmarks/locomo/` (`run.py`, `score_evidence.py`)
 was run extensively in April 2026; what was missing was a *publishable
@@ -142,8 +215,9 @@ rows (0.9%) stored with only the auto `path:*` tag, no
 the ground-truth rate; the 13 retrieved-unique rows are consistent with it
 (retrieved-unique is a lower bound on stored tagless rows for the
 conversations involved, since most tagless rows are never retrieved into any
-QA's top-5). Same underlying write-path bug measured at two sampling depths,
-not conflicting numbers.
+QA's top-5). Same underlying harness bug measured at two sampling depths
+(see "Correction 2026-07-05" above -- this is the harness's `shell=True`
+newline truncation, not a hippo write-path bug), not conflicting numbers.
 
 **Mem0 / Letta context (not a comparison — different metric, different
 harness, never used to gate a feature):**

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -101,6 +101,8 @@ python score_evidence.py \
 
 **v1.25.0 baseline (2026-07-05):** evidence recall@5 = **0.363** — 2.10x the April v0.32.0 baseline (0.173) under the identical protocol (top-k 5, `--budget 4000`, fresh store per conversation, same on-disk data file — unmodified since 2026-04-22 per mtime; no April sha exists for cryptographic confirmation). This is a single-run point estimate with measured run-to-run variance (repeat stdev 0.0175 on a 197-QA conversation slice), and it is deterministic evidence recall, not comparable to Mem0/Letta's published LLM-judge LoCoMo numbers — different metric, different harness. Informational only; never gates a feature (ROADMAP F7). Full table, protocol, and caveats: `LOCOMO_INVESTIGATION.md`.
 
+**Same-day correction (2026-07-05):** the "tag-loss" finding published earlier the same day alongside this baseline was misattributed to hippo's write path. Root cause is a harness bug — `locomo/run.py` shelled out on Windows (`shell=True`), and cmd.exe truncates the command line at the first embedded newline, dropping every `--tag` argument on turns whose text ends with `"\n"`. Hippo's write path is exonerated; fixed via `locomo/hippo_subproc.py` (never uses `shell=True`). The measured rates stand as harness-bug data and the canonical 0.363 recall number is unaffected (content-recovery fallback already absorbed the tag-less rows). Full writeup: `LOCOMO_INVESTIGATION.md`, "Correction 2026-07-05".
+
 ## What each benchmark proves
 
 | | Sequential Learning | LongMemEval | LoCoMo |

--- a/benchmarks/locomo/README.md
+++ b/benchmarks/locomo/README.md
@@ -36,9 +36,14 @@ describe the April-era setup.
 
 ```bash
 pip install -r requirements.txt
-# Binary under test: globally installed `hippo` CLI by default, or point
-# HIPPO_BIN at any build (e.g. HIPPO_BIN="node <repo>/bin/hippo.js") —
-# the 2026-07-05 v1.25.0 baseline used HIPPO_BIN against a worktree build.
+# Binary under test: point HIPPO_BIN at a build (recommended), e.g.
+# HIPPO_BIN="node <repo>/bin/hippo.js" — the 2026-07-05 v1.25.0 baseline
+# used HIPPO_BIN against a worktree build this way. Without HIPPO_BIN, the
+# harness falls back to `hippo` on PATH, but ONLY if that resolves to a
+# real executable: a `.cmd`/`.bat` shim (e.g. a bare npm global install on
+# Windows) is refused with an actionable error rather than silently run
+# through cmd.exe, which can mangle argv content (see "Windows / HIPPO_BIN"
+# below).
 # Judge (judged mode only): uses `claude -p` CLI (no ANTHROPIC_API_KEY required)
 ```
 
@@ -85,8 +90,26 @@ Flags:
   `claude-cli`, gpt-4.1-mini for `openai`)
 - `--judge-command` — shell command for `--judge-backend command`
 - `--judge-timeout` — seconds per judge call (default: 60)
-- `HIPPO_BIN` — override the Hippo command for judged runs, for example
+- `HIPPO_BIN` — override the Hippo command used for every hippo
+  invocation (init/remember/recall, not just judged runs), for example
   `HIPPO_BIN='node C:/Users/skf_s/hippo-v032/bin/hippo.js'`
+
+### Windows / HIPPO_BIN
+
+`run.py` and `audit_matched_stores.py` invoke hippo via
+`benchmarks/locomo/hippo_subproc.py`, which never uses `shell=True`. If
+`HIPPO_BIN` resolves (or, when unset, `hippo` on PATH resolves) to a
+`.cmd`/`.bat` shim, the harness refuses to run it and raises an actionable
+error telling you to set `HIPPO_BIN` to a real executable or a direct
+interpreter invocation. This is deliberate: batch files always execute
+through `cmd.exe` regardless of the `shell=` argument passed to
+`subprocess.run` (the BatBadBut / CVE-2024-24576 class), so newlines, `%`
+expansion, `^`, and embedded quotes in turn content can be mangled no
+matter how carefully the argv is built — there is no safe way to shell out
+to a `.cmd`/`.bat` file with untrusted content. Point `HIPPO_BIN` at a
+`node <repo>/bin/hippo.js` invocation (recommended) or a real `hippo`
+executable; a bare `hippo` on PATH works only when PATH resolves to a real
+executable, not an npm `.cmd` shim.
 
 For version parity checks, run the audit with repeated `--hippo-cmd`
 arguments:
@@ -103,7 +126,9 @@ checks only.
 
 ## Non-negotiables honored
 
-1. Uses globally installed `hippo` CLI (v0.31.0 published artifact).
+1. Uses the `hippo` CLI — `HIPPO_BIN` pointed at a build (recommended) or,
+   if unset, a real `hippo` executable resolved from PATH (`.cmd`/`.bat`
+   shims refused, see "Windows / HIPPO_BIN" above).
 2. **Fresh HIPPO_HOME per conversation** (prevents cross-conversation leakage).
 3. No hippo source changes — measurement only.
 4. Judge model id logged in results.

--- a/benchmarks/locomo/audit_matched_stores.py
+++ b/benchmarks/locomo/audit_matched_stores.py
@@ -19,6 +19,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from hippo_subproc import run_hippo_argv
 from run import CATEGORY_NAMES, collect_turns, load_dataset
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -57,22 +58,18 @@ def run_hippo(
         "USERPROFILE": hippo_home,
         "HIPPO_SKIP_AUTO_INTEGRATIONS": "1",
     }
-    full_command = command + args
-    if sys.platform == "win32":
-        cmd: str | list[str] = subprocess.list2cmdline(full_command)
-        shell = True
-    else:
-        cmd = full_command
-        shell = False
-    return subprocess.run(
-        cmd,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
+    # command is the explicit --hippo-cmd argv prefix for this profile; used
+    # verbatim so multi-build comparisons keep targeting the right binary.
+    # hippo_subproc.run_hippo_argv never uses shell=True -- the old
+    # `subprocess.list2cmdline` + shell=True win32 branch let cmd.exe
+    # truncate the command line at the first embedded newline in turn text,
+    # silently dropping every --tag argument after it (see
+    # ../LOCOMO_INVESTIGATION.md, "Correction 2026-07-05").
+    return run_hippo_argv(
+        args,
+        command=command,
         env=env,
-        shell=shell,
+        cwd=cwd,
         timeout=timeout,
     )
 

--- a/benchmarks/locomo/hippo_subproc.py
+++ b/benchmarks/locomo/hippo_subproc.py
@@ -58,6 +58,25 @@ def _is_batch_shim(executable: str) -> bool:
     return Path(executable).suffix.lower() in _BATCH_SUFFIXES
 
 
+def _check_prefix_head(head: str) -> None:
+    """Refuse batch shims, including bare names that PATH-resolve to one.
+
+    Empirically (verified 2026-07-05 on this runtime): a bare name whose
+    only PATH match is a `.cmd`/`.bat` does NOT execute under shell=False --
+    CreateProcess appends `.exe` only, so the call fails with
+    FileNotFoundError and nothing runs. This check exists to turn that raw
+    failure into the actionable HIPPO_BIN hint, and to keep the refusal
+    guarantee independent of platform resolution quirks.
+    """
+    if _is_batch_shim(head):
+        raise HippoResolutionError(_REFUSAL_HINT.format(exe=head))
+    p = Path(head)
+    if p.suffix == "" and p.parent == Path("."):
+        resolved = shutil.which(head)
+        if resolved is not None and _is_batch_shim(resolved):
+            raise HippoResolutionError(_REFUSAL_HINT.format(exe=resolved))
+
+
 def resolve_hippo_command() -> list[str]:
     """Resolve the default argv prefix used to invoke hippo.
 
@@ -72,8 +91,7 @@ def resolve_hippo_command() -> list[str]:
         command = shlex.split(hippo_bin)
         if not command:
             raise HippoResolutionError(_NOT_FOUND_HINT)
-        if _is_batch_shim(command[0]):
-            raise HippoResolutionError(_REFUSAL_HINT.format(exe=command[0]))
+        _check_prefix_head(command[0])
         return command
 
     resolved = shutil.which("hippo")
@@ -114,8 +132,7 @@ def run_hippo_argv(
     if command is not None:
         if not command:
             raise HippoResolutionError(_NOT_FOUND_HINT)
-        if _is_batch_shim(command[0]):
-            raise HippoResolutionError(_REFUSAL_HINT.format(exe=command[0]))
+        _check_prefix_head(command[0])
         prefix = command
     else:
         prefix = resolve_hippo_command()

--- a/benchmarks/locomo/hippo_subproc.py
+++ b/benchmarks/locomo/hippo_subproc.py
@@ -104,8 +104,21 @@ def run_hippo_argv(
 
     `shell` is never set to True. Turn text and tags are passed as separate
     argv elements exactly as given -- no normalization, no quoting games.
+
+    The batch-shim refusal applies to explicit `command` prefixes too: an
+    explicit `.cmd`/`.bat` path executes through cmd.exe under CreateProcess
+    regardless of shell=False (the BatBadBut vector), so
+    `--hippo-cmd current=hippo.cmd` would silently reopen the truncation
+    bug on the audit path without this check.
     """
-    prefix = command if command is not None else resolve_hippo_command()
+    if command is not None:
+        if not command:
+            raise HippoResolutionError(_NOT_FOUND_HINT)
+        if _is_batch_shim(command[0]):
+            raise HippoResolutionError(_REFUSAL_HINT.format(exe=command[0]))
+        prefix = command
+    else:
+        prefix = resolve_hippo_command()
     full_argv = [*prefix, *args]
     return subprocess.run(
         full_argv,

--- a/benchmarks/locomo/hippo_subproc.py
+++ b/benchmarks/locomo/hippo_subproc.py
@@ -1,0 +1,121 @@
+"""Safe subprocess invocation for the hippo CLI (LoCoMo harness only).
+
+Root cause this module fixes: `run_hippo` in `run.py` and
+`audit_matched_stores.py` used `shell=(sys.platform == "win32")`. On
+Windows, `subprocess.run` with `shell=True` builds a `cmd.exe /c <line>`
+command line, and cmd.exe truncates that line at the first embedded
+newline. Any LoCoMo turn whose source text ends with `"\n"` silently lost
+its closing quote and every `--tag` argument after it — exit code stayed 0
+because the truncated line was still valid shell syntax. See
+`../LOCOMO_INVESTIGATION.md` ("Correction 2026-07-05") for the full proof
+chain.
+
+This module never sets `shell=True`. Content and tags are always passed as
+argv list elements, so cmd.exe's line parsing never gets a chance to see
+them. Batch shims (`hippo.cmd` / `hippo.bat`, e.g. an npm global install)
+are refused outright rather than special-cased: `CreateProcess` on a
+`.cmd`/`.bat` target transits `cmd.exe` regardless of the `shell=` argument
+you pass to `subprocess.run` (the BatBadBut / CVE-2024-24576 class), so no
+combination of quoting or escaping makes a batch-shim target safe for
+argv content that may itself contain metacharacters. Point `HIPPO_BIN` at
+a real executable or a `node <path>` invocation instead.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+_BATCH_SUFFIXES = (".cmd", ".bat")
+
+_REFUSAL_HINT = (
+    "hippo_subproc: refusing to invoke a batch shim ({exe!r}) via subprocess. "
+    "Batch files (.cmd/.bat) always execute through cmd.exe regardless of the "
+    "shell= argument, so command-line content (newlines, %VAR%, ^, quotes) can "
+    "be mangled or misinterpreted (the BatBadBut / CVE-2024-24576 class) -- no "
+    "amount of escaping makes this safe. Set HIPPO_BIN to a real executable or "
+    "a direct interpreter invocation, e.g.:\n"
+    '  HIPPO_BIN="node <repo>/bin/hippo.js"\n'
+    "so the hippo CLI is invoked without going through a shell at all."
+)
+
+_NOT_FOUND_HINT = (
+    "hippo_subproc: could not resolve a hippo executable. Set HIPPO_BIN to "
+    "either a single executable path or a command string, e.g.:\n"
+    '  HIPPO_BIN="node <repo>/bin/hippo.js"\n'
+    "or install `hippo` on PATH as a real executable (not a .cmd/.bat shim)."
+)
+
+
+class HippoResolutionError(RuntimeError):
+    """Raised when a safe hippo invocation command cannot be resolved."""
+
+
+def _is_batch_shim(executable: str) -> bool:
+    return Path(executable).suffix.lower() in _BATCH_SUFFIXES
+
+
+def resolve_hippo_command() -> list[str]:
+    """Resolve the default argv prefix used to invoke hippo.
+
+    Resolution order: `HIPPO_BIN` (shlex-split; may be a single executable
+    path or a full command string such as `node <repo>/bin/hippo.js`), else
+    `shutil.which("hippo")`. Raises `HippoResolutionError` if the resolved
+    executable is a `.cmd`/`.bat` batch shim, or if nothing resolves at all.
+    Never returns a value that could cause `None` to reach `subprocess.run`.
+    """
+    hippo_bin = os.environ.get("HIPPO_BIN")
+    if hippo_bin:
+        command = shlex.split(hippo_bin)
+        if not command:
+            raise HippoResolutionError(_NOT_FOUND_HINT)
+        if _is_batch_shim(command[0]):
+            raise HippoResolutionError(_REFUSAL_HINT.format(exe=command[0]))
+        return command
+
+    resolved = shutil.which("hippo")
+    if resolved is None:
+        raise HippoResolutionError(_NOT_FOUND_HINT)
+    if _is_batch_shim(resolved):
+        raise HippoResolutionError(_REFUSAL_HINT.format(exe=resolved))
+    return [resolved]
+
+
+def run_hippo_argv(
+    args: list[str],
+    *,
+    command: list[str] | None = None,
+    env: dict[str, str],
+    cwd: str,
+    timeout: int,
+    stdin_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a hippo CLI invocation safely, with content passed via argv.
+
+    `command` is an explicit argv prefix (e.g. `["node", "C:/repo/bin/hippo.js"]`)
+    used verbatim when given -- this preserves `audit_matched_stores.py`'s
+    multi-build `--hippo-cmd` capability, which must be able to target a
+    specific build regardless of `HIPPO_BIN`. When `command` is omitted, the
+    default resolution (`HIPPO_BIN` else `shutil.which("hippo")`) is used via
+    `resolve_hippo_command()`.
+
+    `shell` is never set to True. Turn text and tags are passed as separate
+    argv elements exactly as given -- no normalization, no quoting games.
+    """
+    prefix = command if command is not None else resolve_hippo_command()
+    full_argv = [*prefix, *args]
+    return subprocess.run(
+        full_argv,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        shell=False,
+        input=stdin_text,
+        timeout=timeout,
+    )

--- a/benchmarks/locomo/run.py
+++ b/benchmarks/locomo/run.py
@@ -12,7 +12,8 @@ Outputs a single JSON at results/hippo-v{version}.json with per-QA scores +
 overall + per-category aggregates.
 
 Honors the brief's non-negotiables:
-  - Uses globally installed `hippo` CLI.
+  - Uses the `hippo` CLI (HIPPO_BIN pointed at a build, recommended; or a
+    real `hippo` executable on PATH -- see README.md "Windows / HIPPO_BIN").
   - Fresh HIPPO_HOME per conversation (no cross-conversation leakage).
   - No hippo source changes.
   - Score mode, judge backend, and model id recorded in the output.
@@ -40,6 +41,8 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from tqdm import tqdm
+
+from hippo_subproc import run_hippo_argv
 
 logger = logging.getLogger(__name__)
 
@@ -165,22 +168,18 @@ def run_hippo(
     # Force isolation from global ~/.hippo as a belt-and-braces measure.
     env["HOME"] = hippo_home
     env["USERPROFILE"] = hippo_home
-    # Override the hippo binary via HIPPO_BIN. This may be either a single
-    # executable path or a command string such as `node C:/repo/bin/hippo.js`.
-    hippo_bin = os.environ.get("HIPPO_BIN")
-    cmd = shlex.split(hippo_bin) if hippo_bin else ["hippo"]
-    cmd += args
-    return subprocess.run(
-        cmd,
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
+    # Command resolution (HIPPO_BIN else PATH) and the actual subprocess
+    # call live in hippo_subproc.py: shell=True on win32 used to let cmd.exe
+    # truncate the command line at the first embedded newline in turn text,
+    # silently dropping every --tag argument after it (see
+    # ../LOCOMO_INVESTIGATION.md, "Correction 2026-07-05"). run_hippo_argv
+    # never uses shell=True.
+    return run_hippo_argv(
+        args,
         env=env,
-        shell=(sys.platform == "win32"),
-        input=stdin_text,
+        cwd=cwd,
         timeout=timeout,
+        stdin_text=stdin_text,
     )
 
 

--- a/benchmarks/locomo/test_hippo_subproc.py
+++ b/benchmarks/locomo/test_hippo_subproc.py
@@ -211,3 +211,21 @@ def test_no_hippo_bin_and_nothing_on_path_raises(tmp_path, monkeypatch):
             timeout=5,
         )
     assert "HIPPO_BIN" in str(exc_info.value)
+
+
+# --- (h): bare names that PATH-resolve to a batch shim are refused ---
+
+
+@pytest.mark.parametrize("via_command", [True, False])
+def test_bare_name_resolving_to_batch_shim_refused(tmp_path, monkeypatch, via_command):
+    shim = tmp_path / "hippo-v032.cmd"
+    shim.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setattr(shutil, "which", lambda name: str(shim) if name == "hippo-v032" else None)
+
+    kwargs = dict(env=dict(os.environ), cwd=str(tmp_path), timeout=10)
+    with pytest.raises(HippoResolutionError, match="batch shim"):
+        if via_command:
+            run_hippo_argv(["--version"], command=["hippo-v032"], **kwargs)
+        else:
+            monkeypatch.setenv("HIPPO_BIN", "hippo-v032")
+            run_hippo_argv(["--version"], **kwargs)

--- a/benchmarks/locomo/test_hippo_subproc.py
+++ b/benchmarks/locomo/test_hippo_subproc.py
@@ -1,0 +1,183 @@
+"""Tests for hippo_subproc.py -- argv fidelity + batch-shim refusal.
+
+Self-contained: no hippo binary required. HIPPO_BIN is stubbed with a
+throwaway python script (written to tmp_path per test) that records
+sys.argv + stdin to a JSON file. This exercises the exact code path that
+lost tags in production -- shell=True on win32 truncating the command line
+at the first embedded newline in turn text (see
+../LOCOMO_INVESTIGATION.md, "Correction 2026-07-05") -- without needing a
+real hippo build.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from hippo_subproc import HippoResolutionError, run_hippo_argv
+
+STUB_SCRIPT_SRC = """\
+import json
+import os
+import sys
+
+record = {"argv": sys.argv, "stdin": sys.stdin.read()}
+with open(os.environ["HIPPO_STUB_OUTPUT"], "w", encoding="utf-8") as f:
+    json.dump(record, f)
+"""
+
+
+def write_stub(tmp_path: Path) -> Path:
+    stub_path = tmp_path / "hippo_stub.py"
+    stub_path.write_text(STUB_SCRIPT_SRC, encoding="utf-8")
+    return stub_path
+
+
+def quoted_command(*parts: str) -> str:
+    """Build a HIPPO_BIN command string that survives shlex.split (posix mode).
+
+    Forward slashes only (matches the documented HIPPO_BIN convention) so
+    posix-mode shlex splitting never mistakes a Windows backslash for an
+    escape character.
+    """
+    return " ".join(shlex.quote(Path(part).as_posix()) for part in parts)
+
+
+def run_stub(
+    tmp_path: Path,
+    args: list[str],
+    *,
+    command: list[str] | None = None,
+    stdin_text: str = "",
+) -> dict:
+    output_path = tmp_path / "record.json"
+    env = {**os.environ, "HIPPO_STUB_OUTPUT": str(output_path)}
+    result = run_hippo_argv(
+        args,
+        command=command,
+        env=env,
+        cwd=str(tmp_path),
+        timeout=30,
+        stdin_text=stdin_text,
+    )
+    assert result.returncode == 0, f"stub failed: {result.stderr}"
+    return json.loads(output_path.read_text(encoding="utf-8"))
+
+
+# --- (a)/(b)/(c): byte-exact argv content ---
+
+
+def test_trailing_newline_content_and_tags_byte_exact(tmp_path, monkeypatch):
+    stub_path = write_stub(tmp_path)
+    monkeypatch.setenv("HIPPO_BIN", quoted_command(sys.executable, str(stub_path)))
+
+    text = "Kit: heading to the store now\n"
+    tags = ["conv:sample-1", "session:3", "speaker:Kit", "dia:D3:12"]
+    args = ["remember", text]
+    for tag in tags:
+        args.extend(["--tag", tag])
+
+    record = run_stub(tmp_path, args)
+    received = record["argv"][1:]  # drop the stub script's own argv[0]
+    assert received == args
+    assert received[1] == text  # exact trailing newline preserved
+
+
+def test_percent_content_byte_exact(tmp_path, monkeypatch):
+    stub_path = write_stub(tmp_path)
+    monkeypatch.setenv("HIPPO_BIN", quoted_command(sys.executable, str(stub_path)))
+
+    text = "%PATH% and 100% off"
+    args = ["remember", text, "--tag", "conv:sample-2"]
+
+    record = run_stub(tmp_path, args)
+    received = record["argv"][1:]
+    assert received == args
+    assert received[1] == text
+
+
+def test_interior_newline_content_byte_exact(tmp_path, monkeypatch):
+    stub_path = write_stub(tmp_path)
+    monkeypatch.setenv("HIPPO_BIN", quoted_command(sys.executable, str(stub_path)))
+
+    text = "first line\nsecond line\nthird line"
+    args = ["remember", text, "--tag", "conv:sample-3", "--tag", "dia:D1:2"]
+
+    record = run_stub(tmp_path, args)
+    received = record["argv"][1:]
+    assert received == args
+    assert received[1] == text
+
+
+# --- (d): .cmd/.bat shim refusal ---
+
+
+@pytest.mark.parametrize("suffix", [".cmd", ".bat"])
+def test_batch_shim_hippo_bin_refused(tmp_path, monkeypatch, suffix):
+    shim_path = tmp_path / f"hippo{suffix}"
+    shim_path.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setenv("HIPPO_BIN", quoted_command(str(shim_path)))
+
+    with pytest.raises(HippoResolutionError) as exc_info:
+        run_hippo_argv(
+            ["--version"],
+            env=os.environ.copy(),
+            cwd=str(tmp_path),
+            timeout=5,
+        )
+    message = str(exc_info.value)
+    assert "HIPPO_BIN" in message
+    assert suffix in message or "batch" in message.lower()
+
+
+def test_batch_shim_from_path_resolution_refused(tmp_path, monkeypatch):
+    monkeypatch.delenv("HIPPO_BIN", raising=False)
+    shim_path = tmp_path / "hippo.cmd"
+    shim_path.write_text("@echo off\n", encoding="utf-8")
+    monkeypatch.setattr(shutil, "which", lambda name: str(shim_path))
+
+    with pytest.raises(HippoResolutionError) as exc_info:
+        run_hippo_argv(
+            ["--version"],
+            env=os.environ.copy(),
+            cwd=str(tmp_path),
+            timeout=5,
+        )
+    assert "HIPPO_BIN" in str(exc_info.value)
+
+
+# --- (e): explicit command= used verbatim, HIPPO_BIN ignored ---
+
+
+def test_explicit_command_overrides_hippo_bin(tmp_path, monkeypatch):
+    stub_path = write_stub(tmp_path)
+    # Point HIPPO_BIN at something that would fail if it were ever consulted.
+    monkeypatch.setenv("HIPPO_BIN", "definitely-not-a-real-hippo-binary")
+
+    args = ["remember", "hello world", "--tag", "conv:sample-4"]
+    record = run_stub(tmp_path, args, command=[sys.executable, str(stub_path)])
+    received = record["argv"][1:]
+    assert received == args
+
+
+# --- (f): no HIPPO_BIN, nothing on PATH ---
+
+
+def test_no_hippo_bin_and_nothing_on_path_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv("HIPPO_BIN", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    with pytest.raises(HippoResolutionError) as exc_info:
+        run_hippo_argv(
+            ["--version"],
+            env=os.environ.copy(),
+            cwd=str(tmp_path),
+            timeout=5,
+        )
+    assert "HIPPO_BIN" in str(exc_info.value)

--- a/benchmarks/locomo/test_hippo_subproc.py
+++ b/benchmarks/locomo/test_hippo_subproc.py
@@ -2,11 +2,12 @@
 
 Self-contained: no hippo binary required. HIPPO_BIN is stubbed with a
 throwaway python script (written to tmp_path per test) that records
-sys.argv + stdin to a JSON file. This exercises the exact code path that
-lost tags in production -- shell=True on win32 truncating the command line
-at the first embedded newline in turn text (see
-../LOCOMO_INVESTIGATION.md, "Correction 2026-07-05") -- without needing a
-real hippo build.
+sys.argv + stdin to a JSON file. These are regression guards for the FIXED
+contract (argv reaches the child byte-exact, batch shims refused); they do
+not re-run the removed shell=True path that originally lost tags in
+production (cmd.exe truncating the command line at the first embedded
+newline in turn text -- see ../LOCOMO_INVESTIGATION.md, "Correction
+2026-07-05").
 """
 
 from __future__ import annotations
@@ -164,6 +165,35 @@ def test_explicit_command_overrides_hippo_bin(tmp_path, monkeypatch):
     record = run_stub(tmp_path, args, command=[sys.executable, str(stub_path)])
     received = record["argv"][1:]
     assert received == args
+
+
+# --- (g): explicit command= prefixes get the same batch-shim refusal ---
+
+
+@pytest.mark.parametrize("suffix", [".cmd", ".bat"])
+def test_explicit_command_batch_shim_refused(tmp_path, suffix):
+    shim = tmp_path / f"other-build{suffix}"
+    shim.write_text("@echo off\n", encoding="utf-8")
+
+    with pytest.raises(HippoResolutionError, match="batch shim"):
+        run_hippo_argv(
+            ["--version"],
+            command=[str(shim)],
+            env=dict(os.environ),
+            cwd=str(tmp_path),
+            timeout=10,
+        )
+
+
+def test_explicit_command_empty_list_refused(tmp_path):
+    with pytest.raises(HippoResolutionError):
+        run_hippo_argv(
+            ["--version"],
+            command=[],
+            env=dict(os.environ),
+            cwd=str(tmp_path),
+            timeout=10,
+        )
 
 
 # --- (f): no HIPPO_BIN, nothing on PATH ---

--- a/docs/plans/2026-07-05-locomo-harness-newline-fix.md
+++ b/docs/plans/2026-07-05-locomo-harness-newline-fix.md
@@ -1,0 +1,149 @@
+# LoCoMo harness newline-truncation fix + published-finding correction
+
+Status: Draft v2 (episode 01KWS4VK43CRKKK87DNZM10A8S, plan stage, revised after plan-eng-critic round 1)
+Date: 2026-07-05
+Branch: `fix/remember-tag-loss` (worktree off origin/master `dbb489e`)
+
+## Root cause (proven at discover; reframes the episode)
+
+The "silent user-tag loss on `remember`" published in PR #124 is NOT a hippo
+bug. `benchmarks/locomo/run.py`'s `run_hippo` uses
+`shell=(sys.platform == "win32")`; cmd.exe truncates the built command line
+at the first embedded newline, so any turn whose source text ends with
+`"\n"` silently loses its closing quote and EVERY subsequent `--tag`
+argument (exit code stays 0 — only the first line executes). Proof chain:
+
+- All 10 conv-41 tagless rows' SOURCE texts end with trailing newline(s);
+  stored contents are newline-stripped; healthy rows have no trailing
+  newline. Same for conv-43 (2 rows).
+- Deterministic 2-row-store repro: identical content, `shell=True` → row
+  with only auto `path:*` tags + stripped newline; `shell=False` → full
+  tags + newline preserved.
+- Full-sequence replays: `shell=False` 0/663 tagless; `shell=True`
+  (uncontended) exactly the same 10/663 as the original runs.
+- Hippo-side exoneration (debugger enumeration, complete): exactly one SQL
+  statement writes `memories.tags_json` (`upsertEntryRow`,
+  src/store.ts:992); id entropy makes its ON CONFLICT branch unreachable
+  across distinct `remember` calls; both files→DB import paths are
+  hard-gated (empty-DB-only / new-ids-only); the markdown mirror of an
+  affected row carries the SAME stripped tags, proving the loss predates
+  `writeEntry`; `parseArgs` is positional and content-blind.
+
+Published-number impact: NONE on the canonical baseline — the post-hoc
+scorer's content-recovery fallback absorbed tag-less rows in both April and
+July runs. The tie-breaking nondeterminism follow-up SURVIVES (truncation
+is deterministic and identical across repeat runs).
+
+## Exposure audit (which call sites actually pass content via argv)
+
+Verified per-script (plan-eng-critic round 1 corrected the first draft's
+over-broad "fix every shell= site" framing — exposure is a function of the
+content-passing MECHANISM, not of newlines in data):
+
+| Site | Content path | Exposed? | Action |
+|---|---|---|---|
+| `locomo/run.py` `run_hippo` (:157-185; used by remember + recall) | content + tags via **argv** | YES (the proven bug) | fix via helper |
+| `locomo/audit_matched_stores.py` (invocation `run_hippo` :46-77; argv content `remember_turn` :105-117) | content via **argv**, multi-build `--hippo-cmd` | YES | fix via helper (explicit command param) |
+| `locomo/run.py` :406, :506 (claude / command judge) | prompt via **stdin** (`input=`), not a hippo call | no | scope OUT, rationale documented |
+| `longmemeval/ingest.py` (:110 area) | `remember -` content via **stdin** | no | scope OUT, documented as unexposed |
+| `longmemeval/ingest_direct.py`, `ingest_enriched.py` (incl. :160 seed) | direct sqlite INSERT; only fixed dummy strings via argv | no | scope OUT, documented |
+| `longmemeval/retrieve.py` (:90, :104) | queries via argv (single-line question strings) | not content-exposed in practice | document ONLY — no code change to retrieve.py in this PR (a naive shell=False flip would break bare `hippo.cmd` resolution without the helper) |
+
+## Tasks
+
+- **T1 — safe invocation helper (sonnet executor).** New
+  `benchmarks/locomo/hippo_subproc.py` (SAME directory as its two
+  consumers — imports work exactly like the existing `from run import ...`
+  sibling pattern; no sys.path games):
+  - `run_hippo_argv(args, *, command=None, env, cwd, timeout, stdin_text=None)`
+    — `command` is an explicit argv-prefix list (preserves
+    `audit_matched_stores`' multi-build `--hippo-cmd` capability); default
+    resolution: `HIPPO_BIN` (shlex.split) else `shutil.which("hippo")`.
+  - `shell` is NEVER used. If the resolved default is a `.cmd`/`.bat` shim
+    (npm global), REFUSE with a clear error instructing `HIPPO_BIN=` —
+    no cmd.exe fallback at all (eliminates the whole metacharacter class:
+    newlines, `%` expansion, `^`, embedded quotes — rather than guarding a
+    denylist; batch shims always transit cmd.exe, the BatBadBut /
+    CVE-2024-24576 class, so no shell= setting makes them safe). If
+    resolution yields nothing at all (no `HIPPO_BIN`, `hippo` absent from
+    PATH), raise the SAME actionable error — never pass None to subprocess.
+  - `locomo/run.py` `run_hippo` and `audit_matched_stores.py` switch to it.
+    Judge subprocesses (:406/:506) untouched (stdin-fed, non-hippo).
+    Turn text stays byte-exact — no normalization.
+- **T2 — regression test (sonnet executor).**
+  `benchmarks/locomo/test_hippo_subproc.py` (pytest, self-contained): stub
+  HIPPO_BIN (python script dumping `sys.argv` + stdin to a file) receives
+  byte-exact: (a) trailing-newline content + 4 tags, (b) `%PATH%`- and
+  `100%`-bearing content, (c) interior-newline content; plus (d) the
+  `.cmd`-shim refusal raises with the HIPPO_BIN hint; (e) explicit
+  `command=` list is used verbatim (no HIPPO_BIN interference); (f) empty
+  resolution (no HIPPO_BIN, nothing on PATH) raises the actionable error.
+- **T3 — published-finding correction (sonnet executor, same dispatch).**
+  - `benchmarks/LOCOMO_INVESTIGATION.md`: dated correction amending the
+    2026-07-05 tag-loss paragraph — cause reattributed to the harness;
+    the measured rates KEPT as measurements of the harness bug (no silent
+    deletion of published measurements); hippo exoneration summary (the
+    writer enumeration + mirror-parity fact); numbers-unaffected rationale
+    scoped to the canonical rescored metric.
+  - `TODOS.md`: tag-loss follow-up replaced with a resolution note
+    (harness bug, fixed this episode, pointer); tie-breaking follow-up
+    KEPT unchanged.
+  - `benchmarks/locomo/README.md`: reconcile EVERY assertion of the
+    bare-global-`hippo` default with the new refusal behavior — the Setup
+    block (:37-43), the "globally installed hippo CLI by default" line
+    (:39-40), and Non-negotiable #1 (:106, "Uses globally installed hippo
+    CLI") — plus the HIPPO_BIN guidance and .cmd refusal rationale
+    (BatBadBut class). A Windows reader following the documented default
+    must not hit a refusal the doc elsewhere presents as supported.
+  - `benchmarks/README.md` + `LOCOMO_INVESTIGATION.md`: one-paragraph
+    exposure-audit table (the mechanism table above) so LongMemEval is
+    explicitly documented as UNEXPOSED (stdin / direct-sqlite ingestion) —
+    no taint follow-up is filed because no longmemeval script passes
+    content via argv.
+  - April-era note: same truncation existed in all April locomo runs;
+    affected rows likewise absorbed by content recovery. One sentence.
+- **T4 — ship.** Single PR: helper + run.py + audit_matched_stores.py +
+  test + 4 docs. No `src/` changes, no version bump, no npm publish.
+  Deploy = squash-merge.
+
+## Success criteria (falsifiable)
+
+Unit (self-contained pytest):
+1. `test_hippo_subproc.py` green: argv fidelity for newline/percent/interior
+   cases, `.cmd` refusal, explicit-command override.
+
+Integration (env prerequisite: worktree build + local locomo10.json):
+2. The 2-row deterministic repro run through the FIXED `run_hippo` stores
+   full tags + preserved trailing newline.
+   **Outcome note (post-verification):** tags full — PASS (the bug-fix
+   proof). The trailing-newline clause was MIS-SPECIFIED: hippo trims
+   content at intake by design (`src/memory.ts:484` `content.trim()`),
+   identically in every invocation mode, so stored trailing whitespace was
+   never the harness's to preserve. The correct byte-exactness contract is
+   at the process boundary (argv reaches hippo intact) — proven by the
+   stub-argv unit tests (trailing-newline, interior-newline, %-bearing
+   cases). April comparability unaffected (same intake trim then as now).
+3. Full 663-turn conv-41 re-ingest through the fixed harness: 0 tagless
+   rows (was deterministically 10). **Outcome: PASS — 663/663 rows, 0
+   tagless.**
+
+Docs:
+4. No remaining claim on master attributing tag loss to hippo's write path
+   (grep the corrected files); measured rates preserved as harness-bug data.
+5. Exposure-audit table present; no false LongMemEval taint claim anywhere.
+6. Tie-breaking follow-up still present in TODOS.md.
+7. No `src/` changes.
+
+## Risks
+
+- `.cmd` refusal changes behavior for bare-`hippo`-on-PATH Windows users of
+  the harness: they now get an actionable error instead of silent
+  mangling — strictly better; documented in the README note.
+- Correction wording must not oversell; "numbers unaffected" stays scoped
+  to the canonical rescored metric.
+
+## Out of scope
+
+Hippo src/ changes; re-running benchmarks (canonical numbers stand);
+longmemeval script refactors beyond documentation (unexposed); the
+tie-breaking follow-up (separate episode).


### PR DESCRIPTION
## What

Root-causes and fixes the "silent user-tag loss on `remember`" finding published this morning in #124, and corrects that finding: **it was never a hippo bug.** The LoCoMo harness invoked the hippo CLI with `shell=True` on Windows; cmd.exe truncates the built command line at the first embedded newline, so any turn whose source text ends with `\n` silently lost its closing quote and every `--tag` argument after it (exit code stayed 0). Benchmarks + docs only; no `src/` changes, no version bump, no npm publish.

## Proof chain

- All 12 tag-less rows across conv-41/conv-43 have trailing-newline source text and newline-stripped stored content; healthy rows have neither.
- Deterministic 2-row repro: identical content, `shell=True` loses tags, `shell=False` keeps them.
- Full-sequence replays: `shell=False` 0/663 tagless; `shell=True` (uncontended) the exact same 10/663 as the original runs.
- Hippo exonerated: exactly one SQL statement writes `memories.tags_json`; its conflict branch is unreachable across distinct remember calls; both file-import paths hard-gated; the markdown mirror of an affected row carries the same stripped tags (loss predates `writeEntry`); `parseArgs` is positional and content-blind.
- Canonical benchmark numbers unaffected: the post-hoc scorer's content-recovery fallback absorbed tag-less rows in April and July alike.
- After the fix: full 663-turn re-ingest through the harness yields 663/663 rows, 0 tagless (was deterministically 10).

## Changes

- New `benchmarks/locomo/hippo_subproc.py`: safe invocation helper. Never `shell=True`; explicit `command=` prefix preserves `audit_matched_stores`' multi-build capability; refuses `.cmd`/`.bat` batch shims outright, including bare names that PATH-resolve to one (batch files always transit cmd.exe regardless of `shell=` - the BatBadBut / CVE-2024-24576 class); actionable errors instead of silent mangling.
- `run.py` and `audit_matched_stores.py` rewired to the helper (env/stdin/timeout semantics preserved; stdin-fed judge calls untouched).
- New `test_hippo_subproc.py`: 13 self-contained argv-fidelity and refusal tests.
- Published-finding correction: `LOCOMO_INVESTIGATION.md` dated correction entry (proof chain, exoneration, exposure-audit table showing the LongMemEval scripts are structurally unexposed via stdin/direct-SQLite ingestion, measured rates kept as harness-bug data), `TODOS.md` tag-loss item resolved (tie-breaking follow-up unchanged), both READMEs reconciled.

## Test plan

- [x] 13/13 pytest (run three times: executor, code-review critic, ship-readiness critic)
- [x] Integration: 663-turn re-ingest via fixed harness = 0 tagless; 2-row repro tags intact
- [x] Empirical settlement of a cross-model reviewer disagreement (bare-name PATHEXT behavior tested live, not argued)
- [x] Zero `src/` changes; zero `benchmarks/longmemeval/` code changes
- [x] Secrets grep clean; no residual hippo-write-path claims outside the correction context

Gates (Opus critic arm, A/B round 2): plan-eng 58 to 85 (1 retry - caught a would-be false LongMemEval taint claim), code-review 92, independent-review 91, codex 3 rounds to clean (1 real find, 1 empirically refuted), ship-readiness 95. Episode 01KWS4VK43CRKKK87DNZM10A8S.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
