### PR TITLE
fix(security): opt-in Codex wrapper, zero-dep default install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,49 @@
   when neither is present, and the CLI prints the install command where
   embeddings would apply.
 
+- **Dependency audit is clean at high severity and above** (#116). Upgrade
+  the root test runner from Vitest 1.6.1 to patched 3.2.6, force the
+  transformer stack onto patched `protobufjs` 7.6.4 via `overrides`, and
+  refresh the UI lockfile onto patched Vite/Undici releases.
+  `npm run audit:security` checks both lockfiles, and CI now runs that gate
+  on every push.
+- **One local embedding backend per process** (#116). Backend resolution
+  happens BEFORE import, so a process never loads two native ONNX Runtime
+  versions even when both Transformers.js packages are installed manually.
+  Loading both pulled incompatible native runtimes into one process and
+  could abort successful `remember`/`recall` commands during native
+  finalization (macOS arm64 SIGABRT). `@huggingface/transformers` is
+  preferred; `@xenova/transformers` remains a legacy fallback.
+
+### Fixed
+- **`hippo invalidate` tag matching is now EXACT** (#109; incident
+  2026-06-09: a pattern containing the word "hippo" weakened 10 bystander
+  memories tagged `hippo` while the actual target escaped). A memory's tags
+  now only match when the FULL pattern equals a tag; token-level matching
+  applies to content only. Both the CLI command and the auto-learn-from-git
+  invalidation path inherit the safer contract.
+- **Rollback guard rejects malformed versions** (#119). `compareSemver`
+  now requires exactly three numeric components, so `'1.24'` or
+  `'1.24.0.999'` fail loudly instead of comparing as `'1.24.0'`.
+- **Fractional drill depths are rejected** (#121). Depth validation uses
+  `Number.isInteger` across CLI, HTTP, MCP, and the direct API, so
+  `--depth 1.5` no longer walks 2 levels.
+- **MCP context honors a zero budget** (#122). `budget: 0` previously fell
+  through `Number(x) || default` to the default budget, returning context
+  and marking memories retrieved on a request that asked for none.
+
+### Added
+- **`hippo invalidate --dry-run`** (#109) previews exactly which memories
+  would be hit (id + headline) and writes nothing.
+- **`hippo invalidate --id <memory-id>`** (#109) invalidates exactly one
+  memory (tenant-scoped; pattern and `--id` are mutually exclusive). Pinned
+  memories are never touched and are now reported as skipped.
+
+### Changed
+- **Value-less boolean flags no longer swallow a following positional**
+  (#109). `--dry-run` is parsed as boolean everywhere, so
+  `hippo <cmd> --dry-run <arg>` works in any argument order.
+
 ### Upgrade note
 - An already-installed Codex wrapper is preserved and self-repairs.
 - Local embeddings need one manual install after upgrading:
@@ -203,29 +246,6 @@
 - `shareMemory` stamps the canonical `origin_project` on global copies (derived from the entry's own write-time stamp, not the local path basename).
 - Migration v39 (schema 38 -> 39): adds `memories.origin_project` + evidence-based backfill. Additive and idempotent; no data is removed.
 - **Upgrade in lockstep on shared machines.** v39 stamps `min_compatible_binary: 1.24.0` on every store it migrates, including the shared `~/.hippo` global store. Any still-installed pre-1.24.0 hippo binary (pinned project dependency, old plugin bundle, stale hook install) will then refuse to open that store by design - the refusal is what prevents an old binary from silently leaking cross-project rows again. Upgrade all hippo installs on the machine together.
-
-### Fixed
-- **`hippo invalidate` tag matching is now EXACT** (incident 2026-06-09: a pattern containing the word "hippo" weakened 10 bystander memories tagged `hippo` while the actual target escaped). A memory's tags now only match when the FULL pattern equals a tag; token-level matching applies to content only. Both the CLI command and the auto-learn-from-git invalidation path inherit the safer contract.
-
-### Added
-- **`hippo invalidate --dry-run`** previews exactly which memories would be hit (id + headline) and writes nothing.
-- **`hippo invalidate --id <memory-id>`** invalidates exactly one memory (tenant-scoped; pattern and `--id` are mutually exclusive). Pinned memories are never touched and are now reported as skipped.
-
-### Changed
-- **Value-less boolean flags no longer swallow a following positional.** `--dry-run` is parsed as boolean everywhere, so `hippo <cmd> --dry-run <arg>` now works in any argument order (previously the argument was silently consumed as the flag's value).
-
-### Security
-- **Dependency audit is clean at high severity and above.** Upgrade the root
-  test runner from Vitest 1.6.1 to patched 3.2.6, force the optional transformer
-  stack onto patched `protobufjs` 7.6.4, and refresh the UI lockfile onto patched
-  Vite/Undici releases. `npm run audit:security` checks both lockfiles, and CI
-  now runs that gate on every push.
-- **One local embedding backend per install.** The maintained
-  `@huggingface/transformers` package is now the optional default; the legacy
-  `@xenova/transformers` package remains a runtime fallback when installed by
-  the user, but is no longer installed alongside it. Loading both packages
-  pulled incompatible native ONNX Runtime versions into one process and could
-  abort successful `remember`/`recall` commands during native finalization.
 
 ## 1.23.0 (2026-06-08): pluggable embedding providers (bring a frontier embedder)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- **The Codex session-capture wrapper is now strictly opt-in** (issue #133).
+  Previously `npm install` (postinstall) and routine commands (`remember`,
+  `recall`, `status`, ...) silently renamed a detected `codex` launcher and
+  replaced it with Hippo's wrapper. Swapping another vendor's binary without
+  an explicit ask is a consent violation, and supply-chain scanners correctly
+  flag it as hijack-shaped behavior (Socket.dev gptAnomaly on 1.27.0). Now:
+  first install happens ONLY via `hippo hook install codex`; postinstall and
+  routine commands run a repair-only pass that re-ensures the wrapper solely
+  for users whose opt-in metadata already exists (e.g. after a Codex update
+  restores the real binary over the shim); `npm install` and `hippo init`
+  print a one-line nudge with the opt-in command when Codex is detected but
+  unwrapped. Users who got the wrapper under the old behavior keep it
+  (metadata counts as opt-in); `hippo hook uninstall codex` removes it.
+- **Local embedding backends are no longer auto-installed** (issue #133).
+  `@xenova/transformers` and `@huggingface/transformers` moved from
+  `optionalDependencies` (which npm installs by default) to optional peers.
+  A default install is now genuinely zero-dependency instead of pulling a
+  ~140-package native tree containing a critical-CVE protobufjs 6.11.6 (via
+  the frozen @xenova chain), an adm-zip CVE, and two sharp advisories.
+  Embeddings users opt in with `npm i @xenova/transformers` (or
+  `@huggingface/transformers`); every code path already degrades gracefully
+  when neither is present, and the CLI prints the install command where
+  embeddings would apply.
+
+### Upgrade note
+- Existing installs keep working: an already-installed Codex wrapper is
+  preserved and self-repairs, and an already-installed transformers package
+  keeps powering embeddings. Fresh installs that want local embeddings run
+  one extra command: `npm i @xenova/transformers`.
+
 ## 1.27.0 - 2026-07-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,15 @@
   embeddings would apply.
 
 ### Upgrade note
-- Existing installs keep working: an already-installed Codex wrapper is
-  preserved and self-repairs, and an already-installed transformers package
-  keeps powering embeddings. Fresh installs that want local embeddings run
-  one extra command: `npm i @xenova/transformers`.
+- An already-installed Codex wrapper is preserved and self-repairs.
+- Local embeddings need one manual install after upgrading:
+  `npm i @huggingface/transformers` (or legacy `@xenova/transformers` if
+  your model cache came from it). This applies to upgrades, not just fresh
+  installs: `npm update -g hippo-memory` rebuilds the package's
+  node_modules, so a backend that arrived via the old auto-install
+  disappears with it. Recall degrades gracefully to lexical search until a
+  backend is installed; the CLI prints the install command where
+  embeddings would apply.
 
 ## 1.27.0 - 2026-07-18
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ One command. Every git repo on your machine gets memory.
 Works with:    Claude Code, Codex, Cursor, OpenClaw, OpenCode, Pi, any MCP client
 Imports from:  ChatGPT, Claude (CLAUDE.md), Cursor (.cursorrules), Slack, markdown
 Storage:       SQLite backbone with markdown mirrors. Git-trackable, human-readable.
-Dependencies:  Zero runtime deps. Node.js 22.5+. Optional embeddings: local @huggingface/transformers (default) or an opt-in API embedder (OpenAI/Voyage/Cohere).
+Dependencies:  Zero runtime deps. Node.js 22.5+. Optional embeddings: bring-your-own local Transformers.js (`npm i @huggingface/transformers`, or legacy `@xenova/transformers`) or an opt-in API embedder (OpenAI/Voyage/Cohere). Nothing is auto-installed.
 ```
 
 ---
@@ -106,7 +106,7 @@ hippo init
 #    Auto-installed claude-code hook in CLAUDE.md
 ```
 
-If you have a `CLAUDE.md`, it patches it. `AGENTS.md` for Codex/OpenClaw/OpenCode. `.cursorrules` for Cursor. For Codex, Hippo also wraps the detected launcher in place so `/exit` can consolidate memory without a manual PATH step. No manual `hook install` needed. Your agent starts using Hippo on its next session.
+If you have a `CLAUDE.md`, it patches it. `AGENTS.md` for Codex/OpenClaw/OpenCode. `.cursorrules` for Cursor. Your agent starts using Hippo on its next session. For Codex session capture, Hippo wraps the codex launcher only when you explicitly opt in with `hippo hook install codex` (init prints the command when it detects Codex; undo anytime with `hippo hook uninstall codex`).
 
 It also registers the current project in Hippo's workspace registry and installs one machine-level daily runner (6:15am). That runner sweeps every registered workspace, runs `hippo learn --git --days 1`, then `hippo sleep`. You get strict daily consolidation without creating one OS task per project.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.24.1",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.24.1",
+      "version": "1.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -20,18 +20,13 @@
       "engines": {
         "node": ">=22.5.0"
       },
-      "optionalDependencies": {
-        "@huggingface/transformers": "^4.2.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "@xenova/transformers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -476,681 +471,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/@huggingface/tokenizers": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
-      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
-      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@huggingface/jinja": "^0.5.6",
-        "@huggingface/tokenizers": "^0.1.3",
-        "onnxruntime-node": "1.24.3",
-        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
-        "sharp": "^0.34.5"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/@huggingface/jinja": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
-      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/flatbuffers": {
-      "version": "25.9.23",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
-      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers/node_modules/onnxruntime-common": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
-      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers/node_modules/onnxruntime-node": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
-      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32",
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "adm-zip": "^0.5.16",
-        "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.24.3"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web": {
-      "version": "1.26.0-dev.20260416-b7804b056c",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
-      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "flatbuffers": "^25.1.24",
-        "guid-typescript": "^1.0.9",
-        "long": "^5.2.3",
-        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
-        "platform": "^1.3.6",
-        "protobufjs": "^7.2.4"
-      }
-    },
-    "node_modules/@huggingface/transformers/node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.24.0-dev.20251116-b39e144322",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
-      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@huggingface/transformers/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1244,9 +570,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +584,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +598,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +612,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,9 +626,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +640,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,9 +654,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,9 +668,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1380,9 +682,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +696,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,9 +710,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1431,9 +724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1448,9 +738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,7 +857,7 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1691,16 +978,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1710,14 +987,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1784,92 +1053,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1911,19 +1100,6 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -1979,87 +1155,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2076,19 +1177,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -2115,16 +1203,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/pathe": {
@@ -2164,13 +1242,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -2198,55 +1269,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/protobufjs/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/rollup": {
@@ -2294,42 +1316,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2346,13 +1332,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause",
-      "optional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -2442,26 +1421,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2480,7 +1439,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1187,9 +1187,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1243,9 +1243,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -1263,7 +1263,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -66,8 +66,13 @@
     "typescript": "^5.4.0",
     "vitest": "^3.2.6"
   },
-  "optionalDependencies": {
-    "@huggingface/transformers": "^4.2.0"
+  "peerDependenciesMeta": {
+    "@xenova/transformers": {
+      "optional": true
+    },
+    "@huggingface/transformers": {
+      "optional": true
+    }
   },
   "overrides": {
     "protobufjs": "7.6.4"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,8 @@ import {
   defaultSleepLogPath,
   ensureCodexWrapperInstalled,
   installCodexWrapper,
+  isCodexWrapperInstalled,
+  repairCodexWrapperIfInstalled,
   uninstallCodexWrapper,
   resolveCodexSessionTranscript,
   resolveCodexWrapperPaths,
@@ -591,6 +593,13 @@ function autoInstallHooks(quiet: boolean): void {
       fs.writeFileSync(targetPath, existing + sep + block + '\n', 'utf8');
       installed.add(targetPath);
       console.log(`   Auto-installed ${hook} hook in ${hookDef.file}`);
+    }
+
+    // The Codex session-capture wrapper swaps the codex launcher binary, so
+    // init never installs it silently — it points at the explicit opt-in
+    // command instead (issue #133).
+    if (hook === 'codex' && !isCodexWrapperInstalled()) {
+      console.log('   Codex detected. To capture Codex sessions: hippo hook install codex');
     }
 
     // For Claude Code, also install SessionEnd+SessionStart entries in its
@@ -3129,7 +3138,7 @@ function cmdCodexSessionEndWorker(
   }
 }
 
-function shouldAutoInstallCodexWrapper(currentCommand: string, currentArgs: string[]): boolean {
+function shouldAutoRepairCodexWrapper(currentCommand: string, currentArgs: string[]): boolean {
   if (process.env.HIPPO_SKIP_AUTO_INTEGRATIONS === '1') return false;
   if (!['context', 'remember', 'recall', 'sleep', 'capture', 'outcome', 'status', 'init'].includes(currentCommand)) {
     return false;
@@ -3138,10 +3147,15 @@ function shouldAutoInstallCodexWrapper(currentCommand: string, currentArgs: stri
   return true;
 }
 
-function maybeAutoInstallCodexWrapper(currentCommand: string, currentArgs: string[]): void {
-  if (!shouldAutoInstallCodexWrapper(currentCommand, currentArgs)) return;
+// Repair-only: keeps the wrapper healthy for users who opted in via `hippo
+// hook install codex` (a Codex update can restore the real binary over our
+// shim). Never first-installs — silently swapping the codex binary on routine
+// commands is a consent violation and reads as binary hijacking to
+// supply-chain scanners (issue #133).
+function maybeRepairCodexWrapper(currentCommand: string, currentArgs: string[]): void {
+  if (!shouldAutoRepairCodexWrapper(currentCommand, currentArgs)) return;
   try {
-    ensureCodexWrapperInstalled();
+    repairCodexWrapperIfInstalled();
   } catch {
     // best-effort only
   }
@@ -8199,7 +8213,7 @@ async function main(): Promise<void> {
     console.log(version);
     process.exit(0);
   }
-  maybeAutoInstallCodexWrapper(command, args);
+  maybeRepairCodexWrapper(command, args);
   /** Global --scope well-formedness guard (v1.26.2). parseArgs stores a value-less
    *  flag as boolean true; downstream the 14 consumer sites either coerced that to
    *  the literal scope string 'true' (recall filter/unlock input, wm session scope,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -499,6 +499,29 @@ export function ensureCodexWrapperInstalled(): EnsureCodexWrapperResult {
   };
 }
 
+/**
+ * True if Codex wrapper metadata exists on this machine, i.e. the user opted
+ * in to the wrapper at some point (via `hippo hook install codex`).
+ */
+export function isCodexWrapperInstalled(): boolean {
+  return readCodexWrapperMetadata() !== null;
+}
+
+/**
+ * Repair-only variant of `ensureCodexWrapperInstalled`: re-ensures the wrapper
+ * ONLY when wrapper metadata already exists — that metadata is the user's
+ * opt-in record. Never performs a first install. Replacing another vendor's
+ * binary must stay behind the explicit `hippo hook install codex` command;
+ * doing it from postinstall or routine commands is a consent violation and
+ * reads as binary hijacking to security scanners (issue #133).
+ */
+export function repairCodexWrapperIfInstalled(): EnsureCodexWrapperResult {
+  if (readCodexWrapperMetadata() === null) {
+    return { status: 'not-found' };
+  }
+  return ensureCodexWrapperInstalled();
+}
+
 function collectFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return [];
   const out: string[] = [];

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,19 +1,35 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { ensureCodexWrapperInstalled } from './hooks.js';
+import {
+  detectRealCodexPath,
+  isCodexWrapperInstalled,
+  repairCodexWrapperIfInstalled,
+} from './hooks.js';
 
 function main(): void {
   if (process.env.HIPPO_SKIP_POSTINSTALL === '1') return;
 
   try {
-    ensureCodexWrapperInstalled();
+    // Repair-only: re-ensure the wrapper for users who previously opted in
+    // (e.g. a Codex update restored the real binary over our shim). A first
+    // install never happens here — swapping the codex binary from a package
+    // postinstall is a consent violation and reads as binary hijacking to
+    // supply-chain scanners (issue #133). First install is `hippo hook
+    // install codex` only.
+    repairCodexWrapperIfInstalled();
   } catch {
     // Never fail package install because auto-integration could not be applied.
   }
 
   try {
     printClaudeCodeNudge();
+  } catch {
+    // Never fail package install because the install hint could not be printed.
+  }
+
+  try {
+    printCodexNudge();
   } catch {
     // Never fail package install because the install hint could not be printed.
   }
@@ -62,6 +78,27 @@ function printClaudeCodeNudge(): void {
   line('    hippo init --global');
   line('');
   line('To skip this message on future installs: export HIPPO_SKIP_POSTINSTALL=1');
+  line('');
+}
+
+/**
+ * Read-only nudge: if the Codex CLI is on PATH and the Hippo session-capture
+ * wrapper is NOT installed, print the opt-in command. Mirrors the Claude Code
+ * nudge above — same least-authority reasoning: we tell the user what to run,
+ * we never swap their binary for them.
+ */
+function printCodexNudge(): void {
+  if (isCodexWrapperInstalled()) return;
+  if (!detectRealCodexPath()) return; // Codex not installed — silent
+
+  const line = (s: string) => process.stderr.write(s + '\n');
+  line('');
+  line('Codex CLI detected on this machine.');
+  line('');
+  line('To capture Codex sessions into Hippo (wraps the codex launcher;');
+  line('undo anytime with `hippo hook uninstall codex`), run:');
+  line('');
+  line('    hippo hook install codex');
   line('');
 }
 

--- a/tests/codex-wrapper.test.ts
+++ b/tests/codex-wrapper.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   ensureCodexWrapperInstalled,
   installCodexWrapper,
+  isCodexWrapperInstalled,
+  repairCodexWrapperIfInstalled,
   uninstallCodexWrapper,
   resolveCodexSessionTranscript,
   resolveCodexWrapperPaths,
@@ -111,6 +113,40 @@ describe.skipIf(process.platform !== 'win32')('Codex wrapper install', () => {
 
     expect(result.status).toBe('installed');
     expect(metadata.commandPath).toBe(realCodex);
+    expect(fs.readFileSync(realCodex, 'utf8')).toContain('codex-run');
+  });
+
+  it('repair-only ensure never first-installs, even with codex on PATH', () => {
+    const realBin = path.join(env.home, 'real-bin');
+    const realCodex = path.join(realBin, 'codex.cmd');
+    fs.mkdirSync(realBin, { recursive: true });
+    fs.writeFileSync(realCodex, '@echo off\r\necho real codex\r\n', 'utf8');
+    process.env.PATH = realBin;
+
+    const result = repairCodexWrapperIfInstalled();
+
+    expect(result.status).toBe('not-found');
+    expect(isCodexWrapperInstalled()).toBe(false);
+    // The user's real launcher is untouched: no wrapper content, no backup.
+    expect(fs.readFileSync(realCodex, 'utf8')).toContain('real codex');
+    expect(fs.existsSync(path.join(realBin, 'codex.hippo-real.cmd'))).toBe(false);
+  });
+
+  it('repair-only ensure restores a clobbered wrapper for an opted-in user', () => {
+    const realBin = path.join(env.home, 'real-bin');
+    const realCodex = path.join(realBin, 'codex.cmd');
+    fs.mkdirSync(realBin, { recursive: true });
+    fs.writeFileSync(realCodex, '@echo off\r\necho real codex\r\n', 'utf8');
+    process.env.PATH = realBin;
+
+    // Explicit opt-in first (what `hippo hook install codex` runs).
+    expect(ensureCodexWrapperInstalled().status).toBe('installed');
+    // Simulate a Codex update clobbering the shim with a fresh real launcher.
+    fs.writeFileSync(realCodex, '@echo off\r\necho updated real codex\r\n', 'utf8');
+
+    const result = repairCodexWrapperIfInstalled();
+
+    expect(result.status).toBe('installed');
     expect(fs.readFileSync(realCodex, 'utf8')).toContain('codex-run');
   });
 });

--- a/tests/dag-rebuild-summaries.test.ts
+++ b/tests/dag-rebuild-summaries.test.ts
@@ -547,6 +547,11 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
         writeEntry(hippoRoot, sum);
         writeEntry(hippoRoot, makeChild(sum.id, `fact-${i}`));
         forceMarkDirty(hippoRoot, sum.id);
+        // Yield every 50 rows so the fork can service Vitest's birpc
+        // heartbeat: a fully synchronous 4500-insert stretch can exceed
+        // birpc's hardcoded 60s RPC timeout on loaded hosts, failing a run
+        // whose tests all passed (vitest-dev/vitest#8164).
+        if (i % 50 === 49) await new Promise((res) => setImmediate(res));
       }
 
       // Mock global fetch so the consolidate path's apiKey gate is satisfied

--- a/tests/dag-rebuild-summaries.test.ts
+++ b/tests/dag-rebuild-summaries.test.ts
@@ -577,5 +577,5 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
         delete process.env.HIPPO_DAG_REBUILD_CAP;
       }
     }
-  }, 120_000); // 1500-row real-DB seed is intentionally slow on low-power CI/dev hosts
+  }, 240_000); // 1500-row real-DB seed is intentionally slow on low-power CI/dev hosts; passes in ~90s solo but full-suite fork-pool contention can double it
 });

--- a/tests/transformers-backend-safety.test.ts
+++ b/tests/transformers-backend-safety.test.ts
@@ -9,24 +9,31 @@ function readJson(file: string): Record<string, any> {
 }
 
 describe('Transformers.js backend safety', () => {
-  it('ships one optional backend, with Xenova left as a manual legacy fallback', () => {
+  it('auto-installs no backend: both Transformers.js packages are optional peers', () => {
     const manifest = readJson('package.json');
-    expect(manifest.optionalDependencies).toHaveProperty('@huggingface/transformers');
-    expect(manifest.optionalDependencies).not.toHaveProperty('@xenova/transformers');
+    // No optionalDependencies at all — npm installs those by default, which
+    // is exactly what issue #133 was about. Backends are bring-your-own.
+    expect(manifest.optionalDependencies).toBeUndefined();
+    expect(manifest.dependencies).toBeUndefined();
+    expect(manifest.peerDependenciesMeta?.['@huggingface/transformers']?.optional).toBe(true);
+    expect(manifest.peerDependenciesMeta?.['@xenova/transformers']?.optional).toBe(true);
   });
 
-  it('locks one native ONNX Runtime implementation', () => {
+  it('locks zero Transformers.js backends and zero native ONNX Runtimes', () => {
     const lock = readJson('package-lock.json');
     const installedPaths = Object.keys(lock.packages as Record<string, unknown>);
 
-    expect(installedPaths).toContain('node_modules/@huggingface/transformers');
+    expect(installedPaths).not.toContain('node_modules/@huggingface/transformers');
     expect(installedPaths).not.toContain('node_modules/@xenova/transformers');
 
+    // Count-based, not path-based, so an npm hoist can never false-pass a
+    // second runtime. A user may manually install one backend (that is the
+    // supported opt-in); the SHIPPED graph must contain none, and the
+    // resolve-before-import logic in src/embeddings.ts guarantees a single
+    // native runtime per process even when both are installed manually.
     const nativeOrtPaths = installedPaths.filter((name) =>
       name.endsWith('/onnxruntime-node'),
     );
-    expect(nativeOrtPaths).toEqual([
-      'node_modules/@huggingface/transformers/node_modules/onnxruntime-node',
-    ]);
+    expect(nativeOrtPaths).toHaveLength(0);
   });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1157,9 +1157,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,9 +1171,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1185,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1208,9 +1199,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,9 +1213,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1242,9 +1227,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1259,9 +1241,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,9 +1255,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1293,9 +1269,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,9 +1283,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1327,9 +1297,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1311,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1361,9 +1325,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2431,9 +2392,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2569,9 +2530,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -2589,7 +2550,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,5 +24,11 @@ export default defineConfig({
     // module scope above covers the main process. Both are required.
     env: { HIPPO_HOME: isolatedHippoHome },
     globalSetup: ['tests/_real-store-guard.ts'],
+    // Real-DB suite: every test hits SQLite on disk, and Vitest 3's fork pool
+    // runs files in parallel, so under worker contention (Windows especially)
+    // individual tests that take ~2s in isolation exceed the 5s default and
+    // flake. 30s matches the slowest observed contention multiple; genuinely
+    // hung tests still fail, just later.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Problem

Issue #133: Socket.dev flags hippo-memory 1.27.0 on two fronts.

1. The two `optionalDependencies` (`@xenova/transformers`, `@huggingface/transformers`) are installed by npm by default, pulling a ~140-package native tree with a critical-CVE protobufjs 6.11.6 (via the frozen @xenova -> onnxruntime-web 1.14.0 chain), an adm-zip CVE, and two sharp advisories. #116 removed the worst chain; this PR removes the rest from default installs.
2. Socket's anomaly detector flagged the postinstall: on `npm install`, a detected `codex` launcher was silently renamed and replaced with Hippo's wrapper. The same silent swap also ran on routine commands. Intentional functionality, but the wrong consent model, and it reads as binary hijacking to any scanner.

## Fix

**Codex wrapper is strictly opt-in.**
- First install happens ONLY via `hippo hook install codex`.
- Postinstall and routine commands now call `repairCodexWrapperIfInstalled()`: it re-ensures the wrapper only when opt-in metadata already exists (self-heal after a Codex update clobbers the shim) and never first-installs.
- `npm install` and `hippo init` print a one-line nudge with the opt-in command when Codex is detected but unwrapped.
- Users wrapped under the old behavior keep working (their metadata counts as opt-in); `hippo hook uninstall codex` still removes everything.

**No embedding backend is auto-installed.**
- Both Transformers.js packages move from `optionalDependencies` to optional peers (`peerDependenciesMeta`). A default install is genuinely zero-dependency; the entire flagged tree disappears from the Socket page.
- All code paths already degrade gracefully with no backend installed; the CLI prints the install command where embeddings would apply.

**Repairs master's red CI.** The audit gate added by #116 fails on master: new advisories landed against the optional `@huggingface/transformers` tree after that PR was verified (adm-zip GHSA-xcpc-8h2w-3j85 and sharp GHSA-f88m-g3jw-g9cj, both high, both "no fix available") plus a fixable postcss advisory. Removing the auto-installed tree eliminates the unfixable advisories; `npm audit fix` resolves postcss. Both lockfiles now audit clean at high severity.

**Follow-ups from the #116 review**, folded in here:
- `tests/transformers-backend-safety.test.ts` now asserts the shipped graph contains zero backends and zero native ONNX runtimes, count-based instead of a hardcoded nested path.
- README/CHANGELOG note that upgrades (not just fresh installs) need one manual `npm i @huggingface/transformers` for local embeddings, since `npm update -g` rebuilds node_modules and drops a backend that arrived via the old auto-install.
- Global `testTimeout: 30_000` in vitest.config.ts: this real-DB suite under Vitest 3's fork pool trips the 5s default on slower machines (tests that take ~2s in isolation exceed 5s under worker contention). Generalizes the per-file calibration #116 started.
- CHANGELOG hygiene: the #109/#116 entries had landed under already-shipped version headings (those PRs predate 1.25-1.27); moved to Unreleased, and added missing entries for #119/#121/#122.

## Verification

- Full suite on this branch, rebased on master after #109/#116/#119/#121/#122: all tests pass with NO transformers package installed (proves graceful degradation end to end).
- New tests: repair-only never first-installs even with codex on PATH; repair restores a clobbered wrapper for an opted-in user.
- `package-lock.json` regenerated: no transformers/onnxruntime/sharp/protobufjs entries remain.
- `npm run audit:security`: 0 vulnerabilities in root and UI lockfiles (master currently fails this gate).

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQj31NzZZSfTwXzNaSXTnq
