### PR TITLE
fix: deterministic recall across fresh ingests (v1.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.26.0 (2026-07-09)
+
+### Fixed
+- **Recall is now deterministic across fresh ingests of identical data.** Re-running an identical ingest into a fresh store used to produce different recall rankings run to run (LoCoMo conv-1 x4 fresh runs: evidence-recall@5 stdev 0.0175, range 0.3401-0.3820). Root cause was NOT a missing sort tiebreak alone: the dominant source was that embedding input text was `content + ALL tags`, and the auto `path:*` tags embed the store directory's path components - so a store created in a different directory (every fresh benchmark run, any renamed project folder) embedded DIFFERENT text for identical content, shifting similarities at the 1e-2 scale. Embedding input now excludes `path:*` tags (`embeddingInputText`, src/embeddings.ts). Retrieval semantics no longer depend on where the store lives. Verified: two fresh independent LoCoMo smoke runs now produce byte-identical per-question top-5 sets (10/10), with aggregate quality flat vs the previous build; the two-store probe's score deltas dropped from 6.6e-2 to 6.6e-8 (pure decay-at-read residual).
+- **Deterministic tie-breaking in recall ranking** (the residual half). New leaf module `src/compare.ts`: score ties at first-ranking sorts now break by content (UTF-16 code-unit order) then id, instead of falling to SQLite scan order / `crypto.randomUUID()` artifacts. SQL candidate loaders that decide LIMIT windows (`loadSearchRows` FTS + LIKE branches, `loadFreshRawMemories`, `loadEntriesByIds`) gained `content ASC, id ASC` tie keys so window membership is content-stable, not UUID-random. The physics scorer accepts a content tie key from `hybridSearch`/`physicsSearch` so the `cluster_top_k` amplification set is selected content-stably. Re-rank passes (goal boost, `--value-aware`, `--rerank-utility`, F6 boost, `--salience-threshold`, cross-encoder) deliberately stay PLAIN stable score sorts: their ties must preserve the prior meaningful ranking (a no-signal rerank pass must not reorder its input), and JS sort stability inherits the upstream determinism.
+
+### Changed
+- **One-time embedding reindex on upgrade (intended).** The stored embedding-index identity now carries an embed-text-format version (`<model>#t2`). Pre-1.26.0 indexes were computed over path-contaminated text, so the first embed-touching operation after upgrade rebuilds the index via the existing atomic reindex path. Until that happens, a RECALL-ONLY store gates dense/hybrid scoring off (BM25-only, deterministic) - run `hippo embed` once after upgrading to reindex immediately. Mixed hippo versions sharing a store will ping-pong reindexes (same class as an embedding-model swap); upgrade installs together.
+- `--evc-adaptive`'s on-topic test now accepts candidates by query coverage (fraction of query tokens present) as well as by score floor. The score floor alone proxied topicality through ranking score, and the disambiguating update the mechanic exists to surface (phrased differently by nature) measured 0.33x max under the corrected embeddings - below any sane floor. Query coverage is the mechanic's own "same topic, different fact" definition applied to the query, and is score-scale independent.
+
+### Known limitations
+- The lexical (BM25/FTS) corpus still tokenizes `path:*` tags: two stores whose directory paths differ in DEPTH have slightly different doc lengths, a residual determinism gap for BM25-only ranking flagged by cross-model review. Stripping path tags from the lexical index changes real matching behavior (project-name queries currently match `path:<project>` tags), so it is deferred as its own eval-gated change - tracked in TODOS.md.
+- Same-millisecond `created` collisions at SQL LIMIT boundaries and in the dedup survivor selection (`deduplicateStore`) remain per-instance-deterministic only - tracked in TODOS.md.
+
 ## 1.25.0 (2026-07-04)
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -25,14 +25,34 @@ Surfaced while publishing the v1.25.0 LoCoMo baseline refresh
 publication. The first is a recall correctness item; the second was
 reattributed and resolved the same day (harness bug, not hippo).
 
-- **Deterministic tie-breaking in recall ranking.** Cross-store run-to-run
-  rank variance among near-duplicate score plateaus: no RNG exists in the
-  retrieval code path (zero `Math.random` in `src/`), but wall-clock-derived
-  state (timestamps/ids) flips ordering among near-tied candidates across
-  independent runs on identical data. Measured on LoCoMo: 4 fresh
-  conversation-1 repeats gave mean_score 0.3630, stdev 0.0175 (range
-  0.3401-0.3820, n=197 QAs per run). Candidate fix: a stable secondary sort
-  key (e.g. content hash) at score ties.
+- **RESOLVED 2026-07-09 (v1.26.0, episode 01KX434KMAQSX4HRHYC67WDTJQ) -
+  deterministic tie-breaking in recall ranking.** The filed candidate fix
+  (content-hash at score ties) turned out to be DOWNSTREAM of the real
+  dominant cause: embedding input text included auto `path:*` tags (store
+  directory path), so every fresh benchmark run embedded different text for
+  identical content. Fixed at the producer (`embeddingInputText` excludes
+  `path:*`; stored index identity versioned `#t2` for a one-time reindex)
+  PLUS the residual tie keys (leaf `src/compare.ts` comparators at
+  first-ranking sorts; `content ASC, id ASC` SQL keys at window-deciding
+  loaders; content tie key threaded into the physics cluster_top_k
+  selection). Evidence: LoCoMo smoke x2 fresh runs 10/10 byte-identical
+  top-5 (was stdev 0.0175); probe deltas 6.6e-2 -> 6.6e-8; micro 11/11.
+  See `docs/plans/2026-07-09-recall-determinism.md` + CHANGELOG 1.26.0.
+  Follow-ups filed below.
+- **Follow-up (eval-gated): strip `path:*` tags from the lexical BM25/FTS
+  corpus too.** codex review (v1.26.0 episode, round 2): stores whose
+  directory paths differ in DEPTH still get different doc lengths in BM25
+  normalization - a residual determinism gap for BM25-only ranking. Blocked
+  on an eval because path tokens currently do real lexical work
+  (project-name queries match `path:<project>` tags in the FTS index,
+  db.ts fts5(id, content, tags)).
+- **Follow-up: dedup survivor selection is per-instance nondeterministic.**
+  `deduplicateStore` (src/dedupe.ts:41) sorts strength desc ->
+  retrieval_count desc with no further key; freshly-ingested near-duplicates
+  tie on both, so WHICH duplicate survives `hippo sleep` falls to random-id
+  load order. Same class as the v1.26.0 fix but changes surviving CONTENT
+  during consolidation - needs its own tests (independent-review finding,
+  v1.26.0 episode).
 - **RESOLVED 2026-07-05 (same day) — silent loss of user-supplied `--tag`
   values was a harness bug, not a hippo write-path bug.** The rows this
   bullet originally described (13 tagless rows in the LoCoMo v1.25.0 run)

--- a/benchmarks/LOCOMO_INVESTIGATION.md
+++ b/benchmarks/LOCOMO_INVESTIGATION.md
@@ -191,6 +191,27 @@ considerably — a rough guide (not a formal CI) is stdev/sqrt(10) ≈ 0.006 on
 the full-run aggregate. Candidate fix filed in `TODOS.md`: a stable
 secondary sort key (e.g. content hash) at score ties.
 
+**Correction 2026-07-09 (v1.26.0): the dominant mechanism was identified
+and fixed — it was NOT tie ordering.** The "wall-clock-derived state
+(timestamps/ids)" attribution above was refined by a controlled two-store
+probe (identical content, identical ingest order, differently-named store
+directories, one recall each): the dominant variance source was that
+**embedding input text included the auto `path:*` tags**, which carry every
+path component of the store directory — `run.py` uses
+`tempfile.mkdtemp(prefix="hippo_locomo_...")`, so every run embedded
+different text for identical content (measured: same-content embedding
+similarity 0.386 vs 0.374 across two stores differing only in dir name;
+final-score deltas up to 6.6e-2). Rebuilding a store at the SAME path was
+already order-identical with only ~1e-8 score jitter. v1.26.0 excludes
+`path:*` tags from embedding input (`embeddingInputText`) and adds the
+deterministic tie keys as the residual half. Post-fix: this smoke
+(`--conversations 1 --sample 10`) run twice on fresh stores produces
+byte-identical per-QA top-5 sets (10/10); aggregate flat vs pre-fix. The
+det-a..det-d spread above characterizes pre-1.26.0 builds only. See
+`docs/plans/2026-07-09-recall-determinism.md` and CHANGELOG 1.26.0
+(including the BM25 path-tag depth residual left as an eval-gated
+follow-up).
+
 **Tag-loss finding.** Full recount over the result file
 (`hippo-v1.25.0-evidence.json`, all 1,986 QAs x top-5 = 9,930 slots): **13
 distinct memory rows** carry no user-supplied

--- a/benchmarks/longmemeval/chunk_per_turn_hybrid_retrieve.mjs
+++ b/benchmarks/longmemeval/chunk_per_turn_hybrid_retrieve.mjs
@@ -286,7 +286,12 @@ for (let qi = 0; qi < questions.length; qi++) {
       }
     }
   }
-  const denseRanked = [...denseSessionMax.entries()].sort((a, b) => b[1].score - a[1].score);
+  // score desc -> session-id lexicographic tiebreak, so eval artifacts stop
+  // encoding Map iteration / scan order at ties (T2, deterministic tie keys).
+  const denseRanked = [...denseSessionMax.entries()].sort((a, b) => {
+    const d = b[1].score - a[1].score;
+    return d !== 0 ? d : (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+  });
 
   // ---- BM25 ----
   const qTerms = tokenize(q.question);
@@ -311,15 +316,26 @@ for (let qi = 0; qi < questions.length; qi++) {
       bm25SessionMax.set(sid, { score: s, bestDocIdx: i });
     }
   }
-  const bm25Ranked = [...bm25SessionMax.entries()].sort((a, b) => b[1].score - a[1].score);
+  // score desc -> session-id lexicographic tiebreak (same rationale as
+  // denseRanked above).
+  const bm25Ranked = [...bm25SessionMax.entries()].sort((a, b) => {
+    const d = b[1].score - a[1].score;
+    return d !== 0 ? d : (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+  });
 
   // ---- RRF fuse ----
   const bm25Sids = bm25Ranked.map(([sid]) => sid);
   const denseSids = denseRanked.map(([sid]) => sid);
   const fused = rrfFuse([bm25Sids, denseSids], [W_BM25, W_DENSE], { k: RRF_K_USED });
 
-  // Sort fused by score descending, take top-K
-  const topSids = [...fused.entries()].sort((a, b) => b[1] - a[1]).slice(0, TOP_K);
+  // Sort fused by score descending, take top-K. score desc -> session-id
+  // lexicographic tiebreak (same rationale as denseRanked/bm25Ranked above).
+  const topSids = [...fused.entries()]
+    .sort((a, b) => {
+      const d = b[1] - a[1];
+      return d !== 0 ? d : (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+    })
+    .slice(0, TOP_K);
 
   // Build retrieved_memories. Each row tagged with the session_id so
   // evaluate_retrieval.py's matcher works against `answer_session_ids`.

--- a/benchmarks/micro/fixtures/vmpfc_value.json
+++ b/benchmarks/micro/fixtures/vmpfc_value.json
@@ -1,27 +1,45 @@
 {
   "name": "vmpfc-value",
   "mechanic": "vmpfc-value",
-  "description": "vmPFC continuous value attribution (RESEARCH.md §PFC.vmPFC). Two near-equal-topic memories. The 'good' option accumulates positive outcomes; the 'bad' option accumulates negative outcomes. Without --value-aware, the bad option wins on raw BM25 (it has more query-term repetitions). With --value-aware, the cumulative outcome value attribution boosts good and demotes bad enough to flip the ranking. Reuses outcome_positive / outcome_negative columns; no schema change.",
+  "description": "vmPFC continuous value attribution (RESEARCH.md \u00a7PFC.vmPFC). Two near-equal-topic memories. The 'good' option accumulates positive outcomes; the 'bad' option accumulates negative outcomes. Without --value-aware, the bad option wins on raw lexical dominance; with --value-aware, the wider [0.7,1.3] multiplier flips the ranking. Premise recalibrated 2026-07-09 for the #t2 embed-text format (path tags removed from embeddings de-compressed similarity gaps): the pair was MEASURED to a raw no-outcome edge of 1.45x (MongoDB/Postgres), inside the (1.353, 1.857) window where the always-on outcome boost [0.85,1.15] preserves the bad option's no-flag win AND the --value-aware swing [0.7,1.3] flips it. See docs/plans/2026-07-09-recall-determinism.md.",
   "remembers": [
-    "Postgres is good for backend database tasks",
-    "MongoDB is good for backend database storage and backend database queries"
+    "Postgres works well for backend data storage",
+    "MongoDB is the backend database choice for backend database storage and backend database queries"
   ],
   "actions": [
-    {"type": "outcomes", "remember_index": 0, "good": 3, "bad": 0},
-    {"type": "outcomes", "remember_index": 1, "good": 0, "bad": 3}
+    {
+      "type": "outcomes",
+      "remember_index": 0,
+      "good": 3,
+      "bad": 0
+    },
+    {
+      "type": "outcomes",
+      "remember_index": 1,
+      "good": 0,
+      "bad": 3
+    }
   ],
   "queries": [
     {
       "q": "backend database choice",
-      "must_contain_any": ["MongoDB"],
+      "must_contain_any": [
+        "MongoDB"
+      ],
       "top_k": 1
     },
     {
       "q": "backend database choice",
-      "must_contain_any": ["Postgres"],
-      "must_not_contain_any": ["MongoDB"],
+      "must_contain_any": [
+        "Postgres"
+      ],
+      "must_not_contain_any": [
+        "MongoDB"
+      ],
       "top_k": 1,
-      "cli_args": ["--value-aware"]
+      "cli_args": [
+        "--value-aware"
+      ]
     }
   ]
 }

--- a/docs/plans/2026-07-09-recall-determinism.md
+++ b/docs/plans/2026-07-09-recall-determinism.md
@@ -1,0 +1,333 @@
+# Recall determinism: fix embed-text path contamination + deterministic tie keys
+
+Status: Draft (episode 01KX434KMAQSX4HRHYC67WDTJQ, branch `feat/recall-tie-break`)
+Date: 2026-07-09
+Origin: TODOS.md "New follow-ups from the F7 LoCoMo baseline episode" item 1
+("Deterministic tie-breaking in recall ranking", filed 2026-07-05).
+
+## Problem
+
+Cross-fresh-ingest rank variance: re-ingesting identical data into a fresh
+store produces different recall rankings run to run. Measured on LoCoMo
+conv-1 x4 fresh runs: mean evidence-recall@5 0.3630, stdev 0.0175
+(`benchmarks/LOCOMO_INVESTIGATION.md` "Determinism characterization").
+The filed candidate fix was "a stable secondary sort key (e.g. content hash)
+at score ties". Episode diagnosis shows that fix alone CANNOT close the
+measured variance: the dominant mechanism is upstream of any comparator.
+
+## Root cause (diagnosed empirically this episode)
+
+Probe: two fresh isolated stores, 15 identical rows ingested in identical
+order, ONE identical recall each (`--no-mmr`), scratchpad `tie_probe.py`.
+
+1. **DOMINANT - embedding text includes location noise.** Embedding input is
+   `` `${e.content} ${e.tags.join(' ')}`.trim() `` (src/embeddings.ts:236,
+   :401, :502) and auto `path:*` tags carry every cwd path component,
+   including the store directory name (cli.ts `extractPathTags(process.cwd())`).
+   Fresh benchmark runs use `tempfile.mkdtemp(prefix="hippo_locomo_...")`
+   (benchmarks/locomo/run.py:596) - a new dir name every run - so every run
+   embeds DIFFERENT text for the same content. Observed: `--why` embedding
+   similarity 0.386 vs 0.374 for the same row across two stores differing only
+   in dir name; final-score deltas up to 6e-2; whole-list rank reshuffles.
+   Beyond benchmarks this is a real product defect: retrieval semantics depend
+   on WHERE the store lives (rename a project dir -> similarity shifts).
+2. **RESIDUAL - no deterministic tie keys.** With identical store paths
+   (rebuild-in-place), ranking is already order-identical; scores differ only
+   at ~1e-8 (decay evaluated at a different `now`). True plateaus (score
+   spacing below that jitter; exact ties at the 1.0 normalization cap; RRF
+   integer-rank ties) are ordered by SQLite scan order / `crypto.randomUUID()`
+   id artifacts. Explore-agent map (episode trajectory) enumerates ~25
+   unbroken-tie `.sort()` sites and the SQL branches without tie keys:
+   store.ts:818 (FTS: `ORDER BY bm25, m.updated_at DESC` - updated_at is
+   SECOND-truncated), :839 (LIKE), :1532 (fresh-tail), plus
+   `loadEntriesByIds` (store.ts:1372) and `loadEntitiesByMemoryId`
+   (graph.ts:496) with no ORDER BY at all.
+3. **Context, not a defect:** recall mutates the store (markRetrieved:
+   retrieval_count+1, half_life +2d), so any initial flip is amplified across
+   a 197-query benchmark run. By design (retrieval strengthening); harnesses
+   must account for it; no change here.
+
+## Fix
+
+### T1 - exclude `path:*` tags from embedding input text
+
+- New helper `embeddingInputText(entry: {content, tags}): string` in
+  src/embeddings.ts: `content + ' ' + tags.filter(t => !t.startsWith('path:')).join(' ')`,
+  trimmed. Replace the three inline constructions (embeddings.ts:236 area
+  [rebuildEmbeddingIndex], :401 [embedMemory], :502 [embedAll]) with the helper.
+  Grep for any other `` `${e.content} ${e.tags.join(' ')}` `` construction and
+  route ALL of them through the helper (parallel-allowlist rule: enumerate
+  every site, one helper, no clones).
+- Only `path:*` is excluded. User/semantic tags (conv:, session:, speaker:,
+  dia:, error, scope:, etc.) remain embedded - they carry meaning. Path
+  relevance at recall time is ALREADY handled explicitly by the v39 scope
+  isolation layer (origin_project, pathOverlapScore), so embedding-level path
+  tokens are redundant with a dedicated mechanism, not a feature.
+- **Reindex invalidation (required) - choke-point design, not per-caller
+  edits.** Stored embedding indexes were computed with the old text format.
+  Fold an embed-text-format version into the stored index identity INSIDE the
+  two embeddings.ts seams, so every external caller that passes a bare
+  `provider.id` gets versioning for free (r1 critic CRIT resolved at the
+  root rather than by enumor-and-patch):
+  - `embeddingIndexIdentity(providerId): string` = `` `${providerId}#t2` ``
+    (new, embeddings.ts).
+  - `embeddingModelRequiresReindex(hippoRoot, model, index)` internally
+    compares `stored !== embeddingIndexIdentity(model)` (embeddings.ts:220).
+  - EVERY `saveStoredEmbeddingModel(hippoRoot, X)` call stores
+    `embeddingIndexIdentity(X)` (write sites: embeddings.ts:396, :408, :471 -
+    apply inside `saveStoredEmbeddingModel` itself so future writers can't
+    drift).
+  - Consistency invariant (the failure the r1 critic flagged): compare-side
+    and save-side MUST version identically, else every call reindexes in a
+    loop or none ever do. One helper used by both is the guarantee. Unit test
+    asserts: fresh store -> embed -> requiresReindex false; legacy store with
+    bare-id meta -> requiresReindex true (one-time migration reindex).
+  - External callers verified untouched-and-correct under this design:
+    search.ts:457 (hybridSearch embed gate), search.ts:897 (physicsSearch
+    fallback gate), cli.ts:3218 (status "model changed" hint), embeddings.ts
+    :388/:468 internal callers. `resolveIndexedEmbeddingModel`'s
+    DEFAULT_EMBEDDING_MODEL fallback for legacy index-without-meta stores
+    compares bare-vs-versioned -> mismatch -> exactly one reindex, then
+    stable. Executor MUST re-grep `embeddingModelRequiresReindex|
+    saveStoredEmbeddingModel|EMBEDDING_MODEL_META_KEY|getMeta.*embedding_model`
+    and reconcile any site not listed here.
+  Result: on next embed-touching operation, the index rebuilds with the new
+  text, atomically, via the existing reindex path - no new machinery, no
+  migration. Old stores keep working before reindex (embeddings are advisory;
+  BM25 path unaffected).
+- **FTS/BM25 deliberately untouched:** path tokens in the FTS index are
+  corpus-uniform per store (every row carries the same path tags), never match
+  benchmark queries, and BM25 doc-length effects are identical across
+  same-corpus stores. Not a cross-run variance source. Removing them from FTS
+  would be a separate, eval-gated change - out of scope.
+
+### T2 - deterministic tie keys (the filed item's literal ask)
+
+- Shared comparators in a NEW LEAF MODULE `src/compare.ts` (r2 critic HIGH:
+  search.ts placement would create a search.ts<->physics.ts ESM import cycle
+  since search.ts already imports physicsScore/computeMass from physics.ts).
+  `src/compare.ts` imports NOTHING from any sort-site module (type-only
+  imports acceptable; prefer structural param types so it stays a true leaf):
+  - `compareEntryIdentity(a, b)`: content ascending byte compare
+    (`<`/`>`, not localeCompare) -> id ascending. The cross-ingest-stable
+    tail (ids are `crypto.randomUUID()`, per-instance only; content is the
+    cross-ingest key). Full-content byte compare is O(len) worst case but
+    ties are rare post-T1 - no hashing needed.
+  - `compareScoredResults(a, b)`: score desc -> compareEntryIdentity.
+  Mirror the deliberate-determinism pattern already in
+  graph-stream.ts:88,165,233 (comments included).
+- Two distinct application shapes (r1 critic HIGH resolved - the shared
+  comparator must never REPLACE a site's true primary key):
+  a. **Score-primary sites with entry/content in scope** - delegate
+     wholesale to `compareScoredResults`:
+     search.ts:680, :725, :1034, :1154, :1195;
+     shared.ts:145, :290; goals.ts:360; api.ts:2276, :2296, :2305, :2307;
+     cli.ts:1207, :1235, :1270, :1344, :1426; graph-recall.ts:266;
+     multihop.ts:41; rerankers/cross-encoder.ts:109 (score field there is
+     `rerankScore` - thin arrow delegating the tail).
+  b. **Non-score-primary sites** - KEEP the site's true primary key and
+     append the deterministic TAIL (`compareEntryIdentity`: content asc ->
+     id asc) only where the existing keys tie:
+     - api.ts:833 - primary = overflow-child count desc (DAG substitution);
+     - cli.ts:1167 - primary = created recency desc (--evc-adaptive);
+     - graph-recall.ts:248 - primary = hops asc, then score desc, THEN tail.
+     Export the tail as its own tiny function so (a)'s comparator composes it
+     (`compareScoredResults = score desc -> compareEntryIdentity`).
+  c. **Physics-layer sites (no content in scope)** - physics.ts:436, :442
+     sort `ScoredPhysicsResult` ({memoryId, baseScore, clusterAmplification,
+     finalScore} - NO entry/content at that layer; r2 critic HIGH). Rule
+     there: score desc -> `memoryId` asc, via a
+     `comparePhysicsResults`-style thin comparator in src/compare.ts
+     (documented as per-instance-only determinism - kills scan-order
+     dependence and stabilizes the cluster_top_k amplification cut).
+     Cross-ingest identity is enforced DOWNSTREAM at search.ts:1034, where
+     the physics+classic merge has `entry.content` in scope and gets the
+     full `compareScoredResults`.
+  d. **Already-deterministic sites, kept with a note** - api.ts:2232
+     (includeRecent: created desc -> id localeCompare) already carries an
+     explicit per-instance tiebreak; created reflects ingest order so it is
+     cross-ingest stable at ms granularity. Leave logic as-is; add a comment
+     referencing compare.ts so future editors know the pattern is deliberate
+     (r2 critic LOW - dropped from the r1 map without note).
+  - Also: search.ts:499-500 (`bm25Ranked`/`cosineRanked` pre-RRF rankings,
+    feed selectGraphSeeds + RRF rank assignment) get the tail appended after
+    their score keys (r1 critic LOW - on the recall path, was missing from
+    the map).
+  Where the sorted element shape differs (e.g. `{entry, score}` vs raw rows
+  vs `{score, rerankScore}`), use a thin arrow that delegates to the shared
+  key logic - no per-site reimplementation of the ordering rule. The executor
+  MUST re-grep `\.sort\(` across src/ and reconcile against this list before
+  finishing - the list is a map, the grep is the law (enumerate-all rule);
+  every site is classified (a), (b), (c), (d), or explicitly out-of-scope
+  with reason. MMR's strict-`>` first-wins loop
+  (search.ts:788-841) is already deterministic given deterministic input
+  order - add a comment, no logic change.
+- SQL tie keys (per-instance stability so scan order never decides):
+  store.ts:818 FTS -> append `, m.id ASC`; :839 LIKE -> append `, id ASC`;
+  :1532 fresh-tail -> `ORDER BY created DESC, id DESC`; loadEntriesByIds
+  (store.ts:1372) -> `ORDER BY created ASC, id ASC`; graph.ts
+  `loadEntitiesByMemoryId` -> `ORDER BY id ASC`.
+- Benchmark harness sorts (benchmarks/longmemeval/chunk_per_turn_hybrid_retrieve.mjs:289,
+  :314, :322): add `|| sid-lexicographic` tiebreaks so eval artifacts stop
+  encoding scan order. Small, isolated, keeps future eval numbers honest.
+
+### T3 - regression tests (real DB, per project convention)
+
+- `tests/recall-cross-store-determinism.test.ts`: build two stores in temp
+  dirs with DIFFERENT directory names, identical content ingested in identical
+  order (via writeEntry with path-style tags mimicking cmdRemember), run
+  `hybridSearch` (and `searchBothHybrid`) with identical queries -> assert
+  identical top-K CONTENT sequences. This is the acceptance criterion as a
+  permanent test; it FAILS on master today (validated in-episode before fix).
+- Comparator unit tests: equal scores -> content order decides; equal
+  score+content -> id decides; embeddingInputText excludes exactly `path:*`.
+- Primary-key preservation tests for the three non-score-primary sites (r1
+  critic MED): DAG substitution still orders by overflow-child count when
+  counts differ (api.ts:833); --evc-adaptive still orders by recency
+  (cli.ts:1167 - test at the sorted-array level or via existing CLI-path
+  tests); graph-hop ordering still puts 1-hop before 2-hop regardless of
+  score (graph-recall.ts:248). Each asserts the primary key WINS over the
+  new tail, plus one tie case where the tail decides.
+- Reindex-identity tests: fresh store embed -> requiresReindex false
+  (compare/save consistency - catches the reindex-loop failure mode);
+  legacy store with bare-id meta -> requiresReindex true exactly once.
+
+### T4 - docs
+
+- CHANGELOG 1.26.0 entry (root cause + both fixes + reindex note).
+  MUST include the legacy-store degradation window explicitly (r2 critic
+  LOW): a pre-upgrade store on a recall-only workload gates embeddings on
+  `!embeddingModelRequiresReindex` (search.ts:457, :897) and therefore runs
+  BM25-only until an embed-touching op fires - advise running `hippo embed`
+  once after upgrade to reindex immediately.
+- TODOS.md: close the item with the corrected root cause (the filed
+  "content-hash at ties" hypothesis was downstream; path-tag embedding
+  contamination was dominant).
+- benchmarks/LOCOMO_INVESTIGATION.md: append a dated correction to the
+  "Determinism characterization" paragraph attributing the measured stdev to
+  path-tag embed contamination (with the same-path rebuild evidence), pointing
+  at this plan.
+- README "What's new" line.
+
+### T5 - version + release
+
+Minor bump 1.25.0 -> 1.26.0 (behavior change: embedding text composition +
+reindex trigger; additive determinism guarantees). 5 lockstep manifests
+(package.json, openclaw.plugin.json, extensions/openclaw-plugin/{package.json,
+openclaw.plugin.json}, src/version.ts) - `scripts/check-manifest-versions.mjs`
+enforces via prepublishOnly. `npm run build:all` before ship (AGENTS.md).
+
+## Verify-stage evidence (gates)
+
+1. `npm test` (vitest, real DB) green including new tests.
+2. Tier-1 micro-eval 100% (`python benchmarks/micro/run.py`).
+3. Determinism probe (the acceptance): two fresh DIFFERENT-path stores,
+   identical ingest, identical recalls -> identical top-5 content sets. Both
+   as the new vitest test and re-running the episode probe script.
+4. Tier-2 LoCoMo smoke (`--conversations 1 --sample 10 --score-mode evidence`,
+   data from main repo `benchmarks/locomo/data/locomo10.json`, HIPPO_BIN =
+   worktree build): delta vs prior smoke within noise; PLUS run twice with
+   fresh temp dirs -> identical per-QA top-5 evidence sets (the LoCoMo-scale
+   acceptance).
+5. Within-store no-regression: same-path rebuild ordering unchanged vs master
+   for a non-tied fixture (micro-eval covers).
+
+## Risks / mitigations
+
+- **Retrieval-quality shift from removing path tokens (T1).** Path tokens
+  could have been doing accidental useful work in similarity for
+  project-scoped queries (e.g. a query naming a project matching its
+  `path:<project>` tag). Mitigation: (a) the FTS index covers tags
+  (`fts5(id UNINDEXED, content, tags)`, db.ts:2336), so project-name queries
+  still match path tags through the BM25 channel; (b) recall-time path
+  relevance has a dedicated mechanism (v39 origin_project/pathOverlapScore);
+  (c) micro-eval non-regression gate + LoCoMo smoke delta. If micro-eval
+  regresses, STOP and re-scope with the operator.
+- **Residual 1e-8 decay jitter can still cross near-ties.** The comparator
+  fires on EXACT score equality only; two distinct scores 1e-9 apart can
+  still swap across runs recalled at different times. Post-fix probability is
+  negligible for real data; the double LoCoMo smoke (verify item 4) is the
+  falsifier. If it flips there, epsilon-banding is the pre-registered
+  escalation - operator decision, NOT silently added here (arbitrary epsilon
+  changes ranking semantics).
+- **Mixed-version stores ping-pong reindexes.** An older hippo reading a
+  `#t2`-identity index sees a mismatch and reindexes back. Same class as an
+  embedding-model swap; single-version deployments unaffected. CHANGELOG note.
+- **Reindex cost on large stores.** First embed-touching op after upgrade
+  rebuilds the index. Existing machinery already does this on model change;
+  atomic (no partial index on failure). Note in CHANGELOG.
+- **Comparator perf.** Content byte-compare only runs on exact score ties;
+  post-T1 ties are rare. No measurable hot-path cost expected; p99 harness
+  exists if challenged.
+- **25-site sweep touching hot paths.** Mechanical, but wide. Mitigation:
+  one shared comparator (no divergent clones), full vitest suite, micro-eval,
+  snapshot tests already lock CLI render output.
+
+## Out of scope
+
+- **dedupe.ts:41-45 survivor selection** (independent-review finding, review
+  round 1). `deduplicateStore` sorts by strength desc -> retrieval_count desc
+  with no further key; for freshly-ingested near-duplicates the stable-sort
+  fallback resolves to `created ASC, id ASC` load order, and `id` is a random
+  UUID - so WHICH duplicate row survives consolidation can differ across
+  fresh ingests. Same determinism class as this episode, but it changes
+  surviving CONTENT during `hippo sleep`, not recall rank - a behavior
+  change to consolidation deserving its own test coverage. Filed as a
+  follow-up in TODOS.md at ship stage rather than folded in late at review.
+- **api.ts assemble-path `cmpIso` chronological sorts** (same review, low).
+  Pre-existing, same-ms residual only, context assembly not recall ranking.
+- FTS/BM25 indexing of tags (separate eval-gated change).
+- `scope:` tag semantics (detectScope derivation) - noted, not changed.
+- api.recall's positional scoring divergence from CLI/MCP (A7.2 unification,
+  has its own roadmap slot).
+- Retrieval-strengthening mutation semantics.
+- Full LoCoMo re-baseline (tier-3): follow-up after merge; tier-2 smoke is
+  the in-episode evidence.
+
+## Execution deviations (recorded 2026-07-09, post-verify; reviewers judge
+## the code against THIS section where it supersedes T2 above)
+
+1. **Shape (a) split into first-ranking vs re-rank sites.** Applying the
+   content tail at RE-RANK sites broke the reranker-cross-encoder micro
+   fixture: when a rerank pass produces tied scores (no-signal case), the old
+   stable sort preserved the meaningful prior relevance order; the tail
+   replaced it with arbitrary content order. Corrected architecture: the
+   content tail lives ONLY at first-ranking sorts (search.ts:499-500, :680,
+   :725, :1034, :1154, :1195; api.ts getContext x4; the (b)/(c)/(d) sites
+   unchanged). Re-rank/merge re-sorts (goals.ts:360, cli.ts x5 opt-in blocks,
+   rerankers/cross-encoder.ts:109, graph-recall.ts:266, multihop.ts:41,
+   shared.ts:145/:290) are PLAIN stable score sorts: JS sort stability
+   inherits the upstream deterministic order, and ties preserve the prior
+   (meaningful) rank. Cross-ingest determinism is unchanged - it enters at
+   the first sort and survives stability.
+2. **EVC on-topic clause (micro gate remediation, measured).** T1's removal
+   of path-tag dilution DE-COMPRESSES the similarity distribution; the
+   acc-evc disambiguator measured 0.33x max (was above the 0.5 floor on the
+   compressed scale). The floor stays 0.5; an OR-clause adds query-coverage
+   (fraction of query tokens present in the candidate) >= 0.6 as the
+   score-scale-independent on-topic test - the mechanic's own "same topic,
+   different fact" definition applied to the query. Principled EVC
+   calibration remains B1 depth.
+3. **vmpfc fixture premise re-measured.** The fixture's no-flag query pins
+   "bad option wins raw"; post-T1 the raw edge (1.21x) fell below the
+   always-on outcome-boost swing (1.353x). The pair was re-worded and
+   MEASURED to a 1.45x raw edge, inside the (1.353, 1.857) window where the
+   no-flag premise holds AND --value-aware still flips. Measurement method
+   recorded in the fixture description.
+4. **tests/embedding-provider.test.ts contract update.** The "no forced
+   reindex on upgrade" back-compat test pinned the pre-#t2 contract; updated
+   to assert stale-exactly-once + stable-after-reindex, matching T1's
+   deliberate one-time migration. Header comment in embedding-provider.ts
+   updated likewise.
+5. **LoCoMo smoke evidence (verify item 4).** Two fresh independent runs of
+   the fixed build: 10/10 QAs byte-identical top-5 + scores (determinism
+   acceptance MET at benchmark scale). Quality vs master baseline: mean 0.5
+   vs 0.5 (n=10) - flat, no regression signal. Cross-path probe: identical
+   order, max score delta 6.6e-8 (decay-at-now residual, as predicted).
+
+## Acceptance mapping (from .devrl-backlog.md item 4)
+
+- "stable secondary sort key at ties" -> T2 comparator + SQL keys.
+- "two fresh identical ingests produce identical top-5 sets" -> T1 (dominant
+  mechanism) + T2 (residue); proven by T3 test + verify item 3/4.
+- "micro-eval no regression" -> verify item 2.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.25.0",
+  "version": "1.26.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,6 +65,7 @@ import {
 } from './auth.js';
 import { applyGoalStackBoost } from './goals.js';
 import { markRetrieved, estimateTokens, hybridSearch, physicsSearch, type RerankStep } from './search.js';
+import { compareEntryIdentity, compareScoredResults } from './compare.js';
 import { scopeMatch } from './scope.js';
 import { consolidate } from './consolidate.js';
 import { loadConfig } from './config.js';
@@ -829,11 +830,15 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
       );
       const maxSub = Math.max(1, Math.ceil(limit * 0.3));
       // Order parents by overflow count descending so the most
-      // information-dense substitutions come first.
+      // information-dense substitutions come first. Overflow count is the
+      // true primary key (unchanged); compareEntryIdentity is only a TAIL
+      // for the case two parents overflow the same number of children —
+      // without it that tie fell to SQLite scan order / loadEntriesByIds
+      // batch order (T2, deterministic tie keys).
       eligibleParents.sort((a, b) => {
         const ac = overflowByParent.get(a.id)?.length ?? 0;
         const bc = overflowByParent.get(b.id)?.length ?? 0;
-        return bc - ac;
+        return bc !== ac ? bc - ac : compareEntryIdentity(a, b);
       });
       substituted = eligibleParents.slice(0, maxSub).map((p) => ({
         entry: p,
@@ -2229,6 +2234,16 @@ export async function getContext(
         ...localEntries.map((entry) => ({ entry, isGlobal: false })),
         ...globalEntries.map((entry) => ({ entry, isGlobal: true })),
       ]
+        // T2 (src/compare.ts) note: this already carries an explicit
+        // per-instance tiebreak (created desc -> id localeCompare) and is
+        // deliberately left as-is rather than routed through
+        // compareEntryIdentity. `created` reflects ingest order, so it is
+        // cross-ingest stable at ms granularity; the residual is honest,
+        // not silently ignored — rows created in the same millisecond fall
+        // to `id.localeCompare`, which is per-instance random (id is
+        // crypto.randomUUID()), so this listing is per-instance-
+        // deterministic but NOT cross-ingest-stable under same-ms
+        // collisions.
         .sort((a, b) => {
           const byCreated = Date.parse(b.entry.created) - Date.parse(a.entry.created);
           return byCreated !== 0 ? byCreated : b.entry.id.localeCompare(a.entry.id);
@@ -2273,7 +2288,7 @@ export async function getContext(
           isGlobal,
         };
       })
-      .sort((a, b) => b.score - a.score);
+      .sort(compareScoredResults);
 
     for (const r of rankedPinned) {
       if (selectedIds.has(r.entry.id)) continue;
@@ -2293,7 +2308,7 @@ export async function getContext(
         tokens: estimateTokens(e.content),
         isGlobal: false,
       }))
-      .sort((a, b) => b.score - a.score);
+      .sort(compareScoredResults);
 
     const globalRanked = globalEntries
       .map((e) => ({
@@ -2302,9 +2317,9 @@ export async function getContext(
         tokens: estimateTokens(e.content),
         isGlobal: true,
       }))
-      .sort((a, b) => b.score - a.score);
+      .sort(compareScoredResults);
 
-    const combined = [...localRanked, ...globalRanked].sort((a, b) => b.score - a.score);
+    const combined = [...localRanked, ...globalRanked].sort(compareScoredResults);
 
     let used = 0;
     for (const r of combined) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,8 @@ import {
   RECALL_DEFAULT_DENY_SCOPES,
 } from './store.js';
 import type { SessionHandoff } from './handoff.js';
-import { search, markRetrieved, estimateTokens, hybridSearch, physicsSearch, explainMatch, textOverlap, type RerankStep } from './search.js';
+import { search, markRetrieved, estimateTokens, hybridSearch, physicsSearch, explainMatch, textOverlap, tokenize as tokenizeQuery, type RerankStep } from './search.js';
+import { compareEntryIdentity } from './compare.js';
 import { renderTraceContent, parseSteps } from './trace.js';
 import { consolidate } from './consolidate.js';
 import { deduplicateStore } from './dedupe.js';
@@ -1159,15 +1160,37 @@ async function cmdRecall(
       const tail = results.slice(poolSize);
       const maxScore = pool.reduce((m, r) => Math.max(m, r.score), 0);
       const scoreFloor = maxScore * 0.5;
+      // On-topic test: score floor OR query coverage. The score floor alone
+      // proxied topicality via ranking score, but the disambiguating update
+      // this mechanic exists to surface is BY NATURE phrased differently
+      // (weaker lexical/embedding overlap), so under the #t2 embed-text
+      // format (docs/plans/2026-07-09-recall-determinism.md T1, which
+      // de-compressed similarity gaps) it fell below any sane floor
+      // (measured 0.33x max on the acc-evc micro fixture). Query coverage —
+      // the fraction of query tokens present in the candidate — is the
+      // mechanic's own definition of "same topic, different fact" applied
+      // to the query, and is score-scale-independent. Principled EVC
+      // calibration remains roadmapped as B1 depth.
+      const queryTokens = new Set(tokenizeQuery(query));
       const onTopic: typeof pool = [];
       const offTopic: typeof pool = [];
       for (const r of pool) {
-        (r.score >= scoreFloor ? onTopic : offTopic).push(r);
+        let hits = 0;
+        if (queryTokens.size > 0) {
+          const candTokens = new Set(tokenizeQuery(r.entry.content));
+          for (const t of queryTokens) if (candTokens.has(t)) hits++;
+        }
+        const queryCoverage = queryTokens.size > 0 ? hits / queryTokens.size : 0;
+        (r.score >= scoreFloor || queryCoverage >= 0.6 ? onTopic : offTopic).push(r);
       }
+      // Recency is the true primary key (unchanged) — that's the whole
+      // point of --evc-adaptive. compareEntryIdentity is only a TAIL for
+      // entries created at the exact same timestamp, which previously fell
+      // to array/scan order (T2, deterministic tie keys).
       onTopic.sort((a, b) => {
         const ta = new Date(a.entry.created).getTime();
         const tb = new Date(b.entry.created).getTime();
-        return tb - ta;
+        return tb !== ta ? tb - ta : compareEntryIdentity(a.entry, b.entry);
       });
       results = [...onTopic, ...offTopic, ...tail];
     }
@@ -1204,6 +1227,11 @@ async function cmdRecall(
       }
       return next;
     });
+    // T2 note: PLAIN stable score sort on purpose (here and in the rerank
+    // blocks below) -- these are RE-SORTS of an already deterministically-
+    // ordered ranking, so sort stability inherits the upstream content-tail
+    // determinism, and ties preserve the prior rank rather than reordering
+    // by content (a no-signal boost must not shuffle its input).
     results.sort((a, b) => b.score - a.score);
   }
 
@@ -1232,7 +1260,7 @@ async function cmdRecall(
       }
       return next;
     });
-    results.sort((a, b) => b.score - a.score);
+    results.sort((a, b) => b.score - a.score); // T2: plain stable re-sort, see --filter-conflicts note
   }
 
   // OFC option-value re-ranker MVP (RESEARCH.md §PFC.OFC). Combine relevance,
@@ -1267,7 +1295,7 @@ async function cmdRecall(
         }
         return next;
       })
-      .sort((a, b) => b.score - a.score);
+      .sort((a, b) => b.score - a.score); // T2: plain stable re-sort, see --filter-conflicts note
   }
 
   // F6 reranker pass (docs/plans/2026-05-10-f6-reranker-hardening.md). When
@@ -1341,7 +1369,7 @@ async function cmdRecall(
         }
         return boosted;
       })
-      .sort((a, b) => b.score - a.score);
+      .sort((a, b) => b.score - a.score); // T2: plain stable re-sort, see --filter-conflicts note
   }
 
   // dlPFC depth (B3, v0.38; lifted v1.7.4 into applyGoalStackBoost). When
@@ -1423,7 +1451,7 @@ async function cmdRecall(
         }
         return next;
       })
-      .sort((a, b) => b.score - a.score);
+      .sort((a, b) => b.score - a.score); // T2: plain stable re-sort, see --filter-conflicts note
   }
 
   // --outcome filter: drop trace entries whose trace_outcome !== target.

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministic tie-break comparators for recall ranking.
+ *
+ * A true LEAF module: imports NOTHING from any sort-site module (search.ts,
+ * physics.ts, api.ts, cli.ts, shared.ts, goals.ts, graph-recall.ts,
+ * multihop.ts, rerankers/*). Every comparator here takes a structural param
+ * type instead of an imported one, on purpose — a type-only import back to
+ * search.ts would still create the search.ts <-> physics.ts ESM import
+ * cycle this module exists to avoid (r2 critic HIGH,
+ * docs/plans/2026-07-09-recall-determinism.md T2).
+ *
+ * Mirrors the deliberate-determinism comment style already established in
+ * graph-stream.ts:88, :165-168, :233-236 — a sort with a documented,
+ * reproducible tiebreak instead of leaving ties to array/scan order.
+ */
+
+/** Minimal shape needed to break a tie deterministically across fresh
+ *  ingests of the same content into different stores. */
+export interface EntryIdentity {
+  content: string;
+  id: string;
+}
+
+/**
+ * content ascending (UTF-16 code-unit compare) -> id ascending.
+ *
+ * `content` is the cross-ingest-stable key: identical text ingested into two
+ * independently-created stores (different directory name, different insert
+ * order of everything else on disk) sorts identically. `id`
+ * (`crypto.randomUUID()`) is per-instance only — two stores ingesting the
+ * same content never produce the same id, so it is a last-resort tiebreak
+ * for genuine duplicate-content rows within one comparison, not a
+ * cross-ingest-stable key on its own.
+ *
+ * Plain `<`/`>` (UTF-16 code-unit order), NOT `localeCompare`:
+ * `localeCompare` is locale- and ICU-version-dependent (a determinism leak
+ * in its own right) and is needlessly slow for a tiebreak that only needs a
+ * total order, not a linguistically "correct" one. Full-content compare is O(len) worst case;
+ * fine because ties are rare post-T1 (path-tag embedding fix) — no hashing
+ * needed.
+ */
+export function compareEntryIdentity(a: EntryIdentity, b: EntryIdentity): number {
+  if (a.content < b.content) return -1;
+  if (a.content > b.content) return 1;
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+/** Minimal shape for score-primary sort sites (SearchResult and friends
+ *  that carry `{ score, entry: { content, id } }`). */
+export interface ScoredEntryLike {
+  score: number;
+  entry: EntryIdentity;
+}
+
+/**
+ * score descending -> `compareEntryIdentity`. The shared ordering rule for
+ * every score-primary recall sort site (search.ts, shared.ts, goals.ts,
+ * api.ts, cli.ts, graph-recall.ts, multihop.ts, rerankers/cross-encoder.ts).
+ * Sites delegate wholesale to this (via a thin arrow where the element
+ * shape's score field is named something other than `score`, e.g.
+ * `rerankScore`) rather than reimplementing `b.score - a.score` locally, so
+ * the tiebreak can't silently drift between call sites.
+ */
+export function compareScoredResults(a: ScoredEntryLike, b: ScoredEntryLike): number {
+  const d = b.score - a.score;
+  return d !== 0 ? d : compareEntryIdentity(a.entry, b.entry);
+}
+
+/**
+ * Build a score-desc -> tie-key comparator for the physics layer.
+ *
+ * `ScoredPhysicsResult` (physics.ts) carries `{ memoryId, baseScore,
+ * clusterAmplification, finalScore }` -- NO `entry`/`content` in scope at
+ * that layer, so `compareEntryIdentity` cannot apply directly (plan T2
+ * shape (c)). With only the default memoryId key this is PER-INSTANCE-ONLY
+ * determinism; callers that need CROSS-INGEST stability supply `tieKeyOf`
+ * mapping the result to its memory CONTENT (codex review finding: the
+ * baseScore tie order selects the cluster_top_k amplification set, which
+ * MUTATES scores before the downstream content-aware merge sort runs -- so
+ * the tie key must be content-stable at THIS layer, not just downstream).
+ *
+ * A factory (not a fixed-field comparator) because physics.ts re-sorts the
+ * same result array by two different score fields in sequence (`baseScore`
+ * for top-K selection, then `finalScore` after cluster amplification) — one
+ * shared tiebreak rule, parameterised by which field is primary this pass.
+ */
+export function comparePhysicsResultsBy<T extends { memoryId: string }>(
+  scoreOf: (r: T) => number,
+  tieKeyOf?: (r: T) => string,
+): (a: T, b: T) => number {
+  return (a: T, b: T): number => {
+    const d = scoreOf(b) - scoreOf(a);
+    if (d !== 0) return d;
+    const ai = tieKeyOf ? tieKeyOf(a) : a.memoryId;
+    const bi = tieKeyOf ? tieKeyOf(b) : b.memoryId;
+    if (ai < bi) return -1;
+    if (ai > bi) return 1;
+    // Tie-key collision (e.g. duplicate content): fall through to memoryId
+    // so the comparator still yields a total order within one store.
+    return a.memoryId < b.memoryId ? -1 : a.memoryId > b.memoryId ? 1 : 0;
+  };
+}

--- a/src/embedding-provider.ts
+++ b/src/embedding-provider.ts
@@ -9,9 +9,13 @@
  * `config.embeddings.provider` (default `'local'`).
  *
  * Design contract (see docs/plans/2026-06-08-b-pluggable-embedding-provider.md):
- *   - Local provider `id` is the BARE model string, so existing stores whose DB
- *     meta `embedding_model` is `Xenova/all-MiniLM-L6-v2` see NO identity change
- *     and are NOT force-reindexed on upgrade.
+ *   - Local provider `id` is the BARE model string. (Historical note: this
+ *     originally guaranteed NO identity change on upgrade; since the
+ *     embed-text-format versioning in embeddings.ts (`embeddingIndexIdentity`,
+ *     `${id}#t2`, docs/plans/2026-07-09-recall-determinism.md T1), the STORED
+ *     identity carries a `#t<N>` suffix and pre-#t2 stores get exactly one
+ *     forced reindex on their next embed-touching operation — deliberate,
+ *     because their vectors were computed over path-contaminated text.)
  *   - API provider `id` is `${kind}:${model}`; switching to/from an API embedder
  *     (or a dimension change) flips the identity and triggers the existing
  *     reindex-on-change path.

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -25,7 +25,62 @@ const _pipelineInstances = new Map<string, unknown>();
 const _pipelineLoading = new Map<string, Promise<unknown>>();
 
 export const DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2';
-const EMBEDDING_MODEL_META_KEY = 'embedding_model';
+export const EMBEDDING_MODEL_META_KEY = 'embedding_model';
+
+/**
+ * Bump whenever `embeddingInputText`'s composition changes in a way that
+ * changes the resulting vectors for existing entries. Folded into the stored
+ * index identity (see `embeddingIndexIdentity`) so a text-format change is
+ * treated exactly like an embedding-model change: the next embed-touching
+ * operation detects the mismatch and reindexes automatically. Format 2 =
+ * `path:*` tags excluded (see `embeddingInputText`); format 1 (implicit, no
+ * suffix) = `${content} ${tags.join(' ')}` including path tags.
+ */
+export const EMBED_TEXT_FORMAT = 2;
+
+/**
+ * The stored-index identity for a given embedding provider id: folds
+ * `EMBED_TEXT_FORMAT` into the provider id so index-identity comparisons
+ * automatically invalidate on either a model change OR a text-format change.
+ * This is the ONE choke point both `embeddingModelRequiresReindex` (compare
+ * side) and `saveStoredEmbeddingModel` (save side) go through — they MUST
+ * version identically, or every call reindexes in a loop (or none ever do).
+ */
+export function embeddingIndexIdentity(providerId: string): string {
+  return `${providerId}#t${EMBED_TEXT_FORMAT}`;
+}
+
+/**
+ * Build the text embedded for a memory entry: content plus its tags, joined
+ * by a space and trimmed — the same shape as the legacy
+ * `` `${e.content} ${e.tags.join(' ')}`.trim() `` composition, minus `path:*`
+ * tags.
+ *
+ * `path:*` tags are excluded because they are auto-derived from
+ * `process.cwd()` (see `extractPathTags` in cli.ts) and carry every path
+ * component of the store's location, INCLUDING the store directory name
+ * itself. That means identical content embeds to a DIFFERENT vector
+ * depending on WHERE the store happens to live — e.g. a fresh benchmark run
+ * under `tempfile.mkdtemp()` gets a new directory name (hence new path
+ * tokens, hence a new vector) every single run, even with byte-identical
+ * content ingested in byte-identical order. This was diagnosed as the
+ * DOMINANT root cause of cross-fresh-ingest recall-rank variance measured on
+ * LoCoMo (mean evidence-recall@5 stdev 0.0175 across 4 fresh re-ingests of
+ * identical data; see `benchmarks/LOCOMO_INVESTIGATION.md`, "Determinism
+ * characterization"). It is a real product defect beyond benchmarks too:
+ * retrieval semantics should not depend on a project directory's name.
+ *
+ * Only `path:*` is excluded. Other tags (`conv:`, `session:`, `speaker:`,
+ * `dia:`, `error`, `scope:`, etc.) remain embedded — they carry semantic
+ * meaning. Path relevance at recall time is already handled explicitly by
+ * the v39 scope-isolation layer (`origin_project`, `pathOverlapScore`), so
+ * embedding-level path tokens are redundant with a dedicated mechanism
+ * rather than a feature.
+ */
+export function embeddingInputText(entry: { content: string; tags: string[] }): string {
+  const tags = entry.tags.filter((t) => !t.startsWith('path:'));
+  return `${entry.content} ${tags.join(' ')}`.trim();
+}
 
 /**
  * Per-model pooling dispatch for `@xenova/transformers`'s feature-extraction
@@ -199,10 +254,16 @@ function loadStoredEmbeddingModel(hippoRoot: string): string | null {
   }
 }
 
-function saveStoredEmbeddingModel(hippoRoot: string, model: string): void {
+/**
+ * Persist the stored-index identity for `model` (see `embeddingIndexIdentity`).
+ * Versioning happens INSIDE this function, not at call sites, so every caller
+ * — current and future — gets the identity format for free. Must stay
+ * consistent with the compare side in `embeddingModelRequiresReindex`.
+ */
+export function saveStoredEmbeddingModel(hippoRoot: string, model: string): void {
   const db = openHippoDb(hippoRoot);
   try {
-    setMeta(db, EMBEDDING_MODEL_META_KEY, model);
+    setMeta(db, EMBEDDING_MODEL_META_KEY, embeddingIndexIdentity(model));
   } finally {
     closeHippoDb(db);
   }
@@ -222,8 +283,8 @@ export function embeddingModelRequiresReindex(
   model: string,
   index: Record<string, number[]> = loadEmbeddingIndex(hippoRoot),
 ): boolean {
-  const indexedModel = resolveIndexedEmbeddingModel(hippoRoot, index);
-  return indexedModel !== null && indexedModel !== model;
+  const stored = resolveIndexedEmbeddingModel(hippoRoot, index);
+  return stored !== null && stored !== embeddingIndexIdentity(model);
 }
 
 async function rebuildEmbeddingIndex(
@@ -233,7 +294,7 @@ async function rebuildEmbeddingIndex(
   const rebuilt: Record<string, number[]> = {};
   if (entries.length === 0) return rebuilt;
 
-  const texts = entries.map((e) => `${e.content} ${e.tags.join(' ')}`.trim());
+  const texts = entries.map((e) => embeddingInputText(e));
   // provider.embed batches internally; on a hard transport/auth failure it
   // throws, so the caller aborts WITHOUT saving a partial index (atomic
   // reindex: the old index + stored identity are preserved).
@@ -398,7 +459,7 @@ export async function embedMemory(
         return;
       }
 
-      const text = `${entry.content} ${entry.tags.join(' ')}`.trim();
+      const text = embeddingInputText(entry);
       const [vector] = await provider.embed([text], 'passage');
       if (!vector || vector.length === 0) return;
 
@@ -499,7 +560,7 @@ export async function embedAll(
       let vectors: number[][];
       try {
         vectors = await provider.embed(
-          chunk.map((e) => `${e.content} ${e.tags.join(' ')}`.trim()),
+          chunk.map((e) => embeddingInputText(e)),
           'passage',
         );
       } catch (err) {

--- a/src/goals.ts
+++ b/src/goals.ts
@@ -357,6 +357,10 @@ export function applyGoalStackBoost<R extends { entry: MemoryEntry; score: numbe
         _goalMatches: matches,
       } as R & { _goalMatches: string[] };
     })
+    // T2 note: deliberately a PLAIN stable score sort, no compareEntryIdentity
+    // tail -- a re-sort of an already deterministically-ordered ranking
+    // inherits its determinism via sort stability, and ties preserve the
+    // prior (meaningful) rank instead of reordering by content.
     .sort((a, b) => b.score - a.score) as R[];
 
   // Filter to local memories only -- global memory IDs aren't in this DB's

--- a/src/graph-recall.ts
+++ b/src/graph-recall.ts
@@ -39,6 +39,7 @@
 import { loadEntriesByIds } from './store.js';
 import type { MemoryEntry } from './memory.js';
 import { type SearchResult, estimateTokens } from './search.js';
+import { compareEntryIdentity } from './compare.js';
 import {
   loadEntitiesByMemoryId,
   loadEntitiesByIds,
@@ -244,8 +245,16 @@ export function graphExpandRecall(
 
   if (hitsByOrigin.size === 0) return baseResults;
   // Closer hops first within each origin group, then by inherited score.
+  // Hops asc and score desc are both true primary keys (unchanged);
+  // compareEntryIdentity is only the TAIL for a same-hop, same-score tie
+  // (T2, deterministic tie keys).
   for (const hits of hitsByOrigin.values()) {
-    hits.sort((a, b) => a.graphVia.hops - b.graphVia.hops || b.score - a.score);
+    hits.sort((a, b) => {
+      const byHops = a.graphVia.hops - b.graphVia.hops;
+      if (byHops !== 0) return byHops;
+      const byScore = b.score - a.score;
+      return byScore !== 0 ? byScore : compareEntryIdentity(a.entry, b.entry);
+    });
   }
   const allHits = [...hitsByOrigin.values()].flat();
 
@@ -263,6 +272,10 @@ export function graphExpandRecall(
   const protectedCount = Math.min(Math.max(minResults, 1), baseResults.length);
   const keep = new Set<SearchResult>(baseResults.slice(0, protectedCount));
   let usedTokens = [...keep].reduce((s, r) => s + r.tokens, 0);
+  // T2 note: PLAIN stable score sort on purpose -- both input lists are
+  // deterministically ordered by this point, stability inherits that, and a
+  // base-vs-graph-hit tie keeps the BASE result first (the concat order),
+  // preserving pre-T2 semantics.
   for (const r of [...baseResults.slice(protectedCount), ...allHits].sort((a, b) => b.score - a.score)) {
     if (usedTokens + r.tokens > budget) continue;
     usedTokens += r.tokens;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -506,9 +506,12 @@ export function loadEntitiesByMemoryId(
     for (let i = 0; i < memoryIds.length; i += IN_LIST_CHUNK) {
       const slice = memoryIds.slice(i, i + IN_LIST_CHUNK);
       const ph = slice.map(() => '?').join(',');
+      // T2: no ORDER BY meant chunk-local scan order decided ties; id ASC
+      // makes it deterministic (entities.id is an autoincrement integer PK).
       const rows = db.prepare(`
         SELECT ${ENTITY_COLS} FROM entities
         WHERE tenant_id = ? AND memory_id IN (${ph})
+        ORDER BY id ASC
       `).all(tenantId, ...slice) as EntityRow[];
       out.push(...rows.map(rowToEntity));
     }

--- a/src/multihop.ts
+++ b/src/multihop.ts
@@ -38,5 +38,8 @@ export function multihopSearch(
     }
   }
 
+  // T2 note: PLAIN stable score sort on purpose -- pass1/pass2 inputs are
+  // deterministically ordered (search() carries the content tail), stability
+  // inherits that, and ties keep pass-1 results ahead of pass-2 follow-ups.
   return [...merged.values()].sort((a, b) => b.score - a.score);
 }

--- a/src/physics.ts
+++ b/src/physics.ts
@@ -13,6 +13,7 @@
 import { isRecallBoostAblated } from './ablation.js';
 import type { EmotionalValence } from './memory.js';
 import type { PhysicsConfig } from './physics-config.js';
+import { comparePhysicsResultsBy } from './compare.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -417,6 +418,11 @@ export function physicsScore(
   particles: PhysicsParticle[],
   queryEmbedding: number[],
   config: PhysicsConfig,
+  /** Cross-ingest-stable tie key per memoryId (typically the memory's
+   *  content, supplied by the caller which has entries in scope). Without
+   *  it ties fall to memoryId -- per-instance only, which lets the
+   *  cluster_top_k amplification set vary across fresh ingests. */
+  tieKeyOf?: (memoryId: string) => string,
 ): ScoredPhysicsResult[] {
   if (particles.length === 0 || queryEmbedding.length === 0) return [];
 
@@ -432,14 +438,18 @@ export function physicsScore(
     };
   });
 
-  // Sort by base score for top-K selection
-  results.sort((a, b) => b.baseScore - a.baseScore);
+  // Sort by base score for top-K selection: score desc -> tie key asc.
+  // The tie order here picks the cluster_top_k amplification SET (which
+  // mutates scores), so it must be cross-ingest-stable when the caller
+  // supplies a content tie key. See compare.ts comparePhysicsResultsBy.
+  const tie = tieKeyOf ? (r: ScoredPhysicsResult) => tieKeyOf(r.memoryId) : undefined;
+  results.sort(comparePhysicsResultsBy((r) => r.baseScore, tie));
 
   // Pass 2: cluster amplification on top K
   applyClusterAmplification(results, particles, config);
 
-  // Re-sort by final score
-  results.sort((a, b) => b.finalScore - a.finalScore);
+  // Re-sort by final score, same tiebreak rule.
+  results.sort(comparePhysicsResultsBy((r) => r.finalScore, tie));
 
   return results;
 }

--- a/src/rerankers/cross-encoder.ts
+++ b/src/rerankers/cross-encoder.ts
@@ -106,6 +106,12 @@ export const crossEncoderReranker: RerankerFn = async (
     }),
   );
 
+  // T2 note: PLAIN stable score sort on purpose. The input `head` is already
+  // deterministically ordered (upstream content tail), so stability inherits
+  // that -- and when the cross-encoder produces tied scores (degenerate or
+  // no-signal cases), ties MUST fall back to the prior relevance order, not
+  // an arbitrary content order (the reranker-cross-encoder micro fixture
+  // fails otherwise: an all-tie rerank pass reordered its input).
   scored.sort((a, b) => b.rerankScore - a.rerankScore);
   scored.forEach((r, i) => (r.postRerankRank = i + 1));
   return scored;

--- a/src/search.ts
+++ b/src/search.ts
@@ -21,6 +21,7 @@ import { loadPhysicsState } from './physics-state.js';
 import { openHippoDb, closeHippoDb } from './db.js';
 import { rrfFuse } from './rrf.js';
 import { graphRankStream, selectGraphSeeds, DEFAULT_GRAPH_SEED_COUNT } from './graph-stream.js';
+import { compareEntryIdentity, compareScoredResults } from './compare.js';
 
 // ---------------------------------------------------------------------------
 // Tokenizer
@@ -496,8 +497,17 @@ export async function hybridSearch(
     const eligible = entries
       .map((_, i) => i)
       .filter((i) => bm25Scores[i] > 0 || cosineScores[i] > 0);
-    const bm25Ranked = [...eligible].sort((a, b) => bm25Scores[b] - bm25Scores[a]);
-    const cosineRanked = [...eligible].sort((a, b) => cosineScores[b] - cosineScores[a]);
+    // score desc -> compareEntryIdentity tail (deterministic across fresh
+    // ingests): these two rankings feed selectGraphSeeds + RRF rank
+    // assignment, so an unbroken tie here would leak into seed selection.
+    const bm25Ranked = [...eligible].sort((a, b) => {
+      const d = bm25Scores[b] - bm25Scores[a];
+      return d !== 0 ? d : compareEntryIdentity(entries[a], entries[b]);
+    });
+    const cosineRanked = [...eligible].sort((a, b) => {
+      const d = cosineScores[b] - cosineScores[a];
+      return d !== 0 ? d : compareEntryIdentity(entries[a], entries[b]);
+    });
 
     // L1 graph-retrieval stream (opt-in): a 3rd RRF input ranking in-pool candidates by
     // graph proximity to the strong lexical seeds. When absent / weight<=0 / the graph
@@ -676,8 +686,8 @@ export async function hybridSearch(
     scored.push(result);
   }
 
-  // Sort by composite score descending
-  scored.sort((a, b) => b.score - a.score);
+  // Sort by composite score descending, deterministic tiebreak on ties.
+  scored.sort(compareScoredResults);
 
   // Deduplicate: when an extracted fact and its source both appear,
   // keep only the higher-scoring one (typically the fact).
@@ -722,7 +732,7 @@ export async function hybridSearch(
         });
       }
     }
-    scoredDeduped.sort((a, b) => b.score - a.score);
+    scoredDeduped.sort(compareScoredResults);
   }
 
   // MMR re-ranking: de-cluster near-duplicates by trading relevance for
@@ -784,6 +794,11 @@ export async function hybridSearch(
  * Inputs must already be sorted by relevance descending. When `explain` is
  * true, attaches `preMmrRank` / `postMmrRank` to each result's breakdown.
  * Exported for unit tests; production callers go through hybridSearch.
+ *
+ * Determinism note (T2): the picking loop below uses strict `mmr > bestMmr`
+ * (first-wins on ties), so it is already deterministic GIVEN a
+ * deterministic `scored` input order — no comparator change needed here;
+ * the tiebreak lives upstream, in how `scored` was sorted before this runs.
  */
 export function mmrRerank(
   scored: SearchResult[],
@@ -956,8 +971,15 @@ export async function physicsSearch(
   // Score physics-enabled memories
   const physicsResults: SearchResult[] = [];
   if (physicsParticles.length > 0) {
-    const scored = computePhysicsScores(physicsParticles, queryVector, config);
     const entryMap = new Map(physicsEntries.map(e => [e.id, e]));
+    // Content tie key: the physics baseScore tie order selects the
+    // cluster_top_k amplification set, so it must be cross-ingest-stable
+    // (codex review). memoryId fallback covers particles whose entry was
+    // filtered from physicsEntries.
+    const scored = computePhysicsScores(
+      physicsParticles, queryVector, config,
+      (id) => entryMap.get(id)?.content ?? id,
+    );
 
     for (const s of scored) {
       if (s.finalScore <= 0) continue;
@@ -1030,8 +1052,8 @@ export async function physicsSearch(
   // Normalize both pools to [0, 1] and merge
   const merged = mergeScorePools(physicsResults, classicResults);
 
-  // Sort and apply budget
-  merged.sort((a, b) => b.score - a.score);
+  // Sort and apply budget, deterministic tiebreak on ties.
+  merged.sort(compareScoredResults);
 
   const results: SearchResult[] = [];
   let usedTokens = 0;
@@ -1150,8 +1172,8 @@ export function search(
     scored.push({ entry: entries[i], score: composite, bm25, cosine: 0, tokens });
   }
 
-  // Sort by composite score descending
-  scored.sort((a, b) => b.score - a.score);
+  // Sort by composite score descending, deterministic tiebreak on ties.
+  scored.sort(compareScoredResults);
 
   const seenExtractedFromSync = new Set<string>();
   const dedupedSync: typeof scored = [];
@@ -1192,7 +1214,7 @@ export function search(
         });
       }
     }
-    dedupedSync.sort((a, b) => b.score - a.score);
+    dedupedSync.sort(compareScoredResults);
   }
 
   // Apply token budget

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -141,7 +141,11 @@ export function searchBoth(
     return true;
   });
 
-  // Sort by adjusted score descending
+  // T2 note: PLAIN stable score sort on purpose -- local/global inputs are
+  // each deterministically ordered (content tail applied in the underlying
+  // search), stability inherits that, and an exact post-bump tie keeps the
+  // LOCAL result ahead of the global one (the concat order), preserving the
+  // pre-T2 semantics.
   deduped.sort((a, b) => b.score - a.score);
 
   // Apply combined token budget (guarantee at least minResults items)
@@ -286,7 +290,8 @@ export async function searchBothHybrid(
     return true;
   });
 
-  // Sort by adjusted score descending
+  // T2 note: PLAIN stable score sort on purpose -- see searchBoth above;
+  // same rationale (deterministic inputs + stability; local-first on ties).
   deduped.sort((a, b) => b.score - a.score);
 
   // Apply combined token budget (guarantee at least minResults items)

--- a/src/store.ts
+++ b/src/store.ts
@@ -815,7 +815,7 @@ function loadSearchRows(
         FROM memories m
         JOIN memories_fts f ON f.id = m.id
         WHERE memories_fts MATCH ?${tenantPredicate}${archivedClauseAlias}${scopeClauseAlias}
-        ORDER BY bm25(memories_fts), m.updated_at DESC
+        ORDER BY bm25(memories_fts), m.updated_at DESC, m.content ASC, m.id ASC
         LIMIT ?
       `).all(ftsQuery, ...tenantParams, ...scopeParams, limit) as MemoryRow[];
 
@@ -836,7 +836,7 @@ function loadSearchRows(
     SELECT ${MEMORY_SELECT_COLUMNS}
     FROM memories
     WHERE (${where})${tenantPredicateNoAlias}${archivedClauseNoAlias}${scopeClauseNoAlias}
-    ORDER BY updated_at DESC, created DESC
+    ORDER BY updated_at DESC, created DESC, content ASC, id ASC
     LIMIT ?
   `).all(...params, ...tenantParams, ...scopeParams, limit) as MemoryRow[];
 
@@ -1380,12 +1380,15 @@ export function loadEntriesByIds(
   const db = openHippoDb(hippoRoot);
   try {
     const placeholders = capped.map(() => '?').join(',');
+    // T2: no ORDER BY meant row order followed SQLite's IN(...) scan order
+    // (undefined w.r.t. the caller's `ids` order). created ASC, id ASC
+    // makes it deterministic.
     const rows = tenantId !== undefined
       ? db.prepare(
-          `SELECT ${MEMORY_SELECT_COLUMNS} FROM memories WHERE id IN (${placeholders}) AND tenant_id = ?`,
+          `SELECT ${MEMORY_SELECT_COLUMNS} FROM memories WHERE id IN (${placeholders}) AND tenant_id = ? ORDER BY created ASC, content ASC, id ASC`,
         ).all(...capped, tenantId) as MemoryRow[]
       : db.prepare(
-          `SELECT ${MEMORY_SELECT_COLUMNS} FROM memories WHERE id IN (${placeholders})`,
+          `SELECT ${MEMORY_SELECT_COLUMNS} FROM memories WHERE id IN (${placeholders}) ORDER BY created ASC, content ASC, id ASC`,
         ).all(...capped) as MemoryRow[];
     return rows.map(rowToEntry);
   } finally {
@@ -1529,7 +1532,12 @@ export function loadFreshRawMemories(
       sql += ' AND source_session_id = ?';
       params.push(sessionId);
     }
-    sql += ' ORDER BY created DESC LIMIT ?';
+    // T2: tie tail keeps the LIMIT window keyed on `created` while making
+    // same-`created` rows deterministic. `content` before `id` (codex
+    // review): ids are random UUIDs, so an id-only tail would pick WHICH
+    // same-created rows make the window per-instance; content is
+    // cross-ingest-stable.
+    sql += ' ORDER BY created DESC, content ASC, id ASC LIMIT ?';
     params.push(capped);
     const rows = db.prepare(sql).all(...params) as MemoryRow[];
     return rows.map(rowToEntry);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.25.0';
+export const PACKAGE_VERSION = '1.26.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the deterministic tie-break comparators in src/compare.ts
+ * (docs/plans/2026-07-09-recall-determinism.md T2/T3). Pure functions, no
+ * store/DB needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  compareEntryIdentity,
+  compareScoredResults,
+  comparePhysicsResultsBy,
+} from '../src/compare.js';
+
+describe('compareEntryIdentity', () => {
+  it('orders by content ascending when content differs', () => {
+    const a = { content: 'apple', id: 'zzz' };
+    const b = { content: 'banana', id: 'aaa' };
+    expect(compareEntryIdentity(a, b)).toBeLessThan(0);
+    expect(compareEntryIdentity(b, a)).toBeGreaterThan(0);
+  });
+
+  it('falls back to id ascending when content is identical', () => {
+    const a = { content: 'same text', id: 'b-id' };
+    const b = { content: 'same text', id: 'a-id' };
+    // content ties -> id decides: 'a-id' < 'b-id'
+    expect(compareEntryIdentity(a, b)).toBeGreaterThan(0);
+    expect(compareEntryIdentity(b, a)).toBeLessThan(0);
+  });
+
+  it('returns 0 for fully identical content and id', () => {
+    const a = { content: 'x', id: 'y' };
+    const b = { content: 'x', id: 'y' };
+    expect(compareEntryIdentity(a, b)).toBe(0);
+  });
+
+  it('is a byte compare, not localeCompare — uppercase sorts before lowercase', () => {
+    // Byte/ASCII order: 'B' (0x42) < 'a' (0x61), so content "Bravo" < "alpha".
+    // localeCompare('Bravo', 'alpha') would place "alpha" first (case-insensitive
+    // locale collation) — the opposite order. This pins the byte-compare choice.
+    const a = { content: 'Bravo', id: '1' };
+    const b = { content: 'alpha', id: '2' };
+    expect('Bravo' < 'alpha').toBe(true); // sanity: JS default string compare is byte order
+    expect(compareEntryIdentity(a, b)).toBeLessThan(0); // a (Bravo) sorts first
+    expect('Bravo'.localeCompare('alpha')).toBeGreaterThan(0); // localeCompare disagrees
+  });
+});
+
+describe('compareScoredResults', () => {
+  it('orders by score descending when scores differ', () => {
+    const a = { score: 1, entry: { content: 'z', id: 'z' } };
+    const b = { score: 2, entry: { content: 'a', id: 'a' } };
+    expect(compareScoredResults(a, b)).toBeGreaterThan(0); // b (higher score) first
+  });
+
+  it('falls back to compareEntryIdentity on an exact score tie', () => {
+    const a = { score: 5, entry: { content: 'zebra', id: 'x' } };
+    const b = { score: 5, entry: { content: 'apple', id: 'y' } };
+    // scores tie -> content decides: 'apple' < 'zebra'
+    expect(compareScoredResults(a, b)).toBeGreaterThan(0); // b (apple) sorts first
+    expect(compareScoredResults(b, a)).toBeLessThan(0);
+  });
+
+  it('produces a stable full sort across repeated ties (order-independent of input array order)', () => {
+    const items = [
+      { score: 5, entry: { content: 'zebra', id: 'x' } },
+      { score: 5, entry: { content: 'apple', id: 'y' } },
+      { score: 5, entry: { content: 'mango', id: 'z' } },
+      { score: 9, entry: { content: 'kiwi', id: 'w' } },
+    ];
+    const shuffled = [items[2], items[0], items[3], items[1]];
+    const sorted = [...shuffled].sort(compareScoredResults);
+    expect(sorted.map((r) => r.entry.content)).toEqual(['kiwi', 'apple', 'mango', 'zebra']);
+  });
+});
+
+describe('comparePhysicsResultsBy', () => {
+  it('orders by the supplied score field descending', () => {
+    const cmp = comparePhysicsResultsBy<{ memoryId: string; s: number }>((r) => r.s);
+    const a = { memoryId: 'm1', s: 1 };
+    const b = { memoryId: 'm2', s: 2 };
+    expect(cmp(a, b)).toBeGreaterThan(0); // b (higher score) first
+  });
+
+  it('falls back to memoryId ascending on an exact score tie (no content available)', () => {
+    const cmp = comparePhysicsResultsBy<{ memoryId: string; s: number }>((r) => r.s);
+    const a = { memoryId: 'mem-z', s: 5 };
+    const b = { memoryId: 'mem-a', s: 5 };
+    expect(cmp(a, b)).toBeGreaterThan(0); // b (mem-a) sorts first
+    expect(cmp(b, a)).toBeLessThan(0);
+  });
+
+  it('supports two independent passes over the same array with different score fields', () => {
+    type R = { memoryId: string; baseScore: number; finalScore: number };
+    const results: R[] = [
+      { memoryId: 'a', baseScore: 1, finalScore: 9 },
+      { memoryId: 'b', baseScore: 2, finalScore: 1 },
+    ];
+    const byBase = [...results].sort(comparePhysicsResultsBy<R>((r) => r.baseScore));
+    expect(byBase.map((r) => r.memoryId)).toEqual(['b', 'a']);
+
+    const byFinal = [...results].sort(comparePhysicsResultsBy<R>((r) => r.finalScore));
+    expect(byFinal.map((r) => r.memoryId)).toEqual(['a', 'b']);
+  });
+});
+
+describe('comparePhysicsResultsBy tieKeyOf (content-stable cluster selection)', () => {
+  it('breaks score ties by the supplied tie key, not memoryId', () => {
+    const a = { memoryId: 'id-zzz', baseScore: 1 };
+    const b = { memoryId: 'id-aaa', baseScore: 1 };
+    const cmp = comparePhysicsResultsBy<typeof a>((r) => r.baseScore, (r) => (r.memoryId === 'id-zzz' ? 'alpha content' : 'beta content'));
+    // tie key 'alpha content' < 'beta content' -> a first despite larger memoryId
+    expect([b, a].sort(cmp).map((r) => r.memoryId)).toEqual(['id-zzz', 'id-aaa']);
+  });
+
+  it('falls through tie-key collisions to memoryId for a total order', () => {
+    const a = { memoryId: 'id-bbb', baseScore: 1 };
+    const b = { memoryId: 'id-aaa', baseScore: 1 };
+    const cmp = comparePhysicsResultsBy<typeof a>((r) => r.baseScore, () => 'same content');
+    expect([a, b].sort(cmp).map((r) => r.memoryId)).toEqual(['id-aaa', 'id-bbb']);
+  });
+});

--- a/tests/embedding-input-text.test.ts
+++ b/tests/embedding-input-text.test.ts
@@ -1,0 +1,119 @@
+/**
+ * T1 regression tests (episode 01KX434KMAQSX4HRHYC67WDTJQ,
+ * docs/plans/2026-07-09-recall-determinism.md).
+ *
+ * Covers two things:
+ *  1. `embeddingInputText` excludes exactly `path:*` tags — the fix for the
+ *     dominant root cause of cross-fresh-ingest recall-rank variance (auto
+ *     path tags carry the store directory name, so identical content embeds
+ *     to a different vector per store location).
+ *  2. The reindex-identity choke point (`embeddingIndexIdentity`,
+ *     `embeddingModelRequiresReindex`, `saveStoredEmbeddingModel`) versions
+ *     consistently: a store just saved via the current format reports no
+ *     reindex needed, while a legacy store with a bare (unversioned) stored
+ *     model id reports a reindex is needed exactly once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb, setMeta } from '../src/db.js';
+import {
+  embeddingInputText,
+  embeddingIndexIdentity,
+  embeddingModelRequiresReindex,
+  saveStoredEmbeddingModel,
+  EMBEDDING_MODEL_META_KEY,
+  EMBED_TEXT_FORMAT,
+} from '../src/embeddings.js';
+
+describe('embeddingInputText', () => {
+  it('excludes tags starting with path: but keeps other tags', () => {
+    const text = embeddingInputText({
+      content: 'hello world',
+      tags: ['path:c:/users/keith/hippo', 'conv:x', 'error', 'scope:private'],
+    });
+    expect(text).toBe('hello world conv:x error scope:private');
+  });
+
+  it('keeps a tag literally named pathfinder (startsWith, not includes)', () => {
+    const text = embeddingInputText({
+      content: 'hello world',
+      tags: ['pathfinder', 'path:c:/users/keith/hippo'],
+    });
+    expect(text).toBe('hello world pathfinder');
+  });
+
+  it('returns content only, trimmed, when tags is empty', () => {
+    const text = embeddingInputText({ content: 'hello world', tags: [] });
+    expect(text).toBe('hello world');
+  });
+
+  it('returns content only, trimmed, when every tag is a path: tag', () => {
+    const text = embeddingInputText({
+      content: 'hello world',
+      tags: ['path:c:/users/keith/hippo', 'path:hippo'],
+    });
+    expect(text).toBe('hello world');
+  });
+
+  it('excludes multiple path: tags interleaved with kept tags', () => {
+    const text = embeddingInputText({
+      content: 'note',
+      tags: ['path:a', 'conv:x', 'path:a/b', 'dia:3', 'path:a/b/c'],
+    });
+    expect(text).toBe('note conv:x dia:3');
+  });
+});
+
+describe('reindex identity consistency', () => {
+  let root: string;
+  let hippoRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'hippo-embed-identity-'));
+    hippoRoot = join(root, '.hippo');
+    initStore(hippoRoot);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('a store saved via saveStoredEmbeddingModel reports no reindex needed for the same model', () => {
+    saveStoredEmbeddingModel(hippoRoot, 'modelX');
+    const fakeIndex = { some_id: [0.1, 0.2, 0.3] };
+    expect(embeddingModelRequiresReindex(hippoRoot, 'modelX', fakeIndex)).toBe(false);
+  });
+
+  it('a store saved via saveStoredEmbeddingModel still requires reindex for a different model', () => {
+    saveStoredEmbeddingModel(hippoRoot, 'modelX');
+    const fakeIndex = { some_id: [0.1, 0.2, 0.3] };
+    expect(embeddingModelRequiresReindex(hippoRoot, 'modelY', fakeIndex)).toBe(true);
+  });
+
+  it('a legacy store with a bare (unversioned) stored model id requires reindex exactly once', () => {
+    // Simulate a pre-T1 store: meta holds the bare provider id with no
+    // `#t<N>` suffix, as `saveStoredEmbeddingModel` used to write it.
+    const db = openHippoDb(hippoRoot);
+    try {
+      setMeta(db, EMBEDDING_MODEL_META_KEY, 'modelX');
+    } finally {
+      closeHippoDb(db);
+    }
+    const fakeIndex = { some_id: [0.1, 0.2, 0.3] };
+
+    expect(embeddingModelRequiresReindex(hippoRoot, 'modelX', fakeIndex)).toBe(true);
+
+    // The migration reindex re-saves the identity in the current format —
+    // after that, the same model no longer requires reindex.
+    saveStoredEmbeddingModel(hippoRoot, 'modelX');
+    expect(embeddingModelRequiresReindex(hippoRoot, 'modelX', fakeIndex)).toBe(false);
+  });
+
+  it('embeddingIndexIdentity folds EMBED_TEXT_FORMAT into the provider id', () => {
+    expect(embeddingIndexIdentity('modelX')).toBe(`modelX#t${EMBED_TEXT_FORMAT}`);
+  });
+});

--- a/tests/embedding-provider.test.ts
+++ b/tests/embedding-provider.test.ts
@@ -7,7 +7,7 @@ import {
   resolveEmbeddingIdentity,
   isEmbeddingConfigured,
 } from '../src/embedding-provider.js';
-import { saveEmbeddingIndex, embeddingModelRequiresReindex } from '../src/embeddings.js';
+import { saveEmbeddingIndex, embeddingModelRequiresReindex, saveStoredEmbeddingModel } from '../src/embeddings.js';
 
 function mkRoot(embeddings: Record<string, unknown>): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-provider-'));
@@ -78,12 +78,20 @@ describe('EmbeddingProvider', () => {
     });
   });
 
-  describe('backwards compatibility (no forced reindex on upgrade)', () => {
-    it('an existing MiniLM index is NOT stale for the local provider', () => {
+  describe('upgrade reindex contract (embed-text format #t2)', () => {
+    // Contract change (docs/plans/2026-07-09-recall-determinism.md T1): a
+    // pre-#t2 store's vectors were computed over path-contaminated text, so
+    // the upgrade DOES force exactly one reindex — the historical
+    // "no forced reindex on upgrade" guarantee is deliberately retired.
+    it('a legacy MiniLM index is stale exactly once, then stable after reindex', () => {
       const root = mkRoot({ provider: 'local', model: 'Xenova/all-MiniLM-L6-v2' });
       // Legacy store: index present, model defaults to MiniLM (the historical default).
       saveEmbeddingIndex(root, { mem_legacy: [0.1, 0.2, 0.3] });
       const identity = resolveEmbeddingIdentity(root);
+      expect(embeddingModelRequiresReindex(root, identity)).toBe(true);
+      // The reindex path persists the versioned identity; after that the
+      // same provider id compares clean (no reindex loop).
+      saveStoredEmbeddingModel(root, identity);
       expect(embeddingModelRequiresReindex(root, identity)).toBe(false);
     });
 

--- a/tests/recall-cross-store-determinism.test.ts
+++ b/tests/recall-cross-store-determinism.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Acceptance test for docs/plans/2026-07-09-recall-determinism.md T2/T3:
+ * "two fresh identical ingests (different store paths) produce identical
+ * top-K recall content sequences." This FAILED on master before T2 (SQLite
+ * scan order / crypto.randomUUID() ids decided unbroken score ties; see the
+ * plan's "Root cause" section for the empirical probe).
+ *
+ * Provider-agnostic on purpose: no embedding index is ever saved for either
+ * store, so `loadEmbeddingIndex` returns `{}` and hybridSearch's
+ * `entries.some((e) => (idx[e.id]?.length ?? 0) > 0)` gate keeps
+ * `useEmbeddings` false regardless of whether @xenova/transformers happens
+ * to be installed in the test environment — every assertion here exercises
+ * the BM25-only path and, specifically, src/compare.ts's tiebreak. The
+ * embedding-text-contamination fix (T1, src/embeddings.ts) is unit-tested
+ * separately; LoCoMo smoke is the cross-fix integration evidence (plan
+ * verify-stage item 4).
+ *
+ * Real SQLite stores in temp dirs, no mocks (project convention).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initStore, writeEntry, loadAllEntries } from '../src/store.js';
+import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
+import { hybridSearch } from '../src/search.js';
+import { searchBothHybrid } from '../src/shared.js';
+
+// Fixed clock: pins calculateStrength/recencyBoost so two stores produce
+// byte-identical composite scores for byte-identical content — otherwise
+// two writes a few real-clock ms apart would introduce a genuine (not
+// artifact) score delta and mask what this test exists to catch.
+const NOW = new Date('2026-01-15T00:00:00.000Z');
+
+// Content set, inserted in this exact order into BOTH stores:
+//   [0] never matches the probe query -> must be excluded from results.
+//   [1]..[4] SAME token multiset (anagrams of each other) AND the same
+//           pinned timestamp -> identical BM25, strength, and recency, so
+//           their composite scores tie EXACTLY. This is the tie the T2
+//           comparator must break identically across stores, by content
+//           ascending. A GROUP of four (not a pair) so that unmodified
+//           master — where the tie falls to random per-store ids — passes
+//           the lexicographic-order assertion only with ~1/4! luck per run
+//           rather than 1/2 (master is nondeterministic here, so
+//           red-on-master is necessarily probabilistic; four items make it
+//           overwhelmingly red).
+//   [5] matches the probe query but is much longer -> different (lower)
+//       BM25 score, giving a non-tied anchor in the ranking.
+const CONTENTS = [
+  'orbit nebula quasar pulsar filler content wholly unrelated to the probe',
+  'zzyzx wombat jackal ocelot signalword',
+  'wombat jackal zzyzx ocelot signalword',
+  'jackal zzyzx wombat ocelot signalword',
+  'ocelot jackal wombat zzyzx signalword',
+  'signalword appears here too but this particular document is padded with a great many additional filler words so its length differs substantially from the short tie group above',
+];
+
+// The tie group [1..4] in content-ascending order (what compareEntryIdentity
+// must produce in BOTH stores regardless of ids):
+const TIE_GROUP_SORTED = [CONTENTS[3], CONTENTS[4], CONTENTS[2], CONTENTS[1]].sort();
+
+const QUERY = 'signalword';
+
+/** Per-row timestamp offsets. The anagram tie GROUP [1..4] MUST share the
+ *  exact same timestamp: `created`/`last_retrieved` feed calculateStrength and
+ *  recencyBoost, so even a 1-second offset makes their composite scores
+ *  differ at the ~1e-8 scale — no longer an exact tie, and the stable sort
+ *  resolves them by score without ever consulting the comparator. (Review
+ *  finding: an earlier version of this fixture used NOW + i*1000 for every
+ *  row and PASSED on unmodified master because of exactly that — the
+ *  recency delta, not the T2 tiebreak, produced the expected order.
+ *  Red-on-master was re-verified after this fix.) */
+const TS_OFFSET_MS = [0, 1000, 1000, 1000, 1000, 2000];
+
+/** Ingest CONTENTS in identical order into `root`, tagged with `pathTag`
+ *  (mimics cmdRemember's auto path-tag, per the plan's T3 instruction) and
+ *  pinned to fixed offsets from NOW so both stores are byte-identical in
+ *  every score input, independent of real wall-clock timing. */
+function ingestFixture(root: string, pathTag: string): void {
+  initStore(root);
+  CONTENTS.forEach((content, i) => {
+    const entry: MemoryEntry = createMemory(content, {
+      layer: Layer.Episodic,
+      tags: [pathTag],
+    });
+    const ts = new Date(NOW.getTime() + TS_OFFSET_MS[i]).toISOString();
+    entry.created = ts;
+    entry.last_retrieved = ts;
+    writeEntry(root, entry);
+  });
+}
+
+describe('recall cross-store determinism (T2/T3 acceptance)', () => {
+  let storeA: string;
+  let storeB: string;
+
+  beforeEach(() => {
+    // Deliberately DIFFERENT directory name shapes (distinct prefixes AND
+    // the mkdtemp-generated random suffix), matching the plan's probe
+    // setup: rank variance was traced to store-path-dependent behaviour.
+    storeA = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-tiebreak-storeA-'));
+    storeB = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-tiebreak-storeB-different-name-'));
+    ingestFixture(storeA, 'path:store-a');
+    ingestFixture(storeB, 'path:store-b');
+  });
+
+  afterEach(() => {
+    fs.rmSync(storeA, { recursive: true, force: true });
+    fs.rmSync(storeB, { recursive: true, force: true });
+  });
+
+  it('hybridSearch returns identical top-K content sequences across differently-named fresh stores', async () => {
+    const entriesA = loadAllEntries(storeA);
+    const entriesB = loadAllEntries(storeB);
+    expect(entriesA.length).toBe(CONTENTS.length);
+    expect(entriesB.length).toBe(CONTENTS.length);
+
+    const resultsA = await hybridSearch(QUERY, entriesA, {
+      budget: 100_000,
+      now: NOW,
+      hippoRoot: storeA,
+      minResults: 1,
+    });
+    const resultsB = await hybridSearch(QUERY, entriesB, {
+      budget: 100_000,
+      now: NOW,
+      hippoRoot: storeB,
+      minResults: 1,
+    });
+
+    const contentsA = resultsA.map((r) => r.entry.content);
+    const contentsB = resultsB.map((r) => r.entry.content);
+
+    // The acceptance criterion: identical top-K CONTENT sequences,
+    // independent of the store's directory name / per-instance ids.
+    expect(contentsA).toEqual(contentsB);
+
+    // The unrelated filler doc never matches the probe query.
+    expect(contentsA).not.toContain(CONTENTS[0]);
+
+    // The genuine 4-way tie (anagram group: identical BM25 AND identical
+    // pinned timestamps -> exactly equal composite scores) is broken by
+    // content ascending in BOTH stores — not by scan order / random id,
+    // which would order the group differently across the two
+    // independently-created stores (and only match lexicographic order
+    // with ~1/24 luck).
+    const groupOrderA = contentsA.filter((c) => TIE_GROUP_SORTED.includes(c));
+    const groupOrderB = contentsB.filter((c) => TIE_GROUP_SORTED.includes(c));
+    expect(groupOrderA).toEqual(TIE_GROUP_SORTED);
+    expect(groupOrderB).toEqual(TIE_GROUP_SORTED);
+  });
+
+  it('searchBothHybrid returns identical top-K content sequences across differently-named fresh stores', async () => {
+    // Empty (non-existent) global root on both sides isolates this to the
+    // local-store comparator path (shared.ts) while still exercising the
+    // store.ts SQL tiebreaks via loadSearchEntries (FTS/LIKE branches).
+    const emptyGlobalA = path.join(os.tmpdir(), 'hippo-tiebreak-no-such-global-a');
+    const emptyGlobalB = path.join(os.tmpdir(), 'hippo-tiebreak-no-such-global-b-x');
+
+    const resultsA = await searchBothHybrid(QUERY, storeA, emptyGlobalA, {
+      budget: 100_000,
+      now: NOW,
+      localBump: 1.0, // remove the local-bias multiplier so this mirrors the plain hybridSearch case
+    });
+    const resultsB = await searchBothHybrid(QUERY, storeB, emptyGlobalB, {
+      budget: 100_000,
+      now: NOW,
+      localBump: 1.0,
+    });
+
+    const contentsA = resultsA.map((r) => r.entry.content);
+    const contentsB = resultsB.map((r) => r.entry.content);
+    expect(contentsA).toEqual(contentsB);
+    expect(contentsA.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/recall-tiebreak-primary-keys.test.ts
+++ b/tests/recall-tiebreak-primary-keys.test.ts
@@ -1,0 +1,238 @@
+/**
+ * T3 primary-key-preservation tests (docs/plans/2026-07-09-recall-determinism.md).
+ *
+ * The T2 rule for non-score-primary sort sites is: the site's true primary
+ * key must keep winning; compareEntryIdentity (src/compare.ts) is ONLY a
+ * tail for when the primary key ties. Each site below gets a "primary
+ * wins" case (real pipeline where practical) plus a "tail decides" tie
+ * case (comparator-level where invoking the full pipeline to engineer an
+ * exact tie would be disproportionate — sanctioned by the plan).
+ *
+ * Sites covered:
+ *   - api.ts:833      DAG-substitution ordering (overflow-child count desc)
+ *   - cli.ts:1167     --evc-adaptive ordering (recency desc)
+ *   - graph-recall.ts:248  graph-hop ordering (hops asc, then score desc)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory, Layer, type MemoryEntry, MemoryKind } from '../src/memory.js';
+import { recall, type Context } from '../src/api.js';
+import { estimateTokens, type SearchResult } from '../src/search.js';
+import { insertEntity, insertRelation } from '../src/graph.js';
+import { graphExpandRecall } from '../src/graph-recall.js';
+import { compareEntryIdentity } from '../src/compare.js';
+
+function safeRmSync(p: string): void {
+  try { rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// api.ts:833 — DAG-substitution ordering (overflow-child count desc)
+// ---------------------------------------------------------------------------
+
+describe('api.ts:833 DAG substitution ordering', () => {
+  function makeRoot(prefix: string): string {
+    const root = mkdtempSync(join(tmpdir(), `hippo-${prefix}-`));
+    mkdirSync(join(root, '.hippo'), { recursive: true });
+    initStore(root);
+    return root;
+  }
+  function ctxFor(root: string, tenantId: string = 'default'): Context {
+    return { hippoRoot: root, tenantId, actor: { subject: 'test:tiebreak', role: 'admin' } };
+  }
+  function makeLeaf(text: string, opts: Partial<MemoryEntry> = {}): MemoryEntry {
+    return createMemory(text, {
+      layer: Layer.Buffer,
+      tags: opts.tags ?? [],
+      confidence: 'observed',
+      dag_level: opts.dag_level ?? 0,
+      dag_parent_id: opts.dag_parent_id,
+      tenantId: opts.tenantId ?? 'default',
+      kind: (opts.kind ?? 'distilled') as MemoryKind,
+    });
+  }
+  function makeSummary(text: string, opts: Partial<MemoryEntry> = {}): MemoryEntry {
+    return createMemory(text, {
+      layer: Layer.Semantic,
+      tags: opts.tags ?? ['dag-summary'],
+      confidence: 'inferred',
+      dag_level: 2,
+      tenantId: opts.tenantId ?? 'default',
+    });
+  }
+
+  let root: string;
+  beforeEach(() => { root = makeRoot('dag-tiebreak'); });
+  afterEach(() => safeRmSync(root));
+
+  it('primary wins: the summary with MORE overflowing children is substituted, not the one with fewer', () => {
+    // Every leaf under both topics tokenizes to the SAME 4-term bag ("alpha
+    // zulu topic event") — the numeric/letter suffix ("a-0", "b-3", ...) is
+    // stripped by tokenize()'s length>1 filter (hyphen splits it into two
+    // 1-char tokens). So all 9 leaves score EXACTLY equal under BM25; with
+    // limit=1 the single baseSlice winner is decided purely by our T2
+    // content-ascending tiebreak, i.e. deterministically "alpha zulu topic
+    // event a-0" (topic A's own leaf 0). That leaves topic A's overflow
+    // count at 2 (3 - 1) and topic B's at 6 (untouched) REGARDLESS of any
+    // scoring wobble — 6 > 2 always holds, so this isolates the overflow-
+    // count primary key from the tiebreak being tested elsewhere.
+    const summaryA = makeSummary('topic A summary', { tags: ['dag-summary', 'topic:a'] });
+    writeEntry(root, summaryA);
+    for (let i = 0; i < 3; i++) {
+      writeEntry(root, makeLeaf(`alpha zulu topic event a-${i}`, {
+        dag_level: 1,
+        dag_parent_id: summaryA.id,
+      }));
+    }
+
+    const summaryB = makeSummary('topic B summary', { tags: ['dag-summary', 'topic:b'] });
+    writeEntry(root, summaryB);
+    for (let i = 0; i < 6; i++) {
+      writeEntry(root, makeLeaf(`alpha zulu topic event b-${i}`, {
+        dag_level: 1,
+        dag_parent_id: summaryB.id,
+      }));
+    }
+
+    // maxSub = max(1, ceil(limit * 0.3)) = 1 at limit=1, so only the WINNING
+    // (highest overflow count) summary is substituted — a clean single-slot
+    // assertion instead of inspecting relative order in a longer list.
+    const r = recall(ctxFor(root), { query: 'alpha zulu topic event', limit: 1 });
+    const summaries = r.results.filter((it) => it.isSummary);
+    expect(summaries.length).toBe(1);
+    expect(summaries[0].id).toBe(summaryB.id); // topic B (6 overflow) beats topic A (2 overflow)
+  });
+
+  it('tail decides: equal overflow counts fall back to compareEntryIdentity (content ascending)', () => {
+    // Engineering an EXACT overflow-count tie end-to-end through recall()
+    // depends on which leaf wins baseSlice, which is itself governed by the
+    // same tiebreak under test — disproportionate to pin reliably. Per the
+    // plan's explicit allowance, test the api.ts:833 comparator expression
+    // directly at the sorted-array level (same expression, just inlined —
+    // api.ts does not export it).
+    const parentA = { id: 'parent-zzz', content: 'zzz summary of topic zzz', tags: [] } as unknown as MemoryEntry;
+    const parentB = { id: 'parent-aaa', content: 'aaa summary of topic aaa', tags: [] } as unknown as MemoryEntry;
+    const overflowByParent = new Map<string, number>([
+      [parentA.id, 2],
+      [parentB.id, 2], // tied overflow count with parentA
+    ]);
+    const eligibleParents = [parentA, parentB];
+    eligibleParents.sort((a, b) => {
+      const ac = overflowByParent.get(a.id) ?? 0;
+      const bc = overflowByParent.get(b.id) ?? 0;
+      return bc !== ac ? bc - ac : compareEntryIdentity(a, b);
+    });
+    // counts tie -> content ascending: 'aaa summary...' < 'zzz summary...'
+    expect(eligibleParents.map((p) => p.id)).toEqual([parentB.id, parentA.id]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cli.ts:1167 — --evc-adaptive ordering (recency desc)
+// ---------------------------------------------------------------------------
+
+describe('cli.ts:1167 --evc-adaptive ordering', () => {
+  // cli.ts:1167's `onTopic.sort(...)` is a local closure inside `cmdRecall`
+  // (not exported — cmdRecall is CLI-internal), and a CLI-process spawn
+  // (execFileSync against bin/hippo.js) would run the COMPILED dist/cli.js,
+  // which this session must not rebuild (shared node_modules junction; the
+  // orchestrator builds after all executors land — see episode brief). So
+  // per the plan's explicit allowance, this is a sorted-array-level test of
+  // the exact comparator expression now at cli.ts:1167, re-declared here
+  // (not exported, to avoid widening cli.ts's public surface for a test).
+  interface OnTopicRow {
+    entry: { created: string; content: string; id: string };
+    score: number;
+  }
+  function sortOnTopic(rows: OnTopicRow[]): OnTopicRow[] {
+    return [...rows].sort((a, b) => {
+      const ta = new Date(a.entry.created).getTime();
+      const tb = new Date(b.entry.created).getTime();
+      return tb !== ta ? tb - ta : compareEntryIdentity(a.entry, b.entry);
+    });
+  }
+
+  it('primary wins: recency desc decides regardless of score or content', () => {
+    const older: OnTopicRow = { entry: { created: '2020-01-01T00:00:00.000Z', content: 'zzz older but higher score', id: 'id-older' }, score: 9 };
+    const newer: OnTopicRow = { entry: { created: '2026-01-01T00:00:00.000Z', content: 'aaa newer but lower score', id: 'id-newer' }, score: 1 };
+    // Shuffle input order so the result isn't an accidental array-order no-op.
+    expect(sortOnTopic([older, newer]).map((r) => r.entry.id)).toEqual([newer.entry.id, older.entry.id]);
+    expect(sortOnTopic([newer, older]).map((r) => r.entry.id)).toEqual([newer.entry.id, older.entry.id]);
+  });
+
+  it('tail decides: entries created at the exact same timestamp fall back to compareEntryIdentity (content ascending)', () => {
+    const tiedTimestamp = '2026-03-01T00:00:00.000Z';
+    const higherScore: OnTopicRow = { entry: { created: tiedTimestamp, content: 'zebra higher pre-evc score', id: 'id-z' }, score: 9 };
+    const lowerScore: OnTopicRow = { entry: { created: tiedTimestamp, content: 'apple lower pre-evc score', id: 'id-a' }, score: 1 };
+    // Recency ties -> content ascending decides ('apple...' < 'zebra...'),
+    // NOT score (which would have put higherScore first) and not input order.
+    expect(sortOnTopic([higherScore, lowerScore]).map((r) => r.entry.id)).toEqual([lowerScore.entry.id, higherScore.entry.id]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// graph-recall.ts:248 — graph-hop ordering (hops asc, then score desc, then
+// compareEntryIdentity tail)
+// ---------------------------------------------------------------------------
+
+describe('graph-recall.ts:248 graph-hop ordering', () => {
+  function makeRoot(): string {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-hop-tiebreak-'));
+    mkdirSync(join(home, '.hippo'), { recursive: true });
+    initStore(home);
+    return home;
+  }
+  function mem(home: string, tenant: string, text: string): MemoryEntry {
+    const m = createMemory(text, { tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: tenant });
+    writeEntry(home, m, { actor: 'test' });
+    return m;
+  }
+  function sr(entry: MemoryEntry, score: number): SearchResult {
+    return { entry, score, bm25: score, cosine: 0, tokens: estimateTokens(entry.content) };
+  }
+  function ent(home: string, tenant: string, m: MemoryEntry, name: string): number {
+    return insertEntity(home, tenant, { entityType: 'decision', name, memoryId: m.id }).id;
+  }
+
+  let home: string;
+  const T = 'default';
+  beforeEach(() => { home = makeRoot(); });
+  afterEach(() => safeRmSync(home));
+
+  it('primary wins (hop distance) and the tail decides same-hop ties', () => {
+    // a (origin, base seed) --1hop--> b, c (tied score: same origin+hop under
+    // the score = originScore * (1 - HOP_DISCOUNT*hops) formula) --1hop from
+    // b--> d (2 hops from a, therefore strictly lower score than b/c under
+    // that SAME formula — hops and score can never disagree for one origin,
+    // which is exactly why this sort's real job is: same-hop ties broken by
+    // content, and hop-groups never interleave).
+    const a = mem(home, T, 'origin alpha node for hop ordering test');
+    const ea = ent(home, T, a, 'A');
+
+    const b = mem(home, T, 'aaa hop one neighbor left of origin');
+    const c = mem(home, T, 'zzz hop one neighbor right of origin');
+    const eb = ent(home, T, b, 'B');
+    const ec = ent(home, T, c, 'C');
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: eb, relType: 'supersedes', memoryId: a.id });
+    insertRelation(home, T, { fromEntityId: ea, toEntityId: ec, relType: 'supersedes', memoryId: a.id });
+
+    const d = mem(home, T, 'mmm hop two neighbor reached via b');
+    const ed = ent(home, T, d, 'D');
+    insertRelation(home, T, { fromEntityId: eb, toEntityId: ed, relType: 'supersedes', memoryId: b.id });
+
+    const base = [sr(a, 1.0)];
+    const out = graphExpandRecall(base, {
+      hops: 2, hippoRoot: home, tenantId: T, budget: 40_000, includeSuperseded: true,
+    });
+
+    const ids = out.map((r) => r.entry.id);
+    // a (seed) first, then its hits in hitsByOrigin sort order: hop=1 group
+    // (b, c — tied score, content tail puts 'aaa...' before 'zzz...') BEFORE
+    // the hop=2 hit (d), regardless of any score magnitude.
+    expect(ids).toEqual([a.id, b.id, c.id, d.id]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the "deterministic tie-breaking in recall ranking" item (TODOS, filed 2026-07-05 from the F7 LoCoMo episode). Diagnosis showed the filed fix (a tie-break key) was downstream of the dominant cause:

1. **Root cause (dominant): embedding text included store-location noise.** Embedding input was `content + ALL tags`, and auto `path:*` tags carry the store directory's path components. Every fresh benchmark run (`tempfile.mkdtemp`) and any renamed project dir embedded *different text for identical content* (measured: same-content similarity 0.386 vs 0.374 across stores differing only by dir name; final-score deltas to 6.6e-2). Fix: `embeddingInputText()` excludes `path:*`; stored index identity is versioned (`<model>#t2`) so pre-upgrade indexes reindex exactly once through the existing atomic reindex path.
2. **Residual: unbroken score ties.** New leaf module `src/compare.ts` (content, then id) applied at first-ranking sorts; `content ASC, id ASC` SQL keys at the four window-deciding loaders; content tie key threaded into the physics `cluster_top_k` selection (its tie order mutates scores via amplification). Re-rank passes deliberately stay plain stable sorts: ties there must preserve the prior meaningful ranking, and sort stability inherits upstream determinism.
3. **Mechanism recalibrations forced by the corrected score scale** (embeddings de-compress similarity gaps): `--evc-adaptive` gains a query-coverage on-topic clause (the disambiguating target measured 0.33x max, below any sane score floor); the vmpfc micro fixture premise was re-measured into the (1.353, 1.857) raw-edge window.

## Evidence

- Two fresh independent LoCoMo smoke runs (conv 1, sample 10, evidence mode): **10/10 per-QA top-5 + scores byte-identical** (pre-fix characterization: conv-1 stdev 0.0175). Quality flat vs master (0.5 vs 0.5 mean).
- Two-store probe (identical content, different dir names, one recall each): identical order, max score delta **6.6e-8** (was 6.6e-2, whole-list reshuffles).
- Acceptance test proven **red on pristine master** (4-item exact-tie anagram group; independently reproduced by the review critic), green here.
- Micro-eval **11/11** (master baseline 11/11). Vitest **2698 passed**; sole failure is the pre-existing `server-concurrency` ECONNRESET flake (filed pre-episode; passes in isolation).

## Review trail

devrl episode `01KX434KMAQSX4HRHYC67WDTJQ` (critic A/B arm: default-sonnet). Plan: 3 rounds (fail 62, fail 78, pass 88). Review: independent-review-critic fail 68 then **pass 88** (it empirically falsified the first acceptance-test design by reconstructing master; fixed and re-proven); codex 2 rounds, converged to one documented residual.

## Known limitations (deliberate, filed in TODOS)

- BM25/FTS corpus still tokenizes `path:*` tags: different-DEPTH store paths shift doc-length normalization (codex P2). Stripping them changes real lexical matching (project-name queries hit `path:<project>` tags), so it is deferred as its own eval-gated change.
- Dedup survivor selection (`deduplicateStore`) remains per-instance: which near-duplicate survives `hippo sleep` can differ across fresh ingests. Needs its own tests; filed.
- Same-ms `created` collisions at SQL LIMIT boundaries are per-instance-deterministic only.

## Upgrade note

First embed-touching op after upgrade reindexes embeddings (one-time, atomic). Recall-only stores run BM25-only until then: run `hippo embed` once after upgrading. Mixed hippo versions sharing a store will ping-pong reindexes; upgrade installs together.

## Test plan

- [x] `npm test` (2698 passed; 1 pre-existing flake, passes in isolation)
- [x] `python benchmarks/micro/run.py` 11/11 (= master baseline)
- [x] Cross-store determinism test red-on-master, green here (verified twice, once independently by the review critic)
- [x] LoCoMo tier-2 smoke x2 fresh runs byte-identical; quality flat vs master
- [x] `npm run build:all`; 5 lockstep manifests at 1.26.0 (`check-manifest-versions.mjs` OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B36qQR2yRhDr564J4KxMzB
