### PR TITLE
feat: embed promoted/shared global-store rows + hippo embed --global (v1.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 1.27.0 - 2026-07-18
+
+### Fixed
+- **Rows promoted or shared to the global store now enter its embedding
+  index** (backlog A2#1). Every local write path embeds best-effort at write
+  time, but neither `promoteToGlobal` nor `shareMemory` did, and nothing ever
+  ran `embedAll` against the global root, so promoted/shared rows scored
+  bm25-only in hybrid recall: measured 3.15x hybrid-base deficit vs an
+  identical local twin on the minimal probe (0.2877 vs 0.9074; the richer
+  S5-era probe measured 5.4x). After the fix the promoted copy's hybrid base
+  is bit-identical to its local twin (same embedding input text since 1.26.0
+  excludes `path:*` tags). The producers now follow one invariant:
+  single-row producers (`promote`, `share`) fire the same best-effort
+  `embedMemory` contract `remember` uses; batch producers (`autoShare`
+  during sleep, `hippo sync`, `hippo import` including `--vault`) run one
+  best-effort `embedAll` on the destination store after their loop.
+  Evidence: red/green probes, micro-eval 12/12, full suite 345 files /
+  2752 tests. See `docs/evals/2026-07-18-global-row-embeddings-result.md`.
+
+### Added
+- **`hippo embed --global`**: runs the embedding backfill against the global
+  store (initializes it if needed; no local store required, mirroring
+  `auth --global` routing). This is the healing path for stores created
+  before 1.27.0.
+- `shareMemory` gained an optional `skipEmbed` flag (additive; used
+  internally by `autoShare` for batching).
+
+### Upgrade note
+- Run `hippo embed --global` once after upgrading to backfill vectors for
+  global rows promoted/shared under earlier versions. Until then those rows
+  keep their old bm25-only ranking. The first sleep after upgrading may also
+  take longer on a large legacy global store: `autoShare` now triggers the
+  backfill when it shares rows, and `embedMemory`/`embedAll` can trigger a
+  one-time full reindex if the store's embedding-model identity changed.
+
 ## 1.26.4 - 2026-07-18
 
 ### Fixed

--- a/docs/evals/2026-07-18-global-row-embeddings-result.md
+++ b/docs/evals/2026-07-18-global-row-embeddings-result.md
@@ -1,0 +1,30 @@
+# 2026-07-18 Global-row embeddings (v1.27.0) - Result
+
+**Status:** COMPLETE, all 4 pre-registered instruments PASS. Plan + pre-registration: `docs/plans/2026-07-18-global-row-embeddings.md` (episode 01KXV39T951THW81ZSD088FKZX).
+
+## Defect
+
+Rows written to the global store by `promoteToGlobal` / `shareMemory` (and local stores by `syncGlobalToLocal` / `hippo import`, including `--vault`) never entered the destination store's embedding index; hybrid recall scored them bm25-only. Discovered by score-verified precheck in the S5 episode (01KXTBPR, `2026-07-18-s5-path-overlap-result.md`), which measured ~5.4x hybrid-base deficit in a 3-competitor corpus.
+
+## RED (pre-fix, v1.26.4 build; scratch HIPPO_HOME + scratch cwd; full precision)
+
+- LOCAL twin base: `0.9074030329496725` (mode=hybrid, cosine 0.8456717215827875)
+- PROMOTED g_ row base: `0.28768207245178085` (mode=bm25-only, cosine 0) - ratio 3.154186930093688x on this single-row corpus
+- Global store `embeddings.json`: never created; promoted id absent.
+
+## GREEN (post-fix, same probe method)
+
+- LOCAL `0.9074030329496725` vs PROMOTED `0.9074030329496725` - **bit-identical** (ratio 1). Predicted by v1.26.0's `path:*` exclusion from embedding input text: identical content + tags -> identical vector.
+- Global index contains the promoted id, 384-dim vector.
+
+## Non-regression instruments
+
+- **Micro-eval 12/12**; named watch `path_boost` (its fixture's promoted rows now gain vectors) 2/2, no ranking interaction.
+- **Full suite**: 345 files passed / 3 skipped, 2752 tests passed / 4 skipped; +1 file / +9 tests vs the 1.26.4 baseline = exactly the new `tests/global-row-embeddings.test.ts`.
+- **LoCoMo smoke**: grep proves `benchmarks/locomo` never calls promote/share/autoShare (ingest = init/remember/recall), so the diff is structurally outside that path; two fresh-store conv-26 sample-10 runs byte-identical (0/10 mismatches). Caveat recorded honestly: no live 1.26.4 binary head-to-head; the verdict rests on the code-identity argument plus the determinism reconfirmation.
+
+## Known limitation
+
+vitest's VM execution breaks `embeddings.ts`'s `_dynImport` (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`, pre-existing and environment-wide), so in-process positive-embedding tests skip; real-path coverage rides on two real-`node` subprocess tests (producer wiring for `promote`, and `hippo embed --global` from a cwd with no local store). `embeddingIsFunctional()` in the test file swallows only that specific error and rethrows anything else.
+
+Raw probe transcripts + instrument outputs: episode trajectory dir (gitignored) `trajectories/01KXV39T951THW81ZSD088FKZX/`; every probe command is recorded in the transcripts and re-runnable against scratch stores.

--- a/docs/plans/2026-07-18-global-row-embeddings.md
+++ b/docs/plans/2026-07-18-global-row-embeddings.md
@@ -1,0 +1,59 @@
+# Plan: embed promoted/shared global-store rows (v1.27.0) — Revision 1
+
+Status: Draft r2 (episode 01KXV39T951THW81ZSD088FKZX; r1 plan-eng FAIL 61, all 5 must-fix addressed below)
+
+## Problem
+
+Rows written to the global store by promote/share/import paths never enter the destination store's embedding index, so they score bm25-only in hybrid recall: measured ~5.4x hybrid-base deficit vs an identical local twin (episode 01KXTBPR, `docs/evals/2026-07-18-s5-path-overlap-result.md`; ~0.165 vs ~0.898). Mirrored defect: `syncGlobalToLocal` writes global rows into local stores unembedded.
+
+## Root cause + COMPLETE producer table (r1 must-fix 1)
+
+The invariant that broke: a row entering a store must enter that store's embedding index under the same best-effort contract as `remember`. All FIVE writeEntry sites that can target the global root, audited:
+
+| Site | Embeds today? | Action |
+|---|---|---|
+| `shared.ts:86` promoteToGlobal | NO | FIX: `void embedMemory(globalRoot, globalEntry).catch(()=>{})` after writeEntry (single-row producer) |
+| `shared.ts:402` shareMemory | NO | FIX: same one-liner, unless new optional `opts.skipEmbed` is set (single-row producer; skipEmbed is for autoShare batching only, additive param) |
+| `cli.ts:798` remember --global | YES (:809) | none (already correct) |
+| `capture.ts:594` capture --global | YES (:599) | none (already correct) |
+| `importers.ts:143` import (targetRoot may be global) | NO | FIX in `cmdImport`: after a non-dry-run import that wrote >=1 row, one `void embedAll(targetRoot).catch(()=>{})` (batch producer) |
+
+`api.ts:2458` recall-refresh rewrites existing global rows with unchanged content — vector stays valid, no change.
+
+**Batching invariant (r1 must-fix 4):** single-row producers use `embedMemory`; batch producers use ONE `embedAll` on the destination after their loop. So `autoShare` passes `{skipEmbed: true}` to shareMemory and runs one `void embedAll(globalRoot).catch(()=>{})` when it shared >=1 row — avoiding N serialized full-index rewrites per sleep batch (each embedMemory rewrites the whole multi-MB index JSON). `syncGlobalToLocal` likewise: one `void embedAll(localRoot).catch(()=>{})` when count > 0.
+
+**embedAll characterization (r1 med):** embedAll backfills ALL unembedded rows in the destination store (not only the just-copied ones — accepted as healing) and, if the index identity changed, full-rebuilds the index + resets physics. Perf note documented in code comment + CHANGELOG.
+
+## Design decision: compute-on-destination, not vector-copy
+
+`embedMemory`/`embedAll` own the full per-store contract (provider resolution, availability gate, identity check + reindex, index write, storedModel stamp, physics init — embeddings.ts:432-560); a copied vector is silently wrong whenever the destination identity differs (pluggable providers, PR #100). **Acknowledged asymmetry (r1 med):** when the destination provider is unavailable but the source vector exists, compute leaves the row unembedded until healed, where copy would have filled it — accepted: per-store correctness + the healing paths dominate, and the config split (local embeddable, global not) is an edge state.
+
+## hippo embed --global (r1 must-fix 2)
+
+`cmdEmbed` currently opens with `requireInit(hippoRoot)` (cli.ts:5715). The flag must mirror `resolveAuthRoot` (cli.ts:6900): when `--global` is set, `initGlobal()` + use `getGlobalRoot()` and SKIP the local requireInit; the resolved root is threaded through EVERY hippoRoot reference inside cmdEmbed (requireInit, resolveEmbeddingProvider :5753, loadConfig :5764, embedAll call :5784, partial-progress loadEmbeddingIndex :5787, and any physics/status refs). This is the documented healing path for pre-1.27.0 global stores and MUST work from a directory with no initialized local store. Sleep-integrated auto-backfill stays DEFERRED (hook-latency risk; follow-up filed).
+
+## Versioning
+
+1.27.0 (new CLI surface = minor). 5 lockstep manifests (`package.json`, `openclaw.plugin.json`, `extensions/openclaw-plugin/package.json` + its `openclaw.plugin.json`, `src/version.ts`); `check-manifest-versions.mjs` enforces. CHANGELOG upgrade note: run `hippo embed --global` once to heal existing global stores.
+
+## Fail-soft windows (audit rule 12)
+
+Embeds run AFTER committed writeEntry. (a) process exit before unawaited embed settles → healed by `hippo embed --global` / next batch embedAll; (b) provider failure → `.catch` no-op, same healing; (c) no second-DB-connection hazard: index is a JSON file behind withEmbedLock; physics init opens its own connection after writeEntry's transaction closed (identical to remember path today).
+
+## Tests (real stores; conventions per tests/embeddings.test.ts; r1 must-fix 5)
+
+- **Deterministic unavailable-provider test:** force `embeddings.enabled=false` in the scratch store config (NOT reliance on model absence); promote/share succeed, return entries, write NO index entry, never throw.
+- **Awaited wiring tests:** call the producers, then `await embedMemory(...)`-equivalent seam? No — test the observable contract instead: with embeddings enabled and available, `await vi.waitFor(() => loadEmbeddingIndex(globalRoot)[gId])` with generous timeout (>=30s first-run model load), gated on `isEmbeddingAvailable()`. Plus one direct `await embedAll(destRoot)` test per batch producer asserting the copied ids gain vectors (await removes the poll entirely for batch paths).
+- **embed --global CLI test:** from a cwd with NO local store: seed a global row without vector, run `hippo embed --global`, assert exit 0 + index entry (gated on availability). Also asserts no requireInit failure — the r1 catch.
+- **Existing suites green:** shared, secret-detect (veto ordering unchanged — embed fires only post-veto), v039 tenant isolation.
+
+## Acceptance (pre-registered; r1 must-fix 3 resolved)
+
+1. **S5-style probe** (scratch HIPPO_HOME + scratch cwd; full-precision pairs): promoted row's hybrid base within noise of its local twin. RED captured on master pre-fix (`trajectories/.../red-probe-globalembed.txt`); GREEN after.
+2. **LoCoMo smoke byte-identical vs 1.26.4** — the smoke harness ingests into per-conversation local stores and never promotes/shares (VERIFY this claim at execute entry with a grep of the harness ingest path; if promoted/shared rows DO exist in the corpus, STOP and re-scope this criterion before executing). Byte-identical is therefore expected; the cross-store dedup interplay is NOT pinned by LoCoMo — it is pinned by the S5-style probe (green run exercises promote + cross-store recall + content dedup) and the micro path_boost fixture.
+3. **Micro-eval 12/12** — with a NAMED WATCH: the path_boost fixture's promoted rows now legitimately gain vectors, so its rankings could shift. Pre-analysis: its assertions are nonce-term top-1 memberships where embedding similarity aligns with bm25; expected green. If it goes red, that is a REAL ranking interaction: stop, analyze, escalate to review — never silently re-baseline the fixture.
+4. **Full suite green.**
+
+## Out of scope
+
+Sleep-integrated global backfill (follow-up); per-tenant embedding indices; localBump/equal-sources rebalancing; api.ts:2458 refresh path (update-only, vector remains valid).

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.26.4",
+  "version": "1.27.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.26.4",
+  "version": "1.27.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.26.4",
+  "version": "1.27.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.26.4",
+  "version": "1.27.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5712,15 +5712,18 @@ async function cmdEmbed(
   hippoRoot: string,
   flags: Record<string, string | boolean | string[]>
 ): Promise<void> {
-  requireInit(hippoRoot);
+  // --global mirrors resolveAuthRoot (cli.ts:6900): initGlobal() + the global
+  // root, skipping the local requireInit entirely, so this is the healing
+  // path for pre-1.27.0 global stores from a directory with no local .hippo.
+  const root = resolveAuthRoot(hippoRoot, flags);
 
   // --status and --reset-physics only read cached state, so they must work even
   // when no provider key is present (e.g. embedded earlier with a key that was
   // later removed). The provider-availability gate is deferred to the embed path.
   if (flags['reset-physics']) {
-    const entries = loadAllEntries(hippoRoot);
-    const embIndex = loadEmbeddingIndex(hippoRoot);
-    const db = openHippoDb(hippoRoot);
+    const entries = loadAllEntries(root);
+    const embIndex = loadEmbeddingIndex(root);
+    const db = openHippoDb(root);
     try {
       const count = resetAllPhysicsState(db, entries, embIndex);
       console.log(`Reset physics state: ${count} particles re-initialized from embeddings.`);
@@ -5731,8 +5734,8 @@ async function cmdEmbed(
   }
 
   if (flags['status']) {
-    const entries = loadAllEntries(hippoRoot);
-    const embIndex = loadEmbeddingIndex(hippoRoot);
+    const entries = loadAllEntries(root);
+    const embIndex = loadEmbeddingIndex(root);
     const activeIds = new Set(entries.map((e) => e.id));
     const activeEmbedded = Object.keys(embIndex).filter((id) => activeIds.has(id)).length;
     const orphaned = Object.keys(embIndex).length - activeEmbedded;
@@ -5750,7 +5753,7 @@ async function cmdEmbed(
   // Embedding (unlike status/reset) needs an available provider.
   const embedProvider = (() => {
     try {
-      return resolveEmbeddingProvider(hippoRoot);
+      return resolveEmbeddingProvider(root);
     } catch (err) {
       console.error(err instanceof Error ? err.message : String(err));
       return null;
@@ -5761,7 +5764,7 @@ async function cmdEmbed(
     return;
   }
   if (!embedProvider.isAvailable()) {
-    if (loadConfig(hippoRoot).embeddings.enabled === false) {
+    if (loadConfig(root).embeddings.enabled === false) {
       console.log('Embeddings are disabled in config (embeddings.enabled = false). Set it to true or "auto" to enable.');
       return;
     }
@@ -5781,18 +5784,18 @@ async function cmdEmbed(
   console.log('Embedding all memories (this may take a moment on first run to download model)...');
   let count: number;
   try {
-    count = await embedAll(hippoRoot, resolveEmbeddingModel(hippoRoot));
+    count = await embedAll(root, resolveEmbeddingModel(root));
   } catch (err) {
     console.error(`Embedding failed: ${err instanceof Error ? err.message : String(err)}`);
-    const partial = loadEmbeddingIndex(hippoRoot);
+    const partial = loadEmbeddingIndex(root);
     console.error(
       `Partial progress saved: ${Object.keys(partial).length} embeddings on disk. Re-run \`hippo embed\` to resume.`,
     );
     process.exitCode = 1;
     return;
   }
-  const entriesAfter = loadAllEntries(hippoRoot);
-  const embIndexAfter = loadEmbeddingIndex(hippoRoot);
+  const entriesAfter = loadAllEntries(root);
+  const embIndexAfter = loadEmbeddingIndex(root);
   console.log(`Done. ${count} new embeddings created. ${Object.keys(embIndexAfter).length}/${entriesAfter.length} total.`);
 }
 
@@ -6036,6 +6039,12 @@ function cmdImport(
     console.log(`  Skipped (unchanged):   ${vaultResult.skipped}`);
     console.log(`  ${dryRun ? 'Would archive:        ' : 'Archived (removed):   '}${vaultResult.archived ?? 0}`);
     console.log(`  Store:                 ${hippoRoot}`);
+    // Batch producer, same contract as the single-file import below: vault rows
+    // write through api.remember (which never embeds), so backfill them here.
+    // Floating promise is deliberate; see the comment at the single-file site.
+    if (!dryRun && vaultResult.imported >= 1) {
+      void embedAll(hippoRoot).catch(() => {});
+    }
     return;
   }
 
@@ -6082,6 +6091,16 @@ function cmdImport(
   }
 
   const result = importer(filePath, importOptions);
+
+  // Batch producer: embed newly-imported rows on targetRoot in one pass
+  // rather than per-row (importers.ts writeEntry sites don't embed). The
+  // floating promise is deliberate: libuv keeps the process alive until it
+  // settles, so it is not dropped on process exit; `hippo embed --global` (or
+  // a local `hippo embed`) is the backstop if it does get interrupted. Do not
+  // "fix" this by awaiting it, that would block the CLI on model load/backfill.
+  if (!dryRun && result.imported >= 1) {
+    void embedAll(targetRoot).catch(() => {});
+  }
 
   const storeLabel = useGlobal ? `global (${getGlobalRoot()})` : targetRoot;
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -23,6 +23,7 @@ import { search, hybridSearch, SearchResult } from './search.js';
 import { evalNow } from './ablation.js';
 import { deriveOriginProject, classifyOriginProject, resolveGlobalRootDir } from './project-identity.js';
 import { detectSecret } from './secret-detect.js';
+import { embedMemory, embedAll } from './embeddings.js';
 
 /**
  * Returns the path to the global Hippo store.
@@ -84,6 +85,13 @@ export function promoteToGlobal(
   };
 
   writeEntry(globalRoot, globalEntry, { actor: opts?.actor });
+
+  // Fire-and-forget: embedMemory's own availability gate (embeddings.ts:438)
+  // already no-ops when embeddings are unavailable/disabled, so a pre-guard
+  // here would be redundant (capture.ts:598 pre-guards instead; both
+  // contracts are correct, see docs/plans/2026-07-18-global-row-embeddings.md).
+  void embedMemory(globalRoot, globalEntry).catch(() => {});
+
   return globalEntry;
 }
 
@@ -360,7 +368,7 @@ export function transferScore(entry: MemoryEntry): number {
 export function shareMemory(
   localRoot: string,
   id: string,
-  options: { force?: boolean; tenantId?: string } = {}
+  options: { force?: boolean; tenantId?: string; skipEmbed?: boolean } = {}
 ): MemoryEntry | null {
   // tenantId is OPTIONAL for backward compat — autoShare's internal call at
   // :370 passes only `{ force: true }` in a single-tenant context. MCP/REST
@@ -400,6 +408,16 @@ export function shareMemory(
   };
 
   writeEntry(globalRoot, globalEntry);
+
+  // Single-row producer: embed here unless the caller opts out. autoShare
+  // sets skipEmbed so it can batch its whole run through one embedAll() at
+  // the end instead of N serialized full-index rewrites (embedMemory rewrites
+  // the whole index JSON per call). Same redundant-pre-guard reasoning as
+  // promoteToGlobal above.
+  if (!options.skipEmbed) {
+    void embedMemory(globalRoot, globalEntry).catch(() => {});
+  }
+
   return globalEntry;
 }
 
@@ -517,8 +535,14 @@ export function autoShare(
 
   const shared: MemoryEntry[] = [];
   for (const entry of candidates) {
-    const result = shareMemory(localRoot, entry.id, { force: true });
+    // skipEmbed: batching invariant, this is a batch producer, so it embeds
+    // once via embedAll() below rather than once per row inside shareMemory.
+    const result = shareMemory(localRoot, entry.id, { force: true, skipEmbed: true });
     if (result) shared.push(result);
+  }
+
+  if (shared.length > 0) {
+    void embedAll(globalRoot).catch(() => {});
   }
 
   return shared;
@@ -560,6 +584,12 @@ export function syncGlobalToLocal(
 
     writeEntry(localRoot, entry);
     count++;
+  }
+
+  // Batch producer: one embedAll() on the destination rather than an
+  // embedMemory() per copied row (same batching invariant as autoShare).
+  if (count > 0) {
+    void embedAll(localRoot).catch(() => {});
   }
 
   return count;

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.26.4';
+export const PACKAGE_VERSION = '1.27.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/global-row-embeddings.test.ts
+++ b/tests/global-row-embeddings.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'node:child_process';
+import {
+  promoteToGlobal,
+  shareMemory,
+  autoShare,
+  syncGlobalToLocal,
+} from '../src/shared.js';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory } from '../src/memory.js';
+import { embedAll, loadEmbeddingIndex, isEmbeddingAvailable } from '../src/embeddings.js';
+import { resolveEmbeddingProvider } from '../src/embedding-provider.js';
+
+// docs/plans/2026-07-18-global-row-embeddings.md: rows written to the global
+// store by promote/share/autoShare/sync/import must enter that store's
+// embedding index under the same best-effort contract as `remember`.
+
+const HIPPO_BIN = path.join(process.cwd(), 'bin', 'hippo.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpStore(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-'));
+  initStore(dir);
+  return dir;
+}
+
+function disableEmbeddings(root: string): void {
+  fs.writeFileSync(path.join(root, 'config.json'), JSON.stringify({ embeddings: { enabled: false } }), 'utf8');
+}
+
+function cleanUp(...dirs: string[]): void {
+  for (const d of dirs) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+}
+
+let _embeddingFunctional: boolean | null = null;
+
+/**
+ * isEmbeddingAvailable() only confirms the local provider package resolves;
+ * it does not confirm the pipeline can actually load in-process. Under
+ * vitest's VM-based test execution, embeddings.ts's `_dynImport` (a
+ * `new Function('s', 'return import(s)')` trick used to keep the peer dep
+ * optional) throws ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING because it escapes
+ * Vite's SSR module graph. That is a harness limitation, not a producer-
+ * wiring bug: the identical call embeds successfully in a plain `node`
+ * script outside vitest, and the CLI test below (which spawns a real `node`
+ * subprocess) is unaffected. Probe once with a real embed call and cache the
+ * result, so in-process tests that need a genuine vector skip cleanly here
+ * instead of failing on an empty/undefined one.
+ */
+async function embeddingIsFunctional(): Promise<boolean> {
+  if (_embeddingFunctional !== null) return _embeddingFunctional;
+  if (!isEmbeddingAvailable()) {
+    _embeddingFunctional = false;
+    return false;
+  }
+  const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-probe-'));
+  try {
+    initStore(probeRoot);
+    const provider = resolveEmbeddingProvider(probeRoot);
+    const [vector] = await provider.embed(['embedding functional probe'], 'passage');
+    _embeddingFunctional = Array.isArray(vector) && vector.length > 0;
+  } catch (err) {
+    // Only the documented VM limitation (see the comment above) is a known
+    // "unavailable in this harness" condition. Anything else is a genuine
+    // embed-pipeline regression and must fail loud, not masquerade as a skip.
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    const message = err instanceof Error ? err.message : String(err);
+    const isKnownVmLimitation =
+      code === 'ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING' ||
+      message.includes('ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING');
+    if (!isKnownVmLimitation) throw err;
+    _embeddingFunctional = false;
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true });
+  }
+  return _embeddingFunctional;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic: embeddings.enabled=false on the destination store
+// ---------------------------------------------------------------------------
+
+describe('global-row-embeddings: embeddings disabled (deterministic)', () => {
+  let localRoot: string;
+  let globalRoot: string;
+  let prevHippoHome: string | undefined;
+
+  beforeEach(() => {
+    localRoot = makeTmpStore();
+    globalRoot = makeTmpStore();
+    disableEmbeddings(globalRoot);
+    // promoteToGlobal/shareMemory/autoShare resolve their destination via
+    // getGlobalRoot(), which reads HIPPO_HOME (same isolation pattern as
+    // tests/shared.test.ts's promoteToGlobal describe block).
+    prevHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalRoot;
+  });
+
+  afterEach(() => {
+    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = prevHippoHome;
+    cleanUp(localRoot, globalRoot);
+  });
+
+  it('promoteToGlobal succeeds and writes no embedding index entry', () => {
+    const entry = createMemory('deterministic no-embed promote test content');
+    writeEntry(localRoot, entry);
+
+    const promoted = promoteToGlobal(localRoot, entry.id);
+    expect(promoted.id).toMatch(/^g_/);
+
+    // provider.isAvailable() is synchronous and false here (config-disabled),
+    // so embedMemory's fire-and-forget call returns before any fs write,
+    // no waitFor needed, the absence is observable immediately.
+    const index = loadEmbeddingIndex(globalRoot);
+    expect(index[promoted.id]).toBeUndefined();
+  });
+
+  it('shareMemory succeeds and writes no embedding index entry', () => {
+    const entry = createMemory('deterministic no-embed share test content', { tags: ['error'] });
+    writeEntry(localRoot, entry);
+
+    const shared = shareMemory(localRoot, entry.id, { force: true });
+    expect(shared).not.toBeNull();
+    expect(shared!.id).toMatch(/^g_/);
+
+    const index = loadEmbeddingIndex(globalRoot);
+    expect(index[shared!.id]).toBeUndefined();
+  });
+
+  it('autoShare succeeds and writes no embedding index entry (skipEmbed + batch embedAll no-op)', () => {
+    const entry = createMemory('deterministic no-embed autoshare test content');
+    writeEntry(localRoot, entry);
+
+    const shared = autoShare(localRoot, { minScore: 0 });
+    expect(shared.length).toBe(1);
+
+    const index = loadEmbeddingIndex(globalRoot);
+    expect(index[shared[0].id]).toBeUndefined();
+  });
+
+  it('syncGlobalToLocal succeeds and writes no embedding index entry on the local store', () => {
+    disableEmbeddings(localRoot);
+    const entry = createMemory('deterministic no-embed sync test content');
+    writeEntry(globalRoot, entry);
+
+    const count = syncGlobalToLocal(localRoot, globalRoot);
+    expect(count).toBe(1);
+
+    const index = loadEmbeddingIndex(localRoot);
+    expect(index[entry.id]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Awaited batch producers (embeddings available)
+// ---------------------------------------------------------------------------
+
+describe('global-row-embeddings: awaited batch producers', () => {
+  let localRoot: string;
+  let globalRoot: string;
+  let prevHippoHome: string | undefined;
+
+  beforeEach(() => {
+    localRoot = makeTmpStore();
+    globalRoot = makeTmpStore();
+    prevHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalRoot;
+  });
+
+  afterEach(() => {
+    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = prevHippoHome;
+    cleanUp(localRoot, globalRoot);
+  });
+
+  it('syncGlobalToLocal-copied rows gain vectors after an awaited embedAll(localRoot)', async () => {
+    if (!(await embeddingIsFunctional())) {
+      console.warn('SKIP: embeddings unavailable in this environment');
+      return;
+    }
+    const entry = createMemory('awaited batch sync test content unique alpha');
+    writeEntry(globalRoot, entry);
+
+    const count = syncGlobalToLocal(localRoot, globalRoot);
+    expect(count).toBe(1);
+
+    // syncGlobalToLocal already fired its own embedAll(localRoot); this call
+    // is idempotent and, because embed writes are serialized through the
+    // module's embed lock, awaiting it guarantees the earlier fire-and-forget
+    // call has also settled by the time this resolves.
+    await embedAll(localRoot);
+
+    const index = loadEmbeddingIndex(localRoot);
+    expect(index[entry.id]).toBeDefined();
+    expect(index[entry.id].length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('autoShare-shared rows gain vectors after an awaited embedAll(globalRoot)', async () => {
+    if (!(await embeddingIsFunctional())) {
+      console.warn('SKIP: embeddings unavailable in this environment');
+      return;
+    }
+    const entry = createMemory('awaited batch autoshare test content unique beta');
+    writeEntry(localRoot, entry);
+
+    const shared = autoShare(localRoot, { minScore: 0 });
+    expect(shared.length).toBe(1);
+
+    await embedAll(globalRoot);
+
+    const index = loadEmbeddingIndex(globalRoot);
+    expect(index[shared[0].id]).toBeDefined();
+    expect(index[shared[0].id].length).toBeGreaterThan(0);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Fire-and-forget integration (single-row producers, no explicit embedAll)
+// ---------------------------------------------------------------------------
+
+describe('global-row-embeddings: fire-and-forget integration', () => {
+  let localRoot: string;
+  let globalRoot: string;
+  let prevHippoHome: string | undefined;
+
+  beforeEach(() => {
+    localRoot = makeTmpStore();
+    globalRoot = makeTmpStore();
+    prevHippoHome = process.env.HIPPO_HOME;
+    process.env.HIPPO_HOME = globalRoot;
+  });
+
+  afterEach(() => {
+    if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+    else process.env.HIPPO_HOME = prevHippoHome;
+    cleanUp(localRoot, globalRoot);
+  });
+
+  it('promoteToGlobal fire-and-forget embed eventually lands in the global index', async () => {
+    if (!(await embeddingIsFunctional())) {
+      console.warn('SKIP: embeddings unavailable in this environment');
+      return;
+    }
+    const entry = createMemory('fire and forget integration promote test content gamma');
+    writeEntry(localRoot, entry);
+
+    const promoted = promoteToGlobal(localRoot, entry.id);
+
+    // Generous timeout: first-run model load can be slow.
+    await vi.waitFor(() => {
+      const index = loadEmbeddingIndex(globalRoot);
+      expect(index[promoted.id]).toBeDefined();
+    }, { timeout: 30_000, interval: 250 });
+  }, 35_000);
+});
+
+// ---------------------------------------------------------------------------
+// hippo embed --global (CLI)
+// ---------------------------------------------------------------------------
+
+describe('global-row-embeddings: hippo embed --global CLI', () => {
+  it('embeds a seeded global row from a cwd with no local store, without requireInit failing', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-cli-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-cli-cwd-'));
+    const globalRoot = path.join(home, '.hippo');
+    const env = { ...process.env, HIPPO_HOME: globalRoot };
+
+    try {
+      // Seed an unembedded global row directly, bypassing the CLI, so the
+      // row predates any embed call.
+      initStore(globalRoot);
+      const entry = createMemory('cli embed --global test content delta');
+      writeEntry(globalRoot, entry);
+
+      let exitCode = 0;
+      let stderr = '';
+      try {
+        execFileSync('node', [HIPPO_BIN, 'embed', '--global'], { cwd, env, encoding: 'utf-8' });
+      } catch (err) {
+        const e = err as { status?: number | null; stderr?: string };
+        exitCode = e.status ?? 1;
+        stderr = e.stderr ?? '';
+      }
+
+      // Ungated: cwd has no local .hippo at all, so --global must skip
+      // requireInit entirely (the r1 must-fix), regardless of embedding
+      // availability in this environment.
+      expect(stderr).not.toMatch(/No \.hippo directory found/);
+
+      if (isEmbeddingAvailable()) {
+        expect(exitCode).toBe(0);
+        const index = loadEmbeddingIndex(globalRoot);
+        expect(index[entry.id]).toBeDefined();
+      }
+    } finally {
+      cleanUp(home, cwd);
+    }
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// promoteToGlobal producer wiring (subprocess, real node process)
+// ---------------------------------------------------------------------------
+
+describe('global-row-embeddings: promoteToGlobal producer wiring (subprocess)', () => {
+  // Real-process counterpart of the in-process "fire-and-forget integration"
+  // test above, which skips under vitest's VM (embeddingIsFunctional() ->
+  // ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING). Spawns real `node` subprocesses
+  // (same pattern as the "hippo embed --global CLI" test above) so the actual
+  // promoteToGlobal -> embedMemory fire is exercised end-to-end: init, remember,
+  // embed (warms the local vector + model cache), promote, then poll the
+  // GLOBAL store's embedding index for the minted g_ id. A producer-wiring
+  // regression (wrong root, dropped void embed call) would fail this test even
+  // when every in-process test above is skipping.
+  it('promoting a remembered row lands a vector in the GLOBAL embedding index', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-wiring-home-'));
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-gre-wiring-cwd-'));
+    const globalRoot = path.join(home, '.hippo');
+    const env = { ...process.env, HIPPO_HOME: globalRoot };
+
+    try {
+      execFileSync(
+        'node',
+        [HIPPO_BIN, 'init', '--no-hooks', '--no-schedule', '--no-learn'],
+        { cwd, env, encoding: 'utf-8' },
+      );
+
+      const nonce = `wiring-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const rememberOut = execFileSync(
+        'node',
+        [HIPPO_BIN, 'remember', `${nonce} wiring probe`],
+        { cwd, env, encoding: 'utf-8' },
+      );
+      const rememberMatch = rememberOut.match(/Remembered \[(\S+)\]/);
+      expect(rememberMatch).not.toBeNull();
+      const localId = rememberMatch![1];
+
+      // Ensures the local vector exists (deterministic, not racing remember's
+      // own fire-and-forget embed) and warms the on-disk model cache before
+      // promote runs.
+      execFileSync('node', [HIPPO_BIN, 'embed'], { cwd, env, encoding: 'utf-8' });
+
+      const promoteOut = execFileSync(
+        'node',
+        [HIPPO_BIN, 'promote', localId],
+        { cwd, env, encoding: 'utf-8' },
+      );
+      const promoteMatch = promoteOut.match(/Promoted \S+ to global store as (\S+)/);
+      expect(promoteMatch).not.toBeNull();
+      const globalId = promoteMatch![1];
+      expect(globalId).toMatch(/^g_/);
+
+      if (isEmbeddingAvailable()) {
+        // Bounded poll (<=60s): promoteToGlobal's embed fire is best-effort
+        // fire-and-forget, but `execFileSync` only returns once the `promote`
+        // subprocess has fully exited, and that process has no explicit
+        // process.exit() call on the success path (cli.ts's main() returns
+        // naturally), so Node's event loop keeps it alive until the floating
+        // embedMemory promise settles — same reasoning as cmdImport's batch
+        // embed comment (src/cli.ts:6086-6093). The poll is a safety margin,
+        // not a requirement to wait out a race.
+        await vi.waitFor(() => {
+          const index = loadEmbeddingIndex(globalRoot);
+          expect(index[globalId]).toBeDefined();
+          expect(index[globalId].length).toBeGreaterThan(0);
+        }, { timeout: 60_000, interval: 250 });
+      }
+    } finally {
+      cleanUp(home, cwd);
+    }
+  }, 90_000);
+});


### PR DESCRIPTION
## Problem

Rows promoted or shared to the global store never entered its embedding index, so they scored bm25-only in hybrid recall: measured 3.15x hybrid-base deficit vs an identical local twin (0.28768207245178085 vs 0.9074030329496725; the richer S5-era probe measured 5.4x). Same defect class in the local direction: `hippo sync` and `hippo import` (including `--vault`) copies landed unembedded. Filed from episode 01KXTBPR's score-verified precheck (backlog A2#1, research round 2026-07-18).

## Fix

One invariant at every producer into a store: single-row producers (`promote`, `share`) fire the same best-effort `embedMemory` contract `remember` uses; batch producers (`autoShare` in sleep, `sync`, `import` incl. `--vault`) run one best-effort `embedAll` on the destination after their loop. New `hippo embed --global` heals pre-1.27.0 global stores (routes via `resolveAuthRoot`; no local store required). `shareMemory` gains an additive `skipEmbed` option for autoShare batching.

## Evidence

- RED (pre-fix): promoted row 0.28768207245178085 bm25-only; global `embeddings.json` never created.
- GREEN (post-fix): promoted row 0.9074030329496725, bit-identical to its local twin (predicted by 1.26.0's `path:*` exclusion from embedding input text).
- Micro-eval 12/12 (named-watch `path_boost` 2/2, no ranking interaction); full suite 345 files / 2752 tests; LoCoMo smoke byte-identical determinism with grep proof the corpus never promotes/shares.
- `docs/evals/2026-07-18-global-row-embeddings-result.md` has the full trail incl. the honest LoCoMo caveat and the vitest-VM known limitation.

## Gates (episode 01KXV39T951THW81ZSD088FKZX, critic arm default-opus)

plan-eng FAIL 61 (real: incomplete producer list, requireInit break, acceptance contradiction) -> PASS 88; code-review PASS 84 (advisories closed in-stage); independent-review PASS 88; codex R1 one real P2 (vault import early-return skipped the backfill) fixed + re-tested -> R2 clean.

## Test plan

- [x] 9 new real-store tests incl. two real-node subprocess tests (producer wiring; `embed --global` from a cwd with no local store)
- [x] Full suite green (345 files / 2752 tests)
- [x] Red/green probes on scratch stores, full precision
- [x] Version lockstep check green; release-notes dash check green

Upgrade note: run `hippo embed --global` once after upgrading to backfill existing global rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
