### PR TITLE
feat: LC1 retrieval-trace persistence (schema v40)

### DIFF
--- a/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
+++ b/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
@@ -1,0 +1,221 @@
+# LC1 — Retrieval-trace persistence (ROADMAP Part IV, Track LC)
+
+Status: Draft (episode 01KZ1FHCK9TPJ14A549PQ03HNF)
+Branch: `feat/lc1-recall-trace` (worktree `hippo-wt-lc1`, from origin/master v1.28.0, schema v39)
+
+## Problem
+
+Recall audit rows persist only `{query_hash, query_length, results: <count>}`
+(`src/api.ts:962-966`). The returned memory ids, their ranks, and their scores
+are never written anywhere, and outcome events do not reference the recall
+they judge. The (query -> shown -> outcome) training triple that every Track LC
+learned component needs does not exist on disk. `last_retrieval_ids` persists
+only the single most recent id set, with no history, no scores, no linkage.
+
+## Goal (from ROADMAP Part IV / LC1)
+
+- Every recall writes a trace row: ids + ranks + scores, per-stage rerank data
+  when available.
+- Every outcome event references the trace(s) it scores.
+- Storage overhead < 5% of DB size; 30 days of dogfood accumulates a
+  re-loadable (query, shown, outcome) dataset.
+
+## Design
+
+### Migration v40 — three tables (follows v18 `goal_recall_log` style)
+
+```sql
+CREATE TABLE IF NOT EXISTS recall_traces (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  session_id TEXT,
+  pipeline TEXT NOT NULL CHECK (pipeline IN ('api','cli','context','mcp')),
+    -- 'mcp' reserved for the deferred MCP wire-up. Deliberate (critic round-1
+    -- noted it as premature): SQLite cannot ALTER a CHECK constraint, so
+    -- extending it later means a full table-rebuild migration. One unused
+    -- enum value now is cheaper than that rebuild.
+  query_hash TEXT NOT NULL,          -- sha256/16, NEVER raw query (audit convention, cli.ts:1532)
+  query_length INTEGER NOT NULL,
+  result_count INTEGER NOT NULL,
+  explain_mode INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_recall_traces_tenant_ts ON recall_traces(tenant_id, ts DESC);
+
+CREATE TABLE IF NOT EXISTS recall_trace_results (
+  trace_id INTEGER NOT NULL REFERENCES recall_traces(id) ON DELETE CASCADE,
+  tenant_id TEXT NOT NULL DEFAULT 'default',  -- denormalized like goal_recall_log (v18
+                                              -- precedent): tenant-scoped training queries
+                                              -- over the memory index must not need a join
+                                              -- back through recall_traces
+  memory_id TEXT NOT NULL,           -- NO FK to memories: traces must OUTLIVE forgotten
+                                     -- memories (they are LC2's negative class). PRAGMA
+                                     -- foreign_keys=ON is real (db.ts:2239), so an FK
+                                     -- would either block inserts or cascade-delete
+                                     -- exactly the rows training needs. Deliberate.
+  result_rank INTEGER NOT NULL,      -- NOT "rank" (SQL keyword; audit rule 10)
+  score REAL NOT NULL,
+  rerank_json TEXT,                  -- compact RerankStep[] when explain/trace present; else NULL
+  PRIMARY KEY (trace_id, result_rank)
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS idx_recall_trace_results_tenant_memory
+  ON recall_trace_results(tenant_id, memory_id);
+
+CREATE TABLE IF NOT EXISTS recall_trace_outcomes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  trace_id INTEGER NOT NULL REFERENCES recall_traces(id) ON DELETE CASCADE,
+  ts TEXT NOT NULL,
+  tenant_id TEXT NOT NULL DEFAULT 'default',
+  outcome TEXT NOT NULL CHECK (outcome IN ('positive','negative')),
+  memory_ids_json TEXT NOT NULL      -- ids actually credited by this outcome event
+);
+CREATE INDEX IF NOT EXISTS idx_recall_trace_outcomes_trace ON recall_trace_outcomes(trace_id);
+```
+
+Outcome linkage lives in its own append-only table, NOT in audit metadata:
+`audit_log` is pruned by `pruneAuditLog` (op `audit_prune`), and pruning must
+never erase training data. No new audit op is added anywhere — the
+`AuditOp` union + `VALID_AUDIT_OPS` in cli.ts:7096 + server.ts lockstep
+(v1.11.5 CRIT A rule) stays untouched.
+
+### New module `src/recall-trace.ts` — the single producer
+
+One shared writer called from every instrumented path (no per-site SQL):
+
+- `writeRecallTrace(db, input): number | null` — inserts the trace row + its
+  result rows in ONE transaction on the connection it is handed.
+  `writeRecallTraceAtRoot(root, input)` — convenience wrapper that opens a
+  fresh short-lived connection, writes, closes. **Connection policy is
+  per-site, stated explicitly** (plan-eng-critic round-1 catch — the original
+  blanket "same handle everywhere" claim was false at getContext):
+  - `api.recall`: caller's already-open handle (the trace write sits inside
+    the existing try/finally that owns `db`, next to the audit emit).
+  - `api.getContext` and `cmdRecall`: `writeRecallTraceAtRoot` — a fresh
+    short-lived connection AT the `last_retrieval_ids` write block. The audit
+    handles at getContext (~2390-2412) are already closed by then, and that
+    block's own convention is per-call handles (`writeEntry`, `saveIndex`).
+    This placement is REQUIRED for correctness, not just style: it runs after
+    the post-limit slice (~2417) and origin/category annotation (~2424), so
+    the trace captures the entries actually returned — writing earlier
+    against the still-open audit handle would persist the pre-limit,
+    pre-annotation candidate set and silently corrupt the training triple.
+  **Fail-soft:** wrapped in try/catch; a trace-write failure must never break
+  recall. Loss windows (audit rule 12): (a) crash between recall and trace
+  write -> trace lost, accepted, self-healing (next recall traces normally);
+  (b) trace INSERT throws -> caught, recall returns normally, unconditional
+  `console.error` line (matches the existing fail-soft precedent at api.ts
+  ~2843 "api.sleep audit emit failed" — no new debug env var); (c) the fresh
+  short-lived connection at getContext/cmdRecall opens only after all read
+  work and other writes in the block are complete — short transaction, same
+  process, same busy-timeout regime as the block's other per-call handles.
+- `writeLastTraceId(root, traceId)` / `readLastTraceId(root)` — meta key
+  `last_trace_id`, stored EXACTLY like `last_retrieval_ids` (store.ts:69
+  type, 1118 load, 1182 save, db.ts:2320 default, store.ts:887 legacy
+  migration, 934/940 empty-index defaults — ALL seven sites, enumerated by
+  the pre-plan audit; missing one is silent data loss).
+- `recordTraceOutcome(db, {traceId, tenantId, outcome, memoryIds})` — called
+  from the outcome choke point.
+
+JSDoc on all exports (AGENTS.md). All additive; no public CLI or API surface
+changes; no new CLI flags (so no `choices`/DB-CHECK twin risk).
+
+### Wire sites (v1 scope — three pipelines)
+
+1. **`api.recall`** (api.ts ~960, inside the existing try/finally that owns
+   the open db handle): write the trace next to the existing audit emit.
+   **The v1.11.5 contract lock holds**: api.recall still does NOT touch
+   `last_retrieval_ids` (locked by `tests/api-recall-no-side-effects.test.ts`)
+   and does NOT write `last_trace_id`. A trace INSERT is the same
+   observability class as the audit row it sits beside — not retrieval state.
+   SDK callers that batch recalls get one trace per recall (inserts, no
+   overwrite race — matching the batched-recall lock test's semantics).
+2. **`api.getContext`** (api.ts ~2462, the block that writes
+   `last_retrieval_ids` — NOT the earlier audit block): write trace +
+   `last_trace_id` together via `writeRecallTraceAtRoot` (fresh short-lived
+   connection; see connection policy above — the trace must capture the
+   post-limit, post-annotation `selectedItems`, and the audit handles are
+   already closed at this point). Skipped in `pinnedOnly` mode (hot path
+   stays read-only, same reason it skips markRetrieved).
+3. **CLI `cmdRecall`** (cli.ts ~1788): write ONE trace at `hippoRoot` (where
+   `last_retrieval_ids` and outcome attribution live) + `last_trace_id`.
+   The globalRoot audit emit stays as-is; no second trace row.
+
+**Out of scope, documented:** the MCP handler's own physics/hybrid pipeline
+(J2) — follow-up item; server HTTP recall is covered via api.recall. No
+sampling. No retention knob in v1 (measure first; `audit_prune`-style lever
+is a follow-up if the <5% budget is ever threatened).
+
+Per-stage scores: persisted opportunistically. When the caller ran with
+`explain` (A7) the RerankStep[] lands in `rerank_json`; the default path
+persists ids + ranks + final scores only. Forcing explain-mode computation on
+every recall is explicitly NOT done (hot-path cost; A7.2 unification is a
+separate roadmap item). ids+ranks+scores+outcomes is the load-bearing training
+triple; rerank steps are enrichment.
+
+### Outcome linkage
+
+Linkage is recorded ONLY where the credited ids actually come from the
+last-retrieval mechanism — `outcomeForLastRecall` (api.ts:2857-2881, which
+reads `last_retrieval_ids` and forwards to api.outcome) and any CLI outcome
+flow that resolves its targets from last-retrieval state. It is NOT recorded
+unconditionally in `api.outcome`: an SDK caller passing explicit ids with no
+preceding CLI/context recall would otherwise get linked to a stale, unrelated
+`last_trace_id` (grill catch — wrong-attribution bug). For programmatic
+callers, `api.outcome` gains an OPTIONAL additive `traceId?` opt so SDKs can
+link explicitly. Tenant-mismatched ids are already filtered upstream — the
+linkage records what was actually credited, after filtering. If
+`last_trace_id` is unset (fresh store, pre-v40 flow), skip silently — the
+outcome path's existing behavior is unchanged. Staleness note: `last_trace_id`
+inherits exactly `last_retrieval_ids`' attribution semantics (most recent
+interactive recall wins); no new staleness class is introduced.
+
+Other external api.outcome callers, named for completeness (critic round-2
+note): server.ts POST /v1/outcome passes explicit ids and no `traceId` — no
+linkage, correct; mcp/server.ts calls api.outcome from the MCP pipeline,
+which never writes a trace in v1 — no linkage, correct. Neither caller
+changes behavior.
+
+## Tasks (executors; T1 -> T2 -> T3 sequential, same files overlap)
+
+- **T1**: migration v40 + `src/recall-trace.ts` + meta plumbing (all seven
+  `last_retrieval_ids`-pattern sites for `last_trace_id`) + unit tests
+  (scratch HIPPO_HOME, never a repo checkout).
+- **T2**: wire the three recall paths + tests: api.recall writes trace rows
+  and does NOT write last_trace_id (extends the no-side-effects invariant in a
+  NEW test file — the locked test file is not edited); getContext writes
+  trace + linkage; cmdRecall writes trace + linkage at hippoRoot only.
+- **T3**: outcome linkage at api.outcome + E2E test: recall -> outcome ->
+  recall_trace_outcomes row references the right trace + ids; plus a
+  storage-overhead smoke (100 traced recalls, assert DB growth sane).
+
+## Test plan
+
+- Migration: fresh store lands at v40 with all three tables; v39 store
+  upgrades cleanly (fresh + upgrade paths).
+- Helper: happy path; fail-soft (trace write against a closed/readonly db
+  does not throw out of `writeRecallTrace`); WITHOUT ROWID composite-PK
+  uniqueness.
+- Wiring: one trace row per recall on each of the three paths; pinnedOnly
+  writes nothing; api.recall leaves `last_retrieval_ids` AND `last_trace_id`
+  untouched (new test file beside the locked one).
+- Outcome E2E: cmdRecall-style flow then outcome positive -> linkage row;
+  outcome with no prior trace -> no row, no error.
+- Full suite: `npm run build` + `npm test` in the worktree (fresh worktree
+  needs dist build first — probation memory).
+
+## Rollback / safety
+
+Derived, additive, rebuildable: dropping the three tables and the
+`last_trace_id` meta key restores v39 behavior exactly. No existing rows are
+mutated. Never-rules respected: no memory history deleted, no CLI names
+changed, no secrets in traces (hash-only queries).
+
+## Success criteria (falsifiable)
+
+1. Every recall on the three wired paths writes exactly one trace row with
+   the full returned id+rank+score list (tests assert).
+2. An outcome following a CLI/context recall writes a
+   `recall_trace_outcomes` row referencing that recall's trace id (E2E test).
+3. Storage: 100 traced recalls of 10 results grow the DB by < ~250KB
+   (smoke-test bound; sanity proxy for the <5% criterion).
+4. Full test suite green; no locked test modified.

--- a/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
+++ b/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
@@ -300,6 +300,20 @@ changed, no secrets in traces (hash-only queries).
 
 ## Limitations (added final review round)
 
+- **Mixed binary versions can contaminate linkage attribution (codex round-2
+  med, ACCEPTED with rationale).** A pre-v40 binary writing to a v40 store
+  updates `last_retrieval_ids` without touching `last_trace_id`. A new-binary
+  outcome then reads a stale trace id; membership validation filters the
+  credited ids against that stale trace, but ids that OVERLAP (similar
+  queries recall similar memories) still pass and get attributed to the
+  wrong recall event. Prevention would mean raising `min_compatible_binary`
+  at v40 — locking every pre-1.29 binary out of the store and breaking this
+  plan's v39-rollback promise. Deliberately NOT done: the contamination is
+  bounded to mixed-binary usage (a transitional state), affects training
+  attribution rather than user-facing behavior, and LC2's training loader
+  can additionally drop linkages whose outcome ts falls implausibly far
+  from the trace ts. Weighed and surfaced at the ship gate; revisit only if
+  mixed-binary usage becomes a standing configuration.
 - **Partial per-memory outcome failure can omit the linkage row.** `outcome()`
   loops over ids, calling `readEntry`/`writeEntry`/`appendAuditEvent` per id,
   and only calls `recordTraceOutcome` once at the end with whatever ended up

--- a/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
+++ b/docs/plans/2026-08-02-lc1-recall-trace-persistence.md
@@ -83,11 +83,17 @@ never erase training data. No new audit op is added anywhere — the
 One shared writer called from every instrumented path (no per-site SQL):
 
 - `writeRecallTrace(db, input): number | null` — inserts the trace row + its
-  result rows in ONE transaction on the connection it is handed.
+  result rows in ONE transaction on the connection it is handed. Per-result
+  rerank steps are sanitized before persisting: only `{stage, multiplier,
+  scoreBefore, scoreAfter}` survive (F3 privacy fix, final review round) —
+  `note` and any other free-form field (e.g. the CLI goal-boost step's
+  matched-tag text) are stripped, allowlist not denylist, so raw user
+  content can never leak into `rerank_json`.
   `writeRecallTraceAtRoot(root, input)` — convenience wrapper that opens a
-  fresh short-lived connection, writes, closes. **Connection policy is
-  per-site, stated explicitly** (plan-eng-critic round-1 catch — the original
-  blanket "same handle everywhere" claim was false at getContext):
+  fresh short-lived connection, writes, closes, and returns the trace id (or
+  null). **Connection policy is per-site, stated explicitly** (plan-eng-critic
+  round-1 catch — the original blanket "same handle everywhere" claim was
+  false at getContext):
   - `api.recall`: caller's already-open handle (the trace write sits inside
     the existing try/finally that owns `db`, next to the audit emit).
   - `api.getContext` and `cmdRecall`: `writeRecallTraceAtRoot` — a fresh
@@ -108,13 +114,46 @@ One shared writer called from every instrumented path (no per-site SQL):
   short-lived connection at getContext/cmdRecall opens only after all read
   work and other writes in the block are complete — short transaction, same
   process, same busy-timeout regime as the block's other per-call handles.
-- `writeLastTraceId(root, traceId)` / `readLastTraceId(root)` — meta key
-  `last_trace_id`, stored EXACTLY like `last_retrieval_ids` (store.ts:69
-  type, 1118 load, 1182 save, db.ts:2320 default, store.ts:887 legacy
-  migration, 934/940 empty-index defaults — ALL seven sites, enumerated by
-  the pre-plan audit; missing one is silent data loss).
+- **`last_trace_id` stamping — atomic lockstep with `last_retrieval_ids`
+  (F1 structural fix, final review round; supersedes the original design
+  below).** `writeRecallTraceAtRoot` does NOT touch the `last_trace_id` meta
+  key — a first-round independent-review fix had it stamp-then-clear on its
+  OWN connection, but that was still a second commit relative to
+  `last_retrieval_ids`, so a crash between the two writes (or a failed
+  second write) could advance one without the other. The fix moves the
+  stamp into `store.ts`'s `saveIndex`, which now persists BOTH meta keys in
+  ONE transaction (`BEGIN`/`COMMIT`, F1(c)). Callers (`getContext`,
+  `cmdRecall`) call `writeRecallTraceAtRoot` FIRST, fold the returned id
+  into `localIndex.last_trace_id` (`String(traceId)` on success, `null` on a
+  failed trace write), THEN call `saveIndex` once. Call sites that trace
+  WITHOUT advancing `last_retrieval_ids` (CLI zero-result, getContext's bare
+  empty-result return — see Wire sites) never touch `localIndex` at all, so
+  they cannot desync by construction. `readLastTraceId` / `writeLastTraceId`
+  standalone accessors were DELETED (F1(e)) — no production caller remained
+  once `outcomeForLastRecall` reads `last_trace_id` off the same `loadIndex`
+  snapshot it already holds (see Outcome linkage below) and every writer
+  goes through `saveIndex`. The strict parse that used to live in
+  `readLastTraceId` (trim, `/^\d+$/`, `n>0` — a bare `Number(raw)` let a
+  whitespace-only meta value parse as usable `0`, which would reach an
+  INSERT as a masked FK violation) now lives in `store.ts`'s
+  `parseLastTraceId`, called once inside `buildIndexFromDb` so every
+  consumer of `HippoIndex.last_trace_id` gets an already-clean value or
+  `null`. `last_trace_id` is still stored EXACTLY like `last_retrieval_ids`
+  at the same seven sites (store.ts:69 type, 1118ish load, 1192ish save,
+  db.ts meta default, store.ts bootstrap-legacy migration, two empty-index
+  defaults).
 - `recordTraceOutcome(db, {traceId, tenantId, outcome, memoryIds})` — called
-  from the outcome choke point.
+  from the outcome choke point. **F4 validation (final review round):**
+  before inserting, the function re-reads the named trace's own
+  `tenant_id` and skips (console.error, no throw) if the trace is missing or
+  belongs to a different tenant than `input.tenantId` — caller-side state
+  (`last_trace_id`, applied outcome ids) can go stale relative to the trace
+  it names (a tenant switch mid-session, a race between callers). It then
+  intersects `input.memoryIds` against that trace's OWN
+  `recall_trace_results.memory_id` set and records ONLY the intersection —
+  an id that was never actually in this trace's result set is dropped
+  rather than recorded as a false credit. If the intersection is empty, no
+  row is written at all.
 
 JSDoc on all exports (AGENTS.md). All additive; no public CLI or API surface
 changes; no new CLI flags (so no `choices`/DB-CHECK twin risk).
@@ -129,21 +168,49 @@ changes; no new CLI flags (so no `choices`/DB-CHECK twin risk).
    observability class as the audit row it sits beside — not retrieval state.
    SDK callers that batch recalls get one trace per recall (inserts, no
    overwrite race — matching the batched-recall lock test's semantics).
+   **F2 fix (final review round):** `RecallOpts` gains an additive
+   `suppressRecallTrace?: boolean`, mirroring `suppressAvailabilityHint`'s
+   established pattern — when true, this trace write is skipped entirely.
+   The MCP handler (`mcp/server.ts` ~502) sets it: its user-visible primary
+   ranking comes from a separate physics/hybrid scorer over the full tenant
+   store, not this internal `apiRecall` call's BM25 band, so tracing it as
+   pipeline `'api'` would mislabel training data with ids/ranks/scores the
+   user never actually saw. Real MCP tracing is the reserved `'mcp'`
+   pipeline value (schema v40) — an explicit follow-up, not v1 scope.
 2. **`api.getContext`** (api.ts ~2462, the block that writes
-   `last_retrieval_ids` — NOT the earlier audit block): write trace +
-   `last_trace_id` together via `writeRecallTraceAtRoot` (fresh short-lived
-   connection; see connection policy above — the trace must capture the
-   post-limit, post-annotation `selectedItems`, and the audit handles are
-   already closed at this point). Skipped in `pinnedOnly` mode (hot path
-   stays read-only, same reason it skips markRetrieved).
+   `last_retrieval_ids`): write the trace FIRST via `writeRecallTraceAtRoot`
+   (fresh short-lived connection; see connection policy above — the trace
+   must capture the post-limit, post-annotation `selectedItems`, and the
+   audit handles are already closed at this point), fold the returned id
+   into `localIndex.last_trace_id`, THEN one `saveIndex` call persists both
+   meta keys atomically (F1 lockstep — see connection-policy section).
+   Skipped in `pinnedOnly` mode (hot path stays read-only, same reason it
+   skips markRetrieved).
+   **F5 fix (final review round):** getContext's OTHER early return — the
+   bare `selectedItems.length === 0 && !activeSnapshot && !sessionHandoff &&
+   recentSessionEvents.length === 0` check right after the origin/category
+   annotation, which used to skip tracing entirely — now also writes an
+   empty trace (`pipeline: 'context'`, `results: []`) before returning. A
+   query that finds nothing is exactly the coverage-gap signal Track LC
+   needs. This path never touches `localIndex` (nothing to advance), so it
+   cannot desync `last_trace_id`/`last_retrieval_ids` by construction.
+   Also skipped when `pinnedOnly` (defensive — in the current control flow
+   `pinnedOnly` always exits via its own earlier returns before reaching
+   this check, so this guard cannot actually fire today, but is required by
+   the same read-only-hot-path contract as the rest of `pinnedOnly`).
 3. **CLI `cmdRecall`** (cli.ts ~1788): write ONE trace at `hippoRoot` (where
-   `last_retrieval_ids` and outcome attribution live) + `last_trace_id`.
-   The globalRoot audit emit stays as-is; no second trace row.
+   `last_retrieval_ids` and outcome attribution live), FIRST, then fold its
+   id into `localIndex.last_trace_id` before the single `saveIndex` call —
+   same F1 lockstep pattern as getContext. The globalRoot audit emit stays
+   as-is; no second trace row. The zero-result branch (independent-review
+   must-fix, kept under F1) writes an empty trace but never touches
+   `localIndex` — same reasoning as getContext's F5 empty path.
 
 **Out of scope, documented:** the MCP handler's own physics/hybrid pipeline
-(J2) — follow-up item; server HTTP recall is covered via api.recall. No
-sampling. No retention knob in v1 (measure first; `audit_prune`-style lever
-is a follow-up if the <5% budget is ever threatened).
+(J2) — follow-up item, see the F2 fix above; server HTTP recall is covered
+via api.recall. No sampling. No retention knob in v1 (measure first;
+`audit_prune`-style lever is a follow-up if the <5% budget is ever
+threatened).
 
 Per-stage scores: persisted opportunistically. When the caller ran with
 `explain` (A7) the RerankStep[] lands in `rerank_json`; the default path
@@ -155,15 +222,36 @@ triple; rerank steps are enrichment.
 ### Outcome linkage
 
 Linkage is recorded ONLY where the credited ids actually come from the
-last-retrieval mechanism — `outcomeForLastRecall` (api.ts:2857-2881, which
-reads `last_retrieval_ids` and forwards to api.outcome) and any CLI outcome
-flow that resolves its targets from last-retrieval state. It is NOT recorded
+last-retrieval mechanism — `outcomeForLastRecall` (api.ts, which reads
+`last_retrieval_ids` and forwards to api.outcome) and any CLI outcome flow
+that resolves its targets from last-retrieval state. It is NOT recorded
 unconditionally in `api.outcome`: an SDK caller passing explicit ids with no
 preceding CLI/context recall would otherwise get linked to a stale, unrelated
 `last_trace_id` (grill catch — wrong-attribution bug). For programmatic
 callers, `api.outcome` gains an OPTIONAL additive `traceId?` opt so SDKs can
-link explicitly. Tenant-mismatched ids are already filtered upstream — the
-linkage records what was actually credited, after filtering. If
+link explicitly.
+
+**Single-snapshot read (F1(d) fix, final review round):** `outcomeForLastRecall`
+reads the trace id off the SAME `loadIndex(ctx.hippoRoot)` snapshot it
+already holds for `last_retrieval_ids` (`idx.last_trace_id`) instead of a
+second DB round trip via the (now-deleted) `readLastTraceId` helper — one
+read, no read-after-read race window between the two values. The value is
+already strict-parsed by `buildIndexFromDb`'s `parseLastTraceId`
+(store.ts), so `outcomeForLastRecall` never has to re-validate it.
+
+**Consumer-side validation (F4 fix, final review round):** `recordTraceOutcome`
+itself re-validates before inserting — see the connection-policy section
+above. This is what makes the linkage path robust to staleness beyond the
+single-snapshot read: even if `last_trace_id` names a trace from a different
+tenant (should not happen via the normal read path, but a defense-in-depth
+backstop) or names a trace whose result set doesn't actually contain the
+credited ids (e.g. an old-binary write from before F1's lockstep fix, or a
+`last_retrieval_ids` update racing a trace write under an unrelated
+failure), the row is skipped or filtered down to the true intersection
+rather than recording a false credit. Tenant-mismatched ids passed to
+`outcome()` itself are still filtered upstream by `outcome()`'s own
+`readEntry(..., ctx.tenantId)` loop, before `recordTraceOutcome` ever runs —
+the linkage records what was actually credited, after BOTH filters. If
 `last_trace_id` is unset (fresh store, pre-v40 flow), skip silently — the
 outcome path's existing behavior is unchanged. Staleness note: `last_trace_id`
 inherits exactly `last_retrieval_ids`' attribution semantics (most recent
@@ -209,6 +297,26 @@ Derived, additive, rebuildable: dropping the three tables and the
 `last_trace_id` meta key restores v39 behavior exactly. No existing rows are
 mutated. Never-rules respected: no memory history deleted, no CLI names
 changed, no secrets in traces (hash-only queries).
+
+## Limitations (added final review round)
+
+- **Partial per-memory outcome failure can omit the linkage row.** `outcome()`
+  loops over ids, calling `readEntry`/`writeEntry`/`appendAuditEvent` per id,
+  and only calls `recordTraceOutcome` once at the end with whatever ended up
+  in `appliedIds`. If the loop applies some ids and then a later id in the
+  same call fails partway (e.g. a write error on that specific memory), the
+  ids that DID apply still get credited correctly, but this is an accepted,
+  pre-existing write pattern (matches how `appliedIds`/`applied` already
+  worked before LC1) — not a new gap introduced by tracing, and not
+  reworked here.
+- **External `traceId` exposure (HTTP/SDK) is a scoped follow-up.** The
+  `traceId?` opt on `api.outcome` is reachable today only from in-process TS
+  callers. Neither `server.ts`'s POST `/v1/outcome` route nor the Python SDK
+  currently accept or forward a caller-supplied trace id — an external
+  caller cannot yet do explicit SDK linkage. Wiring that through (request
+  body field, SDK method signature) is out of v1 scope; the last-retrieval
+  path (`outcomeForLastRecall`) already covers the CLI/HTTP no-body
+  last-recall flow without it.
 
 ## Success criteria (falsifiable)
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,6 +55,7 @@ import {
   type AuditOp,
 } from './audit.js';
 import { promoteToGlobal, getGlobalRoot, autoShare, searchBothHybrid } from './shared.js';
+import { writeRecallTrace, writeRecallTraceAtRoot, readLastTraceId, recordTraceOutcome } from './recall-trace.js';
 import { evalNow, isRecallBoostAblated } from './ablation.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
@@ -965,6 +966,25 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
       results: rankedOut.length,
     },
   });
+
+  // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): trace the
+  // returned ids+ranks+scores next to the audit emit, on the SAME open
+  // handle. v1.11.5 contract lock holds — api.recall does NOT write
+  // last_trace_id (tests/api-recall-no-side-effects.test.ts); a trace INSERT
+  // is the same observability class as the audit row it sits beside, not
+  // retrieval state. Fail-soft internally; never throws.
+  writeRecallTrace(db, {
+    tenantId: ctx.tenantId,
+    sessionId: opts.sessionId ?? null,
+    pipeline: 'api',
+    query: opts.query,
+    explainMode: opts.explain === true,
+    results: rankedOut.map((r) => ({
+      memoryId: r.id,
+      score: r.score,
+      rerankSteps: r.rerankTrace,
+    })),
+  });
   } finally {
     closeHippoDb(db);
   }
@@ -1573,11 +1593,21 @@ export function drillDown(
  * MUST return `appliedIds` instead of the raw input list — otherwise the
  * non-applied (cross-tenant) ids leak to the caller. Added in v1.11.4 to
  * close that disclosure path on POST /v1/outcome.
+ *
+ * `opts.traceId` (LC1, docs/plans/2026-08-02-lc1-recall-trace-persistence.md):
+ * OPTIONAL additive opt so a programmatic caller can link this outcome to
+ * the recall_traces row it judges. NOT applied unconditionally — an SDK
+ * caller passing explicit ids with no preceding CLI/context recall would
+ * otherwise get linked to a stale, unrelated trace. `outcomeForLastRecall`
+ * supplies this automatically from `last_trace_id`; every other caller
+ * (server.ts explicit-ids path, MCP hippo_outcome) omits it and gets no
+ * linkage, which is correct.
  */
 export function outcome(
   ctx: Context,
   ids: ReadonlyArray<string>,
   good: boolean,
+  opts?: { traceId?: number },
 ): { applied: number; appliedIds: string[] } {
   const appliedIds: string[] = [];
   const db = openHippoDb(ctx.hippoRoot);
@@ -1595,6 +1625,17 @@ export function outcome(
         metadata: { good },
       });
       appliedIds.push(id);
+    }
+    // LC1: link the outcome to its trace, recording only the ids actually
+    // credited (post tenant-filtering, matches appliedIds). Lives in its own
+    // append-only table so audit_log pruning can never erase training data.
+    if (opts?.traceId !== undefined && appliedIds.length > 0) {
+      recordTraceOutcome(db, {
+        traceId: opts.traceId,
+        tenantId: ctx.tenantId,
+        outcome: good ? 'positive' : 'negative',
+        memoryIds: appliedIds,
+      });
     }
   } finally {
     closeHippoDb(db);
@@ -2461,6 +2502,26 @@ export async function getContext(
 
     localIndex.last_retrieval_ids = updatedEntries.map((u) => u.id);
     saveIndex(ctx.hippoRoot, localIndex);
+
+    // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): trace the
+    // post-limit, post-annotation `selectedItems` actually returned. Fresh
+    // short-lived connection — the audit handles above (~2410) are already
+    // closed by this point, matching this block's own per-call-handle
+    // convention (writeEntry, saveIndex). Writes last_trace_id too (skipped
+    // entirely in pinnedOnly mode by virtue of this whole block being
+    // skipped). Fail-soft internally; never throws.
+    writeRecallTraceAtRoot(ctx.hippoRoot, {
+      tenantId: ctx.tenantId,
+      sessionId: activeSnapshot?.session_id ?? null,
+      pipeline: 'context',
+      query,
+      explainMode: false,
+      results: selectedItems.map((s) => ({
+        memoryId: s.entry.id,
+        score: s.score,
+      })),
+    });
+
     updateStats(ctx.hippoRoot, { recalled: selectedItems.length });
 
     // Replace selectedItems entries with markRetrieved-updated copies so
@@ -2880,6 +2941,11 @@ export function outcomeForLastRecall(
   const idx = loadIndex(ctx.hippoRoot);
   const ids = idx.last_retrieval_ids;
   if (ids.length === 0) return { applied: 0, ids: [] };
-  const { applied, appliedIds } = outcome(ctx, ids, good);
+  // LC1: this IS the last-retrieval mechanism the plan requires linkage for
+  // (docs/plans/2026-08-02-lc1-recall-trace-persistence.md). readLastTraceId
+  // returns null on a fresh store / pre-v40 flow / api.recall-only usage —
+  // outcome() skips linkage silently when traceId is undefined.
+  const traceId = readLastTraceId(ctx.hippoRoot);
+  const { applied, appliedIds } = outcome(ctx, ids, good, traceId !== null ? { traceId } : undefined);
   return { applied, ids: appliedIds };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,7 +55,7 @@ import {
   type AuditOp,
 } from './audit.js';
 import { promoteToGlobal, getGlobalRoot, autoShare, searchBothHybrid } from './shared.js';
-import { writeRecallTrace, writeRecallTraceAtRoot, readLastTraceId, recordTraceOutcome } from './recall-trace.js';
+import { writeRecallTrace, writeRecallTraceAtRoot, recordTraceOutcome } from './recall-trace.js';
 import { evalNow, isRecallBoostAblated } from './ablation.js';
 import { archiveRawMemory } from './raw-archive.js';
 import {
@@ -387,6 +387,19 @@ export interface RecallOpts {
    * reranker/retrieval-count-downweight) are A7.2.
    */
   explain?: boolean;
+  /**
+   * LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md) / F2 fix.
+   * When true, api.recall does NOT write a recall_traces row for this call.
+   * Mirrors `suppressAvailabilityHint`'s pattern: callers that run their OWN
+   * tracing over a DIFFERENT result set must suppress api.recall's copy so
+   * the training corpus doesn't get a trace mislabeled as 'api' pipeline
+   * when the caller's actual user-visible results came from elsewhere. The
+   * MCP handler sets this — its primary ranked band comes from a separate
+   * physics/hybrid scorer, not this api.recall call's BM25 band (real MCP
+   * tracing is the reserved 'mcp' pipeline, a follow-up). HTTP / direct SDK
+   * callers leave this unset and get the trace.
+   */
+  suppressRecallTrace?: boolean;
 }
 
 export interface ContinuityBlock {
@@ -972,19 +985,23 @@ export function recall(ctx: Context, opts: RecallOpts): RecallResult {
   // handle. v1.11.5 contract lock holds — api.recall does NOT write
   // last_trace_id (tests/api-recall-no-side-effects.test.ts); a trace INSERT
   // is the same observability class as the audit row it sits beside, not
-  // retrieval state. Fail-soft internally; never throws.
-  writeRecallTrace(db, {
-    tenantId: ctx.tenantId,
-    sessionId: opts.sessionId ?? null,
-    pipeline: 'api',
-    query: opts.query,
-    explainMode: opts.explain === true,
-    results: rankedOut.map((r) => ({
-      memoryId: r.id,
-      score: r.score,
-      rerankSteps: r.rerankTrace,
-    })),
-  });
+  // retrieval state. F2 fix: suppressed when the caller (currently only the
+  // MCP handler) traces its own, different result set — see
+  // opts.suppressRecallTrace JSDoc. Fail-soft internally; never throws.
+  if (!opts.suppressRecallTrace) {
+    writeRecallTrace(db, {
+      tenantId: ctx.tenantId,
+      sessionId: opts.sessionId ?? null,
+      pipeline: 'api',
+      query: opts.query,
+      explainMode: opts.explain === true,
+      results: rankedOut.map((r) => ({
+        memoryId: r.id,
+        score: r.score,
+        rerankSteps: r.rerankTrace,
+      })),
+    });
+  }
   } finally {
     closeHippoDb(db);
   }
@@ -2474,6 +2491,27 @@ export async function getContext(
     !sessionHandoff &&
     recentSessionEvents.length === 0
   ) {
+    // LC1 F5 fix: this bare early-return used to skip tracing entirely — a
+    // query that found nothing is exactly the coverage-gap signal Track LC
+    // needs. Write an empty trace (result_count 0, no result rows) so it
+    // lands in the training corpus. Never touches localIndex/
+    // last_retrieval_ids/last_trace_id — by construction it can't desync
+    // (mirrors the CLI zero-result path). Skipped under pinnedOnly (hot
+    // path stays read-only, same reason it skips markRetrieved). Fail-soft
+    // internally; never throws.
+    if (!pinnedOnly) {
+      // No sessionId to pull here: !activeSnapshot holds in this branch by
+      // construction (one of the AND conditions above), so there is no
+      // active snapshot to derive a session id from.
+      writeRecallTraceAtRoot(ctx.hippoRoot, {
+        tenantId: ctx.tenantId,
+        sessionId: null,
+        pipeline: 'context',
+        query,
+        explainMode: false,
+        results: [],
+      });
+    }
     return { entries: [], tokens: 0 };
   }
 
@@ -2501,16 +2539,21 @@ export async function getContext(
     }
 
     localIndex.last_retrieval_ids = updatedEntries.map((u) => u.id);
-    saveIndex(ctx.hippoRoot, localIndex);
 
-    // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): trace the
-    // post-limit, post-annotation `selectedItems` actually returned. Fresh
-    // short-lived connection — the audit handles above (~2410) are already
-    // closed by this point, matching this block's own per-call-handle
-    // convention (writeEntry, saveIndex). Writes last_trace_id too (skipped
-    // entirely in pinnedOnly mode by virtue of this whole block being
-    // skipped). Fail-soft internally; never throws.
-    writeRecallTraceAtRoot(ctx.hippoRoot, {
+    // LC1 F1 structural fix (docs/plans/2026-08-02-lc1-recall-trace-persistence.md):
+    // write the trace FIRST — post-limit, post-annotation `selectedItems`
+    // actually returned, on a fresh short-lived connection (the audit
+    // handles above ~2410 are already closed by this point, matching this
+    // block's own per-call-handle convention: writeEntry, saveIndex) — then
+    // fold the resulting id into `localIndex` so the SAME `saveIndex` call
+    // below persists last_retrieval_ids + last_trace_id atomically.
+    // LOCKSTEP INVARIANT: last_trace_id must only ever advance together
+    // with last_retrieval_ids; a two-connection stamp-then-clear design
+    // could desync them on a crash between writes. A failed trace write
+    // (traceId null) sets last_trace_id to null rather than leaving the
+    // OLD id pointing at ids that are about to be overwritten. Fail-soft
+    // internally; never throws.
+    const traceId = writeRecallTraceAtRoot(ctx.hippoRoot, {
       tenantId: ctx.tenantId,
       sessionId: activeSnapshot?.session_id ?? null,
       pipeline: 'context',
@@ -2521,6 +2564,8 @@ export async function getContext(
         score: s.score,
       })),
     });
+    localIndex.last_trace_id = traceId !== null ? String(traceId) : null;
+    saveIndex(ctx.hippoRoot, localIndex);
 
     updateStats(ctx.hippoRoot, { recalled: selectedItems.length });
 
@@ -2941,11 +2986,16 @@ export function outcomeForLastRecall(
   const idx = loadIndex(ctx.hippoRoot);
   const ids = idx.last_retrieval_ids;
   if (ids.length === 0) return { applied: 0, ids: [] };
-  // LC1: this IS the last-retrieval mechanism the plan requires linkage for
-  // (docs/plans/2026-08-02-lc1-recall-trace-persistence.md). readLastTraceId
-  // returns null on a fresh store / pre-v40 flow / api.recall-only usage —
-  // outcome() skips linkage silently when traceId is undefined.
-  const traceId = readLastTraceId(ctx.hippoRoot);
+  // LC1 F1(d) structural fix (docs/plans/2026-08-02-lc1-recall-trace-persistence.md):
+  // read the trace id from the SAME `loadIndex` snapshot already in hand
+  // (idx.last_trace_id) — a single-snapshot read, not a second DB round
+  // trip via a now-deleted readLastTraceId helper. The value is already
+  // strict-parsed by buildIndexFromDb's parseLastTraceId (store.ts): every
+  // consumer gets a clean positive-integer string or null, never a garbage
+  // value that could reach outcome() and INSERT trace_id=0/NaN. null on a
+  // fresh store / pre-v40 flow / api.recall-only usage — outcome() skips
+  // linkage silently when traceId is undefined.
+  const traceId = idx.last_trace_id !== null ? Number(idx.last_trace_id) : null;
   const { applied, appliedIds } = outcome(ctx, ids, good, traceId !== null ? { traceId } : undefined);
   return { applied, ids: appliedIds };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1694,26 +1694,24 @@ async function cmdRecall(
     || recentSessionEvents.length > 0;
 
   if (results.length === 0) {
-    // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md,
-    // independent-review-critic must-fix): trace the zero-result recall too
-    // (result_count 0, no result rows) so a query that reveals a coverage
-    // gap still lands in the training corpus. last_trace_id is deliberately
-    // NOT stamped here — this path never touches last_retrieval_ids (no
-    // memories to update), so stamping last_trace_id would let a later
-    // `hippo outcome` link the OLD last_retrieval_ids against this NEW,
-    // unrelated empty trace. Fail-soft internally; never throws.
-    writeRecallTraceAtRoot(
-      hippoRoot,
-      {
-        tenantId,
-        sessionId: sessionId || null,
-        pipeline: 'cli',
-        query,
-        explainMode: showWhy,
-        results: [],
-      },
-      { stampLastTraceId: false },
-    );
+    // LC1 F1 structural fix (docs/plans/2026-08-02-lc1-recall-trace-persistence.md):
+    // trace the zero-result recall too (result_count 0, no result rows) so
+    // a query that reveals a coverage gap still lands in the training
+    // corpus. Deliberately does NOT touch `localIndex` at all — this path
+    // never advances last_retrieval_ids (no memories to update), and
+    // writeRecallTraceAtRoot no longer stamps last_trace_id on its own
+    // (that only happens via the caller folding the returned id into
+    // localIndex before a SAME saveIndex call, which this path never
+    // reaches). By construction the two can't desync. Fail-soft
+    // internally; never throws.
+    writeRecallTraceAtRoot(hippoRoot, {
+      tenantId,
+      sessionId: sessionId || null,
+      pipeline: 'cli',
+      query,
+      explainMode: showWhy,
+      results: [],
+    });
 
     if (asJson) {
       const out: Record<string, unknown> = {
@@ -1808,13 +1806,16 @@ async function cmdRecall(
 
   // Track last retrieval IDs for outcome command
   localIndex.last_retrieval_ids = updated.map((u) => u.id);
-  saveIndex(hippoRoot, localIndex);
 
-  // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): ONE trace
-  // at hippoRoot (where last_retrieval_ids and outcome attribution live) +
-  // last_trace_id. The globalRoot audit emit (emitCliAudit above) is
-  // untouched — no second trace row. Fail-soft internally; never throws.
-  writeRecallTraceAtRoot(hippoRoot, {
+  // LC1 F1 structural fix (docs/plans/2026-08-02-lc1-recall-trace-persistence.md):
+  // ONE trace at hippoRoot (where last_retrieval_ids and outcome
+  // attribution live). Write the trace FIRST, then fold its id into
+  // `localIndex` so the SAME saveIndex call below persists
+  // last_retrieval_ids + last_trace_id atomically (LOCKSTEP INVARIANT —
+  // see writeRecallTraceAtRoot JSDoc). The globalRoot audit emit
+  // (emitCliAudit above) is untouched — no second trace row. Fail-soft
+  // internally; never throws.
+  const traceId = writeRecallTraceAtRoot(hippoRoot, {
     tenantId,
     sessionId: sessionId || null,
     pipeline: 'cli',
@@ -1826,6 +1827,8 @@ async function cmdRecall(
       rerankSteps: r.rerankTrace,
     })),
   });
+  localIndex.last_trace_id = traceId !== null ? String(traceId) : null;
+  saveIndex(hippoRoot, localIndex);
 
   updateStats(hippoRoot, { recalled: results.length });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,7 @@ import type { SessionHandoff } from './handoff.js';
 import { search, markRetrieved, estimateTokens, hybridSearch, physicsSearch, explainMatch, textOverlap, tokenize as tokenizeQuery, type RerankStep } from './search.js';
 import { compareEntryIdentity } from './compare.js';
 import { renderTraceContent, parseSteps } from './trace.js';
+import { writeRecallTraceAtRoot } from './recall-trace.js';
 import { consolidate } from './consolidate.js';
 import { deduplicateStore } from './dedupe.js';
 import {
@@ -1693,6 +1694,27 @@ async function cmdRecall(
     || recentSessionEvents.length > 0;
 
   if (results.length === 0) {
+    // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md,
+    // independent-review-critic must-fix): trace the zero-result recall too
+    // (result_count 0, no result rows) so a query that reveals a coverage
+    // gap still lands in the training corpus. last_trace_id is deliberately
+    // NOT stamped here — this path never touches last_retrieval_ids (no
+    // memories to update), so stamping last_trace_id would let a later
+    // `hippo outcome` link the OLD last_retrieval_ids against this NEW,
+    // unrelated empty trace. Fail-soft internally; never throws.
+    writeRecallTraceAtRoot(
+      hippoRoot,
+      {
+        tenantId,
+        sessionId: sessionId || null,
+        pipeline: 'cli',
+        query,
+        explainMode: showWhy,
+        results: [],
+      },
+      { stampLastTraceId: false },
+    );
+
     if (asJson) {
       const out: Record<string, unknown> = {
         query,
@@ -1787,6 +1809,23 @@ async function cmdRecall(
   // Track last retrieval IDs for outcome command
   localIndex.last_retrieval_ids = updated.map((u) => u.id);
   saveIndex(hippoRoot, localIndex);
+
+  // LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): ONE trace
+  // at hippoRoot (where last_retrieval_ids and outcome attribution live) +
+  // last_trace_id. The globalRoot audit emit (emitCliAudit above) is
+  // untouched — no second trace row. Fail-soft internally; never throws.
+  writeRecallTraceAtRoot(hippoRoot, {
+    tenantId,
+    sessionId: sessionId || null,
+    pipeline: 'cli',
+    query,
+    explainMode: showWhy,
+    results: results.map((r) => ({
+      memoryId: r.entry.id,
+      score: r.score,
+      rerankSteps: r.rerankTrace,
+    })),
+  });
 
   updateStats(hippoRoot, { recalled: results.length });
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -25,7 +25,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 39;
+const CURRENT_SCHEMA_VERSION = 40;
 
 /**
  * Context passed to migrations that need to know WHERE the store lives.
@@ -2194,6 +2194,63 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 40,
+    up: (db) => {
+      // LC1 retrieval-trace persistence (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+      // Follows the v18 goal_recall_log style: one parent trace row per
+      // recall, a WITHOUT ROWID child table for the ranked results, and a
+      // separate append-only outcomes table so audit_log pruning can never
+      // erase training data.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS recall_traces (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          ts TEXT NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'default',
+          session_id TEXT,
+          pipeline TEXT NOT NULL CHECK (pipeline IN ('api','cli','context','mcp')),
+            -- 'mcp' reserved for the deferred MCP wire-up. Deliberate: SQLite
+            -- cannot ALTER a CHECK constraint, so extending it later means a
+            -- full table-rebuild migration. One unused enum value now is
+            -- cheaper than that rebuild.
+          query_hash TEXT NOT NULL,          -- sha256/16, NEVER raw query (audit convention, cli.ts:1532)
+          query_length INTEGER NOT NULL,
+          result_count INTEGER NOT NULL,
+          explain_mode INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_recall_traces_tenant_ts ON recall_traces(tenant_id, ts DESC);
+
+        CREATE TABLE IF NOT EXISTS recall_trace_results (
+          trace_id INTEGER NOT NULL REFERENCES recall_traces(id) ON DELETE CASCADE,
+          tenant_id TEXT NOT NULL DEFAULT 'default',  -- denormalized like goal_recall_log (v18
+                                                      -- precedent): tenant-scoped training queries
+                                                      -- over the memory index must not need a join
+                                                      -- back through recall_traces
+          memory_id TEXT NOT NULL,           -- NO FK to memories: traces must OUTLIVE forgotten
+                                             -- memories (they are LC2's negative class). PRAGMA
+                                             -- foreign_keys=ON is real, so an FK would either
+                                             -- block inserts or cascade-delete exactly the rows
+                                             -- training needs. Deliberate.
+          result_rank INTEGER NOT NULL,      -- NOT "rank" (SQL keyword; audit rule 10)
+          score REAL NOT NULL,
+          rerank_json TEXT,                  -- compact RerankStep[] when explain/trace present; else NULL
+          PRIMARY KEY (trace_id, result_rank)
+        ) WITHOUT ROWID;
+        CREATE INDEX IF NOT EXISTS idx_recall_trace_results_tenant_memory
+          ON recall_trace_results(tenant_id, memory_id);
+
+        CREATE TABLE IF NOT EXISTS recall_trace_outcomes (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          trace_id INTEGER NOT NULL REFERENCES recall_traces(id) ON DELETE CASCADE,
+          ts TEXT NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'default',
+          outcome TEXT NOT NULL CHECK (outcome IN ('positive','negative')),
+          memory_ids_json TEXT NOT NULL      -- ids actually credited by this outcome event
+        );
+        CREATE INDEX IF NOT EXISTS idx_recall_trace_outcomes_trace ON recall_trace_outcomes(trace_id);
+      `);
+    },
+  },
 ];
 
 function tableHasColumn(db: DatabaseSyncLike, tableName: string, columnName: string): boolean {
@@ -2318,6 +2375,7 @@ function ensureMetaDefaults(db: DatabaseSyncLike): void {
   const defaults: Array<[string, string]> = [
     ['schema_version', String(CURRENT_SCHEMA_VERSION)],
     ['last_retrieval_ids', '[]'],
+    ['last_trace_id', ''],
     ['total_remembered', '0'],
     ['total_recalled', '0'],
     ['total_forgotten', '0'],

--- a/src/db.ts
+++ b/src/db.ts
@@ -2202,6 +2202,22 @@ const MIGRATIONS: Migration[] = [
       // recall, a WITHOUT ROWID child table for the ranked results, and a
       // separate append-only outcomes table so audit_log pruning can never
       // erase training data.
+      //
+      // F6 (deliberate, not an oversight): unlike v39, this migration does
+      // NOT bump `min_compatible_binary`. A pre-v40 binary opening this DB
+      // ignores the three new tables and keeps writing `last_retrieval_ids`
+      // exactly as before — it never touches `last_trace_id` (that key
+      // simply stays whatever it was). recordTraceOutcome's F4 consumer-
+      // side validation (recall-trace.ts) makes any resulting staleness
+      // harmless to linkage: it re-validates the named trace's tenant AND
+      // intersects credited ids against the trace's OWN result set before
+      // inserting, so a stale/mismatched trace id from an old-binary write
+      // gets silently skipped rather than mislinked. That preserves the
+      // plan's "drop the three tables + last_trace_id restores v39 behavior
+      // exactly" rollback promise — a min_compatible_binary bump would
+      // additionally lock old binaries out of the WHOLE store for what is
+      // purely an observability/training feature, which the rollback
+      // promise does not require.
       db.exec(`
         CREATE TABLE IF NOT EXISTS recall_traces (
           id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -508,6 +508,13 @@ async function executeTool(
         // physics/hybrid result set below; suppress api.recall's BM25-band copy
         // so one MCP recall does not emit recall_availability_detected twice.
         suppressAvailabilityHint: true,
+        // LC1 F2 fix — MCP's user-visible primary ordering comes from the
+        // physics/hybrid scorer below, NOT this api.recall call's BM25 band
+        // (see the comment above apiRecall). Tracing this call as pipeline
+        // 'api' would mislabel training data with ids/ranks/scores the user
+        // never actually saw. Real MCP tracing is the reserved 'mcp'
+        // pipeline value (schema v40) — a follow-up, not v1 scope.
+        suppressRecallTrace: true,
         ...(freshTailCount !== undefined ? { freshTailCount } : {}),
         ...(freshTailSessionId !== undefined ? { freshTailSessionId } : {}),
         ...(summarizeOverflow !== undefined ? { summarizeOverflow } : {}),

--- a/src/recall-trace.ts
+++ b/src/recall-trace.ts
@@ -1,0 +1,244 @@
+/**
+ * LC1 — retrieval-trace persistence
+ * (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+ *
+ * Single producer for the `recall_traces` / `recall_trace_results` /
+ * `recall_trace_outcomes` tables (schema v40). Every recall on the three
+ * wired paths (api.recall, api.getContext, CLI cmdRecall) writes a trace
+ * row: the ids + ranks + scores actually returned. Outcome events that
+ * resolve their targets from last-retrieval state link back to the trace
+ * they judge via `recordTraceOutcome`. This is the (query, shown, outcome)
+ * training triple every Track LC learned component needs.
+ *
+ * All writes here are fail-soft: a broken trace write must never break the
+ * surrounding recall or outcome call. Failures are logged to stderr and
+ * swallowed (matches the api.ts ~2843 "audit emit failed" precedent — no
+ * new debug env var).
+ */
+
+import { createHash } from 'node:crypto';
+import { openHippoDb, closeHippoDb, getMeta, setMeta, type DatabaseSyncLike } from './db.js';
+import type { RerankStep } from './search.js';
+
+/** One ranked result to persist alongside its trace row. */
+export interface RecallTraceResultInput {
+  memoryId: string;
+  score: number;
+  /** Per-stage rerank steps when the caller ran with explain/--why; omitted
+   *  (or empty) persists `rerank_json` as NULL. */
+  rerankSteps?: RerankStep[];
+}
+
+/** Input to `writeRecallTrace` / `writeRecallTraceAtRoot`. */
+export interface RecallTraceInput {
+  tenantId: string;
+  sessionId?: string | null;
+  pipeline: 'api' | 'cli' | 'context' | 'mcp';
+  /** Raw query text. NEVER persisted — only its sha256/16 hash + length are
+   *  stored (GDPR Path A / audit convention, cli.ts:1532). */
+  query: string;
+  /** True when the caller ran with explain/--why (per-result rerank steps
+   *  may be present). Defaults to false. */
+  explainMode?: boolean;
+  /** Results in returned rank order (index 0 = rank 1). */
+  results: RecallTraceResultInput[];
+}
+
+/**
+ * Insert a `recall_traces` row + its `recall_trace_results` rows in ONE
+ * transaction, on the connection handed in. Fail-soft: never throws —
+ * logs to stderr and returns null on any failure.
+ *
+ * Connection policy (per the plan): api.recall calls this directly on its
+ * own already-open handle. api.getContext and CLI cmdRecall go through
+ * `writeRecallTraceAtRoot` instead, since their audit handles are already
+ * closed by the time tracing runs.
+ */
+export function writeRecallTrace(db: DatabaseSyncLike, input: RecallTraceInput): number | null {
+  try {
+    const queryHash = createHash('sha256').update(input.query).digest('hex').slice(0, 16);
+    const ts = new Date().toISOString();
+    db.exec('BEGIN');
+    try {
+      const insertTrace = db.prepare(`
+        INSERT INTO recall_traces (ts, tenant_id, session_id, pipeline, query_hash, query_length, result_count, explain_mode)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      const traceResult = insertTrace.run(
+        ts,
+        input.tenantId,
+        input.sessionId ?? null,
+        input.pipeline,
+        queryHash,
+        input.query.length,
+        input.results.length,
+        input.explainMode ? 1 : 0,
+      );
+      const traceId = Number(traceResult.lastInsertRowid);
+
+      const insertResult = db.prepare(`
+        INSERT INTO recall_trace_results (trace_id, tenant_id, memory_id, result_rank, score, rerank_json)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      input.results.forEach((r, i) => {
+        insertResult.run(
+          traceId,
+          input.tenantId,
+          r.memoryId,
+          i + 1,
+          r.score,
+          r.rerankSteps && r.rerankSteps.length > 0 ? JSON.stringify(r.rerankSteps) : null,
+        );
+      });
+
+      db.exec('COMMIT');
+      return traceId;
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`[hippo] recall trace write failed: ${(error as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Convenience wrapper: opens a fresh short-lived connection at `root`,
+ * writes the trace, and (by default) stamps the `last_trace_id` meta key,
+ * then closes.
+ *
+ * Used at api.getContext and CLI cmdRecall — sites where the block's own
+ * convention is per-call handles (writeEntry, saveIndex) and the earlier
+ * audit handles are already closed. NOT used by api.recall, which must
+ * reuse the caller's open handle and must NOT touch `last_trace_id`
+ * (v1.11.5 no-side-effects contract, tests/api-recall-no-side-effects.test.ts).
+ *
+ * `opts.stampLastTraceId` (default true, independent-review-critic
+ * must-fix): pass `false` at any call site that traces a recall WITHOUT
+ * also advancing `last_retrieval_ids` — e.g. CLI cmdRecall's zero-result
+ * path, which still writes an (empty) trace for training-corpus coverage
+ * but does not touch `last_retrieval_ids` (nothing to update). LOCKSTEP
+ * INVARIANT: `last_trace_id` must only ever advance when
+ * `last_retrieval_ids` also advances in the SAME call. Stamping it from a
+ * trace that isn't paired with a `last_retrieval_ids` update would let a
+ * later `hippo outcome` link the OLD (stale) last_retrieval_ids against
+ * the NEW, unrelated trace — a silent mislinkage in the training data.
+ *
+ * Fail-soft: never throws, including on connection failure.
+ */
+export function writeRecallTraceAtRoot(
+  root: string,
+  input: RecallTraceInput,
+  opts?: { stampLastTraceId?: boolean },
+): number | null {
+  const stampLastTraceId = opts?.stampLastTraceId ?? true;
+  let db: DatabaseSyncLike;
+  try {
+    db = openHippoDb(root);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`[hippo] recall trace connection failed: ${(error as Error).message}`);
+    return null;
+  }
+  try {
+    const traceId = writeRecallTrace(db, input);
+    if (stampLastTraceId) {
+      try {
+        if (traceId !== null) {
+          setMeta(db, 'last_trace_id', String(traceId));
+        } else {
+          // Failed trace write: CLEAR the key so a later outcome cannot link
+          // this recall's ids against the previous, unrelated trace.
+          setMeta(db, 'last_trace_id', '');
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(`[hippo] last_trace_id write failed: ${(error as Error).message}`);
+      }
+    }
+    return traceId;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/**
+ * Read the `last_trace_id` meta key at `root`. Returns null when unset
+ * (fresh store, pre-v40 flow, or a store whose last recall went through
+ * api.recall only — api.recall never sets this key). Fail-soft like the
+ * writers: a broken connection returns null rather than breaking the
+ * surrounding outcome call.
+ */
+export function readLastTraceId(root: string): number | null {
+  try {
+    const db = openHippoDb(root);
+    try {
+      // Strict parse (independent-review-critic MED finding): a bare
+      // Number(raw) turns '', whitespace, or garbage into 0/NaN handling
+      // that let a whitespace-only meta value parse as 0 — outcome() would
+      // then INSERT recall_trace_outcomes.trace_id=0, a masked FK
+      // violation (no row id 0 ever exists). Require a clean positive
+      // integer string; anything else is treated as unset.
+      const raw = getMeta(db, 'last_trace_id', '').trim();
+      if (!/^\d+$/.test(raw)) return null;
+      const n = Number(raw);
+      return n > 0 ? n : null;
+    } finally {
+      closeHippoDb(db);
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`[hippo] last_trace_id read failed: ${(error as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Write the `last_trace_id` meta key at `root` on its own short-lived
+ * connection.
+ */
+export function writeLastTraceId(root: string, traceId: number): void {
+  const db = openHippoDb(root);
+  try {
+    setMeta(db, 'last_trace_id', String(traceId));
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/** Input to `recordTraceOutcome`. */
+export interface RecordTraceOutcomeInput {
+  traceId: number;
+  tenantId: string;
+  outcome: 'positive' | 'negative';
+  /** Ids actually credited by this outcome event (post tenant-filtering). */
+  memoryIds: string[];
+}
+
+/**
+ * Record an outcome event against a trace, linking the (query, shown,
+ * outcome) triple. Called ONLY where the credited ids actually come from
+ * the last-retrieval mechanism (api.outcomeForLastRecall and any outcome
+ * flow that resolves its targets from last-retrieval state) or from an
+ * SDK caller's explicit `traceId` opt — never unconditionally from
+ * api.outcome, which would mislink an explicit-id caller to a stale,
+ * unrelated trace.
+ *
+ * Lives in its own append-only table, not audit_log metadata: audit_log is
+ * pruned by `pruneAuditLog`, and pruning must never erase training data.
+ *
+ * Fail-soft: never throws.
+ */
+export function recordTraceOutcome(db: DatabaseSyncLike, input: RecordTraceOutcomeInput): void {
+  try {
+    db.prepare(`
+      INSERT INTO recall_trace_outcomes (trace_id, ts, tenant_id, outcome, memory_ids_json)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(input.traceId, new Date().toISOString(), input.tenantId, input.outcome, JSON.stringify(input.memoryIds));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`[hippo] recall trace outcome write failed: ${(error as Error).message}`);
+  }
+}

--- a/src/recall-trace.ts
+++ b/src/recall-trace.ts
@@ -17,7 +17,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { openHippoDb, closeHippoDb, getMeta, setMeta, type DatabaseSyncLike } from './db.js';
+import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import type { RerankStep } from './search.js';
 
 /** One ranked result to persist alongside its trace row. */
@@ -42,6 +42,26 @@ export interface RecallTraceInput {
   explainMode?: boolean;
   /** Results in returned rank order (index 0 = rank 1). */
   results: RecallTraceResultInput[];
+}
+
+/**
+ * Strip a RerankStep down to {stage, multiplier, scoreBefore, scoreAfter}
+ * before persisting (F3 privacy fix, codex cross-model finding). `note` is
+ * free-form human text — the CLI's goal-boost step embeds matched goal tag
+ * text there, so persisting it verbatim would leak raw user content into
+ * training data via `rerank_json`. Only the four structured fields survive;
+ * any other/future free-form field is dropped by construction (allowlist,
+ * not a denylist).
+ */
+function sanitizeRerankSteps(
+  steps: RerankStep[],
+): Array<Pick<RerankStep, 'stage' | 'multiplier' | 'scoreBefore' | 'scoreAfter'>> {
+  return steps.map((s) => ({
+    stage: s.stage,
+    multiplier: s.multiplier,
+    scoreBefore: s.scoreBefore,
+    scoreAfter: s.scoreAfter,
+  }));
 }
 
 /**
@@ -87,7 +107,7 @@ export function writeRecallTrace(db: DatabaseSyncLike, input: RecallTraceInput):
           r.memoryId,
           i + 1,
           r.score,
-          r.rerankSteps && r.rerankSteps.length > 0 ? JSON.stringify(r.rerankSteps) : null,
+          r.rerankSteps && r.rerankSteps.length > 0 ? JSON.stringify(sanitizeRerankSteps(r.rerankSteps)) : null,
         );
       });
 
@@ -106,34 +126,31 @@ export function writeRecallTrace(db: DatabaseSyncLike, input: RecallTraceInput):
 
 /**
  * Convenience wrapper: opens a fresh short-lived connection at `root`,
- * writes the trace, and (by default) stamps the `last_trace_id` meta key,
- * then closes.
+ * writes the trace, and closes. Returns the new trace id, or null on any
+ * failure (fail-soft).
  *
  * Used at api.getContext and CLI cmdRecall — sites where the block's own
  * convention is per-call handles (writeEntry, saveIndex) and the earlier
  * audit handles are already closed. NOT used by api.recall, which must
- * reuse the caller's open handle and must NOT touch `last_trace_id`
- * (v1.11.5 no-side-effects contract, tests/api-recall-no-side-effects.test.ts).
+ * reuse the caller's open handle (v1.11.5 no-side-effects contract,
+ * tests/api-recall-no-side-effects.test.ts).
  *
- * `opts.stampLastTraceId` (default true, independent-review-critic
- * must-fix): pass `false` at any call site that traces a recall WITHOUT
- * also advancing `last_retrieval_ids` — e.g. CLI cmdRecall's zero-result
- * path, which still writes an (empty) trace for training-corpus coverage
- * but does not touch `last_retrieval_ids` (nothing to update). LOCKSTEP
- * INVARIANT: `last_trace_id` must only ever advance when
- * `last_retrieval_ids` also advances in the SAME call. Stamping it from a
- * trace that isn't paired with a `last_retrieval_ids` update would let a
- * later `hippo outcome` link the OLD (stale) last_retrieval_ids against
- * the NEW, unrelated trace — a silent mislinkage in the training data.
+ * F1 structural fix (replaces the earlier stamp-then-clear design): this
+ * function does NOT touch the `last_trace_id` meta key. Stamping lived here
+ * originally, on its own connection, separate from the `last_retrieval_ids`
+ * write in `saveIndex` — two connections meant two commits, so a crash or
+ * a failed second write could advance one without the other. LOCKSTEP
+ * INVARIANT: `last_trace_id` must only ever advance in the SAME write as
+ * `last_retrieval_ids`. The caller now does: call this function FIRST, set
+ * `localIndex.last_trace_id` from the returned id, THEN call `saveIndex`
+ * once — `saveIndex` persists both meta keys in one transaction
+ * (store.ts). Call sites that trace WITHOUT advancing `last_retrieval_ids`
+ * (CLI cmdRecall's zero-result path, getContext's empty-result path) simply
+ * never touch `localIndex` at all — they can't desync by construction.
  *
  * Fail-soft: never throws, including on connection failure.
  */
-export function writeRecallTraceAtRoot(
-  root: string,
-  input: RecallTraceInput,
-  opts?: { stampLastTraceId?: boolean },
-): number | null {
-  const stampLastTraceId = opts?.stampLastTraceId ?? true;
+export function writeRecallTraceAtRoot(root: string, input: RecallTraceInput): number | null {
   let db: DatabaseSyncLike;
   try {
     db = openHippoDb(root);
@@ -143,66 +160,7 @@ export function writeRecallTraceAtRoot(
     return null;
   }
   try {
-    const traceId = writeRecallTrace(db, input);
-    if (stampLastTraceId) {
-      try {
-        if (traceId !== null) {
-          setMeta(db, 'last_trace_id', String(traceId));
-        } else {
-          // Failed trace write: CLEAR the key so a later outcome cannot link
-          // this recall's ids against the previous, unrelated trace.
-          setMeta(db, 'last_trace_id', '');
-        }
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(`[hippo] last_trace_id write failed: ${(error as Error).message}`);
-      }
-    }
-    return traceId;
-  } finally {
-    closeHippoDb(db);
-  }
-}
-
-/**
- * Read the `last_trace_id` meta key at `root`. Returns null when unset
- * (fresh store, pre-v40 flow, or a store whose last recall went through
- * api.recall only — api.recall never sets this key). Fail-soft like the
- * writers: a broken connection returns null rather than breaking the
- * surrounding outcome call.
- */
-export function readLastTraceId(root: string): number | null {
-  try {
-    const db = openHippoDb(root);
-    try {
-      // Strict parse (independent-review-critic MED finding): a bare
-      // Number(raw) turns '', whitespace, or garbage into 0/NaN handling
-      // that let a whitespace-only meta value parse as 0 — outcome() would
-      // then INSERT recall_trace_outcomes.trace_id=0, a masked FK
-      // violation (no row id 0 ever exists). Require a clean positive
-      // integer string; anything else is treated as unset.
-      const raw = getMeta(db, 'last_trace_id', '').trim();
-      if (!/^\d+$/.test(raw)) return null;
-      const n = Number(raw);
-      return n > 0 ? n : null;
-    } finally {
-      closeHippoDb(db);
-    }
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(`[hippo] last_trace_id read failed: ${(error as Error).message}`);
-    return null;
-  }
-}
-
-/**
- * Write the `last_trace_id` meta key at `root` on its own short-lived
- * connection.
- */
-export function writeLastTraceId(root: string, traceId: number): void {
-  const db = openHippoDb(root);
-  try {
-    setMeta(db, 'last_trace_id', String(traceId));
+    return writeRecallTrace(db, input);
   } finally {
     closeHippoDb(db);
   }
@@ -229,14 +187,48 @@ export interface RecordTraceOutcomeInput {
  * Lives in its own append-only table, not audit_log metadata: audit_log is
  * pruned by `pruneAuditLog`, and pruning must never erase training data.
  *
+ * F4 validation (codex cross-model finding): `traceId`/`memoryIds` reach
+ * this function from caller-side state (`last_trace_id` / applied outcome
+ * ids) that can go stale relative to the trace it names — a forgotten
+ * memory, a tenant switch mid-session, or a race between two callers. Two
+ * checks run before the insert, both skip silently (console.error one
+ * line) rather than throw:
+ *   1. The named trace must exist and belong to `input.tenantId` — a
+ *      tenant mismatch or a dangling id (deleted trace) skips.
+ *   2. `input.memoryIds` is intersected against the trace's OWN
+ *      `recall_trace_results.memory_id` set — only ids that trace actually
+ *      returned are recorded. An id that was never in this trace's result
+ *      set (stale caller state) is silently dropped rather than recorded
+ *      as a false credit. If the intersection is empty, no row is written.
+ *
  * Fail-soft: never throws.
  */
 export function recordTraceOutcome(db: DatabaseSyncLike, input: RecordTraceOutcomeInput): void {
   try {
+    const trace = db.prepare(`SELECT tenant_id FROM recall_traces WHERE id = ?`).get(input.traceId) as
+      | { tenant_id?: string }
+      | undefined;
+    if (!trace || trace.tenant_id !== input.tenantId) {
+      // eslint-disable-next-line no-console
+      console.error(`[hippo] recall trace outcome skipped: trace ${input.traceId} missing or tenant mismatch`);
+      return;
+    }
+
+    const memberRows = db
+      .prepare(`SELECT memory_id FROM recall_trace_results WHERE trace_id = ?`)
+      .all(input.traceId) as Array<{ memory_id: string }>;
+    const members = new Set(memberRows.map((r) => r.memory_id));
+    const credited = input.memoryIds.filter((id) => members.has(id));
+    if (credited.length === 0) {
+      // eslint-disable-next-line no-console
+      console.error(`[hippo] recall trace outcome skipped: no credited ids intersect trace ${input.traceId}'s results`);
+      return;
+    }
+
     db.prepare(`
       INSERT INTO recall_trace_outcomes (trace_id, ts, tenant_id, outcome, memory_ids_json)
       VALUES (?, ?, ?, ?, ?)
-    `).run(input.traceId, new Date().toISOString(), input.tenantId, input.outcome, JSON.stringify(input.memoryIds));
+    `).run(input.traceId, new Date().toISOString(), input.tenantId, input.outcome, JSON.stringify(credited));
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`[hippo] recall trace outcome write failed: ${(error as Error).message}`);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1142,11 +1142,22 @@ function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
     };
   }
 
+  // LC1 codex round-2 med: the two lockstep keys must be read in ONE
+  // statement. Two autocommit SELECTs leave a window where a concurrent
+  // saveIndex (which commits both keys in one transaction) lands between
+  // them, handing the reader mismatched last_retrieval_ids / last_trace_id
+  // and re-opening the mislinkage hole saveIndex's BEGIN/COMMIT closed on
+  // the write side. One SELECT = one SQLite read snapshot.
+  const lockstepRows = db.prepare(
+    `SELECT key, value FROM meta WHERE key IN ('last_retrieval_ids', 'last_trace_id')`,
+  ).all() as Array<{ key: string; value: string }>;
+  const lockstep = new Map(lockstepRows.map((r) => [r.key, r.value]));
+
   return {
     version: INDEX_VERSION,
     entries,
-    last_retrieval_ids: parseJsonArray(getMeta(db, 'last_retrieval_ids', '[]')),
-    last_trace_id: parseLastTraceId(getMeta(db, 'last_trace_id', '')),
+    last_retrieval_ids: parseJsonArray(lockstep.get('last_retrieval_ids') ?? '[]'),
+    last_trace_id: parseLastTraceId(lockstep.get('last_trace_id') ?? ''),
   };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -462,6 +462,23 @@ function parseJsonArray(raw: string | null | undefined): string[] {
   }
 }
 
+/**
+ * Strict parse for the `last_trace_id` meta value (LC1 F1(d) structural
+ * fix). A bare Number(raw) would turn '', whitespace, or garbage into a
+ * usable-looking 0/NaN — a consumer INSERTing recall_trace_outcomes with
+ * trace_id=0 would hit a masked FK violation (row id 0 never exists).
+ * Require a clean positive integer string; anything else is treated as
+ * unset. This is the ONE place that decides "clean" — every consumer of
+ * `HippoIndex.last_trace_id` (outcomeForLastRecall, tests) reads the
+ * already-validated value out of `buildIndexFromDb`'s result and never
+ * re-parses the raw meta string itself.
+ */
+function parseLastTraceId(raw: string | null | undefined): string | null {
+  const trimmed = (raw ?? '').trim();
+  if (!/^\d+$/.test(trimmed) || Number(trimmed) <= 0) return null;
+  return trimmed;
+}
+
 function parseJsonObject(raw: string | null | undefined): Record<string, unknown> {
   if (!raw) return {};
   try {
@@ -1129,7 +1146,7 @@ function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
     version: INDEX_VERSION,
     entries,
     last_retrieval_ids: parseJsonArray(getMeta(db, 'last_retrieval_ids', '[]')),
-    last_trace_id: getMeta(db, 'last_trace_id', '') || null,
+    last_trace_id: parseLastTraceId(getMeta(db, 'last_trace_id', '')),
   };
 }
 
@@ -1188,13 +1205,29 @@ export function loadIndex(hippoRoot: string): HippoIndex {
 
 /**
  * Persist mutable index metadata. Entry rows themselves are derived from SQLite.
+ *
+ * LC1 F1(c) structural fix: `last_retrieval_ids` and `last_trace_id` must
+ * land atomically — callers (getContext, cmdRecall) fold a freshly-written
+ * trace id into `index.last_trace_id` before calling this, relying on BOTH
+ * meta keys committing together. Wrapped in BEGIN/COMMIT so a crash or a
+ * mid-write failure can never advance one key without the other. The
+ * filesystem mirror write stays AFTER commit — the DB is the source of
+ * truth, the mirror is best-effort (matches every other per-call-handle
+ * site's convention).
  */
 export function saveIndex(hippoRoot: string, index: HippoIndex): void {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    setMeta(db, 'last_retrieval_ids', JSON.stringify(index.last_retrieval_ids ?? []));
-    setMeta(db, 'last_trace_id', index.last_trace_id ?? '');
+    db.exec('BEGIN');
+    try {
+      setMeta(db, 'last_retrieval_ids', JSON.stringify(index.last_retrieval_ids ?? []));
+      setMeta(db, 'last_trace_id', index.last_trace_id ?? '');
+      db.exec('COMMIT');
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
+    }
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
   } finally {
     closeHippoDb(db);

--- a/src/store.ts
+++ b/src/store.ts
@@ -67,6 +67,12 @@ export interface HippoIndex {
   version: number;
   entries: Record<string, IndexEntry>;
   last_retrieval_ids: string[];
+  /** LC1 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md): id of the
+   *  most recent recall_traces row written by getContext/cmdRecall, mirrored
+   *  from the `last_trace_id` meta key exactly like last_retrieval_ids. null
+   *  when no trace has been written yet (fresh store, pre-v40 flow, or
+   *  api.recall-only usage — api.recall never sets this). */
+  last_trace_id: string | null;
 }
 
 interface MemoryRow {
@@ -885,6 +891,13 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
 
     const legacyIndex = loadLegacyIndexFile(hippoRoot);
     setMeta(db, 'last_retrieval_ids', JSON.stringify(legacyIndex.last_retrieval_ids ?? []));
+    // LC1: legacy index.json predates last_trace_id, so this is '' for every
+    // pre-v40 store — harmless, matches the ensureMetaDefaults default.
+    // Coerce like its neighbors below coerce theirs (independent-review-critic
+    // LOW finding): accept only a clean digit string, else fall back to ''
+    // rather than trusting whatever a hand-edited/corrupt index.json carries.
+    const legacyTraceId = String(legacyIndex.last_trace_id ?? '');
+    setMeta(db, 'last_trace_id', /^\d+$/.test(legacyTraceId) ? legacyTraceId : '');
 
     const legacyStats = loadLegacyStatsFile(hippoRoot);
     setMeta(db, 'total_remembered', String(Number(legacyStats.total_remembered ?? 0)));
@@ -931,13 +944,13 @@ function loadLegacyEntriesFromMarkdown(hippoRoot: string): MemoryEntry[] {
 function loadLegacyIndexFile(hippoRoot: string): HippoIndex {
   const indexPath = path.join(hippoRoot, 'index.json');
   if (!fs.existsSync(indexPath)) {
-    return { version: 1, entries: {}, last_retrieval_ids: [] };
+    return { version: 1, entries: {}, last_retrieval_ids: [], last_trace_id: null };
   }
 
   try {
     return JSON.parse(fs.readFileSync(indexPath, 'utf8')) as HippoIndex;
   } catch {
-    return { version: 1, entries: {}, last_retrieval_ids: [] };
+    return { version: 1, entries: {}, last_retrieval_ids: [], last_trace_id: null };
   }
 }
 
@@ -1116,6 +1129,7 @@ function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
     version: INDEX_VERSION,
     entries,
     last_retrieval_ids: parseJsonArray(getMeta(db, 'last_retrieval_ids', '[]')),
+    last_trace_id: getMeta(db, 'last_trace_id', '') || null,
   };
 }
 
@@ -1180,6 +1194,7 @@ export function saveIndex(hippoRoot: string, index: HippoIndex): void {
   const db = openHippoDb(hippoRoot);
   try {
     setMeta(db, 'last_retrieval_ids', JSON.stringify(index.last_retrieval_ids ?? []));
+    setMeta(db, 'last_trace_id', index.last_trace_id ?? '');
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
   } finally {
     closeHippoDb(db);

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(39);
+    expect(getSchemaVersion(db)).toBe(40);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
-      expect(getCurrentSchemaVersion()).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
+      expect(getCurrentSchemaVersion()).toBe(40);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
-      expect(getCurrentSchemaVersion()).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
+      expect(getCurrentSchemaVersion()).toBe(40);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/cli-recall-autodebias-zero-results.test.ts
+++ b/tests/cli-recall-autodebias-zero-results.test.ts
@@ -45,9 +45,13 @@ describe('cli.ts cmdRecall zero-result branch preserves planningFallacyHint (J3.
   it('isolate the zero-result block by line range', () => {
     // Find the `if (results.length === 0) {` block and slice ~50 lines.
     // Captures the JSON + text early-return paths the codex fix targets.
+    // Window bumped 3000 -> 3800 (LC1 F1 final-review fix, 2026-08-02): the
+    // zero-result branch now ALSO writes an empty recall trace before the
+    // JSON/text rendering, pushing the rendering code further into the
+    // block. Margin left for future additions to this branch.
     const startIdx = cliText.indexOf('if (results.length === 0)');
     expect(startIdx).toBeGreaterThan(0);
-    zeroResultBlock = cliText.slice(startIdx, startIdx + 3000);
+    zeroResultBlock = cliText.slice(startIdx, startIdx + 3800);
   });
 
   it('zero-result JSON output spreads planningFallacyHint when truthy', () => {

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -74,7 +74,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db, 'schema_version')).toBe('39');
+      expect(getMeta(db, 'schema_version')).toBe('40');
     } finally {
       closeHippoDb(db);
     }
@@ -134,7 +134,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db2);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db2, 'schema_version')).toBe('39');
+      expect(getMeta(db2, 'schema_version')).toBe('40');
     } finally {
       closeHippoDb(db2);
     }

--- a/tests/graph-schema.test.ts
+++ b/tests/graph-schema.test.ts
@@ -25,7 +25,7 @@ describe('graph schema v37 (E3.3)', () => {
   afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
 
   it('CURRENT_SCHEMA_VERSION is 38', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
   });
 
   it('creates entities + relations + graph_extraction_queue tables', () => {

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
-      expect(getCurrentSchemaVersion()).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
+      expect(getCurrentSchemaVersion()).toBe(40);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/recall-trace-helper.test.ts
+++ b/tests/recall-trace-helper.test.ts
@@ -1,0 +1,246 @@
+/**
+ * LC1 recall-trace helper unit tests
+ * (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+ *
+ * Covers writeRecallTrace / writeRecallTraceAtRoot / readLastTraceId /
+ * writeLastTraceId / recordTraceOutcome in isolation, against a scratch
+ * HIPPO_HOME (never a repo checkout).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import {
+  writeRecallTrace,
+  writeRecallTraceAtRoot,
+  readLastTraceId,
+  writeLastTraceId,
+  recordTraceOutcome,
+} from '../src/recall-trace.js';
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-recall-trace-helper-'));
+  return {
+    home,
+    restore: () => rmSync(home, { recursive: true, force: true }),
+  };
+}
+
+describe('writeRecallTrace', () => {
+  it('happy path: inserts the trace row + result rows in order, never persists raw query text', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          sessionId: 'sess-1',
+          pipeline: 'api',
+          query: 'super secret raw query text',
+          explainMode: false,
+          results: [
+            { memoryId: 'mem-a', score: 0.9 },
+            { memoryId: 'mem-b', score: 0.5 },
+          ],
+        });
+        expect(traceId).not.toBeNull();
+
+        const trace = db.prepare(`SELECT * FROM recall_traces WHERE id = ?`).get(traceId) as Record<string, unknown>;
+        expect(trace.tenant_id).toBe('default');
+        expect(trace.session_id).toBe('sess-1');
+        expect(trace.pipeline).toBe('api');
+        expect(trace.result_count).toBe(2);
+        expect(trace.explain_mode).toBe(0);
+        expect(String(trace.query_hash)).toMatch(/^[0-9a-f]{16}$/);
+        expect(trace.query_length).toBe('super secret raw query text'.length);
+        // Raw query text must never land in any persisted column.
+        expect(JSON.stringify(trace)).not.toContain('super secret raw query text');
+
+        const results = db.prepare(
+          `SELECT * FROM recall_trace_results WHERE trace_id = ? ORDER BY result_rank ASC`,
+        ).all(traceId) as Array<Record<string, unknown>>;
+        expect(results).toHaveLength(2);
+        expect(results[0].memory_id).toBe('mem-a');
+        expect(results[0].result_rank).toBe(1);
+        expect(results[0].score).toBe(0.9);
+        expect(results[0].rerank_json).toBeNull();
+        expect(results[1].memory_id).toBe('mem-b');
+        expect(results[1].result_rank).toBe(2);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('persists rerank_json only when explain results carry rerankSteps', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          explainMode: true,
+          results: [
+            {
+              memoryId: 'mem-a',
+              score: 0.9,
+              rerankSteps: [{ stage: 'goal-boost', scoreBefore: 0.8, scoreAfter: 0.9 }],
+            },
+          ],
+        });
+        const row = db.prepare(`SELECT rerank_json FROM recall_trace_results WHERE trace_id = ?`).get(traceId) as { rerank_json: string };
+        const steps = JSON.parse(row.rerank_json);
+        expect(steps).toEqual([{ stage: 'goal-boost', scoreBefore: 0.8, scoreAfter: 0.9 }]);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('fail-soft: a trace write against a closed db does not throw, returns null, logs to stderr', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      closeHippoDb(db);
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      let traceId: number | null = -1;
+      expect(() => {
+        traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'api',
+          query: 'q',
+          results: [{ memoryId: 'mem-a', score: 1 }],
+        });
+      }).not.toThrow();
+      expect(traceId).toBeNull();
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    } finally {
+      restore();
+    }
+  });
+
+  it('composite-PK uniqueness (trace_id, result_rank) is upheld by the writer even under duplicate ids in input', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        // Two distinct memory ids at the same array position never happens
+        // in practice, but the writer relies on array index for rank, so
+        // ranks are always unique per trace by construction.
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'api',
+          query: 'q',
+          results: [
+            { memoryId: 'mem-a', score: 0.9 },
+            { memoryId: 'mem-a', score: 0.5 }, // same memory id twice, different ranks
+          ],
+        });
+        const rows = db.prepare(`SELECT result_rank FROM recall_trace_results WHERE trace_id = ? ORDER BY result_rank`).all(traceId) as Array<{ result_rank: number }>;
+        expect(rows.map((r) => r.result_rank)).toEqual([1, 2]);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('writeRecallTraceAtRoot', () => {
+  it('opens its own connection, writes the trace, and stamps last_trace_id', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const traceId = writeRecallTraceAtRoot(home, {
+        tenantId: 'default',
+        pipeline: 'context',
+        query: 'q',
+        results: [{ memoryId: 'mem-a', score: 1 }],
+      });
+      expect(traceId).not.toBeNull();
+      expect(readLastTraceId(home)).toBe(traceId);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('readLastTraceId / writeLastTraceId', () => {
+  it('returns null when unset', () => {
+    const { home, restore } = tmpHome();
+    try {
+      expect(readLastTraceId(home)).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it('round-trips a written trace id', () => {
+    const { home, restore } = tmpHome();
+    try {
+      writeLastTraceId(home, 42);
+      expect(readLastTraceId(home)).toBe(42);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('recordTraceOutcome', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('happy path: inserts an outcome row referencing the trace', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          results: [{ memoryId: 'mem-a', score: 1 }],
+        });
+        recordTraceOutcome(db, {
+          traceId: traceId as number,
+          tenantId: 'default',
+          outcome: 'positive',
+          memoryIds: ['mem-a'],
+        });
+        const row = db.prepare(`SELECT * FROM recall_trace_outcomes WHERE trace_id = ?`).get(traceId) as Record<string, unknown>;
+        expect(row.outcome).toBe('positive');
+        expect(JSON.parse(row.memory_ids_json as string)).toEqual(['mem-a']);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('fail-soft: an outcome write against a closed db does not throw', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      closeHippoDb(db);
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => {
+        recordTraceOutcome(db, { traceId: 1, tenantId: 'default', outcome: 'positive', memoryIds: ['mem-a'] });
+      }).not.toThrow();
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/recall-trace-helper.test.ts
+++ b/tests/recall-trace-helper.test.ts
@@ -2,9 +2,14 @@
  * LC1 recall-trace helper unit tests
  * (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
  *
- * Covers writeRecallTrace / writeRecallTraceAtRoot / readLastTraceId /
- * writeLastTraceId / recordTraceOutcome in isolation, against a scratch
- * HIPPO_HOME (never a repo checkout).
+ * Covers writeRecallTrace / writeRecallTraceAtRoot / recordTraceOutcome in
+ * isolation, against a scratch HIPPO_HOME (never a repo checkout).
+ *
+ * readLastTraceId / writeLastTraceId were DELETED (F1(e) structural fix,
+ * final review round): last_trace_id now only ever advances atomically with
+ * last_retrieval_ids via store.ts's saveIndex, so the standalone meta
+ * accessors had no remaining production caller. See tests/recall-trace-
+ * wiring.test.ts for last_trace_id coverage via loadIndex/saveIndex.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -12,13 +17,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openHippoDb, closeHippoDb } from '../src/db.js';
-import {
-  writeRecallTrace,
-  writeRecallTraceAtRoot,
-  readLastTraceId,
-  writeLastTraceId,
-  recordTraceOutcome,
-} from '../src/recall-trace.js';
+import { writeRecallTrace, writeRecallTraceAtRoot, recordTraceOutcome } from '../src/recall-trace.js';
 
 function tmpHome(): { home: string; restore: () => void } {
   const home = mkdtempSync(join(tmpdir(), 'hippo-recall-trace-helper-'));
@@ -105,6 +104,46 @@ describe('writeRecallTrace', () => {
     }
   });
 
+  it('F3 privacy fix: strips note (and any other free-form field) from rerank_json, keeping only stage/multiplier/scoreBefore/scoreAfter', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          explainMode: true,
+          results: [
+            {
+              memoryId: 'mem-a',
+              score: 0.9,
+              rerankSteps: [
+                {
+                  stage: 'goal-boost',
+                  multiplier: 1.5,
+                  scoreBefore: 0.6,
+                  scoreAfter: 0.9,
+                  note: 'matched goal tag: super-secret-project-codename',
+                } as never,
+              ],
+            },
+          ],
+        });
+        const row = db.prepare(`SELECT rerank_json FROM recall_trace_results WHERE trace_id = ?`).get(traceId) as { rerank_json: string };
+        expect(row.rerank_json).not.toContain('note');
+        expect(row.rerank_json).not.toContain('super-secret-project-codename');
+        const steps = JSON.parse(row.rerank_json);
+        expect(steps).toEqual([{ stage: 'goal-boost', multiplier: 1.5, scoreBefore: 0.6, scoreAfter: 0.9 }]);
+        expect(Object.keys(steps[0]).sort()).toEqual(['multiplier', 'scoreAfter', 'scoreBefore', 'stage']);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
   it('fail-soft: a trace write against a closed db does not throw, returns null, logs to stderr', () => {
     const { home, restore } = tmpHome();
     try {
@@ -157,7 +196,12 @@ describe('writeRecallTrace', () => {
 });
 
 describe('writeRecallTraceAtRoot', () => {
-  it('opens its own connection, writes the trace, and stamps last_trace_id', () => {
+  it('opens its own connection, writes the trace, and returns the new trace id', () => {
+    // F1 structural fix: this function no longer touches last_trace_id at
+    // all — that is now the CALLER's job (fold the returned id into
+    // HippoIndex.last_trace_id, then a single saveIndex call persists it
+    // atomically with last_retrieval_ids). See tests/recall-trace-
+    // wiring.test.ts for the caller-side lockstep behavior.
     const { home, restore } = tmpHome();
     try {
       const traceId = writeRecallTraceAtRoot(home, {
@@ -167,28 +211,15 @@ describe('writeRecallTraceAtRoot', () => {
         results: [{ memoryId: 'mem-a', score: 1 }],
       });
       expect(traceId).not.toBeNull();
-      expect(readLastTraceId(home)).toBe(traceId);
-    } finally {
-      restore();
-    }
-  });
-});
 
-describe('readLastTraceId / writeLastTraceId', () => {
-  it('returns null when unset', () => {
-    const { home, restore } = tmpHome();
-    try {
-      expect(readLastTraceId(home)).toBeNull();
-    } finally {
-      restore();
-    }
-  });
-
-  it('round-trips a written trace id', () => {
-    const { home, restore } = tmpHome();
-    try {
-      writeLastTraceId(home, 42);
-      expect(readLastTraceId(home)).toBe(42);
+      const db = openHippoDb(home);
+      try {
+        const trace = db.prepare(`SELECT * FROM recall_traces WHERE id = ?`).get(traceId) as Record<string, unknown>;
+        expect(trace).toBeDefined();
+        expect(trace.pipeline).toBe('context');
+      } finally {
+        closeHippoDb(db);
+      }
     } finally {
       restore();
     }
@@ -200,7 +231,7 @@ describe('recordTraceOutcome', () => {
     vi.restoreAllMocks();
   });
 
-  it('happy path: inserts an outcome row referencing the trace', () => {
+  it('happy path: inserts an outcome row referencing the trace (normal path unchanged)', () => {
     const { home, restore } = tmpHome();
     try {
       const db = openHippoDb(home);
@@ -220,6 +251,118 @@ describe('recordTraceOutcome', () => {
         const row = db.prepare(`SELECT * FROM recall_trace_outcomes WHERE trace_id = ?`).get(traceId) as Record<string, unknown>;
         expect(row.outcome).toBe('positive');
         expect(JSON.parse(row.memory_ids_json as string)).toEqual(['mem-a']);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('F4 validation: skips (no row, console.error) when the trace belongs to a DIFFERENT tenant', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          results: [{ memoryId: 'mem-a', score: 1 }],
+        });
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        recordTraceOutcome(db, {
+          traceId: traceId as number,
+          tenantId: 'tenant_b', // mismatched — trace belongs to 'default'
+          outcome: 'positive',
+          memoryIds: ['mem-a'],
+        });
+        expect(errSpy).toHaveBeenCalled();
+        const count = db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number };
+        expect(count.c).toBe(0);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('F4 validation: skips (no row) when the named trace does not exist', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        recordTraceOutcome(db, {
+          traceId: 999999,
+          tenantId: 'default',
+          outcome: 'positive',
+          memoryIds: ['mem-a'],
+        });
+        expect(errSpy).toHaveBeenCalled();
+        const count = db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number };
+        expect(count.c).toBe(0);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('F4 validation: records ONLY the intersection when some memoryIds are not members of the trace', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          results: [
+            { memoryId: 'mem-a', score: 0.9 },
+            { memoryId: 'mem-b', score: 0.5 },
+          ],
+        });
+        // mem-c was never in this trace's results (stale caller state).
+        recordTraceOutcome(db, {
+          traceId: traceId as number,
+          tenantId: 'default',
+          outcome: 'positive',
+          memoryIds: ['mem-a', 'mem-c'],
+        });
+        const row = db.prepare(`SELECT * FROM recall_trace_outcomes WHERE trace_id = ?`).get(traceId) as Record<string, unknown>;
+        expect(JSON.parse(row.memory_ids_json as string)).toEqual(['mem-a']);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('F4 validation: skips entirely (no row) when NONE of memoryIds intersect the trace', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const db = openHippoDb(home);
+      try {
+        const traceId = writeRecallTrace(db, {
+          tenantId: 'default',
+          pipeline: 'cli',
+          query: 'q',
+          results: [{ memoryId: 'mem-a', score: 0.9 }],
+        });
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        recordTraceOutcome(db, {
+          traceId: traceId as number,
+          tenantId: 'default',
+          outcome: 'positive',
+          memoryIds: ['mem-z'],
+        });
+        expect(errSpy).toHaveBeenCalled();
+        const count = db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number };
+        expect(count.c).toBe(0);
       } finally {
         closeHippoDb(db);
       }

--- a/tests/recall-trace-migration.test.ts
+++ b/tests/recall-trace-migration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * LC1 schema migration v40 (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+ * Mirrors tests/b3-goal-stack-migration.test.ts conventions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openHippoDb, closeHippoDb, getSchemaVersion, getCurrentSchemaVersion, type DatabaseSyncLike } from '../src/db.js';
+
+function tableNames(db: DatabaseSyncLike): string[] {
+  return (db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+    .all() as Array<{ name: string }>)
+    .map((r) => r.name);
+}
+
+function getMeta(db: DatabaseSyncLike, key: string): string | undefined {
+  const row = db.prepare(`SELECT value FROM meta WHERE key = ?`).get(key) as { value?: string } | undefined;
+  return row?.value;
+}
+
+function setMeta(db: DatabaseSyncLike, key: string, value: string): void {
+  db.prepare(`INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)`).run(key, value);
+}
+
+describe('LC1 schema migration v40', () => {
+  it('a fresh store lands at v40 with all three tables', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      expect(getSchemaVersion(db)).toBe(40);
+      expect(getCurrentSchemaVersion()).toBe(40);
+      const tables = tableNames(db);
+      expect(tables).toContain('recall_traces');
+      expect(tables).toContain('recall_trace_results');
+      expect(tables).toContain('recall_trace_outcomes');
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('recall_traces has the expected columns + CHECK on pipeline', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      const cols = (db.prepare(`PRAGMA table_info(recall_traces)`).all() as Array<{ name: string }>).map((c) => c.name);
+      for (const c of ['id', 'ts', 'tenant_id', 'session_id', 'pipeline', 'query_hash', 'query_length', 'result_count', 'explain_mode']) {
+        expect(cols, `recall_traces.${c} missing`).toContain(c);
+      }
+      const insert = () => db.prepare(
+        `INSERT INTO recall_traces (ts, tenant_id, pipeline, query_hash, query_length, result_count) VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(new Date().toISOString(), 'default', 'bogus_pipeline', 'abc123', 5, 0);
+      expect(insert).toThrow(/CHECK|constraint/i);
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('recall_trace_results has NO FK on memory_id (traces outlive forgotten memories)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      const traceId = Number(
+        db.prepare(
+          `INSERT INTO recall_traces (ts, tenant_id, pipeline, query_hash, query_length, result_count) VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(new Date().toISOString(), 'default', 'api', 'abc123', 5, 1).lastInsertRowid,
+      );
+      // memory_id references a memory that never existed — must succeed (no FK).
+      expect(() => {
+        db.prepare(
+          `INSERT INTO recall_trace_results (trace_id, tenant_id, memory_id, result_rank, score) VALUES (?, ?, ?, ?, ?)`,
+        ).run(traceId, 'default', 'never-existed-mem-id', 1, 0.9);
+      }).not.toThrow();
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('recall_trace_results is WITHOUT ROWID with composite-PK uniqueness on (trace_id, result_rank)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      const traceId = Number(
+        db.prepare(
+          `INSERT INTO recall_traces (ts, tenant_id, pipeline, query_hash, query_length, result_count) VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(new Date().toISOString(), 'default', 'api', 'abc123', 5, 1).lastInsertRowid,
+      );
+      db.prepare(
+        `INSERT INTO recall_trace_results (trace_id, tenant_id, memory_id, result_rank, score) VALUES (?, ?, ?, ?, ?)`,
+      ).run(traceId, 'default', 'mem-a', 1, 0.9);
+      expect(() => {
+        db.prepare(
+          `INSERT INTO recall_trace_results (trace_id, tenant_id, memory_id, result_rank, score) VALUES (?, ?, ?, ?, ?)`,
+        ).run(traceId, 'default', 'mem-b', 1, 0.5);
+      }).toThrow(/UNIQUE|constraint/i);
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('recall_traces -> recall_trace_results / recall_trace_outcomes CASCADE on delete', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      const traceId = Number(
+        db.prepare(
+          `INSERT INTO recall_traces (ts, tenant_id, pipeline, query_hash, query_length, result_count) VALUES (?, ?, ?, ?, ?, ?)`,
+        ).run(new Date().toISOString(), 'default', 'api', 'abc123', 5, 1).lastInsertRowid,
+      );
+      db.prepare(
+        `INSERT INTO recall_trace_results (trace_id, tenant_id, memory_id, result_rank, score) VALUES (?, ?, ?, ?, ?)`,
+      ).run(traceId, 'default', 'mem-a', 1, 0.9);
+      db.prepare(
+        `INSERT INTO recall_trace_outcomes (trace_id, ts, tenant_id, outcome, memory_ids_json) VALUES (?, ?, ?, ?, ?)`,
+      ).run(traceId, new Date().toISOString(), 'default', 'positive', '["mem-a"]');
+
+      db.prepare(`DELETE FROM recall_traces WHERE id = ?`).run(traceId);
+
+      expect((db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_results`).get() as { c: number }).c).toBe(0);
+      expect((db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number }).c).toBe(0);
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a v39 store upgrades to v40 cleanly without data loss', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    // Open once to reach v40, insert a trace row, then roll schema_version
+    // back to 39 and drop the three new tables to simulate a pre-v40 store.
+    let db = openHippoDb(home);
+    closeHippoDb(db);
+    db = openHippoDb(home);
+    try {
+      db.exec('DROP TABLE IF EXISTS recall_trace_outcomes');
+      db.exec('DROP TABLE IF EXISTS recall_trace_results');
+      db.exec('DROP TABLE IF EXISTS recall_traces');
+      setMeta(db, 'schema_version', '39');
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // Re-open triggers runMigrations, which should re-run v40.
+    db = openHippoDb(home);
+    try {
+      expect(getMeta(db, 'schema_version')).toBe('40');
+      const tables = tableNames(db);
+      expect(tables).toContain('recall_traces');
+      expect(tables).toContain('recall_trace_results');
+      expect(tables).toContain('recall_trace_outcomes');
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('last_trace_id meta key defaults to empty string on a fresh store', () => {
+    const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
+    const db = openHippoDb(home);
+    try {
+      expect(getMeta(db, 'last_trace_id')).toBe('');
+    } finally {
+      closeHippoDb(db);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/recall-trace-outcome-linkage.test.ts
+++ b/tests/recall-trace-outcome-linkage.test.ts
@@ -1,0 +1,181 @@
+/**
+ * LC1 outcome linkage + storage smoke
+ * (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+ *
+ * Covers: recall -> outcome -> recall_trace_outcomes row (E2E, via the CLI's
+ * cmdRecall + cmdOutcome last-retrieval flow); outcome with no prior trace
+ * -> no row, no error; the explicit `traceId` SDK opt on api.outcome; and
+ * the storage-overhead smoke bound (success criterion 3).
+ *
+ * Real-DB per project convention. Scratch HIPPO_HOME / cwd, never a repo
+ * checkout.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { initStore, loadIndex, saveIndex } from '../src/store.js';
+import { openHippoDb, closeHippoDb, getHippoDbPath, type DatabaseSyncLike } from '../src/db.js';
+import { remember, recall, outcome, outcomeForLastRecall, type Context } from '../src/api.js';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const hippoBin = join(repoRoot, 'bin', 'hippo.js');
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-recall-trace-outcome-'));
+  initStore(home);
+  return { home, restore: () => rmSync(home, { recursive: true, force: true }) };
+}
+
+describe('outcome linkage E2E (CLI recall -> outcome)', () => {
+  it('a cmdRecall-style flow followed by `hippo outcome --good` writes a recall_trace_outcomes row referencing the recall trace', () => {
+    const hippoRoot = mkdtempSync(join(tmpdir(), 'hippo-cli-outcome-linkage-'));
+    try {
+      const env = { ...process.env, HIPPO_HOME: hippoRoot };
+      execFileSync('node', [hippoBin, 'init', '--no-hooks', '--no-schedule', '--no-learn'], { cwd: hippoRoot, env });
+      execFileSync('node', [hippoBin, 'remember', 'outcome-link-target zeta fact'], { cwd: hippoRoot, env });
+      execFileSync('node', [hippoBin, 'recall', 'outcome-link-target'], { cwd: hippoRoot, env, encoding: 'utf-8' });
+      const outcomeOut = execFileSync('node', [hippoBin, 'outcome', '--good'], { cwd: hippoRoot, env, encoding: 'utf-8' });
+      expect(outcomeOut).toContain('Applied');
+
+      const localStore = join(hippoRoot, '.hippo');
+      const db = openHippoDb(localStore);
+      try {
+        const traces = db.prepare(`SELECT * FROM recall_traces WHERE pipeline = 'cli'`).all() as Array<Record<string, unknown>>;
+        expect(traces).toHaveLength(1);
+        const outcomes = db.prepare(`SELECT * FROM recall_trace_outcomes WHERE trace_id = ?`).all(traces[0].id) as Array<Record<string, unknown>>;
+        expect(outcomes).toHaveLength(1);
+        expect(outcomes[0].outcome).toBe('positive');
+        const memoryIds = JSON.parse(outcomes[0].memory_ids_json as string);
+        expect(memoryIds).toHaveLength(1);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(hippoRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('outcomeForLastRecall — no prior trace', () => {
+  it('applies the outcome but writes NO recall_trace_outcomes row, and does not throw', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      const res = remember(ctx, { content: 'no-trace-outcome-target' });
+      // Seed last_retrieval_ids directly WITHOUT ever calling recall()/getContext()
+      // — last_trace_id stays unset (fresh store, pre-v40-flow shape).
+      const idx = loadIndex(home);
+      idx.last_retrieval_ids = [res.id];
+      saveIndex(home, idx);
+      expect(loadIndex(home).last_trace_id).toBeNull();
+
+      expect(() => {
+        const result = outcomeForLastRecall(ctx, true);
+        expect(result.applied).toBe(1);
+      }).not.toThrow();
+
+      const db = openHippoDb(home);
+      try {
+        const outcomes = db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number };
+        expect(outcomes.c).toBe(0);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('api.outcome explicit traceId opt (SDK linkage)', () => {
+  it('links to the given trace when a caller supplies traceId explicitly', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'explicit-trace-opt-target' });
+      const recallResult = recall(ctx, { query: 'explicit-trace-opt-target', limit: 5 });
+      expect(recallResult.results.length).toBeGreaterThan(0);
+
+      const db = openHippoDb(home);
+      let traceId: number;
+      try {
+        const trace = db.prepare(`SELECT id FROM recall_traces WHERE pipeline = 'api'`).get() as { id: number };
+        traceId = trace.id;
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const ids = recallResult.results.map((r) => r.id);
+      outcome(ctx, ids, true, { traceId });
+
+      const db2 = openHippoDb(home);
+      try {
+        const rows = db2.prepare(`SELECT * FROM recall_trace_outcomes WHERE trace_id = ?`).all(traceId) as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].outcome).toBe('positive');
+      } finally {
+        closeHippoDb(db2);
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  it('without traceId, no linkage row is written (existing behavior unchanged)', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      const res = remember(ctx, { content: 'no-opt-target' });
+      outcome(ctx, [res.id], true);
+
+      const db = openHippoDb(home);
+      try {
+        const count = db.prepare(`SELECT COUNT(*) AS c FROM recall_trace_outcomes`).get() as { c: number };
+        expect(count.c).toBe(0);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('storage overhead smoke (success criterion 3)', () => {
+  it('100 traced recalls of 10 results grow the DB by less than ~250KB', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      for (let i = 0; i < 15; i++) {
+        remember(ctx, { content: `storage-smoke-target memory number ${i} filler content` });
+      }
+
+      const checkpoint = (db: DatabaseSyncLike) => db.exec(`PRAGMA wal_checkpoint(TRUNCATE)`);
+      const dbSizeBytes = (): number => {
+        const db = openHippoDb(home);
+        try {
+          checkpoint(db);
+        } finally {
+          closeHippoDb(db);
+        }
+        return statSync(getHippoDbPath(home)).size;
+      };
+
+      const before = dbSizeBytes();
+      for (let i = 0; i < 100; i++) {
+        recall(ctx, { query: 'storage-smoke-target', limit: 10 });
+      }
+      const after = dbSizeBytes();
+
+      const growth = after - before;
+      expect(growth).toBeGreaterThan(0); // sanity: traces were actually written
+      expect(growth).toBeLessThan(250 * 1024);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/recall-trace-wiring.test.ts
+++ b/tests/recall-trace-wiring.test.ts
@@ -2,8 +2,11 @@
  * LC1 wiring tests (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
  *
  * Covers the three wired recall paths: api.recall, api.getContext, CLI
- * cmdRecall — one trace row per recall, pinnedOnly writes nothing, and the
- * v1.11.5 no-side-effects contract (api.recall must NOT write last_trace_id).
+ * cmdRecall — one trace row per recall, pinnedOnly writes nothing, the
+ * v1.11.5 no-side-effects contract (api.recall must NOT write last_trace_id),
+ * the F1 atomic last_trace_id/last_retrieval_ids lockstep (via loadIndex,
+ * since readLastTraceId was deleted), F2 (suppressRecallTrace), and F5
+ * (getContext's bare empty-result early return also traces).
  *
  * This is a NEW file beside the locked tests/api-recall-no-side-effects.test.ts
  * — that file is never edited (v1.11.5 lock); this file extends the
@@ -22,7 +25,6 @@ import { initStore, loadIndex, writeEntry } from '../src/store.js';
 import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from '../src/db.js';
 import { createMemory } from '../src/memory.js';
 import { remember, recall, getContext, type Context } from '../src/api.js';
-import { readLastTraceId } from '../src/recall-trace.js';
 
 // Invoke this worktree's own bin/hippo.js directly (not the `hippo` binary
 // on PATH) so the CLI test exercises THIS build, not whatever hippo-memory
@@ -66,6 +68,15 @@ function resultRowsFor(home: string, traceId: number): Array<Record<string, unkn
   }
 }
 
+// readLastTraceId was deleted (F1(e) structural fix) — last_trace_id is now
+// read the same way production reads it: via loadIndex, which strict-parses
+// the meta value (store.ts's parseLastTraceId). Returns a number for easy
+// comparison against sqlite row ids, mirroring the deleted helper's shape.
+function lastTraceId(home: string): number | null {
+  const raw = loadIndex(home).last_trace_id;
+  return raw !== null ? Number(raw) : null;
+}
+
 describe('api.recall — trace wiring', () => {
   it('writes exactly one recall_traces row (pipeline=api) with the full returned id+rank+score list', () => {
     const { home, restore } = tmpHome();
@@ -100,12 +111,12 @@ describe('api.recall — trace wiring', () => {
       const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
       remember(ctx, { content: 'recall-trace-no-side-effect-target' });
 
-      expect(readLastTraceId(home)).toBeNull();
+      expect(lastTraceId(home)).toBeNull();
       const result = recall(ctx, { query: 'recall-trace-no-side-effect-target', limit: 5 });
       expect(result.results.length).toBeGreaterThan(0);
 
       // A trace row WAS written (previous test), but last_trace_id stays null.
-      expect(readLastTraceId(home)).toBeNull();
+      expect(lastTraceId(home)).toBeNull();
       // last_retrieval_ids is also untouched (locked invariant, restated here
       // for context — the authoritative lock lives in api-recall-no-side-effects.test.ts).
       expect(loadIndex(home).last_retrieval_ids ?? []).toEqual([]);
@@ -131,10 +142,25 @@ describe('api.recall — trace wiring', () => {
       restore();
     }
   });
+
+  it('F2: suppressRecallTrace:true writes NO trace row', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'suppressed-trace-target' });
+
+      const result = recall(ctx, { query: 'suppressed-trace-target', limit: 5, suppressRecallTrace: true });
+      expect(result.results.length).toBeGreaterThan(0);
+
+      expect(traceRows(home, 'api')).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
 });
 
 describe('api.getContext — trace wiring', () => {
-  it('writes a trace (pipeline=context) + last_trace_id for a real-query recall', async () => {
+  it('writes a trace (pipeline=context) + last_trace_id for a real-query recall, atomically with last_retrieval_ids', async () => {
     const { home, restore } = tmpHome();
     try {
       const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
@@ -147,9 +173,10 @@ describe('api.getContext — trace wiring', () => {
       expect(traces).toHaveLength(1);
       expect(traces[0].result_count).toBe(result.entries.length);
 
-      const lastTraceId = readLastTraceId(home);
-      expect(lastTraceId).toBe(traces[0].id);
-      expect(loadIndex(home).last_trace_id).toBe(String(lastTraceId));
+      const idx = loadIndex(home);
+      expect(idx.last_trace_id).toBe(String(traces[0].id));
+      // F1 lockstep: last_retrieval_ids advanced in the SAME saveIndex call.
+      expect(idx.last_retrieval_ids.length).toBeGreaterThan(0);
     } finally {
       restore();
     }
@@ -165,7 +192,39 @@ describe('api.getContext — trace wiring', () => {
       expect(result.entries.length).toBeGreaterThan(0);
 
       expect(traceRows(home, 'context')).toHaveLength(0);
-      expect(readLastTraceId(home)).toBeNull();
+      expect(lastTraceId(home)).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it('F5: the bare zero-result/no-continuity early return still writes an empty trace (result_count 0), but never touches last_retrieval_ids/last_trace_id', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      // A memory exists, but the query matches nothing, and there is no
+      // active task snapshot / handoff / recent session events — this is
+      // the bare `return { entries: [], tokens: 0 }` early-return path
+      // (api.ts, the check right after the origin/category annotation).
+      remember(ctx, { content: 'context-empty-baseline unrelated content' });
+
+      const before = loadIndex(home);
+      expect(before.last_trace_id).toBeNull();
+      expect(before.last_retrieval_ids ?? []).toEqual([]);
+
+      const result = await getContext(ctx, { q: 'zzz-query-matches-absolutely-nothing-xyzzy', budget: 1000 });
+      expect(result.entries).toEqual([]);
+
+      const traces = traceRows(home, 'context');
+      expect(traces).toHaveLength(1);
+      expect(traces[0].result_count).toBe(0);
+      expect(resultRowsFor(home, traces[0].id as number)).toHaveLength(0);
+
+      // Deliberately untouched — this path never advances last_retrieval_ids,
+      // so last_trace_id must not advance either (lockstep invariant).
+      const after = loadIndex(home);
+      expect(after.last_trace_id).toBeNull();
+      expect(after.last_retrieval_ids ?? []).toEqual([]);
     } finally {
       restore();
     }
@@ -173,7 +232,7 @@ describe('api.getContext — trace wiring', () => {
 });
 
 describe('CLI cmdRecall — trace wiring', () => {
-  it('writes ONE trace (pipeline=cli) at hippoRoot + last_trace_id', () => {
+  it('writes ONE trace (pipeline=cli) at hippoRoot + last_trace_id, atomically with last_retrieval_ids', () => {
     const hippoRoot = mkdtempSync(join(tmpdir(), 'hippo-cli-recall-trace-'));
     try {
       execFileSync('node', [hippoBin, 'init', '--no-hooks', '--no-schedule', '--no-learn'], {
@@ -196,21 +255,21 @@ describe('CLI cmdRecall — trace wiring', () => {
       const localStore = join(hippoRoot, '.hippo');
       const traces = traceRows(localStore, 'cli');
       expect(traces).toHaveLength(1);
-      const lastTraceId = readLastTraceId(localStore);
-      expect(lastTraceId).toBe(traces[0].id);
+      const idx = loadIndex(localStore);
+      expect(idx.last_trace_id).toBe(String(traces[0].id));
+      expect(idx.last_retrieval_ids.length).toBeGreaterThan(0);
     } finally {
       rmSync(hippoRoot, { recursive: true, force: true });
     }
   });
 
   it('a zero-result recall writes an empty trace row (result_count 0, no result rows) but leaves last_trace_id UNCHANGED', () => {
-    // independent-review-critic must-fix: cli.ts's zero-result branch used
-    // to return before the trace-write block entirely, so it wrote NO trace
-    // at all. It must now write a trace (for training-corpus coverage) but
-    // NOT stamp last_trace_id, since this path also leaves
-    // last_retrieval_ids stale — stamping last_trace_id here would let a
-    // later `hippo outcome` link the OLD last_retrieval_ids against the
-    // NEW, unrelated empty trace.
+    // Final-review must-fix: cli.ts's zero-result branch used to return
+    // before the trace-write block entirely, so it wrote NO trace at all.
+    // It must now write a trace (for training-corpus coverage) without
+    // touching localIndex at all — this path never advances
+    // last_retrieval_ids (no memories to update), so last_trace_id must not
+    // advance either (F1 lockstep invariant).
     const hippoRoot = mkdtempSync(join(tmpdir(), 'hippo-cli-recall-trace-zero-'));
     try {
       const env = { ...process.env, HIPPO_HOME: hippoRoot };
@@ -220,7 +279,7 @@ describe('CLI cmdRecall — trace wiring', () => {
       execFileSync('node', [hippoBin, 'recall', 'zero-result-baseline'], { cwd: hippoRoot, env, encoding: 'utf-8' });
 
       const localStore = join(hippoRoot, '.hippo');
-      const baselineTraceId = readLastTraceId(localStore);
+      const baselineTraceId = lastTraceId(localStore);
       expect(baselineTraceId).not.toBeNull();
 
       // Second recall: a query that matches nothing.
@@ -241,7 +300,7 @@ describe('CLI cmdRecall — trace wiring', () => {
       expect(results).toHaveLength(0);
 
       // last_trace_id must still point at the FIRST (non-empty) trace.
-      expect(readLastTraceId(localStore)).toBe(baselineTraceId);
+      expect(lastTraceId(localStore)).toBe(baselineTraceId);
     } finally {
       rmSync(hippoRoot, { recursive: true, force: true });
     }

--- a/tests/recall-trace-wiring.test.ts
+++ b/tests/recall-trace-wiring.test.ts
@@ -1,0 +1,249 @@
+/**
+ * LC1 wiring tests (docs/plans/2026-08-02-lc1-recall-trace-persistence.md).
+ *
+ * Covers the three wired recall paths: api.recall, api.getContext, CLI
+ * cmdRecall — one trace row per recall, pinnedOnly writes nothing, and the
+ * v1.11.5 no-side-effects contract (api.recall must NOT write last_trace_id).
+ *
+ * This is a NEW file beside the locked tests/api-recall-no-side-effects.test.ts
+ * — that file is never edited (v1.11.5 lock); this file extends the
+ * invariant to the new last_trace_id meta key.
+ *
+ * Real-DB per project convention. Scratch HIPPO_HOME, never a repo checkout.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { initStore, loadIndex, writeEntry } from '../src/store.js';
+import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from '../src/db.js';
+import { createMemory } from '../src/memory.js';
+import { remember, recall, getContext, type Context } from '../src/api.js';
+import { readLastTraceId } from '../src/recall-trace.js';
+
+// Invoke this worktree's own bin/hippo.js directly (not the `hippo` binary
+// on PATH) so the CLI test exercises THIS build, not whatever hippo-memory
+// install happens to be globally linked.
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const hippoBin = join(repoRoot, 'bin', 'hippo.js');
+
+function tmpHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'hippo-recall-trace-wiring-'));
+  initStore(home);
+  const origHippoHome = process.env.HIPPO_HOME;
+  process.env.HIPPO_HOME = home;
+  return {
+    home,
+    restore: () => {
+      rmSync(home, { recursive: true, force: true });
+      if (origHippoHome !== undefined) {
+        process.env.HIPPO_HOME = origHippoHome;
+      } else {
+        delete process.env.HIPPO_HOME;
+      }
+    },
+  };
+}
+
+function traceRows(home: string, pipeline: string): Array<Record<string, unknown>> {
+  const db: DatabaseSyncLike = openHippoDb(home);
+  try {
+    return db.prepare(`SELECT * FROM recall_traces WHERE pipeline = ?`).all(pipeline) as Array<Record<string, unknown>>;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+function resultRowsFor(home: string, traceId: number): Array<Record<string, unknown>> {
+  const db: DatabaseSyncLike = openHippoDb(home);
+  try {
+    return db.prepare(`SELECT * FROM recall_trace_results WHERE trace_id = ? ORDER BY result_rank ASC`).all(traceId) as Array<Record<string, unknown>>;
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+describe('api.recall — trace wiring', () => {
+  it('writes exactly one recall_traces row (pipeline=api) with the full returned id+rank+score list', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'recall-trace-target-alpha' });
+      remember(ctx, { content: 'recall-trace-target-beta also matches' });
+
+      const result = recall(ctx, { query: 'recall-trace-target', limit: 5 });
+      expect(result.results.length).toBeGreaterThan(0);
+
+      const traces = traceRows(home, 'api');
+      expect(traces).toHaveLength(1);
+      expect(traces[0].tenant_id).toBe('default');
+      expect(traces[0].result_count).toBe(result.results.length);
+
+      const rows = resultRowsFor(home, traces[0].id as number);
+      expect(rows).toHaveLength(result.results.length);
+      rows.forEach((row, i) => {
+        expect(row.memory_id).toBe(result.results[i].id);
+        expect(row.score).toBe(result.results[i].score);
+        expect(row.result_rank).toBe(i + 1);
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('does NOT write last_trace_id (v1.11.5 no-side-effects contract, extended)', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'recall-trace-no-side-effect-target' });
+
+      expect(readLastTraceId(home)).toBeNull();
+      const result = recall(ctx, { query: 'recall-trace-no-side-effect-target', limit: 5 });
+      expect(result.results.length).toBeGreaterThan(0);
+
+      // A trace row WAS written (previous test), but last_trace_id stays null.
+      expect(readLastTraceId(home)).toBeNull();
+      // last_retrieval_ids is also untouched (locked invariant, restated here
+      // for context — the authoritative lock lives in api-recall-no-side-effects.test.ts).
+      expect(loadIndex(home).last_retrieval_ids ?? []).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('batched api.recall calls each insert their own trace row (no overwrite race)', () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'batched-trace-A' });
+      remember(ctx, { content: 'batched-trace-B' });
+      remember(ctx, { content: 'batched-trace-C' });
+
+      recall(ctx, { query: 'batched-trace-A', limit: 5 });
+      recall(ctx, { query: 'batched-trace-B', limit: 5 });
+      recall(ctx, { query: 'batched-trace-C', limit: 5 });
+
+      expect(traceRows(home, 'api')).toHaveLength(3);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('api.getContext — trace wiring', () => {
+  it('writes a trace (pipeline=context) + last_trace_id for a real-query recall', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      remember(ctx, { content: 'context-trace-target-gamma' });
+
+      const result = await getContext(ctx, { q: 'context-trace-target', budget: 1000 });
+      expect(result.entries.length).toBeGreaterThan(0);
+
+      const traces = traceRows(home, 'context');
+      expect(traces).toHaveLength(1);
+      expect(traces[0].result_count).toBe(result.entries.length);
+
+      const lastTraceId = readLastTraceId(home);
+      expect(lastTraceId).toBe(traces[0].id);
+      expect(loadIndex(home).last_trace_id).toBe(String(lastTraceId));
+    } finally {
+      restore();
+    }
+  });
+
+  it('pinnedOnly writes NO trace row and leaves last_trace_id untouched', async () => {
+    const { home, restore } = tmpHome();
+    try {
+      const ctx: Context = { hippoRoot: home, tenantId: 'default', actor: { subject: 'cli', role: 'admin' } };
+      writeEntry(home, createMemory('pinned-context-trace-delta', { pinned: true }));
+
+      const result = await getContext(ctx, { pinnedOnly: true, budget: 1000 });
+      expect(result.entries.length).toBeGreaterThan(0);
+
+      expect(traceRows(home, 'context')).toHaveLength(0);
+      expect(readLastTraceId(home)).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('CLI cmdRecall — trace wiring', () => {
+  it('writes ONE trace (pipeline=cli) at hippoRoot + last_trace_id', () => {
+    const hippoRoot = mkdtempSync(join(tmpdir(), 'hippo-cli-recall-trace-'));
+    try {
+      execFileSync('node', [hippoBin, 'init', '--no-hooks', '--no-schedule', '--no-learn'], {
+        cwd: hippoRoot,
+        env: { ...process.env, HIPPO_HOME: hippoRoot },
+      });
+      execFileSync('node', [hippoBin, 'remember', 'cli-trace-target epsilon fact'], {
+        cwd: hippoRoot,
+        env: { ...process.env, HIPPO_HOME: hippoRoot },
+      });
+      const out = execFileSync('node', [hippoBin, 'recall', 'cli-trace-target'], {
+        cwd: hippoRoot,
+        env: { ...process.env, HIPPO_HOME: hippoRoot },
+        encoding: 'utf-8',
+      });
+      expect(out).toContain('cli-trace-target');
+
+      // The CLI's local store lives at `<cwd>/.hippo` (getHippoRoot,
+      // store.ts:261) — HIPPO_HOME only governs the separate global store.
+      const localStore = join(hippoRoot, '.hippo');
+      const traces = traceRows(localStore, 'cli');
+      expect(traces).toHaveLength(1);
+      const lastTraceId = readLastTraceId(localStore);
+      expect(lastTraceId).toBe(traces[0].id);
+    } finally {
+      rmSync(hippoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('a zero-result recall writes an empty trace row (result_count 0, no result rows) but leaves last_trace_id UNCHANGED', () => {
+    // independent-review-critic must-fix: cli.ts's zero-result branch used
+    // to return before the trace-write block entirely, so it wrote NO trace
+    // at all. It must now write a trace (for training-corpus coverage) but
+    // NOT stamp last_trace_id, since this path also leaves
+    // last_retrieval_ids stale — stamping last_trace_id here would let a
+    // later `hippo outcome` link the OLD last_retrieval_ids against the
+    // NEW, unrelated empty trace.
+    const hippoRoot = mkdtempSync(join(tmpdir(), 'hippo-cli-recall-trace-zero-'));
+    try {
+      const env = { ...process.env, HIPPO_HOME: hippoRoot };
+      execFileSync('node', [hippoBin, 'init', '--no-hooks', '--no-schedule', '--no-learn'], { cwd: hippoRoot, env });
+      execFileSync('node', [hippoBin, 'remember', 'zero-result-baseline eta fact'], { cwd: hippoRoot, env });
+      // First recall: populates last_trace_id with a real trace id.
+      execFileSync('node', [hippoBin, 'recall', 'zero-result-baseline'], { cwd: hippoRoot, env, encoding: 'utf-8' });
+
+      const localStore = join(hippoRoot, '.hippo');
+      const baselineTraceId = readLastTraceId(localStore);
+      expect(baselineTraceId).not.toBeNull();
+
+      // Second recall: a query that matches nothing.
+      const out = execFileSync(
+        'node',
+        [hippoBin, 'recall', 'zzz-query-matches-absolutely-nothing-xyzzy'],
+        { cwd: hippoRoot, env, encoding: 'utf-8' },
+      );
+      expect(out).toContain('No memories found');
+
+      const traces = traceRows(localStore, 'cli');
+      expect(traces).toHaveLength(2);
+      const zeroTrace = traces.find((t) => t.id !== baselineTraceId);
+      expect(zeroTrace).toBeDefined();
+      expect(zeroTrace!.result_count).toBe(0);
+
+      const results = resultRowsFor(localStore, zeroTrace!.id as number);
+      expect(results).toHaveLength(0);
+
+      // last_trace_id must still point at the FIRST (non-empty) trace.
+      expect(readLastTraceId(localStore)).toBe(baselineTraceId);
+    } finally {
+      rmSync(hippoRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(39);
+      expect(getSchemaVersion(db2)).toBe(40);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(39);
+      expect(getSchemaVersion(db2)).toBe(40);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(39);
+    expect(getCurrentSchemaVersion()).toBe(40);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(39);
+      expect(getSchemaVersion(db)).toBe(40);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
## Summary

LC1 (ROADMAP Part IV, Track LC): persist the (query, shown, outcome) training triple on every recall. This is the training-data producer that unblocks LC2 (learned keep/forget scorer) and LC3 (outcome-trained reranker).

- Migration v40: `recall_traces`, `recall_trace_results` (tenant-denormalized; deliberately no FK on `memory_id` so traces outlive forgotten memories), `recall_trace_outcomes` (append-only, immune to audit_log pruning)
- `src/recall-trace.ts`: single fail-soft producer; a trace failure can never break a recall or outcome call
- Wire sites: `api.recall` (observability-only; the v1.11.5 no-side-effect lock holds, locked test untouched), `api.getContext` + CLI `cmdRecall` (trace + `last_trace_id` in lockstep with `last_retrieval_ids`; zero-result CLI recalls trace without stamping)
- Outcome linkage via `outcomeForLastRecall` + optional additive `traceId` opt on `api.outcome`
- Privacy: sha256/16 query hash + length only; raw query text is never persisted

## Test plan

- [x] 28 new tests (migration fresh+upgrade, helper fail-soft, three wire sites, zero-result path, outcome-linkage E2E, storage-overhead smoke)
- [x] Full suite: 353 files / 2809 tests, 0 failures (baseline confirmed green before changes)
- [x] Locked contract file `tests/api-recall-no-side-effects.test.ts` untouched and passing
- [x] Real-CLI E2E in a scratch store: recall -> trace row + 12 ranked results; outcome -> linked `recall_trace_outcomes` row
- [x] Gates: plan-eng 90/100 (round 2), code-review 93/100, independent-review 93/100 (round 2, zero issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNUTU89QWLRJ3JaeLNCVxE
