### PR TITLE
fix: deterministic dedupe survivor selection (v1.26.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.26.3 (2026-07-16)
+
+### Fixed
+- **Dedup survivor selection is now deterministic.** `deduplicateStore` decided which of two near-duplicate memories survives `hippo sleep` / `hippo dedup` with a comparator that (a) tied exactly on fresh ingests (strength 1 vs 1, retrieval_count 0 vs 0 - measured pre-fix) and had no terminal key, so the survivor fell to arrival order (two stores ingesting the same facts in different orders consolidated to DIFFERENT surviving content), and (b) used a 0.01 abs-diff strength epsilon that is non-transitive (1.0~0.994 ties, 0.994~0.988 ties, but 1.0 beats 0.988), handing `Array.prototype.sort` an inconsistent comparator. Survivor selection is now a strict total order: strength bucket desc (`strengthBucket` = `Math.round(strength / 0.01)`, `Number.isFinite`-guarded so no NaN can break the order - the historical epsilon made transitive), then retrieval_count desc (same non-finite hardening), then `compareEntryIdentity` (content asc -> id asc, the cross-ingest-stable terminal key from 1.26.0's `src/compare.ts`). Which content survives consolidation is now a deterministic function of the store's contents. Behavior nuance: two strengths straddling a 0.01 bucket edge (e.g. 0.0049 vs 0.0051) now compare as different where the old epsilon called them tied; the flip always favors the not-weaker entry, and the old behavior at such pairs was itself order/engine-dependent. Evidence: 9 new real-DB tests (`tests/dedupe-survivor-determinism.test.ts`) incl. opposite-order stores, all-6-permutation invariance over an epsilon-chain triple, and an empirically verified mutant-kill pin for the bucket quantization; captured pre-fix red runs; micro-eval 11/11; full suite green.
+- **Consolidation merge-base tie (same class).** `mergeContents` picked the 2-entry merge base by content length with equal-length ties falling to cluster-assembly order; ties now break on `compareEntryIdentity`. No change when lengths differ. The 3+ entry bullet ORDER still follows cluster order - filed as a follow-up in TODOS.md (a deliberate cluster-ordering decision, not a drive-by).
+
+### Changed
+- New additive export `strengthBucket` from `src/dedupe.ts` (the transitive strength-tie quantizer; JSDoc'd, unit-pinned). No other API surface changes.
+- The 1.26.0 known limitation "dedup survivor selection (`deduplicateStore`) remains per-instance-deterministic only" is resolved by this release. The same-millisecond `created` SQL LIMIT-boundary clause of that limitation is unchanged and stays tracked in TODOS.md.
+
 ## 1.26.2 (2026-07-13)
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -55,6 +55,16 @@ reattributed and resolved the same day (harness bug, not hippo).
   load order. Same class as the v1.26.0 fix but changes surviving CONTENT
   during consolidation - needs its own tests (independent-review finding,
   v1.26.0 episode).
+- **Follow-up (from the dedupe-determinism episode): consolidate 3+ merge
+  bullet ORDER inherits cluster-assembly order.** `mergeContents`
+  (src/consolidate.ts) now breaks equal-LENGTH base ties deterministically,
+  but for 3+ entry clusters the bulleted summary lists members in cluster
+  order, which derives from upstream consolidation assembly (per-instance
+  stable via `created ASC, id ASC`, NOT cross-ingest stable). Content-noise
+  only (no survivor choice); land only with a deliberate cluster-ordering
+  decision in the consolidation pass, not as a drive-by
+  (docs/plans/2026-07-16-dedupe-survivor-determinism.md T2 out-of-scope
+  note).
 - **RESOLVED 2026-07-05 (same day) — silent loss of user-supplied `--tag`
   values was a harness bug, not a hippo write-path bug.** The rows this
   bullet originally described (13 tagless rows in the LoCoMo v1.25.0 run)

--- a/TODOS.md
+++ b/TODOS.md
@@ -48,13 +48,17 @@ reattributed and resolved the same day (harness bug, not hippo).
   on an eval because path tokens currently do real lexical work
   (project-name queries match `path:<project>` tags in the FTS index,
   db.ts fts5(id, content, tags)).
-- **Follow-up: dedup survivor selection is per-instance nondeterministic.**
-  `deduplicateStore` (src/dedupe.ts:41) sorts strength desc ->
-  retrieval_count desc with no further key; freshly-ingested near-duplicates
-  tie on both, so WHICH duplicate survives `hippo sleep` falls to random-id
-  load order. Same class as the v1.26.0 fix but changes surviving CONTENT
-  during consolidation - needs its own tests (independent-review finding,
-  v1.26.0 episode).
+- **RESOLVED 2026-07-16 (v1.26.3, episode 01KXPDKZJF2146W6R5VQA6M7FH) -
+  dedup survivor selection is per-instance nondeterministic.** Wider than
+  filed: besides the missing terminal tie key, the 0.01 abs-diff strength
+  epsilon was NON-TRANSITIVE (1.0~0.994, 0.994~0.988, 1.0>0.988), so a
+  minimal appended tie key would not have fixed the class. Shipped a strict
+  total order (`strengthBucket` bucket desc -> retrieval_count desc ->
+  compareEntryIdentity), plus the same-class equal-length merge-base tie in
+  consolidate.ts mergeContents. 9 real-DB tests incl. permutation invariance
+  + an empirically verified quantization mutant-kill; pre-fix red runs
+  captured. See CHANGELOG 1.26.3 +
+  docs/plans/2026-07-16-dedupe-survivor-determinism.md.
 - **Follow-up (from the dedupe-determinism episode): consolidate 3+ merge
   bullet ORDER inherits cluster-assembly order.** `mergeContents`
   (src/consolidate.ts) now breaks equal-LENGTH base ties deterministically,

--- a/docs/plans/2026-07-16-dedupe-survivor-determinism.md
+++ b/docs/plans/2026-07-16-dedupe-survivor-determinism.md
@@ -1,0 +1,158 @@
+# Deterministic dedupe survivor selection (v1.26.3 candidate)
+
+Status: Draft (episode 01KXPDKZJF2146W6R5VQA6M7FH; not yet engineering-reviewed)
+Date: 2026-07-16
+Branch: `fix/dedupe-survivor-determinism` off `origin/master` @ `fcca2d6`
+
+## Problem
+
+`deduplicateStore` (src/dedupe.ts:41) decides which of two near-duplicate
+memories survives `hippo sleep` / `hippo dedup` with this comparator:
+
+```ts
+entries.sort((a, b) => {
+  const sDiff = (b.strength ?? 0) - (a.strength ?? 0);
+  if (Math.abs(sDiff) > 0.01) return sDiff;
+  return (b.retrieval_count ?? 0) - (a.retrieval_count ?? 0);
+});
+```
+
+Two defects, one visible and one latent:
+
+1. **No final tie key (the filed defect, independent-review finding from the
+   v1.26.0 episode).** Freshly-ingested near-duplicates tie EXACTLY — measured
+   2026-07-16 on `fcca2d6` (probe: two stores, same near-dup pair A/B at
+   Jaccard 0.9091, opposite ingest orders): `strength=1` vs `1`,
+   `retrieval_count=0` vs `0` in both stores. The sort is stable, so the
+   survivor falls to `loadAllEntries` order (`created ASC, id ASC`) — store1
+   kept A, store2 kept B. WHICH CONTENT SURVIVES consolidation depends on
+   arrival order: two runs of the same benchmark ingest, or two agents
+   ingesting the same facts in different orders, consolidate to different
+   surviving content. Same class as the v1.26.0 recall-determinism fix, but
+   this one mutates the store (deletes the loser).
+
+2. **The `0.01` epsilon makes the comparator non-transitive (latent).**
+   Strengths 1.0 / 0.994 / 0.988: `1.0 ≈ 0.994` (tie branch), `0.994 ≈ 0.988`
+   (tie branch), but `1.0 > 0.988` (strength branch). An inconsistent
+   comparator hands `Array.prototype.sort` an unsatisfiable contract; the
+   result is engine- and input-permutation-dependent even for a fixed store.
+   Any appended tie key inherits this — a minimal "add a tie key" patch would
+   NOT fix the class.
+
+Sibling (same class, found by the §3b sibling-clone audit):
+`mergeContents` (src/consolidate.ts:568) picks the merge base by
+`content.length` desc with no tie key; equal-length cluster members fall to
+cluster-assembly order.
+
+## Design
+
+### T1 — total-order comparator in `deduplicateStore`
+
+Replace the sort comparator with a strict total order that preserves the
+documented intent ("keeps the stronger copy, or more retrievals if tied")
+and terminates in a deterministic, cross-ingest-stable key:
+
+```ts
+// Precompute per entry: bucket = strengthBucket(e.strength)
+//   strengthBucket(s) = Number.isFinite(s) ? Math.round(s / STRENGTH_TIE_EPSILON) : 0
+//   where STRENGTH_TIE_EPSILON = 0.01 (the existing epsilon, now transitive).
+//   Non-finite strength (NaN/Infinity; null/undefined already ?? 0 today) maps
+//   to bucket 0 — a NaN bucket would return NaN from the comparator and
+//   silently reintroduce the non-total-order class this fix exists to kill
+//   (plan-eng-critic r1 LOW). Bucket values are integers, so bucketB - bucketA
+//   is exact.
+// Sort by:
+//   1. strength bucket desc      (materially-stronger survives)
+//   2. retrieval_count desc      (more-retrieved survives; ?? 0)
+//   3. compareEntryIdentity      (content asc -> id asc; src/compare.ts)
+```
+
+- **Quantization, not raw compare.** Comparing raw strength first would let a
+  1e-9 decay-noise difference outrank a 10-retrieval difference, discarding
+  the epsilon's intent. Deriving an integer bucket ONCE per entry and
+  comparing buckets is the standard transitive encoding of "differences
+  under ~0.01 are ties". Boundary nuance (documented in a code comment):
+  two strengths straddling a bucket edge (e.g. 0.0049 vs 0.0051) now compare
+  as different where the old epsilon called them tied — the flip always
+  favors the not-weaker entry, and the OLD behavior at such pairs was
+  order/engine-dependent, so there is no stable prior behavior to preserve.
+- **`compareEntryIdentity` (content asc -> id asc) as the terminal key.**
+  Content is the cross-ingest-stable key (the acceptance criterion — two
+  fresh identical ingests consolidate to identical surviving content —
+  requires it). `id` is the per-instance last resort for exact-content
+  duplicates, where either survivor is content-identical.
+  **Rejected alternative — `created ASC` ("keep the oldest").** Arguably
+  nicer provenance semantics, but `created` is per-run wall clock: it is
+  exactly the load-order behavior that produced the filed bug and can never
+  satisfy the cross-ingest criterion.
+- dedupe.ts gains one import from `./compare.js` — a true leaf module
+  (imports nothing), so no cycle risk (v1.26.0 established this pattern).
+- The greedy pair scan, `removed` Set insertion order, `pairs` output order,
+  and `deleteEntry` loop all become deterministic functions of the entry
+  multiset once the sort is a total order; no changes needed there.
+- Semantics NOT changed: threshold, Jaccard measure, host-wide (cross-tenant)
+  scan posture (v1.12.10 `__host__` note), dryRun contract, DedupPair shape.
+
+### T2 — same-class one-liner in `mergeContents` (critic-flagged scope add)
+
+`src/consolidate.ts:568`:
+
+```ts
+const sorted = [...entries].sort(
+  (a, b) => (b.content.length - a.content.length) || compareEntryIdentity(a, b)
+);
+```
+
+Equal-length merge bases then break on content asc instead of cluster-assembly
+order. One line + one test; zero semantic change off-tie. The 3+ entry bullet
+ORDER (inherits upstream cluster order) is explicitly OUT of scope — filed as
+a follow-up in TODOS.md, because cluster assembly order is an upstream
+consolidation concern (recently-stabilized subsystem, #111) and bullets are a
+rendering of all members, not a survivor choice.
+
+### Out of scope
+
+- BM25 path-tag depth residual (eval-gated, filed), S5 tuning (eval-gated),
+  assemble/recall `--scope` asymmetry (decision-shaped, filed).
+- Consolidation cluster-assembly ordering (follow-up filed by this plan).
+- Any change to which rows COUNT as duplicates (threshold/Jaccard untouched).
+
+## Tests (new file `tests/dedupe-survivor-determinism.test.ts`, real DB)
+
+1. **Red-on-master core:** two stores, same near-dup pair ingested in opposite
+   orders -> `deduplicateStore` keeps the SAME content in both (the probe as a
+   regression test; fails on `fcca2d6`).
+2. **Permutation invariance:** 3 near-duplicates at pairwise-tied strength
+   (incl. an epsilon-chain triple 1.0/0.994/0.988 to pin transitivity), all 6
+   ingest permutations -> identical surviving-content set.
+3. **Strength dominance preserved:** materially stronger (>1 bucket apart)
+   survives even when ingested last.
+4. **Retrieval-count tiebreak preserved:** equal bucket, higher
+   retrieval_count survives regardless of ingest order.
+5. **Exact-content duplicates:** dedupe removes one, keeps one; store ends
+   with exactly one copy (id key exercised; content identical either way).
+6. **dryRun parity:** dryRun pairs equal the rows a non-dry run deletes.
+7. **mergeContents tie (T2):** two equal-length contents in a merge cluster ->
+   merged base identical for both ingest orders.
+8. **Non-finite strength (unit-level):** `strengthBucket(NaN)` = 0 and a
+   NaN-strength entry still yields a strict total order (comparator never
+   returns NaN) — pins the plan-eng-critic r1 LOW.
+
+Suite-level gates: full `npm test` green; tier-1 micro-eval 11/11
+non-regression; `npm run build:all` (release rule).
+
+## Release
+
+Patch bump 1.26.2 -> **1.26.3** across the 5 lockstep manifests
+(`package.json`, `openclaw.plugin.json`, `extensions/openclaw-plugin/package.json`,
+`extensions/openclaw-plugin/openclaw.plugin.json`, `src/version.ts`;
+`scripts/check-manifest-versions.mjs` enforces at prepublish). CHANGELOG entry
+documents the behavior change (deterministic survivor selection; bucket-edge
+nuance) with no API change. No migration (no schema touch).
+
+## Evidence base (measured this episode, pre-fix)
+
+- Probe on `fcca2d6` dist: `jaccard(A,B)=0.9090909090909091`;
+  store1 (A,B): both `strength=1 retrieval_count=0`, kept=A;
+  store2 (B,A): both `strength=1 retrieval_count=0`, kept=B.
+  Full-precision tie confirmed (measure-ties-before-fixing memory applied).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.26.2",
+  "version": "1.26.3",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -23,6 +23,7 @@ import {
   listSessionEvents,
 } from './store.js';
 import { textOverlap, markRetrieved } from './search.js';
+import { compareEntryIdentity } from './compare.js';
 import { openHippoDb, closeHippoDb } from './db.js';
 import { loadPhysicsState, savePhysicsState, refreshParticleProperties } from './physics-state.js';
 import { simulate, type ForceContext } from './physics.js';
@@ -564,8 +565,11 @@ export async function consolidate(
 // ---------------------------------------------------------------------------
 
 function mergeContents(entries: MemoryEntry[]): string {
-  // Simple merge: take the longest entry as the base, prepend a summary note
-  const sorted = [...entries].sort((a, b) => b.content.length - a.content.length);
+  // Simple merge: take the longest entry as the base, prepend a summary note.
+  // Equal-length merge bases previously fell to cluster-assembly order;
+  // compareEntryIdentity is a deterministic tie key (content asc -> id asc),
+  // a no-op when lengths differ (docs/plans/2026-07-16-dedupe-survivor-determinism.md T2).
+  const sorted = [...entries].sort((a, b) => (b.content.length - a.content.length) || compareEntryIdentity(a, b));
   const base = sorted[0].content;
 
   if (entries.length === 2) {

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -7,10 +7,19 @@
  * during the consolidation pipeline without violating the cli -> api
  * dependency direction. `cmdDedup` in cli.ts continues to import and use
  * this function unchanged.
+ *
+ * Survivor selection is a total order as of v1.26.3
+ * (docs/plans/2026-07-16-dedupe-survivor-determinism.md): strength bucket
+ * desc -> retrieval_count desc -> compareEntryIdentity (content asc -> id
+ * asc). Previously the strength/retrieval-count comparator could tie
+ * exactly with no terminal key, so the survivor fell to load order
+ * (arrival-order-dependent); see `strengthBucket` below for the bucket
+ * encoding.
  */
 
 import { textOverlap } from './search.js';
 import { loadAllEntries, deleteEntry } from './store.js';
+import { compareEntryIdentity } from './compare.js';
 
 export interface DedupPair {
   kept: string;
@@ -22,6 +31,37 @@ export interface DedupPair {
   removedLayer: string;
   removedStrength: number;
   similarity: number;
+}
+
+/** Quantization step for strength-tie comparisons. The historical 0.01
+ *  epsilon (see `strengthBucket` below) applied via rounding instead of a
+ *  raw abs-diff threshold, so the tiebreak is transitive. */
+const STRENGTH_TIE_EPSILON = 0.01;
+
+/**
+ * Quantize a strength value into an integer "bucket" for tie comparison.
+ *
+ * Encodes the historical 0.01 epsilon transitively: two strengths compare
+ * equal here iff they round to the same multiple of `STRENGTH_TIE_EPSILON`,
+ * which (unlike a raw `Math.abs(a - b) > epsilon` check) is a genuine
+ * equivalence relation — no more "A ties B, B ties C, but A beats C"
+ * (see the file-level history note above).
+ *
+ * Non-finite input (`NaN`, `+/-Infinity`) maps to bucket `0` rather than
+ * propagating: a NaN bucket would make the sort comparator return NaN,
+ * silently reintroducing the non-total-order class this fix exists to kill.
+ * (`null`/`undefined` already default to strength `0` via `?? 0`, same as
+ * before this change.)
+ *
+ * Bucket-edge nuance: two strengths straddling a bucket edge (e.g. 0.0049 vs
+ * 0.0051) now compare as different, where the old raw-epsilon check called
+ * them tied. The flip always favors the not-weaker entry, and the OLD
+ * behavior at such pairs was itself order/engine-dependent (the defect this
+ * fix exists to kill) — so there is no stable prior behavior being broken.
+ */
+export function strengthBucket(strength: number | null | undefined): number {
+  const s = strength ?? 0;
+  return Number.isFinite(s) ? Math.round(s / STRENGTH_TIE_EPSILON) : 0;
 }
 
 /**
@@ -37,11 +77,27 @@ export function deduplicateStore(
   const dryRun = options.dryRun ?? false;
   const entries = loadAllEntries(hippoRoot);
 
-  // Sort by strength desc, then retrieval count, so we keep the most valuable copy
+  // Total order so the survivor is a deterministic function of the entry
+  // multiset, not of load/ingest order: strength bucket desc
+  // (materially-stronger survives) -> retrieval_count desc (more-retrieved
+  // survives on a strength tie) -> compareEntryIdentity (content asc -> id
+  // asc), the cross-ingest-stable terminal key. Without a terminal key,
+  // freshly-ingested near-duplicates tie exactly (strength=1,
+  // retrieval_count=0) and the stable sort falls through to
+  // loadAllEntries's `created ASC, id ASC` order -- arrival order.
+  // finiteCount mirrors strengthBucket's non-finite hardening on the
+  // retrieval leg: a NaN retrieval_count would make the comparator return
+  // NaN and break the total order the same way a NaN bucket would.
+  // Unreachable via the schema (non-nullable INTEGER column), so this is
+  // symmetry, not a live bug.
+  const finiteCount = (n: number | null | undefined): number =>
+    Number.isFinite(n ?? 0) ? (n ?? 0) : 0;
   entries.sort((a, b) => {
-    const sDiff = (b.strength ?? 0) - (a.strength ?? 0);
-    if (Math.abs(sDiff) > 0.01) return sDiff;
-    return (b.retrieval_count ?? 0) - (a.retrieval_count ?? 0);
+    const bucketDiff = strengthBucket(b.strength) - strengthBucket(a.strength);
+    if (bucketDiff !== 0) return bucketDiff;
+    const retrievalDiff = finiteCount(b.retrieval_count) - finiteCount(a.retrieval_count);
+    if (retrievalDiff !== 0) return retrievalDiff;
+    return compareEntryIdentity(a, b);
   });
 
   const removed = new Set<string>();

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.26.2';
+export const PACKAGE_VERSION = '1.26.3';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/dedupe-survivor-determinism.test.ts
+++ b/tests/dedupe-survivor-determinism.test.ts
@@ -73,7 +73,7 @@ function permutationsOf3(): number[][] {
   return out;
 }
 
-// Near-duplicate probe pair: 14 shared tokens, one word swapped
+// Near-duplicate probe pair: 14 tokens per entry, 13 shared, one word swapped
 // ("this" -> "last"). Jaccard = 13/15 = 0.8667 (> 0.7 dedupe threshold),
 // computed against src/search.ts textOverlap's tokenizer (lowercase,
 // punctuation-stripped, length>1 tokens, set-based Jaccard).
@@ -196,6 +196,34 @@ describe('dedupe survivor determinism', () => {
     } finally {
       s1.restore();
       s2.restore();
+    }
+  });
+
+  it('4b. quantization intent: within-epsilon strength difference is a TIE, so retrieval_count decides (kills the raw-strength-compare mutant)', () => {
+    // strengths 1.0 and 0.996 land in the SAME bucket (round(100.0) ==
+    // round(99.6) == 100), so under the shipped comparator retrieval_count
+    // decides -- the 0.996-strength / 5-retrieval entry must survive. A
+    // raw-strength compare ((b.strength ?? 0) - (a.strength ?? 0)) would
+    // keep the 1.0-strength entry instead and fail this test: this is the
+    // one case that pins the bucket quantization itself, not just the
+    // determinism properties (independent-review r1 MED).
+    const { home, restore } = tmpHome('hippo-dedupe-det-4b-');
+    try {
+      const strongRaw = remember(ctxFor(home), { content: CONTENT_A });
+      const retrieved = remember(ctxFor(home), { content: CONTENT_B });
+      setStrength(home, strongRaw.id, 1.0);
+      setStrength(home, retrieved.id, 0.996);
+      setRetrievalCount(home, strongRaw.id, 0);
+      setRetrievalCount(home, retrieved.id, 5);
+
+      const result = deduplicateStore(home);
+
+      expect(result.removed).toBe(1);
+      expect(result.pairs[0].kept).toBe(retrieved.id);
+      expect(result.pairs[0].keptContent).toBe(CONTENT_B);
+      expect(result.pairs[0].removed).toBe(strongRaw.id);
+    } finally {
+      restore();
     }
   });
 

--- a/tests/dedupe-survivor-determinism.test.ts
+++ b/tests/dedupe-survivor-determinism.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Deterministic dedupe survivor selection
+ * (docs/plans/2026-07-16-dedupe-survivor-determinism.md).
+ *
+ * Pins that `deduplicateStore` picks the SAME surviving content regardless
+ * of ingest order: strength bucket desc -> retrieval_count desc ->
+ * compareEntryIdentity (content asc -> id asc). Real-DB per project
+ * convention (measure-ties-before-fixing / real-store-guard): each test
+ * isolates a fresh hippoRoot via mkdtempSync + initStore, following the
+ * tmpHome idiom in tests/api-sleep.test.ts.
+ *
+ * T2 (src/consolidate.ts mergeContents tie key) is exercised through the
+ * public `consolidate()` merge pass (test 7), following the Merge-pass
+ * idiom in tests/consolidate.test.ts -- `mergeContents` itself stays
+ * file-private.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry, loadAllEntries } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { remember, type Context } from '../src/api.js';
+import { deduplicateStore, strengthBucket } from '../src/dedupe.js';
+import { compareEntryIdentity } from '../src/compare.js';
+import { consolidate } from '../src/consolidate.js';
+import { createMemory, Layer } from '../src/memory.js';
+
+function tmpHome(prefix: string): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  initStore(home);
+  return {
+    home,
+    restore: () => rmSync(home, { recursive: true, force: true }),
+  };
+}
+
+function ctxFor(home: string): Context {
+  return { hippoRoot: home, tenantId: 'default', actor: { subject: 'test', role: 'admin' } };
+}
+
+function setStrength(home: string, id: string, strength: number): void {
+  const db = openHippoDb(home);
+  try {
+    db.prepare(`UPDATE memories SET strength = ? WHERE id = ?`).run(strength, id);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+function setRetrievalCount(home: string, id: string, count: number): void {
+  const db = openHippoDb(home);
+  try {
+    db.prepare(`UPDATE memories SET retrieval_count = ? WHERE id = ?`).run(count, id);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+function permutationsOf3(): number[][] {
+  const items = [0, 1, 2];
+  const out: number[][] = [];
+  for (const a of items) {
+    for (const b of items) {
+      if (b === a) continue;
+      for (const c of items) {
+        if (c === a || c === b) continue;
+        out.push([a, b, c]);
+      }
+    }
+  }
+  return out;
+}
+
+// Near-duplicate probe pair: 14 shared tokens, one word swapped
+// ("this" -> "last"). Jaccard = 13/15 = 0.8667 (> 0.7 dedupe threshold),
+// computed against src/search.ts textOverlap's tokenizer (lowercase,
+// punctuation-stripped, length>1 tokens, set-based Jaccard).
+const CONTENT_A =
+  'The quarterly finance report shows revenue grew steadily across all four regions this year';
+const CONTENT_B =
+  'The quarterly finance report shows revenue grew steadily across all four regions last year';
+
+// Three mutually near-duplicate contents for the permutation test: a 20
+// shared-token base sentence, each variant swapping a DIFFERENT single word
+// for a word that appears nowhere else in the set. Any two variants share
+// 18 of 20 tokens each (intersection 18, union 22) -> Jaccard 18/22 = 0.8182
+// (> 0.7), so all three pairs are near-duplicates of each other.
+const VARIANT_A =
+  'our deployment pipeline automatically runs full suite of integration tests before every production release each week without exception this time';
+const VARIANT_B =
+  'the nightly pipeline automatically runs full suite of integration tests before every production release each week without exception this time';
+const VARIANT_C =
+  'the deployment pipeline automatically runs full suite of integration tests before every production release each week without exception last time';
+
+describe('dedupe survivor determinism', () => {
+  it('1. keeps the same surviving content across opposite ingest orders (red-on-master core)', () => {
+    const s1 = tmpHome('hippo-dedupe-det-1a-');
+    const s2 = tmpHome('hippo-dedupe-det-1b-');
+    try {
+      remember(ctxFor(s1.home), { content: CONTENT_A });
+      remember(ctxFor(s1.home), { content: CONTENT_B });
+
+      remember(ctxFor(s2.home), { content: CONTENT_B });
+      remember(ctxFor(s2.home), { content: CONTENT_A });
+
+      const result1 = deduplicateStore(s1.home);
+      const result2 = deduplicateStore(s2.home);
+
+      expect(result1.removed).toBe(1);
+      expect(result2.removed).toBe(1);
+      expect(result1.pairs[0].keptContent).toBe(result2.pairs[0].keptContent);
+    } finally {
+      s1.restore();
+      s2.restore();
+    }
+  });
+
+  it('2. permutation invariance: 3 pairwise near-duplicates with an epsilon-chain triple (1.0/0.994/0.988) survive identically across all 6 ingest orders', () => {
+    const contents = [VARIANT_A, VARIANT_B, VARIANT_C];
+    const strengths = [1.0, 0.994, 0.988]; // pins transitivity: old raw-epsilon check tied 1.0~0.994 and 0.994~0.988 but not 1.0~0.988
+    const survivorContents = new Set<string>();
+
+    for (const perm of permutationsOf3()) {
+      const { home, restore } = tmpHome('hippo-dedupe-det-2-');
+      try {
+        const ids: string[] = [];
+        for (const idx of perm) {
+          const { id } = remember(ctxFor(home), { content: contents[idx] });
+          ids[idx] = id;
+        }
+        for (let idx = 0; idx < contents.length; idx++) {
+          setStrength(home, ids[idx], strengths[idx]);
+        }
+
+        deduplicateStore(home);
+        const remaining = loadAllEntries(home, 'default');
+        expect(remaining.length).toBe(1);
+        survivorContents.add(remaining[0].content);
+      } finally {
+        restore();
+      }
+    }
+
+    expect(survivorContents.size).toBe(1);
+    expect([...survivorContents][0]).toBe(VARIANT_A);
+  });
+
+  it('3. strength dominance preserved: materially stronger entry survives even when ingested last', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-det-3-');
+    try {
+      const weak = remember(ctxFor(home), { content: CONTENT_A });
+      const strong = remember(ctxFor(home), { content: CONTENT_B });
+      setStrength(home, weak.id, 0.5);
+      setStrength(home, strong.id, 1.0);
+
+      const result = deduplicateStore(home);
+
+      expect(result.removed).toBe(1);
+      expect(result.pairs[0].kept).toBe(strong.id);
+      expect(result.pairs[0].keptContent).toBe(CONTENT_B);
+      expect(result.pairs[0].removed).toBe(weak.id);
+    } finally {
+      restore();
+    }
+  });
+
+  it('4. retrieval-count tiebreak preserved on an equal strength bucket, regardless of ingest order', () => {
+    const s1 = tmpHome('hippo-dedupe-det-4a-');
+    const s2 = tmpHome('hippo-dedupe-det-4b-');
+    try {
+      // Order 1: low-retrieval entry ingested first.
+      const low1 = remember(ctxFor(s1.home), { content: CONTENT_A });
+      const high1 = remember(ctxFor(s1.home), { content: CONTENT_B });
+      setStrength(s1.home, low1.id, 1.0);
+      setStrength(s1.home, high1.id, 1.0);
+      setRetrievalCount(s1.home, low1.id, 0);
+      setRetrievalCount(s1.home, high1.id, 5);
+
+      // Order 2: high-retrieval entry ingested first.
+      const high2 = remember(ctxFor(s2.home), { content: CONTENT_B });
+      const low2 = remember(ctxFor(s2.home), { content: CONTENT_A });
+      setStrength(s2.home, high2.id, 1.0);
+      setStrength(s2.home, low2.id, 1.0);
+      setRetrievalCount(s2.home, high2.id, 5);
+      setRetrievalCount(s2.home, low2.id, 0);
+
+      const result1 = deduplicateStore(s1.home);
+      const result2 = deduplicateStore(s2.home);
+
+      expect(result1.pairs[0].keptContent).toBe(CONTENT_B);
+      expect(result2.pairs[0].keptContent).toBe(CONTENT_B);
+      expect(result1.pairs[0].kept).toBe(high1.id);
+      expect(result2.pairs[0].kept).toBe(high2.id);
+    } finally {
+      s1.restore();
+      s2.restore();
+    }
+  });
+
+  it('5. exact-content duplicates: dedupe removes one, store ends with exactly one copy', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-det-5-');
+    try {
+      remember(ctxFor(home), { content: CONTENT_A });
+      remember(ctxFor(home), { content: CONTENT_A });
+
+      const result = deduplicateStore(home);
+
+      expect(result.removed).toBe(1);
+      const remaining = loadAllEntries(home, 'default');
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].content).toBe(CONTENT_A);
+    } finally {
+      restore();
+    }
+  });
+
+  it('6. dryRun parity: dryRun pairs equal what a subsequent real run deletes', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-det-6-');
+    try {
+      remember(ctxFor(home), { content: CONTENT_A });
+      remember(ctxFor(home), { content: CONTENT_B });
+
+      const dry = deduplicateStore(home, { dryRun: true });
+      const real = deduplicateStore(home, { dryRun: false });
+
+      expect(dry.removed).toBe(1);
+      expect(real.removed).toBe(1);
+      expect(dry.pairs.map((p) => p.removed)).toEqual(real.pairs.map((p) => p.removed));
+      expect(dry.pairs.map((p) => p.removedContent)).toEqual(real.pairs.map((p) => p.removedContent));
+      expect(dry.pairs.map((p) => p.keptContent)).toEqual(real.pairs.map((p) => p.keptContent));
+
+      const remaining = loadAllEntries(home, 'default');
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].content).toBe(real.pairs[0].keptContent);
+    } finally {
+      restore();
+    }
+  });
+
+  it('7. mergeContents equal-length tie: merged base identical across opposite ingest orders (content asc tie key)', async () => {
+    // Equal length (verified below), one same-length word swapped -->
+    // Jaccard 5/7 = 0.714 > MERGE_OVERLAP_THRESHOLD (0.35), so the merge
+    // pass fires and mergeContents' content.length primary key is a REAL
+    // tie; only the compareEntryIdentity tie key decides the base. Same
+    // `now` for both consolidate calls guards against decay flakiness.
+    const contentAlpha = 'cache refresh failure data pipeline alpha';
+    const contentOmega = 'cache refresh failure data pipeline omega';
+    expect(contentAlpha.length).toBe(contentOmega.length);
+
+    const now = new Date();
+    const bases: string[] = [];
+
+    for (const order of [[contentAlpha, contentOmega], [contentOmega, contentAlpha]]) {
+      const { home, restore } = tmpHome('hippo-dedupe-det-7-');
+      try {
+        for (const content of order) {
+          writeEntry(home, createMemory(content, { layer: Layer.Episodic }));
+        }
+
+        const result = await consolidate(home, { now });
+        expect(result.merged).toBeGreaterThan(0);
+
+        const semantics = loadAllEntries(home).filter(
+          (e) => e.layer === Layer.Semantic && e.content.startsWith('[Consolidated from 2 related memories]'),
+        );
+        expect(semantics.length).toBe(1);
+        // Content shape: '[Consolidated from 2 related memories]\n\n<base>'.
+        bases.push(semantics[0].content.split('\n\n')[1]);
+      } finally {
+        restore();
+      }
+    }
+
+    expect(bases[0]).toBe(bases[1]);
+    // content asc tie key: the lexicographically smaller content is the base.
+    expect(bases[0]).toBe(contentAlpha);
+  });
+
+  it('8. strengthBucket maps non-finite strength to bucket 0 and the assembled comparator chain never returns NaN', () => {
+    expect(strengthBucket(NaN)).toBe(0);
+    expect(strengthBucket(Infinity)).toBe(0);
+    expect(strengthBucket(-Infinity)).toBe(0);
+    expect(strengthBucket(null)).toBe(0);
+    expect(strengthBucket(undefined)).toBe(0);
+    expect(strengthBucket(0)).toBe(0);
+    expect(strengthBucket(1)).toBe(100);
+
+    // Mirrors dedupe.ts's comparator chain (bucket desc -> retrieval desc ->
+    // compareEntryIdentity) using the same two exported building blocks, to
+    // pin that a NaN-strength entry still yields a strict, non-NaN order --
+    // no DB needed, pure-function test only.
+    const a = { id: 'aaa-nan', content: 'alpha content', strength: NaN, retrieval_count: 0 };
+    const b = { id: 'bbb-normal', content: 'beta content', strength: 0.5, retrieval_count: 0 };
+
+    const bucketDiff = strengthBucket(b.strength) - strengthBucket(a.strength);
+    expect(Number.isNaN(bucketDiff)).toBe(false);
+
+    const retrievalDiff = (b.retrieval_count ?? 0) - (a.retrieval_count ?? 0);
+    expect(Number.isNaN(retrievalDiff)).toBe(false);
+
+    const identity = compareEntryIdentity(a, b);
+    expect(Number.isNaN(identity)).toBe(false);
+
+    const cmp = bucketDiff !== 0 ? bucketDiff : retrievalDiff !== 0 ? retrievalDiff : identity;
+    expect(Number.isNaN(cmp)).toBe(false);
+    expect(typeof cmp).toBe('number');
+  });
+});


### PR DESCRIPTION
## What

Makes dedupe survivor selection deterministic (v1.26.3). Two defects, one visible and one latent, in `deduplicateStore`'s survivor sort:

1. **No terminal tie key (the filed defect).** Fresh near-duplicates tie exactly (strength 1 vs 1, retrieval_count 0 vs 0 - measured pre-fix on a live probe), so which content survives `hippo sleep` fell to arrival order: two stores ingesting the same facts in different orders consolidated to DIFFERENT surviving content.
2. **Non-transitive comparator (latent).** The 0.01 abs-diff strength epsilon breaks transitivity (1.0~0.994 ties, 0.994~0.988 ties, 1.0 beats 0.988) - an inconsistent comparator contract with `Array.prototype.sort`, so even fixed inputs were engine/permutation-dependent. A minimal appended tie key would NOT have fixed this class.

## Fix

Strict total order in `src/dedupe.ts`: `strengthBucket` desc (`Math.round(strength/0.01)`, `Number.isFinite`-guarded - the historical epsilon made transitive) -> retrieval_count desc (same hardening) -> `compareEntryIdentity` (content asc -> id asc, the cross-ingest-stable terminal key from 1.26.0's `src/compare.ts`). Plus the same-class one-liner in `src/consolidate.ts` `mergeContents`: equal-length merge bases tie-break on `compareEntryIdentity` instead of cluster-assembly order.

Behavior nuance (documented in CHANGELOG + JSDoc): strengths straddling a 0.01 bucket edge now compare as different where the old epsilon called them tied; the flip always favors the not-weaker entry, and old behavior at such pairs was itself order-dependent.

## Evidence

- Pre-fix red runs captured on disk: tests 1/2/8 fail on the old comparator (git-stash red run); test 7 fails with only the T2 tie key stashed.
- Quantization mutant-kill verified empirically: raw-strength-compare mutant applied -> test 4b FAILS -> restored.
- 9 new real-DB tests (`tests/dedupe-survivor-determinism.test.ts`): opposite-order stores, all-6-permutation invariance over an epsilon-chain triple (1.0/0.994/0.988), strength dominance, retrieval tiebreak, quantization pin, exact-content dups, dryRun parity, merge-base tie via public `consolidate()`, non-finite unit pins.
- Micro-eval 11/11 pass=1.000; full suite 344 files / 2734 tests green; tsc + build:all clean; 5 lockstep manifests at 1.26.3.

## Gates (dev-framework-rl episode 01KXPDKZJF2146W6R5VQA6M7FH, opus critic arm)

- plan-eng-critic PASS 89 (r1, 0 must-fix); code-review-critic PASS 90 (r1, 0 must-fix, 3 LOW all resolved); independent-review-critic PASS 90 (r1, MED closed with the mutant-kill test); codex-review-critic CLEAN (r1, clean CODEX_HOME profile).

## Test plan

- [x] Red-on-master reproductions captured before the fix
- [x] 9/9 new tests green; adjacent suites (api-sleep, phase-faults, l9-tenant-scoping) 26/26
- [x] Full suite + micro-eval + build:all on the release tree
- [x] Version lockstep check green

Follow-up filed in TODOS.md: 3+ merge bullet ORDER (cluster-assembly ordering decision, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B36qQR2yRhDr564J4KxMzB
