### PR TITLE
feat: AT1 rejected-value tombstone (migration v41, guard, reject verbs)

### DIFF
--- a/MEMORY_ENVELOPE.md
+++ b/MEMORY_ENVELOPE.md
@@ -45,6 +45,99 @@ Every row in `memories` carries the canonical envelope as of schema v14 (A3) + v
 - **E1 ingestion connectors.** Every Slack/Jira/GitHub message lands as `kind='raw'` with full provenance; `hippo sleep` promotes selected receipts to `kind='distilled'`.
 - **E3 graph layer.** Graph indexer reads only `kind IN ('distilled','superseded')` rows; `kind='raw'` is structurally inaccessible.
 
+## Rejected values (AT1, schema v41)
+
+A human who rejects a fact gets a durable say: `hippo reject` tombstones the
+value so it refuses to come back, across every write surface, not just the
+one row the human saw.
+
+### Semantics
+
+- **Exact-normalized-value match, not semantic.** `normalizeValueForRejection`
+  (`src/rejection.ts`) does Unicode NFC → lowercase → collapse whitespace runs
+  → trim. No punctuation stripping — over-normalization creates false
+  refusals, which are worse than misses. `rejectionDigest` is the full
+  sha256 hex (64 chars) of the normalized string.
+- **Digest-keyed.** The `rejected_values` table stores `(tenant_id, digest)`
+  as its primary key — never the raw text. A lookup is one indexed point
+  query.
+- **Per-store.** Each SQLite store carries its own `rejected_values` table.
+  Rejecting a value in the local store refuses local re-writes — including a
+  `syncGlobalToLocal` pull that would otherwise re-import it from global —
+  but does not reach into other stores. Rejecting in the store where the
+  value lives is the v1 contract.
+- **Per-tenant.** The primary key includes `tenant_id`; tenant B can write a
+  value tenant A rejected.
+
+### What is (and isn't) stored
+
+- **No raw content and no preview.** Only `reason`, `rejected_by`,
+  `rejected_at`, `source_memory_id` (provenance only, no FK — the tombstone
+  outlives the row), and `normalized_chars` (a weak sanity aid for humans
+  listing tombstones). `reason` is the tombstone's only human-readable
+  identity, which is why `hippo reject` requires it.
+- **GDPR rationale.** A rejected value may itself be a secret or PII ("never
+  store my key again"); persisting it in the tombstone would defeat the
+  point. This follows the `raw_archive` redaction precedent (payload is
+  `{redacted:true, ...}`). The human sees the content once, at reject time
+  (the CLI echoes it); afterwards `reason` is all that remains.
+
+### Write-refusal contract
+
+The guard lives at the single INSERT choke point, `upsertEntryRow`
+(`src/store.ts`). It fires when an incoming write's content digest matches a
+tombstone AND the write introduces that content (a new row, or a same-id
+UPDATE changing content onto a rejected value). A miss costs one indexed
+point query; a hit adds one more to classify new-row vs content-introduction.
+On a hit it throws `RejectedValueError` — fail-loud, no silent downgrade.
+
+Two shapes of caller, both pinned by tests:
+
+- **Single-item surfaces fail loud.** `hippo remember` (CLI/api/MCP/HTTP),
+  domain-object writers, and `api.supersede`'s successor write propagate the
+  refusal to the caller with the tombstone's reason.
+- **Multi-item surfaces contain the refusal per item and keep going.**
+  `capture`/pre-compact extraction, importers, `learnFromMemoryMd`,
+  `syncGlobalToLocal`/`promoteToGlobal`/`shareMemory`'s sync-down path,
+  connector ingest, and the DAG summary builders (`buildDag`,
+  `buildEntityProfiles`) catch `RejectedValueError` per item, skip it, count
+  it, and finish the batch. A refusal is per-VALUE — sibling items must
+  survive. `bootstrapLegacyStore` and `rebuildIndex` run the same guard
+  per row over legacy markdown mirrors, which closes the resurrection path a
+  stale/never-purged mirror would otherwise open — structurally, regardless
+  of mirror state.
+- **One bypass exists, on purpose.** `batchWriteAndDelete` (consolidation
+  merges + auto-promote rollups) skips the guard: those writes are LLM
+  paraphrase rollups of already-guarded leaf facts, and refusing mid-batch
+  would abort the whole consolidation transaction for a coincidental digest
+  match. The guard belongs on leaf inserts, not rollups.
+- **Refusal audits survive rollback.** The `reject_refusal` audit row is
+  written by the transaction owner (`writeEntry`, `api.supersede`) *after*
+  its own rollback completes, via `auditRejectionRefusal` — never inside a
+  scope the caller's own rollback would claw back.
+
+### `unreject` is the only escape hatch
+
+`hippo unreject <digest-prefix>` deletes the tombstone; there is no per-write
+force-override flag. A second path through the guard is a second thing to
+get wrong — start minimal, add on demand.
+
+### Multi-binary gap
+
+Schema v41 does **not** bump `min_compatible_binary`. Rejection is enforced
+by binaries >= 1.31.0; an older binary sharing a synced store can still
+write the rejected value back in, silently — no refusal, no warning. Upgrade
+every binary that shares a store. This is a deliberate v1 tradeoff (bumping
+would hard-lock every old binary out of the store entirely, disproportionate
+for the dominant single-user single-binary deployment), not an oversight.
+
+### Known limitation
+
+Matching is exact-normalized-value only. A paraphrase of a rejected fact —
+different words, same meaning — is not caught. This is out of scope for v1;
+semantic/paraphrase-tolerant matching is research, not a documented gap in
+the guard's correctness.
+
 ## Out of scope here (deferred)
 
 - `tenant_id` column (A5)

--- a/MEMORY_ENVELOPE.md
+++ b/MEMORY_ENVELOPE.md
@@ -131,6 +131,24 @@ every binary that shares a store. This is a deliberate v1 tradeoff (bumping
 would hard-lock every old binary out of the store entirely, disproportionate
 for the dominant single-user single-binary deployment), not an oversight.
 
+### Mirror cleanup
+
+Purging a removed row's markdown mirror (`.md` file) is best-effort, not
+guaranteed. `cleanupArchivedMirrors` (the reaper, run on every `openHippoDb`)
+only scans `raw_archive` — it retries a failed purge for `kind='raw'` ids
+only. Non-raw ids have no reaper: if the post-commit unlink (retried once)
+still fails, the file stays on disk with no automatic retry, ever. The
+failure message names the exact leftover path(s) for a human to delete.
+
+This is not silent data loss, because the tombstone does the actual work: a
+stale mirror sitting on disk cannot resurrect the value it names.
+`bootstrapLegacyStore` and `rebuildIndex` run the write-refusal guard per row
+over exactly this class of file, so re-inserting from a stale mirror is
+refused the same as any other write. But the FILE itself persists until a
+human deletes it. If the value is later `unreject`ed, that stale mirror CAN
+be re-imported by a subsequent `rebuildIndex` — reject then unreject does
+not guarantee the old mirror is gone.
+
 ### Known limitation
 
 Matching is exact-normalized-value only. A paraphrase of a rejected fact —

--- a/docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+++ b/docs/plans/2026-08-15-at1-rejected-value-tombstone.md
@@ -116,10 +116,22 @@ the **only** `INSERT INTO memories` in src (spot-checked). Guard runs there:
   callers goes through it; they call `upsertEntryRow` directly). Exactly ONE call
   site passes the bypass (round-3 correction), with an in-code comment obligation:
   - `batchWriteAndDelete` (calls `upsertEntryRow` at store.ts:1714) —
-    consolidation merge + auto-promote writes are LLM paraphrase rollups of
-    already-guarded leaf facts; refusing a paraphrase mid-batch would abort the
-    whole consolidation transaction and the digest would almost never match anyway
-    (false confidence, not protection). The guard belongs on leaf inserts.
+    **premise corrected post-ship (review-stage fix):** consolidation merges
+    are DETERMINISTIC CONCATENATION (`mergeContents`, consolidate.ts:736-751),
+    not an LLM paraphrase — refusing mid-batch would still abort the whole
+    consolidation transaction, but the digest matching a tombstone is NOT
+    rare: deterministic concatenation of the same source facts reproduces
+    the exact same rejected string every sleep cycle. The bypass is safe
+    because the PRODUCER now checks first — consolidate.ts's merge pass
+    looks up the merged content's rejection digest against the tenant's
+    tombstones before ever pushing that merge into `pendingWrites`, and
+    skips the whole cluster on a hit (sources stay unmerged, not demoted,
+    not deleted; skip counted, best-effort `reject_refusal` audit, one
+    `console.error` per sleep). Without that producer-side check, an
+    unguarded bypass would resurrect a rejected rollup every cycle: reject
+    a consolidated summary, sleep regenerates the byte-identical content,
+    the bypassed batch writer re-asserts it. The guard itself stays on leaf
+    inserts; the producer-side check is what makes this bypass safe to keep.
   - `writeEntryDbOnly`'s own call (store.ts:1352) passes NO bypass — the guard is
     live for every producer routed through `writeEntry` / `api.supersede`.
 - **Recovery paths run the guard WITH per-row containment — they do NOT bypass

--- a/docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+++ b/docs/plans/2026-08-15-at1-rejected-value-tombstone.md
@@ -1,0 +1,383 @@
+# AT1: Rejected-value tombstone — implementation plan
+
+Status: Draft (episode 01M025CW434ZAPVSFC61BGFGCT; not yet engineering-reviewed)
+Target: v1.31.0 candidate | Base: origin/master 4aeb04c | Branch: feat/at1-rejected-value-tombstone
+Source: ROADMAP.md Part V AT1 [critical, next] (atlas gap, verified real 2026-08-09)
+
+## Problem
+
+`deleteEntry` is a hard `DELETE FROM memories` (store.ts:1654). Supersession hides rows
+on read but keys nothing on the *value*. A human who rejects a fact has no durable say:
+re-extraction (`capture`), re-import (importers), re-sync (`syncGlobalToLocal`), or a
+plain re-`remember` silently re-asserts the rejected value. The Part III DAG
+consolidation item is explicitly blocked on this invalidation story existing.
+
+Discovered adjacent defects, confirmed against source this episode:
+- `resolveConflict` (store.ts:2449) — today's only human-adjudication surface — writes
+  **zero** `audit_log` rows on any path (verified: no `audit()`/`appendAuditEvent` call
+  in the function body, nor in its CLI/MCP callers).
+- `resolveConflict`'s forget-loser branch does a bare `DELETE FROM memories`
+  (store.ts:2502); if the loser is `kind='raw'`, the append-only trigger
+  (`trg_memories_raw_append_only`) aborts the whole resolve transaction.
+
+## Design (framing F1, grilled at brainstorm)
+
+Exact-normalized-value semantics, per the two atlas reference systems that carry the
+mark: `memsem` (refuses `memory_add` when the normalized value matches) and
+`perseus-vault` (digest-keyed tombstone with audited override). Paraphrase/semantic
+matching is explicitly out of scope (documented limitation; the roadmap's named threat
+is byte-stable re-ingestion, which normalized-digest matching fully covers).
+
+Differentiation from the existing sibling capability: `invalidateMatching`
+(invalidation.ts:85) soft-weakens matching live rows (half-life halve + stale tag) but
+prevents nothing — a re-assertion writes a fresh row untouched. The tombstone is the
+missing *write-side* refusal; invalidate stays unchanged.
+
+### 1. New module `src/rejection.ts`
+
+- `normalizeValueForRejection(content: string): string` — Unicode NFC → lowercase →
+  collapse whitespace runs to single space → trim. No punctuation stripping (too
+  aggressive; over-normalization creates false refusals, which are worse than misses).
+- `rejectionDigest(content: string): string` — full sha256 hex (64 chars) of the
+  normalized string. Reuses the strong-identity convention (importers.ts:814
+  content-hash tag), NOT the privacy-lossy 16-char convention (recall-trace query
+  hashing) — a tombstone lookup key needs collision resistance, not redaction.
+- `RejectedValueError` — carries `{digest, reason, rejectedAt}`; thrown by the guard.
+- Check/write helpers used by the guard, the CLI verbs, and `resolveConflict`.
+
+### 2. Migration v41: `rejected_values` (additive; template = v40, db.ts:2197-2268)
+
+```sql
+CREATE TABLE rejected_values (
+  tenant_id  TEXT NOT NULL,
+  digest     TEXT NOT NULL,            -- sha256/64 of normalized content
+  reason     TEXT,                     -- human-supplied; the only description stored
+  rejected_by TEXT,                    -- actor ('user:<id>' / 'cli' / ...)
+  rejected_at TEXT NOT NULL,
+  source_memory_id TEXT,              -- provenance only; NO FK (v40 precedent
+                                       -- db.ts:2245-2249: tombstone outlives the row)
+  normalized_chars INTEGER,            -- weak sanity aid for humans listing tombstones
+  PRIMARY KEY (tenant_id, digest)
+) WITHOUT ROWID;
+```
+
+- **No raw content and no preview stored.** Follows the `raw_archive` redaction
+  precedent (raw-archive.ts payload is `{redacted:true, ...}`): a rejected value may
+  itself be a secret or PII ("never store my key again") — persisting it in the
+  tombstone would defeat the point. The human sees the content at reject time (CLI
+  echoes it); afterwards the `reason` field is the human-readable identity.
+- Reserved-word check on column names: clean (§3b rule 10).
+- **No `min_compatible_binary` bump — a deliberate tradeoff, flagged to the ship
+  gate (critic round-1 med: the v40 "pure observability" analogy is weaker here).**
+  Honest statement: an old binary sharing a synced store writes WITHOUT the guard —
+  no refusal, no warning — until upgraded; that is a real durability gap in
+  multi-binary deployments. Bumping closes it by locking every old binary out of the
+  store entirely (hard refuse-to-open), which is disproportionate for the dominant
+  single-user single-binary local deployment. Decision: no bump; the gap is
+  documented in MEMORY_ENVELOPE.md ("rejection is enforced by binaries >= 1.31.0;
+  upgrade all binaries that share a store"), and the ship-gate human can override to
+  bump before release.
+- Tenant model: tombstones are tenant-scoped (PK includes tenant_id) and **per-store**
+  (each SQLite store carries its own table). Consequence spelled out: a value rejected
+  in the local store refuses local re-writes — including `syncGlobalToLocal`
+  re-importing it from global (the exact roadmap threat) — but does not reach into
+  other stores' tables. Rejecting in the store where the value lives is the v1
+  contract.
+
+### 3. Write-path guard (single choke point)
+
+Placement per the verified write-path enumeration: `upsertEntryRow` (store.ts:997) is
+the **only** `INSERT INTO memories` in src (spot-checked). Guard runs there:
+
+- Fires when the incoming content's digest matches a tombstone AND the write
+  *introduces* that content: the row is new, OR the stored row's content digest
+  differs from the incoming one (`upsertEntryRow` is an UPSERT — a same-id edit TO a
+  rejected value is a content introduction and must be refused; grill issue 2).
+  Unchanged same-id re-persists (recall boost, decay, star toggle) are exempt by
+  construction; `refine-llm`'s in-place paraphrase rewrite is only refused in the
+  pathological case where the rewrite lands exactly on a rejected normalized value —
+  which is a correct refusal.
+- Guard cost, stated honestly (critic round-1 med): `upsertEntryRow` today contains
+  ZERO `SELECT`s — the guard adds NEW queries to the hottest write path. Ordering
+  minimizes them: (a) compute the incoming normalized digest; (b) probe
+  `rejected_values (tenant_id, digest)` — a miss ends the guard (ONE indexed point
+  query; the overwhelmingly common case); (c) only on a tombstone hit, `SELECT` the
+  stored row's content by id to classify new-row vs content-introduction. Net: +1
+  point query per guarded write, +2 on the rare hit path — bounded and small next to
+  the existing FTS + mirror + audit I/O per write, but new, not free. Filter applied
+  in SQL, not post-hoc (probation memory `feedback_sql_filter_before_limit_window`).
+- Hit → throw `RejectedValueError`. **Fail-loud, no fallback** (probation memory
+  `feedback_fallbacks_absent_not_broken`): the caller's write fails with the reason;
+  nothing silently downgrades.
+- **Bypass flag** `bypassRejectionGuard` is a direct optional parameter on
+  `upsertEntryRow` itself (critic round-1 crit 1: threading via `writeEntryDbOnly`
+  opts is architecturally impossible — `writeEntryDbOnly` has exactly two callers,
+  `writeEntry` store.ts:1317 and `api.supersede` api.ts:1831, and none of the bypass
+  callers goes through it; they call `upsertEntryRow` directly). Exactly ONE call
+  site passes the bypass (round-3 correction), with an in-code comment obligation:
+  - `batchWriteAndDelete` (calls `upsertEntryRow` at store.ts:1714) —
+    consolidation merge + auto-promote writes are LLM paraphrase rollups of
+    already-guarded leaf facts; refusing a paraphrase mid-batch would abort the
+    whole consolidation transaction and the digest would almost never match anyway
+    (false confidence, not protection). The guard belongs on leaf inserts.
+  - `writeEntryDbOnly`'s own call (store.ts:1352) passes NO bypass — the guard is
+    live for every producer routed through `writeEntry` / `api.supersede`.
+- **Recovery paths run the guard WITH per-row containment — they do NOT bypass
+  (round-3 redesign; replaces the round-2 mirror-purge-in-archive design the critic
+  correctly killed).** `bootstrapLegacyStore` (store.ts:906) and `rebuildIndex`
+  (store.ts:1861) exist to re-insert rows found in markdown mirrors but missing from
+  SQL — exactly the channel through which a stale mirror could resurrect a rejected
+  value. Instead of bypassing the guard and trying to guarantee no stale mirror ever
+  exists (unwinnable: filesystem purges are best-effort by design here), both paths
+  run the guard per row and catch `RejectedValueError` → skip the row, count it, log
+  once, best-effort `reject_refusal` audit — written INLINE inside the still-open
+  loop transaction (round-3 advisory 3: the per-row skip does not roll anything
+  back, so the post-rollback `auditRejectionRefusal` helper — built for the
+  rolled-back writeEntry/supersede case — is the wrong tool here; a direct `audit()`
+  call in-loop is correct and commits with the pass). The `rejected_values` table lives in the
+  same DB being rebuilt, so it is available during both passes. This closes
+  resurrection STRUCTURALLY: a rejected value cannot re-enter via recovery no matter
+  what state the mirrors are in.
+- **Mirror purge follows the codebase's existing post-commit + reaper pattern
+  (round-2 crit fix, designed from source).** `archiveRawMemory` keeps its exact
+  current signature — db-only work inside its own inner SAVEPOINT, which is what
+  makes it safely composable inside outer transactions (`github_delete_all`
+  deletion.ts:78-101; resolveConflict's BEGIN/COMMIT; the reject verb's
+  transaction). NO filesystem I/O is added anywhere inside any transaction scope
+  (the established rule: batchWriteAndDelete purges mirrors only after
+  `db.exec('COMMIT')`, store.ts:1730-1738; writeEntry/writeEntryDbOnly split exists
+  for the same reason). The reject flow reuses the EXISTING purge + reaper
+  mechanism verbatim from `api.archiveRaw` (api.ts:1913-1938): after the OUTERMOST
+  commit, best-effort `removeEntryMirrors` per removed id; on success stamp
+  `raw_archive.mirror_cleaned_at` for raw rows so the `openHippoDb` reaper stops
+  retrying; on failure the stamp stays NULL and the reaper retries on next open.
+  Non-raw removed rows get the same post-commit best-effort purge (no reaper exists
+  for them — acceptable, because the recovery-path guard above already makes a
+  surviving mirror harmless). `api.archiveRaw` and `connectors/github/deletion.ts`
+  are NOT modified — no duplication, no signature change, no new callers to audit.
+  Pinned by tests: (a) reject a raw row → `rebuildIndex` → value absent (via guard
+  skip, regardless of mirror state); (b) a mid-transaction failure in the reject
+  verb leaves every mirror intact (rollback safety).
+- Every other producer — remember (CLI/api/MCP/HTTP), capture + pre-compact extraction,
+  autolearn/git-learn, all importers, connectors, domain-object writers,
+  promote/share/sync copy paths, supersede's successor write — hits the guard with no
+  code change at their site. Copy paths are deliberately IN scope: promote/share/sync
+  must not carry a rejected value into a wider scope; the guard at the destination
+  store covers them.
+
+**Refusal audit must survive the rollback — written by the transaction OWNER, never
+inside a scope a caller can roll back (critic round-1 crit 3).** The guard only
+throws; `RejectedValueError` carries `{digest, tenantId, entryId, reason}`. The
+`reject_refusal` audit row is written post-rollback by the two connection/transaction
+owners, via one shared helper `auditRejectionRefusal(db, err, actor)` (best-effort
+`audit()` semantics):
+- `writeEntry` (store.ts:1299): catch after its SAVEPOINT unwinds — no outer
+  transaction exists there, so the post-rollback write commits immediately — then
+  rethrow.
+- `api.supersede` (api.ts:1842 catch): after its own `db.exec('ROLLBACK')` — the
+  refusal audit lands in a fresh implicit transaction that the aborted outer one
+  cannot claw back — then rethrow.
+`batchWriteAndDelete` bypasses the guard, so no refusal can originate there. Tests
+assert BOTH surfaces: refused `remember` AND refused `supersede` → no memory row,
+exactly one `reject_refusal` audit row each, with digest metadata.
+
+**Refusal containment at multi-item write loops (grill issue 1 — design requirement,
+not an afterthought).** A refusal is per-VALUE; sibling items must survive:
+- `writeExtractedItems` (capture.ts:261) and `cmdCaptureCore` (capture.ts:649): catch
+  `RejectedValueError` per item — skip, count, continue; summary reports
+  `rejected: N`. The PreCompact path keeps CS1's hard exit-0 contract: a refusal can
+  never crash the hook.
+- `importEntries` (importers.ts:143), `importVault` (via `remember`): per-item catch;
+  `ImportResult` gains an explicit `rejected` counter (round-2 low: folding into the
+  existing `skipped` would make deduped indistinguishable from tombstoned); import
+  summaries print it.
+- `learnFromMemoryMd` (cli.ts:2647) is NOT ImportResult-shaped — it returns a bare
+  `number` with two callers printing a bare count (cli.ts:540, cli.ts:2903; round-3
+  advisory 1). No signature change: per-item catch, count rejected skips internally,
+  and print one summary line from inside the function ("skipped N rejected value(s)")
+  when the count is non-zero. Callers unchanged.
+- Connector ingest (slack/github): a `RejectedValueError` is a PERMANENT skip
+  (acked/marked done), never DLQ-retried — a tombstone hit is not transient.
+- DAG summary builds (critic round-1 high): `buildDag` (writeEntry at dag.ts:155) and
+  `buildEntityProfiles` (dag.ts:378) loop over clusters writing NEW LLM-synthesized
+  summaries through the live guard (they use plain `writeEntry`, not the bypassed
+  batch writer). Per-cluster catch-and-skip — a refused summary skips that cluster
+  and the sleep cycle continues; refusing a summary that lands exactly on a rejected
+  value is correct, aborting the whole DAG phase is not. Their member re-parenting
+  writes (dag.ts:160/383) are same-id updates, unaffected by construction.
+- `syncGlobalToLocal` / `promoteToGlobal` / `shareMemory`: sync skips-and-counts;
+  promote/share of a rejected value is a single-item op and fails loud with the
+  refusal error (correct: the human asked for that one value).
+- Single-item surfaces (remember CLI/api/MCP/HTTP, domain-object writers, supersede):
+  fail loud with the tombstone's reason — no catch.
+Test: transcript yielding 3 extractions with 1 rejected → 2 written + 1
+`reject_refusal` audit row + hook exit 0.
+
+### 4. CLI verbs + api
+
+- `--reason` is REQUIRED on both reject forms (grill issue 4): with no content stored,
+  the reason is the tombstone's only human-readable identity — a nullable reason
+  makes `rejections`/`unreject` listings of anonymous digests nobody can act on.
+- Store targeting (grill issue 6): reject/unreject/rejections follow the same
+  store-resolution flags as `remember`; rejecting in the global store means running
+  against the global store. v1 contract, documented.
+- **`deleteEntryCore` split (round-2 high fix, designed from source).** `deleteEntry`
+  (store.ts:1641) opens and closes its OWN connection and cannot compose inside a
+  caller's transaction. Split it exactly like writeEntry/writeEntryDbOnly: new
+  db-scoped `deleteEntryCore(db, id, opts)` — row-meta SELECT, `DELETE FROM
+  memories`, FTS delete, `forget` audit, DAG dirty-mark; NO filesystem I/O; returns
+  `{tenantId, dagParentId} | null`. `deleteEntry` becomes the thin wrapper (open →
+  core → post-commit `removeEntryMirrors` + `writeIndexMirror` → close), behavior
+  byte-identical for every existing caller.
+- `hippo reject <memory-id> --reason "<why>"` — ONE connection, one transaction:
+  write tombstone; enumerate ALL live rows in the tenant whose normalized digest
+  matches (O(N) scan, human-triggered command on ~1-5k-row stores — acceptable,
+  documented); remove each kind-aware IN-transaction — `kind='raw'` via
+  `archiveRawMemory` (its inner SAVEPOINT nests safely; append-only trigger
+  respected), others via `deleteEntryCore`; audit `reject_value` (metadata: digest,
+  removed count); COMMIT. THEN post-commit: best-effort `removeEntryMirrors` per
+  removed id, `mirror_cleaned_at` stamps for raw ids (reaper backstop), one
+  `writeIndexMirror`. Duplicate handling is the K1/R7 lesson: ALL matching rows,
+  not just the id passed.
+- **Audit-row semantics on the reject path (round-3 advisory 2, following the
+  api.ts:1873-1877 no-double-emit precedent):** `deleteEntryCore` takes
+  `opts.suppressForgetAudit?: boolean`; the reject path sets it so removed non-raw
+  rows do NOT each emit a `forget` row — the single aggregate `reject_value` row
+  (digest + removed ids + count) is the trail. `archiveRawMemory`'s own
+  `archive_raw` audit is KEPT (it is the GDPR archival trail and semantically true —
+  the row was archived). Test 3 pins the contract: one `reject_value`, zero `forget`
+  rows from the reject call, one `archive_raw` per raw removal. Default
+  (`suppressForgetAudit` unset) keeps `deleteEntry` byte-identical.
+- `hippo reject --value "<text>" --reason "<why>"` — pre-emptive tombstone for a value
+  not currently stored (or already deleted); zero-removal path, same audit.
+- `hippo rejections` — list tombstones (digest prefix, reason, rejected_by,
+  rejected_at, source_memory_id, normalized_chars).
+- `hippo unreject <digest-prefix>` — delete tombstone, audit `unreject_value`. This is
+  the **only** escape hatch in v1: no per-write force-override flag (a second path
+  through the guard is a second thing to get wrong; `perseus-vault` has one, `memsem`
+  does not — start minimal, add on demand).
+- `api.ts`: `reject` / `unreject` / `listRejections` (Context-based, tenant-checked) so
+  HTTP/MCP endpoints can be added later without touching store internals. HTTP + MCP
+  *verbs* are a documented follow-up — note the guard itself already protects every
+  surface today; only the reject-administration surface is CLI/api-first.
+
+### 5. `resolveConflict` wiring + audit fix
+
+- Additive-optional signature (public export, index.ts:26 — §3b rule 5):
+  `resolveConflict(hippoRoot, conflictId, keepId, forgetLoser, tenantId, opts?)` with
+  `opts = { rejectLoserValue?, rejectedBy?, reason? }`. Existing call shapes
+  (cli.ts:3705, mcp/server.ts:1144) compile unchanged.
+- `rejectLoserValue` → tombstone the loser's normalized digest + kind-aware removal
+  inside the existing BEGIN/COMMIT (raw → `archiveRawMemory`, else
+  `deleteEntryCore` — both db-scoped, both compose); mirror purge + reaper stamps
+  run AFTER resolveConflict's own COMMIT, same post-commit pattern as the reject
+  verb.
+- Kind-aware removal also fixes the pre-existing forget-loser crash on raw losers
+  (route through the same helper the reject verb uses).
+- Add the missing audit: op `resolve` on every resolution path (metadata: conflictId,
+  keepId, loser disposition). Closes the audit-invisibility gap.
+- CLI: `hippo resolve ... --reject-loser [--reason "..."]`; MCP `hippo_resolve` gains
+  optional `rejectLoser` + `reason` params.
+
+### 6. AuditOp lockstep (§3b rule 2 — all three sites, one commit)
+
+New ops: `reject_value`, `reject_refusal`, `unreject_value`, `conflict_resolve`
+(domain-namespaced per the existing convention — `decision_supersede`,
+`predict_close`, `archive_raw`; bare `resolve` is vague; grill issue 5).
+Sites: `AuditOp` union (audit.ts:130-176), `VALID_AUDIT_OPS` cli.ts:7258,
+`VALID_AUDIT_OPS` server.ts:168. Each entry carries the lockstep comment convention.
+
+### 7. Tests (real DB, per repo convention)
+
+1. **Acceptance (roadmap criterion, verbatim):** reject value X → re-run a capture
+   extraction that re-asserts X → write refused, `audit_log` records the refusal;
+   supersession behavior unchanged for non-rejected corrections (cmdSupersede +
+   api.supersede suites stay green).
+2. Guard: new-row refused across remember/capture/import surfaces; same-id re-persist
+   of a surviving row unaffected; consolidation bypass proven (merged content equal to
+   a rejected value still writes — exemption is by design and the test pins it);
+   tenant isolation (tenant B writes the same value freely); normalization variants
+   (case/whitespace/NFC) all refused; unreject restores writability.
+3. Reject verb: removes ALL same-digest duplicates in one call; raw rows archived not
+   crashed (append-only trigger respected); `reject --value` pre-emptive path; audit
+   rows for `reject_value` with removed-count metadata.
+4. resolveConflict: `resolve` audit row on weaken path AND forget path (was zero);
+   `--reject-loser` tombstones + removes; raw loser no longer aborts; old 5-arg call
+   shape still compiles (additive check).
+5. Copy-path: global→local sync of a locally-rejected value is refused (the roadmap
+   threat, end-to-end).
+6. Migration: v41 applies on fresh + existing stores; idempotent under re-open;
+   schema_version = 41; no min_compatible_binary change.
+7. **AT5 paired case:** after reject, the value never resurfaces via recall (query
+   that previously returned it returns without it, and stays clean after a capture
+   re-assertion attempt).
+
+### 8. Docs
+
+CHANGELOG v1.31.0 entry; MEMORY_ENVELOPE.md "Rejected values" section (semantics,
+per-store scope, no-content-stored rationale, normalization contract);
+ROADMAP.md AT1 status flip is a ship-stage doc edit in the MAIN checkout (hot file —
+targeted Edit only).
+
+## Non-goals (v1)
+
+- Semantic/paraphrase-tolerant matching (research; documented limitation).
+- HTTP/MCP reject-administration endpoints (follow-up; guard already covers those
+  write surfaces).
+- AT3 quarantine tier, AT4 review queue (separate roadmap items; AT4 overlaps AT3 —
+  build together later).
+- Per-write force-override flag.
+- Retroactive store scan (tombstone set starts empty; nothing to backfill).
+
+## Execution split (executors are sonnet sub-agents; orchestrator reviews every diff)
+
+- T1: `src/rejection.ts` + migration v41 + guard in store.ts (+ bypass threading) —
+  the core invariant.
+- T2 (after T1 lands): CLI verbs + api trio + resolveConflict wiring + AuditOps
+  3-site lockstep.
+- T3 (parallel with T2 tail): tests + docs.
+
+## Risks / open questions
+
+- **Wallclock:** 4h episode budget vs 5-6d roadmap effort estimate — the estimate
+  includes human cadence; the episode compresses to the code+tests scope above. If the
+  execute stage overruns, ship T1+T2 with the acceptance tests and move remaining test
+  breadth to a follow-up (cap-honest, human decides at ship).
+- **O(N) duplicate scan in reject verb:** acceptable at current store sizes;
+  follow-up if stores grow 100x (a digest column on memories is the escape, not
+  needed now).
+- **False refusals:** normalization is conservative (no punctuation stripping) to keep
+  false-refusal risk near zero; a false refusal is loud (error names the tombstone +
+  reason + unreject path), never silent.
+- **Reject-vs-concurrent-writer race (grill issue 7, accepted):** a write that passes
+  the guard before the tombstone commits can land after it. Single-user CLI reality;
+  the next reject (or a re-run) catches it. Documented limitation, not v1-blocking.
+
+Grill applied 2026-08-15 (7 issues: multi-item refusal containment; same-id
+content-change gating; mirror-purge proof; required reason; conflict_resolve naming;
+store targeting; race accepted). Test list updated to match: containment test (3
+extractions / 1 rejected / hook exit 0), same-id-edit refusal test, raw-reject →
+rebuild test.
+
+Critic round 2 applied 2026-08-15 (fail 48 → revised from source): the round-1
+mirror fix was itself wrong (fs unlinks inside SAVEPOINT scope = unrecoverable loss
+on rollback; existing api.ts:1913-1938 purge+reaper never reconciled). Round-3
+design read from source: archiveRawMemory signature UNCHANGED (db-only, composable);
+recovery paths (bootstrapLegacyStore/rebuildIndex) switched from bypass to
+guard-with-per-row-skip — structural closure of resurrection independent of mirror
+state; reject/resolve purge mirrors post-OUTERMOST-commit reusing the existing
+reaper bookkeeping; deleteEntryCore split (deleteEntry cannot compose — owns its
+connection); ImportResult gains an explicit `rejected` counter. batchWriteAndDelete
+is now the SOLE bypass caller.
+
+Critic round 1 applied 2026-08-15 (fail 25 → revised): bypass flag moved to a direct
+`upsertEntryRow` parameter (threading via writeEntryDbOnly was impossible — 2 callers
+only); archiveRawMemory mirror-purge designed in-plan with both external callers
+named (api.ts:1908, connectors/github/deletion.ts:81) — also fixes the pre-existing
+archive→rebuild resurrection defect; refusal audit moved to the transaction owners'
+post-rollback catch blocks (writeEntry + api.supersede) via one shared helper, tested
+on both surfaces; dag.ts buildDag/buildEntityProfiles added to containment
+(per-cluster catch-and-skip); guard cost restated honestly (+1 point query common
+case, +2 on tombstone hit — new queries, upsertEntryRow had none); min_compatible_binary
+no-bump restated as an explicit tradeoff with the multi-binary gap documented and
+flagged to the ship gate.

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,9 +35,12 @@ import {
   updateStats,
   isInitialized,
   markSummaryDirtyInTx,
+  auditRejectionRefusal,
   type TaskSnapshot,
   type SessionEvent,
 } from './store.js';
+import { RejectedValueError, type RejectedValueRow } from './rejection.js';
+import { rejectValue, unrejectValue, listRejectionsForTenant } from './reject-flow.js';
 import type { SessionHandoff } from './handoff.js';
 import {
   createMemory,
@@ -1694,6 +1697,77 @@ export function forget(ctx: Context, id: string): { ok: true; id: string } {
 }
 
 // ---------------------------------------------------------------------------
+// AT1: reject / unreject / listRejections
+// docs/plans/2026-08-15-at1-rejected-value-tombstone.md §4
+//
+// Context-based, tenant-checked, so HTTP/MCP reject-administration endpoints
+// can be added later without touching store internals (the write-path guard
+// itself already protects every write surface today — only this admin
+// surface is CLI/api-first, plan §4 non-goals). Shares the exact same
+// transaction flow as `hippo reject`/`rejections`/`unreject` via
+// src/reject-flow.ts — neither surface duplicates it.
+// ---------------------------------------------------------------------------
+
+export interface RejectOpts {
+  /** By-id form: reject the CURRENT content of an existing memory. */
+  memoryId?: string;
+  /** Pre-emptive form: reject a value not currently stored (or already gone). */
+  value?: string;
+  /** Required — the tombstone stores no content; reason is its only identity. */
+  reason: string;
+}
+
+export interface RejectResult {
+  digest: string;
+  removedIds: string[];
+}
+
+export function reject(ctx: Context, opts: RejectOpts): RejectResult {
+  if (opts.memoryId !== undefined) {
+    // Tenant scope, same not-found-shaped denial as forget/promote above:
+    // rejectValue itself also tenant-checks the id, but pre-checking here
+    // keeps the error message consistent with the rest of this module.
+    const db = openHippoDb(ctx.hippoRoot);
+    try {
+      const row = db
+        .prepare(`SELECT tenant_id FROM memories WHERE id = ?`)
+        .get(opts.memoryId) as { tenant_id?: string } | undefined;
+      if (!row || row.tenant_id !== ctx.tenantId) {
+        throw new Error(`memory not found: ${opts.memoryId}`);
+      }
+    } finally {
+      closeHippoDb(db);
+    }
+  }
+  const result = rejectValue({
+    hippoRoot: ctx.hippoRoot,
+    tenantId: ctx.tenantId,
+    actor: ctx.actor.subject,
+    reason: opts.reason,
+    memoryId: opts.memoryId,
+    value: opts.value,
+  });
+  return { digest: result.digest, removedIds: result.removedIds };
+}
+
+export function unreject(ctx: Context, digestOrPrefix: string): { ok: true; digest: string } {
+  const outcome = unrejectValue(ctx.hippoRoot, ctx.tenantId, digestOrPrefix, ctx.actor.subject);
+  if (outcome.status === 'not_found') {
+    throw new Error(`no rejected value matches: ${digestOrPrefix}`);
+  }
+  if (outcome.status === 'ambiguous') {
+    throw new Error(
+      `"${digestOrPrefix}" matches ${outcome.candidates.length} tombstones; use a longer prefix`,
+    );
+  }
+  return { ok: true, digest: outcome.digest };
+}
+
+export function listRejections(ctx: Context): RejectedValueRow[] {
+  return listRejectionsForTenant(ctx.hippoRoot, ctx.tenantId);
+}
+
+// ---------------------------------------------------------------------------
 // promote
 // ---------------------------------------------------------------------------
 
@@ -1841,6 +1915,12 @@ export function supersede(
       db.exec('COMMIT');
     } catch (err) {
       try { db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+      // AT1 (plan §3): refusal audit lands post-ROLLBACK, in a fresh
+      // implicit transaction the aborted outer one cannot claw back — then
+      // rethrow so the caller sees the refusal.
+      if (err instanceof RejectedValueError) {
+        auditRejectionRefusal(db, err, ctx.actor.subject);
+      }
       throw err;
     }
     // Mirrors after COMMIT, while the db handle is still open. Same

--- a/src/api.ts
+++ b/src/api.ts
@@ -2740,6 +2740,15 @@ export interface SleepResult {
    * "NOT redacted" list in src/sleep-redact.ts).
    */
   secretSkipped?: number;
+  /**
+   * AT1: count of auto-share candidates the GLOBAL store's rejection
+   * tombstone refused this sleep (docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+   * plan §3 — copy paths must not let one rejected candidate abort the
+   * batch). Absent when 0 or when auto-share did not run. Same
+   * per-invocation-activity class as `secretSkipped` (sibling counter,
+   * same autoShare call) — NOT redacted on egress, see sleep-redact.ts.
+   */
+  rejectedSkipped?: number;
   ambient?: AmbientState | null;
   /**
    * E3 sleep enqueue-hook: graph re-extraction totals across the tenants rebuilt
@@ -2912,13 +2921,19 @@ export async function sleep(
       if (sleepConfig.autoShareOnSleep) {
         // v1.25.0: surface the secret-veto skip count (v39 follow-up #2) so
         // the veto is observable instead of silent.
-        const autoShareStats = { secretSkipped: 0 };
+        // AT1: rejectedSkipped is autoShare's sibling counter for candidates
+        // the global store's rejection tombstone refused (threaded the same
+        // way as secretSkipped just below).
+        const autoShareStats = { secretSkipped: 0, rejectedSkipped: 0 };
         const shared = phases.autoShare(ctx.hippoRoot, { minScore: 0.6, stats: autoShareStats });
         if (shared.length > 0) {
           result.shared = shared.length;
         }
         if (autoShareStats.secretSkipped > 0) {
           result.secretSkipped = autoShareStats.secretSkipped;
+        }
+        if (autoShareStats.rejectedSkipped > 0) {
+          result.rejectedSkipped = autoShareStats.rejectedSkipped;
         }
       }
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1722,6 +1722,20 @@ export interface RejectResult {
   removedIds: string[];
 }
 
+/**
+ * Reject a value: tombstone its normalized digest so a matching write is
+ * refused everywhere (remember/capture/import/sync) until `unreject`. Two
+ * forms — pass exactly one:
+ *  - `memoryId`: reject the CURRENT content of an existing memory. Removes
+ *    that row and every other live row in the tenant whose normalized
+ *    digest matches (not just the id passed).
+ *  - `value`: pre-emptive form — tombstone content that may not currently
+ *    be stored (or is already gone). Zero removals.
+ *
+ * `reason` is required (the tombstone stores no content; reason is its
+ * only human-readable identity). Throws if the memory id is not found in
+ * `ctx.tenantId`, or if both/neither of `memoryId`/`value` are given.
+ */
 export function reject(ctx: Context, opts: RejectOpts): RejectResult {
   if (opts.memoryId !== undefined) {
     // Tenant scope, same not-found-shaped denial as forget/promote above:
@@ -1750,6 +1764,12 @@ export function reject(ctx: Context, opts: RejectOpts): RejectResult {
   return { digest: result.digest, removedIds: result.removedIds };
 }
 
+/**
+ * Delete a tombstone by exact digest or unambiguous prefix, restoring the
+ * value's writability — the only v1 escape hatch (no per-write force flag).
+ * Throws if `digestOrPrefix` matches no tombstone, is blank, or matches
+ * more than one (use a longer prefix).
+ */
 export function unreject(ctx: Context, digestOrPrefix: string): { ok: true; digest: string } {
   const outcome = unrejectValue(ctx.hippoRoot, ctx.tenantId, digestOrPrefix, ctx.actor.subject);
   if (outcome.status === 'not_found') {
@@ -1763,6 +1783,7 @@ export function unreject(ctx: Context, digestOrPrefix: string): { ok: true; dige
   return { ok: true, digest: outcome.digest };
 }
 
+/** List every rejected-value tombstone for `ctx.tenantId`, newest first. */
 export function listRejections(ctx: Context): RejectedValueRow[] {
   return listRejectionsForTenant(ctx.hippoRoot, ctx.tenantId);
 }

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -173,7 +173,11 @@ export type AuditOp =
   | 'customer_note_create' // E2 customer_note first-class object — emitted by saveCustomerNote
   | 'customer_note_supersede' // E2 — emitted by saveCustomerNote when supersedesNoteId resolves to an active note row
   | 'customer_note_close' // E2 — emitted by closeCustomerNote (active -> closed, retire without successor)
-  | 'mv_rescue'; // LC2-E3 — emitted by consolidate() per rescued entry when config.memoryValue.enabled (docs/plans/2026-08-10-lc2-e3-mv-wiring.md)
+  | 'mv_rescue' // LC2-E3 — emitted by consolidate() per rescued entry when config.memoryValue.enabled (docs/plans/2026-08-10-lc2-e3-mv-wiring.md)
+  | 'reject_value' // AT1 — lockstep with cli.ts VALID_AUDIT_OPS + server.ts VALID_AUDIT_OPS; emitted by the `hippo reject` verb (docs/plans/2026-08-15-at1-rejected-value-tombstone.md)
+  | 'reject_refusal' // AT1 — lockstep; emitted when the rejection guard refuses a write (writeEntry/api.supersede post-rollback, or inline during bootstrapLegacyStore/rebuildIndex skips)
+  | 'unreject_value' // AT1 — lockstep; emitted by the `hippo unreject` verb
+  | 'conflict_resolve'; // AT1 — lockstep; emitted by resolveConflict on every resolution path (domain-namespaced, not bare 'resolve' — grill issue 5)
 
 export interface AppendAuditOpts {
   tenantId: string;

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -28,7 +28,8 @@ import { isEmbeddingConfigured } from './embedding-provider.js';
 import { resolveTenantId } from './tenant.js';
 import { defaultPreCompactLogPath } from './hooks.js';
 import { redactSecrets } from './secret-detect.js';
-import { RejectedValueError } from './rejection.js';
+import { RejectedValueError, checkRejectionGuard } from './rejection.js';
+import { openHippoDb, closeHippoDb } from './db.js';
 
 // ---------------------------------------------------------------------------
 // Pattern definitions
@@ -629,18 +630,24 @@ function cmdCaptureCore(
   let skipped = 0;
   let rejected = 0;
 
-  for (const item of extracted) {
-    if (isDuplicate(item.content, existing)) {
-      skipped++;
-      if (options.dryRun) {
-        console.log(`  [skip] (${item.category}) ${item.content.slice(0, 80)}`);
+  // AT1 P2 fix (dry-run parity, docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
+  // dry-run used to skip the guarded write branch ENTIRELY, so a tombstoned
+  // extraction printed as `[capture]` and counted toward `captured` — the
+  // preview lied about what a real run would do. Mirrors importers.ts's
+  // importEntries dry-run probe (commit 6146e82): open a read-only handle
+  // once, run the same checkRejectionGuard the real write path uses via
+  // writeEntry, never write anything.
+  const dryRunDb = options.dryRun ? openHippoDb(targetRoot) : null;
+  try {
+    for (const item of extracted) {
+      if (isDuplicate(item.content, existing)) {
+        skipped++;
+        if (options.dryRun) {
+          console.log(`  [skip] (${item.category}) ${item.content.slice(0, 80)}`);
+        }
+        continue;
       }
-      continue;
-    }
 
-    if (options.dryRun) {
-      console.log(`  [capture] (${item.category}) ${item.content}`);
-    } else {
       // A3: kind defaults to 'distilled'. capture.ts extracts curated items from
       // session output (not raw transcript chunks), so distilled is correct. If a
       // future variant captures full raw session text, it MUST set kind: 'raw'
@@ -659,26 +666,44 @@ function cmdCaptureCore(
         tenantId: useGlobal ? undefined : options.tenantId,
       });
 
-      // AT1 (plan §3 containment): one rejected item must not abort the
-      // rest of this capture's items.
-      try {
-        writeEntry(targetRoot, entry);
-      } catch (err) {
-        if (err instanceof RejectedValueError) {
-          rejected++;
-          continue;
+      if (options.dryRun) {
+        if (dryRunDb) {
+          try {
+            checkRejectionGuard(dryRunDb, entry.tenantId ?? 'default', entry.id, entry.content);
+          } catch (err) {
+            if (err instanceof RejectedValueError) {
+              rejected++;
+              console.log(`  [reject] (${item.category}) ${item.content.slice(0, 80)} - matches a rejected value`);
+              continue;
+            }
+            throw err;
+          }
         }
-        throw err;
-      }
-      updateStats(targetRoot, { remembered: 1 });
-      existing.push(entry); // within-batch dedup
+        console.log(`  [capture] (${item.category}) ${item.content}`);
+      } else {
+        // AT1 (plan §3 containment): one rejected item must not abort the
+        // rest of this capture's items.
+        try {
+          writeEntry(targetRoot, entry);
+        } catch (err) {
+          if (err instanceof RejectedValueError) {
+            rejected++;
+            continue;
+          }
+          throw err;
+        }
+        updateStats(targetRoot, { remembered: 1 });
+        existing.push(entry); // within-batch dedup
 
-      if (isEmbeddingConfigured(targetRoot)) {
-        embedMemory(targetRoot, entry).catch(() => {});
+        if (isEmbeddingConfigured(targetRoot)) {
+          embedMemory(targetRoot, entry).catch(() => {});
+        }
       }
+
+      captured++;
     }
-
-    captured++;
+  } finally {
+    if (dryRunDb) closeHippoDb(dryRunDb);
   }
 
   const prefix = options.dryRun ? '[dry-run] ' : '';

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -28,6 +28,7 @@ import { isEmbeddingConfigured } from './embedding-provider.js';
 import { resolveTenantId } from './tenant.js';
 import { defaultPreCompactLogPath } from './hooks.js';
 import { redactSecrets } from './secret-detect.js';
+import { RejectedValueError } from './rejection.js';
 
 // ---------------------------------------------------------------------------
 // Pattern definitions
@@ -238,13 +239,14 @@ function writeExtractedItems(
   hippoRoot: string,
   tenantId: string,
   extracted: ExtractedItem[],
-): { captured: number; skipped: number; embeds: Promise<unknown>[] } {
-  if (extracted.length === 0) return { captured: 0, skipped: 0, embeds: [] };
+): { captured: number; skipped: number; rejected: number; embeds: Promise<unknown>[] } {
+  if (extracted.length === 0) return { captured: 0, skipped: 0, rejected: 0, embeds: [] };
 
   const existing = loadAllEntries(hippoRoot, tenantId);
   const embeds: Promise<unknown>[] = [];
   let captured = 0;
   let skipped = 0;
+  let rejected = 0;
 
   for (const item of extracted) {
     if (isDuplicate(item.content, existing)) {
@@ -258,7 +260,17 @@ function writeExtractedItems(
       confidence: 'observed',
       tenantId,
     });
-    writeEntry(hippoRoot, entry);
+    // AT1 (plan §3 containment): a refusal is per-VALUE — one rejected
+    // extraction must not abort the rest of this transcript's captures.
+    try {
+      writeEntry(hippoRoot, entry);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        rejected++;
+        continue;
+      }
+      throw err;
+    }
     updateStats(hippoRoot, { remembered: 1 });
     existing.push(entry); // within-batch dedup
     if (isEmbeddingConfigured(hippoRoot)) {
@@ -267,7 +279,7 @@ function writeExtractedItems(
     captured++;
   }
 
-  return { captured, skipped, embeds };
+  return { captured, skipped, rejected, embeds };
 }
 
 // ---------------------------------------------------------------------------
@@ -615,6 +627,7 @@ function cmdCaptureCore(
 
   let captured = 0;
   let skipped = 0;
+  let rejected = 0;
 
   for (const item of extracted) {
     if (isDuplicate(item.content, existing)) {
@@ -646,7 +659,17 @@ function cmdCaptureCore(
         tenantId: useGlobal ? undefined : options.tenantId,
       });
 
-      writeEntry(targetRoot, entry);
+      // AT1 (plan §3 containment): one rejected item must not abort the
+      // rest of this capture's items.
+      try {
+        writeEntry(targetRoot, entry);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          rejected++;
+          continue;
+        }
+        throw err;
+      }
       updateStats(targetRoot, { remembered: 1 });
       existing.push(entry); // within-batch dedup
 
@@ -661,7 +684,9 @@ function cmdCaptureCore(
   const prefix = options.dryRun ? '[dry-run] ' : '';
   const globalPrefix = useGlobal ? '[global] ' : '';
   console.log(
-    `\n${prefix}${globalPrefix}Captured ${captured} items (${skipped} skipped as duplicates)`
+    `\n${prefix}${globalPrefix}Captured ${captured} items (${skipped} skipped as duplicates` +
+      (rejected > 0 ? `, ${rejected} rejected` : '') +
+      ')'
   );
 }
 
@@ -1039,8 +1064,12 @@ function runPreCompact(hippoRoot: string, stdinText: string | undefined, logFile
   // Capture extraction SECOND, own try/catch: a failure here self-heals at
   // the next SessionEnd capture (existing dedup absorbs the overlap).
   try {
-    const { captured, skipped, embeds } = writeExtractedItems(hippoRoot, tenantId, extracted);
-    appendPreCompactLog(logFile, `capture: ${captured} items captured, ${skipped} skipped`);
+    const { captured, skipped, rejected, embeds } = writeExtractedItems(hippoRoot, tenantId, extracted);
+    appendPreCompactLog(
+      logFile,
+      `capture: ${captured} items captured, ${skipped} skipped` +
+        (rejected > 0 ? `, ${rejected} rejected` : ''),
+    );
     return embeds;
   } catch (err) {
     appendPreCompactLog(logFile, `capture failed: ${(err as Error).message}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6410,7 +6410,7 @@ function cmdImport(
     console.log(`  Notes found:           ${vaultResult.total}`);
     console.log(`  ${dryRun ? 'Would import:         ' : 'Imported:             '}${vaultResult.imported}`);
     console.log(`  Skipped (unchanged):   ${vaultResult.skipped}`);
-    if (vaultResult.rejected > 0) {
+    if ((vaultResult.rejected ?? 0) > 0) {
       console.log(`  Rejected (tombstoned): ${vaultResult.rejected}`);
     }
     console.log(`  ${dryRun ? 'Would archive:        ' : 'Archived (removed):   '}${vaultResult.archived ?? 0}`);
@@ -6484,7 +6484,7 @@ function cmdImport(
   console.log(`  Source entries found:  ${result.total}`);
   console.log(`  Imported:              ${result.imported}`);
   console.log(`  Skipped (dedup/noise): ${result.skipped}`);
-  if (result.rejected > 0) {
+  if ((result.rejected ?? 0) > 0) {
     console.log(`  Rejected (tombstoned): ${result.rejected}`);
   }
   if (dryRun) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,9 @@
  *   hippo handoff <create|latest|show>
  *   hippo current <show>
  *   hippo forget <id> [--archive --reason "<why>"]
+ *   hippo reject <id>|--value "<text>" --reason "<why>"
+ *   hippo rejections
+ *   hippo unreject <digest-prefix>
  *   hippo inspect <id>
  *   hippo embed [--status]
  *   hippo watch "<command>"
@@ -93,6 +96,8 @@ import {
   SessionEvent,
   RECALL_DEFAULT_DENY_SCOPES,
 } from './store.js';
+import { rejectValue, unrejectValue, listRejectionsForTenant } from './reject-flow.js';
+import { RejectedValueError } from './rejection.js';
 import type { SessionHandoff } from './handoff.js';
 import { search, markRetrieved, estimateTokens, hybridSearch, physicsSearch, explainMatch, textOverlap, tokenize as tokenizeQuery, type RerankStep } from './search.js';
 import { compareEntryIdentity } from './compare.js';
@@ -890,9 +895,26 @@ function cmdSupersede(
     confidence: 'verified',
   });
 
+  // AT1: write the SUCCESSOR first. The rejection guard fires on the new
+  // content — if it refuses, nothing has been mutated yet (the old ordering
+  // committed old.superseded_by before the guarded new write, leaving a
+  // dangling pointer to an id that was never created). If the old-row write
+  // below fails instead, the new row exists unpointered — an orphan
+  // successor, strictly less harmful than a dangling pointer. NOTE: unlike
+  // api.supersede (whose CAS + insert commit in ONE transaction), this CLI
+  // path is two independent writes and stays non-atomic; write order is its
+  // only ordering guarantee.
+  try {
+    writeEntry(hippoRoot, newEntry);
+  } catch (err) {
+    if (err instanceof RejectedValueError) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
   old.superseded_by = newEntry.id;
   writeEntry(hippoRoot, old);
-  writeEntry(hippoRoot, newEntry);
   emitCliAudit(hippoRoot, 'supersede', oldId, { newId: newEntry.id });
 
   console.log(`Superseded ${oldId} → ${newEntry.id}`);
@@ -2664,6 +2686,11 @@ export function learnFromMemoryMd(hippoRoot: string, homeDir: string = os.homedi
   const existing = loadAllEntries(hippoRoot);
   let imported = 0;
   let skippedSecret = 0;
+  // AT1 (plan §3 containment): a rejection guard refusal is per-VALUE — one
+  // tombstoned memory file must not abort the whole directory scan. No
+  // signature change (bare number return, cli.ts:540 + cli.ts:2903 callers
+  // unchanged) — counted internally and printed as one summary line.
+  let rejected = 0;
 
   for (const memDir of memoryDirs) {
     try {
@@ -2705,7 +2732,15 @@ export function learnFromMemoryMd(hippoRoot: string, homeDir: string = os.homedi
           confidence: 'observed',
         });
 
-        writeEntry(hippoRoot, entry);
+        try {
+          writeEntry(hippoRoot, entry);
+        } catch (err) {
+          if (err instanceof RejectedValueError) {
+            rejected++;
+            continue;
+          }
+          throw err;
+        }
         existing.push(entry); // prevent self-dedup within batch
         imported++;
       }
@@ -2714,6 +2749,9 @@ export function learnFromMemoryMd(hippoRoot: string, homeDir: string = os.homedi
 
   if (skippedSecret > 0) {
     console.log(`Skipped ${skippedSecret} secret-bearing memory file${skippedSecret === 1 ? '' : 's'} (not ingested).`);
+  }
+  if (rejected > 0) {
+    console.log(`Skipped ${rejected} rejected value${rejected === 1 ? '' : 's'} (run \`hippo unreject\` to allow).`);
   }
 
   return imported;
@@ -3697,20 +3735,155 @@ function cmdResolve(
       console.log(`      ${entryB.content.slice(0, 120)}${entryB.content.length > 120 ? '...' : ''}`);
     }
     console.log('');
-    console.log(`Resolve with: hippo resolve ${conflictId} --keep <memory_id> [--forget]`);
+    console.log(`Resolve with: hippo resolve ${conflictId} --keep <memory_id> [--forget] [--reject-loser [--reason "<why>"]]`);
     return;
   }
 
   const forgetLoser = Boolean(flags['forget']);
-  const result = resolveConflict(hippoRoot, conflictId, keepId, forgetLoser, tenantId);
+  // AT1: --reject-loser tombstones the loser's normalized digest so it
+  // cannot be re-asserted later, in addition to removing it (kind-aware).
+  // --reason defaults to a conflict-context string when omitted (resolve
+  // already has the conflict id + keepId; unlike `hippo reject`, a reason
+  // is not strictly required here).
+  const rejectLoser = Boolean(flags['reject-loser']);
+  const reasonFlag = typeof flags['reason'] === 'string' ? (flags['reason'] as string) : undefined;
+  const result = resolveConflict(hippoRoot, conflictId, keepId, forgetLoser, tenantId, {
+    rejectLoserValue: rejectLoser,
+    reason: reasonFlag,
+  });
 
   if (!result) {
     console.error(`Could not resolve conflict ${conflictId}. Check the ID and --keep value.`);
     process.exit(1);
   }
 
-  const action = forgetLoser ? 'deleted' : 'weakened (half-life halved)';
+  const action = rejectLoser
+    ? 'rejected (tombstoned) and removed'
+    : forgetLoser
+      ? 'deleted'
+      : 'weakened (half-life halved)';
   console.log(`Resolved conflict ${conflictId}: kept ${keepId}, ${action} ${result.loserId}`);
+}
+
+// ---------------------------------------------------------------------------
+// AT1: reject / rejections / unreject
+// docs/plans/2026-08-15-at1-rejected-value-tombstone.md §4
+// ---------------------------------------------------------------------------
+
+function cmdReject(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>,
+): void {
+  // Store resolution mirrors `hippo remember`: --global writes to the
+  // global store, otherwise the local store (requireInit'd via resolveAuthRoot).
+  const root = resolveAuthRoot(hippoRoot, flags);
+  const tenantId = resolveTenantId({});
+
+  // --reason is REQUIRED (plan §4, grill issue 4): the tombstone stores no
+  // content, so reason is its only human-readable identity.
+  const reason = typeof flags['reason'] === 'string' ? (flags['reason'] as string).trim() : '';
+  if (!reason) {
+    console.error('hippo reject requires --reason "<why>" (the tombstone stores no content; reason is its only identity).');
+    process.exit(1);
+  }
+
+  const valueFlag = typeof flags['value'] === 'string' ? (flags['value'] as string) : undefined;
+  const memoryId = args[0];
+
+  if (!memoryId && valueFlag === undefined) {
+    console.error('Usage: hippo reject <memory-id> --reason "<why>"');
+    console.error('   or: hippo reject --value "<text>" --reason "<why>"');
+    process.exit(1);
+  }
+  if (memoryId && valueFlag !== undefined) {
+    // Ambiguous ask: silently preferring one form would ignore the other
+    // without feedback (code-review round-1 low).
+    console.error('hippo reject takes EITHER a memory id OR --value, not both.');
+    process.exit(1);
+  }
+
+  try {
+    const result = rejectValue({
+      hippoRoot: root,
+      tenantId,
+      actor: 'cli',
+      reason,
+      memoryId: valueFlag === undefined ? memoryId : undefined,
+      value: valueFlag,
+    });
+    const digestPrefix = result.digest.slice(0, 12);
+    const preview = result.content.length > 80 ? `${result.content.slice(0, 80)}...` : result.content;
+    console.log(`Rejected [${digestPrefix}...]: "${preview}"`);
+    console.log(`  Reason: ${reason}`);
+    if (result.removedIds.length > 0) {
+      console.log(`  Removed ${result.removedIds.length} matching row(s): ${result.removedIds.join(', ')}`);
+    } else {
+      console.log('  No live rows matched (pre-emptive tombstone).');
+    }
+  } catch (err) {
+    console.error(`Could not reject: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+function cmdRejections(
+  hippoRoot: string,
+  flags: Record<string, string | boolean | string[]>,
+): void {
+  const root = resolveAuthRoot(hippoRoot, flags);
+  const tenantId = resolveTenantId({});
+  const rows = listRejectionsForTenant(root, tenantId);
+
+  if (flags['json']) {
+    console.log(JSON.stringify({ rejections: rows }, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log('No rejected values.');
+    return;
+  }
+
+  console.log(`${rows.length} rejected value(s):\n`);
+  for (const row of rows) {
+    console.log(`--- ${row.digest.slice(0, 12)}...`);
+    console.log(`    Reason:       ${row.reason ?? 'none given'}`);
+    console.log(`    Rejected by:  ${row.rejectedBy ?? 'unknown'}`);
+    console.log(`    Rejected at:  ${row.rejectedAt}`);
+    if (row.sourceMemoryId) console.log(`    Source id:    ${row.sourceMemoryId}`);
+    if (row.normalizedChars !== null) console.log(`    Chars:        ${row.normalizedChars}`);
+    console.log('');
+  }
+}
+
+function cmdUnreject(
+  hippoRoot: string,
+  args: string[],
+  flags: Record<string, string | boolean | string[]>,
+): void {
+  const root = resolveAuthRoot(hippoRoot, flags);
+  const tenantId = resolveTenantId({});
+  const digestOrPrefix = (args[0] ?? '').trim();
+  if (!digestOrPrefix) {
+    console.error('Usage: hippo unreject <digest-or-prefix>');
+    process.exit(1);
+  }
+
+  const outcome = unrejectValue(root, tenantId, digestOrPrefix, 'cli');
+  if (outcome.status === 'not_found') {
+    console.error(`No rejected value matches "${digestOrPrefix}". Run \`hippo rejections\` to list tombstones.`);
+    process.exit(1);
+  }
+  if (outcome.status === 'ambiguous') {
+    console.error(`"${digestOrPrefix}" matches ${outcome.candidates.length} tombstones. Use a longer prefix:`);
+    for (const c of outcome.candidates) {
+      console.error(`  ${c.digest.slice(0, 16)}...  ${c.reason ?? 'none given'}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Unrejected [${outcome.digest.slice(0, 12)}...] (was: ${outcome.reason ?? 'none given'})`);
 }
 
 function cmdSnapshot(
@@ -6000,15 +6173,27 @@ async function cmdWatch(command: string, hippoRoot: string): Promise<void> {
   entry.schema_fit = watchFit;
   entry.half_life_days = deriveHalfLife(7, entry);
   entry.strength = calculateStrength(entry);
-  writeEntry(hippoRoot, entry);
-  updateStats(hippoRoot, { remembered: 1 });
+  // AT1 (plan §3 containment): mechanical content from a failed command — a
+  // rejection-guard refusal here must not crash the watcher. Skip silently
+  // (loud enough via the message below) and still exit with the wrapped
+  // command's real exit code.
+  try {
+    writeEntry(hippoRoot, entry);
+    updateStats(hippoRoot, { remembered: 1 });
 
-  if (isEmbeddingConfigured(hippoRoot)) {
-    embedMemory(hippoRoot, entry).catch(() => {});
+    if (isEmbeddingConfigured(hippoRoot)) {
+      embedMemory(hippoRoot, entry).catch(() => {});
+    }
+
+    const preview = stderr.trim().slice(0, 80);
+    console.error(`\nHippo learned from failure: "${preview}"`);
+  } catch (err) {
+    if (err instanceof RejectedValueError) {
+      console.error(`\nHippo: this failure matches a rejected value (${err.reason ?? 'no reason given'}); not stored.`);
+    } else {
+      throw err;
+    }
   }
-
-  const preview = stderr.trim().slice(0, 80);
-  console.error(`\nHippo learned from failure: "${preview}"`);
 
   process.exit(exitCode);
 }
@@ -6044,6 +6229,11 @@ function learnFromRepo(
 
   let added = 0;
   let skipped = 0;
+  // AT1 (plan §3 containment): per-lesson refusal must not abort the rest
+  // of the git-log scan. No signature change (added/skipped return shape
+  // used by cmdLearn + cmdSleepCore callers) — counted locally, folded into
+  // the existing summary line.
+  let rejected = 0;
   const gitLearnTags = ['error', 'git-learned'];
   const existingForSchema = loadAllEntries(hippoRoot);
 
@@ -6083,7 +6273,15 @@ function learnFromRepo(
       if (!entry.tags.includes(pt)) entry.tags.push(pt);
     }
 
-    writeEntry(hippoRoot, entry);
+    try {
+      writeEntry(hippoRoot, entry);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        rejected++;
+        continue;
+      }
+      throw err;
+    }
     updateStats(hippoRoot, { remembered: 1 });
 
     if (isEmbeddingConfigured(hippoRoot)) {
@@ -6093,7 +6291,11 @@ function learnFromRepo(
     added++;
   }
 
-  console.log(`${prefix}${added} new lessons added, ${skipped} duplicates skipped.`);
+  console.log(
+    `${prefix}${added} new lessons added, ${skipped} duplicates skipped` +
+      (rejected > 0 ? `, ${rejected} rejected value(s) skipped` : '') +
+      '.',
+  );
   return { added, skipped };
 }
 
@@ -6208,6 +6410,9 @@ function cmdImport(
     console.log(`  Notes found:           ${vaultResult.total}`);
     console.log(`  ${dryRun ? 'Would import:         ' : 'Imported:             '}${vaultResult.imported}`);
     console.log(`  Skipped (unchanged):   ${vaultResult.skipped}`);
+    if (vaultResult.rejected > 0) {
+      console.log(`  Rejected (tombstoned): ${vaultResult.rejected}`);
+    }
     console.log(`  ${dryRun ? 'Would archive:        ' : 'Archived (removed):   '}${vaultResult.archived ?? 0}`);
     console.log(`  Store:                 ${hippoRoot}`);
     // Batch producer, same contract as the single-file import below: vault rows
@@ -6279,6 +6484,9 @@ function cmdImport(
   console.log(`  Source entries found:  ${result.total}`);
   console.log(`  Imported:              ${result.imported}`);
   console.log(`  Skipped (dedup/noise): ${result.skipped}`);
+  if (result.rejected > 0) {
+    console.log(`  Rejected (tombstoned): ${result.rejected}`);
+  }
   if (dryRun) {
     console.log('\n  (dry run - nothing written)');
     if (result.entries.length > 0) {
@@ -7302,6 +7510,10 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'customer_note_supersede', // E2 — emitted by saveCustomerNote on a supersession
   'customer_note_close',   // E2 — emitted by closeCustomerNote
   'mv_rescue',             // LC2-E3 — emitted by consolidate() per rescue; lockstep with AuditOp union + server.ts VALID_AUDIT_OPS
+  'reject_value',          // AT1 — emitted by `hippo reject`; lockstep with AuditOp union + server.ts VALID_AUDIT_OPS
+  'reject_refusal',        // AT1 — emitted when the rejection guard refuses a write; lockstep
+  'unreject_value',        // AT1 — emitted by `hippo unreject`; lockstep
+  'conflict_resolve',      // AT1 — emitted by resolveConflict on every resolution path; lockstep
 ]);
 
 function formatAuditRow(ev: AuditEvent): string {
@@ -8070,6 +8282,18 @@ Commands:
   resolve <conflict_id>    Resolve a memory conflict
     --keep <memory_id>     Memory to keep (required)
     --forget               Delete the losing memory (default: halve half-life)
+    --reject-loser         Tombstone the loser's value too (implies removal)
+    --reason "<why>"       Reason for --reject-loser (default: conflict context)
+  reject <memory-id>       Tombstone a value so it refuses re-ingestion
+    reject --value "<t>"   Pre-emptive form: tombstone a value not (currently) stored
+    --reason "<why>"       Required. The tombstone stores no content — this
+                           is its only human-readable identity.
+    --global               Reject in the global store
+  rejections               List rejected-value tombstones for the active tenant
+    --json                 Output as JSON
+    --global               Operate on the global store
+  unreject <digest-prefix> Delete a tombstone (the only escape hatch)
+    --global               Operate on the global store
   snapshot <sub>           Persist or inspect the current active task
     snapshot save          Save active task state
       --task <task>
@@ -8324,6 +8548,10 @@ Examples:
   hippo recall "data pipeline issues" --budget 2000
   hippo context --auto --budget 1500
   hippo conflicts
+  hippo reject mem_abc123 --reason "leaked credential"
+  hippo reject --value "never store my key again" --reason "secret"
+  hippo rejections
+  hippo unreject a1b2c3d4e5f6
   hippo session log --id sess_123 --task "Ship feature" --type progress --content "Build is green, next step is docs"
   hippo session latest --json
   hippo session resume
@@ -8704,6 +8932,18 @@ async function main(): Promise<void> {
 
     case 'resolve':
       cmdResolve(hippoRoot, args, flags);
+      break;
+
+    case 'reject':
+      cmdReject(hippoRoot, args, flags);
+      break;
+
+    case 'rejections':
+      cmdRejections(hippoRoot, flags);
+      break;
+
+    case 'unreject':
+      cmdUnreject(hippoRoot, args, flags);
       break;
 
     case 'snapshot':

--- a/src/connectors/github/ingest.ts
+++ b/src/connectors/github/ingest.ts
@@ -23,6 +23,7 @@
 
 import { remember, type Context, type RememberOpts } from '../../api.js';
 import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from '../../db.js';
+import { RejectedValueError } from '../../rejection.js';
 import { hasSeenKey, lookupMemoryByKey, DuplicateIdempotencyError } from './idempotency.js';
 import { computeIdempotencyKey } from './signature.js';
 import {
@@ -200,6 +201,23 @@ export function ingestEvent(ctx: Context, input: IngestInput): IngestResult {
       } finally {
         closeHippoDb(db3);
       }
+    }
+    if (e instanceof RejectedValueError) {
+      // AT1 (plan §3 containment): a tombstone hit is a PERMANENT skip, not
+      // a transient failure — never DLQ-retry it. Mark the idempotency key
+      // seen exactly like the empty-body branch above so a GitHub retry of
+      // the same delivery acks as done, not error.
+      const db4 = openHippoDb(ctx.hippoRoot);
+      try {
+        db4
+          .prepare(
+            `INSERT OR IGNORE INTO github_event_log (idempotency_key, delivery_id, event_name, ingested_at, memory_id) VALUES (?, ?, ?, ?, ?)`,
+          )
+          .run(idempotencyKey, input.deliveryId, input.event.eventName, new Date().toISOString(), null);
+      } finally {
+        closeHippoDb(db4);
+      }
+      return { status: 'skipped', memoryId: null };
     }
     throw e;
   }

--- a/src/connectors/slack/ingest.ts
+++ b/src/connectors/slack/ingest.ts
@@ -1,5 +1,6 @@
 import { remember, type Context } from '../../api.js';
 import { openHippoDb, closeHippoDb } from '../../db.js';
+import { RejectedValueError } from '../../rejection.js';
 import {
   hasSeenEvent,
   markEventSeen,
@@ -113,6 +114,19 @@ export function ingestMessage(ctx: Context, input: IngestInput): IngestResult {
       } finally {
         closeHippoDb(db3);
       }
+    }
+    if (e instanceof RejectedValueError) {
+      // AT1 (plan §3 containment): a tombstone hit is a PERMANENT skip, not
+      // a transient failure — never DLQ-retry it (retrying would just hit
+      // the same refusal forever). Mark the event seen exactly like the
+      // empty-body branch above so a Slack retry acks as done, not error.
+      const db4 = openHippoDb(ctx.hippoRoot);
+      try {
+        markEventSeen(db4, input.eventId, null);
+      } finally {
+        closeHippoDb(db4);
+      }
+      return { status: 'skipped', memoryId: null };
     }
     throw e;
   }

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -290,6 +290,18 @@ export async function consolidate(
     }
   }
 
+  // AT1 rejection-guard db handle (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
+  // opened ONCE for the whole non-dry-run consolidate, covering BOTH the
+  // auto-promote pass (1.4, immediately below) and the merge pass (3,
+  // further down) — both build deterministic content that batchWriteAndDelete
+  // writes through the guard's bypass, so both need a producer-side
+  // tombstone check before pushing to pendingWrites. A single handle here
+  // replaces what used to be a per-pass open. Dry-run never reaches the
+  // bypass (no batchWriteAndDelete call), so there is nothing for a handle
+  // to protect against — stays null and every `if (consolidateDb)` below is
+  // a no-op.
+  const consolidateDb = dryRun ? null : openHippoDb(hippoRoot);
+
   // -------------------------------------------------------------------------
   // 1.4. Auto-promote complete sessions to traces
   // -------------------------------------------------------------------------
@@ -299,6 +311,7 @@ export async function consolidate(
   // render the action sequence as markdown and persist a Layer.Trace memory.
   // Traces inherit decay, search, replay, and physics from the base MemoryEntry.
   if (!dryRun && config.autoTraceCapture !== false) {
+    let tracesSkippedRejected = 0;
     const windowDays = config.autoTraceWindowDays ?? 7;
     const sinceMs = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
     // Auto-trace currently runs in a single-tenant context (the env-resolved
@@ -344,6 +357,38 @@ export async function consolidate(
           source: 'auto-promote',
         },
       );
+
+      // AT1 (same producer-side pattern as the merge pass below): traceExistsForSession
+      // only sees rows CURRENTLY in the store — once a rejected trace is
+      // removed, that idempotency check no longer blocks regeneration, and
+      // this write would otherwise reach batchWriteAndDelete's guard bypass
+      // unchecked, resurrecting it every sleep. Check under THE ENTRY'S OWN
+      // stamped tenantId (read off `trace` after createMemory — never guess
+      // the tenant) + the built content's digest. A hit skips the push
+      // entirely: not counted as promoted, not added to survivors.
+      if (consolidateDb) {
+        const traceDigest = rejectionDigest(trace.content);
+        const tombstone = findRejectedValue(consolidateDb, trace.tenantId, traceDigest);
+        if (tombstone) {
+          tracesSkippedRejected++;
+          try {
+            appendAuditEvent(consolidateDb, {
+              tenantId: trace.tenantId,
+              actor: 'sleep',
+              op: 'reject_refusal',
+              metadata: {
+                digest: traceDigest,
+                reason: tombstone.reason,
+                sourceSessionId: session.session_id,
+              },
+            });
+          } catch {
+            // Best-effort — mirrors store.ts's audit() semantics.
+          }
+          continue;
+        }
+      }
+
       pendingWrites.push(trace);
       survivors.push(trace);
       result.promotedTraces++;
@@ -355,6 +400,11 @@ export async function consolidate(
     if (result.promotedTraces > 0) {
       result.details.push(
         `  🧬 promoted ${result.promotedTraces} trace${result.promotedTraces === 1 ? '' : 's'} from completed session${result.promotedTraces === 1 ? '' : 's'}`
+      );
+    }
+    if (tracesSkippedRejected > 0) {
+      console.error(
+        `consolidate: skipped ${tracesSkippedRejected} auto-promoted trace(s) whose content matches a rejected value`,
       );
     }
   }
@@ -591,11 +641,11 @@ export async function consolidate(
   const used = new Set<string>();
 
   // AT1 consolidation-loop fix (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
-  // one handle for the whole merge pass' tombstone point-queries + best-effort
-  // reject_refusal audits, opened once rather than per-cluster. Only needed
-  // for real writes — a dry-run preview never reaches batchWriteAndDelete's
-  // guard bypass, so there is nothing here for it to protect against.
-  const mergeDb = dryRun ? null : openHippoDb(hippoRoot);
+  // reuses the single consolidateDb handle opened once above (before the
+  // auto-promote pass, 1.4) for the whole non-dry-run consolidate — see that
+  // declaration's comment. Only needed for real writes — a dry-run preview
+  // never reaches batchWriteAndDelete's guard bypass, so there is nothing
+  // here for it to protect against.
   let mergesSkippedRejected = 0;
   try {
     for (let i = 0; i < mergeCandidates.length; i++) {
@@ -615,21 +665,46 @@ export async function consolidate(
 
       // Create a semantic summary
       const mergedContent = mergeContents(cluster);
+      const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));
+      const maxValence = pickStrongestValence(cluster);
 
-      // AT1: check the merge's content digest against the CLUSTER's tenant
-      // tombstones BEFORE committing to this merge (used.add / result.merged
-      // / the write). mergeContents is DETERMINISTIC CONCATENATION (not an
-      // LLM paraphrase) — if a human rejected exactly this byte-identical
-      // rollup before, an unguarded sleep would regenerate it every cycle
-      // and batchWriteAndDelete's guard bypass (store.ts) would silently
+      // AT1 P2 fix: build the semantic entry FIRST — createMemory is cheap
+      // and pure — so the tombstone check below runs under the tenant the
+      // row will ACTUALLY land in. The prior version checked
+      // cluster[0].tenantId, but createMemory (below) is never passed a
+      // tenantId option, so it always stamps its own default ('default',
+      // see memory.ts) regardless of the cluster's source tenant — the
+      // check was consulting a tenant's tombstones that the write was never
+      // going to land in (a false negative on the real destination, and a
+      // possible false-block on the source tenant's unrelated tombstones).
+      // This fix only makes the CHECK match wherever the row actually
+      // lands; it deliberately does NOT change that destination — merge
+      // rows always landing in 'default' regardless of source tenant is a
+      // real, pre-existing cross-tenant question, tracked separately as an
+      // AT1 follow-up (not this fix's scope) rather than folded in here.
+      let semantic: MemoryEntry | null = null;
+      if (!dryRun) {
+        semantic = createMemory(mergedContent, {
+          layer: Layer.Semantic,
+          tags: allTags,
+          emotional_valence: maxValence,
+          schema_fit: 0.7,
+          source: 'consolidation',
+          confidence: 'inferred',
+        });
+      }
+
+      // mergeContents is DETERMINISTIC CONCATENATION (not an LLM paraphrase)
+      // — if a human rejected exactly this byte-identical rollup before, an
+      // unguarded sleep would regenerate it every cycle and
+      // batchWriteAndDelete's guard bypass (store.ts) would silently
       // re-assert it forever. This producer-side check is what makes that
       // bypass safe. A hit skips the WHOLE cluster: sources stay unmerged —
       // not demoted, not deleted — so a later sleep gets another chance if
       // the tombstone is lifted.
-      if (mergeDb) {
-        const clusterTenantId = cluster[0]?.tenantId ?? 'default';
-        const mergeDigest = rejectionDigest(mergedContent);
-        const tombstone = findRejectedValue(mergeDb, clusterTenantId, mergeDigest);
+      if (consolidateDb && semantic) {
+        const mergeDigest = rejectionDigest(semantic.content);
+        const tombstone = findRejectedValue(consolidateDb, semantic.tenantId, mergeDigest);
         if (tombstone) {
           // Still mark used — these members are not re-tried against a
           // DIFFERENT cluster within this same pass; next sleep re-clusters
@@ -637,8 +712,8 @@ export async function consolidate(
           for (const e of cluster) used.add(e.id);
           mergesSkippedRejected++;
           try {
-            appendAuditEvent(mergeDb, {
-              tenantId: clusterTenantId,
+            appendAuditEvent(consolidateDb, {
+              tenantId: semantic.tenantId,
               actor: 'sleep',
               op: 'reject_refusal',
               metadata: {
@@ -658,22 +733,11 @@ export async function consolidate(
       for (const e of cluster) used.add(e.id);
       result.merged += cluster.length;
 
-      const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));
-      const maxValence = pickStrongestValence(cluster);
-
       result.details.push(
         `  🔀 merged ${cluster.length} episodic entries into semantic: "${mergedContent.slice(0, 60)}..."`
       );
 
-      if (!dryRun) {
-        const semantic = createMemory(mergedContent, {
-          layer: Layer.Semantic,
-          tags: allTags,
-          emotional_valence: maxValence,
-          schema_fit: 0.7,
-          source: 'consolidation',
-          confidence: 'inferred',
-        });
+      if (!dryRun && semantic) {
         pendingWrites.push(semantic);
         result.semanticCreated++;
 
@@ -696,7 +760,7 @@ export async function consolidate(
       }
     }
   } finally {
-    if (mergeDb) closeHippoDb(mergeDb);
+    if (consolidateDb) closeHippoDb(consolidateDb);
   }
 
   if (mergesSkippedRejected > 0) {

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -300,7 +300,28 @@ export async function consolidate(
   // bypass (no batchWriteAndDelete call), so there is nothing for a handle
   // to protect against — stays null and every `if (consolidateDb)` below is
   // a no-op.
+  //
+  // AT1 P2 fix (codex, handle-leak restructure): the open must be followed
+  // IMMEDIATELY by the try whose finally closes it, covering every phase
+  // that can touch consolidateDb — not just the merge pass. Previously the
+  // try/finally wrapped only section 3 (merge pass); an exception thrown by
+  // auto-promote (1.4), replay (1.5), batch extraction (1.6), the DAG
+  // passes (1.7-1.9), or physics (2) would propagate past the open handle
+  // with nothing to close it. No behavior change on the happy path — each
+  // of those phases already best-effort catches its own exceptions today
+  // (physics has its own try/catch below; each DAG pass wraps its own
+  // dynamic import + call in try/catch) — this only closes the handle on
+  // the rare path where one of them throws past its own catch. Deliberately
+  // NOT re-indented (mechanical wrap only, kept surgical): every statement
+  // between this try and its finally (below, at the end of the merge pass)
+  // stays at its original indentation.
   const consolidateDb = dryRun ? null : openHippoDb(hippoRoot);
+  // Declared here (not at the merge pass, its point of use) so it survives
+  // this try/finally — a `let` declared INSIDE the try would go out of
+  // scope before the `if (mergesSkippedRejected > 0)` check that reads it
+  // after the finally closes the handle.
+  let mergesSkippedRejected = 0;
+  try {
 
   // -------------------------------------------------------------------------
   // 1.4. Auto-promote complete sessions to traces
@@ -645,9 +666,10 @@ export async function consolidate(
   // auto-promote pass, 1.4) for the whole non-dry-run consolidate — see that
   // declaration's comment. Only needed for real writes — a dry-run preview
   // never reaches batchWriteAndDelete's guard bypass, so there is nothing
-  // here for it to protect against.
-  let mergesSkippedRejected = 0;
-  try {
+  // here for it to protect against. (mergesSkippedRejected itself is
+  // declared up at the try's opening above 1.4, not here — it has to
+  // survive the try/finally that now wraps this whole section; see the
+  // handle-leak restructure comment there.)
     for (let i = 0; i < mergeCandidates.length; i++) {
       if (used.has(mergeCandidates[i].id)) continue;
 

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -25,6 +25,7 @@ import {
 import { textOverlap, markRetrieved } from './search.js';
 import { compareEntryIdentity } from './compare.js';
 import { openHippoDb, closeHippoDb } from './db.js';
+import { rejectionDigest, findRejectedValue } from './rejection.js';
 import { loadPhysicsState, savePhysicsState, refreshParticleProperties } from './physics-state.js';
 import { simulate, type ForceContext } from './physics.js';
 import { loadConfig } from './config.js';
@@ -589,63 +590,119 @@ export async function consolidate(
   );
   const used = new Set<string>();
 
-  for (let i = 0; i < mergeCandidates.length; i++) {
-    if (used.has(mergeCandidates[i].id)) continue;
+  // AT1 consolidation-loop fix (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
+  // one handle for the whole merge pass' tombstone point-queries + best-effort
+  // reject_refusal audits, opened once rather than per-cluster. Only needed
+  // for real writes — a dry-run preview never reaches batchWriteAndDelete's
+  // guard bypass, so there is nothing here for it to protect against.
+  const mergeDb = dryRun ? null : openHippoDb(hippoRoot);
+  let mergesSkippedRejected = 0;
+  try {
+    for (let i = 0; i < mergeCandidates.length; i++) {
+      if (used.has(mergeCandidates[i].id)) continue;
 
-    const cluster: MemoryEntry[] = [mergeCandidates[i]];
+      const cluster: MemoryEntry[] = [mergeCandidates[i]];
 
-    for (let j = i + 1; j < mergeCandidates.length; j++) {
-      if (used.has(mergeCandidates[j].id)) continue;
-      const overlap = textOverlap(mergeCandidates[i].content, mergeCandidates[j].content);
-      if (overlap >= MERGE_OVERLAP_THRESHOLD) {
-        cluster.push(mergeCandidates[j]);
+      for (let j = i + 1; j < mergeCandidates.length; j++) {
+        if (used.has(mergeCandidates[j].id)) continue;
+        const overlap = textOverlap(mergeCandidates[i].content, mergeCandidates[j].content);
+        if (overlap >= MERGE_OVERLAP_THRESHOLD) {
+          cluster.push(mergeCandidates[j]);
+        }
+      }
+
+      if (cluster.length < MERGE_MIN_CLUSTER) continue;
+
+      // Create a semantic summary
+      const mergedContent = mergeContents(cluster);
+
+      // AT1: check the merge's content digest against the CLUSTER's tenant
+      // tombstones BEFORE committing to this merge (used.add / result.merged
+      // / the write). mergeContents is DETERMINISTIC CONCATENATION (not an
+      // LLM paraphrase) — if a human rejected exactly this byte-identical
+      // rollup before, an unguarded sleep would regenerate it every cycle
+      // and batchWriteAndDelete's guard bypass (store.ts) would silently
+      // re-assert it forever. This producer-side check is what makes that
+      // bypass safe. A hit skips the WHOLE cluster: sources stay unmerged —
+      // not demoted, not deleted — so a later sleep gets another chance if
+      // the tombstone is lifted.
+      if (mergeDb) {
+        const clusterTenantId = cluster[0]?.tenantId ?? 'default';
+        const mergeDigest = rejectionDigest(mergedContent);
+        const tombstone = findRejectedValue(mergeDb, clusterTenantId, mergeDigest);
+        if (tombstone) {
+          // Still mark used — these members are not re-tried against a
+          // DIFFERENT cluster within this same pass; next sleep re-clusters
+          // them fresh.
+          for (const e of cluster) used.add(e.id);
+          mergesSkippedRejected++;
+          try {
+            appendAuditEvent(mergeDb, {
+              tenantId: clusterTenantId,
+              actor: 'sleep',
+              op: 'reject_refusal',
+              metadata: {
+                digest: mergeDigest,
+                reason: tombstone.reason,
+                sourceIds: cluster.map((e) => e.id),
+              },
+            });
+          } catch {
+            // Best-effort — mirrors store.ts's audit() semantics.
+          }
+          continue;
+        }
+      }
+
+      // Mark cluster members as used
+      for (const e of cluster) used.add(e.id);
+      result.merged += cluster.length;
+
+      const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));
+      const maxValence = pickStrongestValence(cluster);
+
+      result.details.push(
+        `  🔀 merged ${cluster.length} episodic entries into semantic: "${mergedContent.slice(0, 60)}..."`
+      );
+
+      if (!dryRun) {
+        const semantic = createMemory(mergedContent, {
+          layer: Layer.Semantic,
+          tags: allTags,
+          emotional_valence: maxValence,
+          schema_fit: 0.7,
+          source: 'consolidation',
+          confidence: 'inferred',
+        });
+        pendingWrites.push(semantic);
+        result.semanticCreated++;
+
+        // Demote source episodics (they've been compressed into neocortex):
+        // scale half_life_days so they decay sooner while staying recoverable.
+        // Immediate ranking is deliberately unchanged: the 2026-06-10 DAG
+        // slice-1 eval measured that dropping children below a worse-retrieving
+        // summary regresses budget-bounded QA (docs/evals/). The stored
+        // strength is refreshed to the live value so inspect, replay sampling,
+        // and strength-sorted assembly see the truth instead of a fake 0.3.
+        // Mutate in place (not a copy): `cluster` holds the same object
+        // references as `survivors`, and the later detectConflicts(survivors)
+        // pass in this same run must see the post-demotion half-life, or it
+        // can persist conflicts for entries the just-written state excludes.
+        for (const e of cluster) {
+          e.half_life_days = Math.max(1, Math.floor(e.half_life_days * MERGE_SOURCE_HALF_LIFE_FACTOR));
+          e.strength = calculateStrength(e, now, decayOpts);
+          pendingWrites.push(e);
+        }
       }
     }
+  } finally {
+    if (mergeDb) closeHippoDb(mergeDb);
+  }
 
-    if (cluster.length < MERGE_MIN_CLUSTER) continue;
-
-    // Mark cluster members as used
-    for (const e of cluster) used.add(e.id);
-    result.merged += cluster.length;
-
-    // Create a semantic summary
-    const mergedContent = mergeContents(cluster);
-    const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));
-    const maxValence = pickStrongestValence(cluster);
-
-    result.details.push(
-      `  🔀 merged ${cluster.length} episodic entries into semantic: "${mergedContent.slice(0, 60)}..."`
+  if (mergesSkippedRejected > 0) {
+    console.error(
+      `consolidate: skipped ${mergesSkippedRejected} merge(s) whose content matches a rejected value`,
     );
-
-    if (!dryRun) {
-      const semantic = createMemory(mergedContent, {
-        layer: Layer.Semantic,
-        tags: allTags,
-        emotional_valence: maxValence,
-        schema_fit: 0.7,
-        source: 'consolidation',
-        confidence: 'inferred',
-      });
-      pendingWrites.push(semantic);
-      result.semanticCreated++;
-
-      // Demote source episodics (they've been compressed into neocortex):
-      // scale half_life_days so they decay sooner while staying recoverable.
-      // Immediate ranking is deliberately unchanged: the 2026-06-10 DAG
-      // slice-1 eval measured that dropping children below a worse-retrieving
-      // summary regresses budget-bounded QA (docs/evals/). The stored
-      // strength is refreshed to the live value so inspect, replay sampling,
-      // and strength-sorted assembly see the truth instead of a fake 0.3.
-      // Mutate in place (not a copy): `cluster` holds the same object
-      // references as `survivors`, and the later detectConflicts(survivors)
-      // pass in this same run must see the post-demotion half-life, or it
-      // can persist conflicts for entries the just-written state excludes.
-      for (const e of cluster) {
-        e.half_life_days = Math.max(1, Math.floor(e.half_life_days * MERGE_SOURCE_HALF_LIFE_FACTOR));
-        e.strength = calculateStrength(e, now, decayOpts);
-        pendingWrites.push(e);
-      }
-    }
   }
 
   // Flush all writes/deletes in a single transaction

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -6,6 +6,7 @@ import {
   applyRebuildResult,
   clearSummaryDirtyAfterBuild,
 } from './store.js';
+import { RejectedValueError } from './rejection.js';
 
 export interface FactCluster {
   label: string;
@@ -114,6 +115,12 @@ export interface DagBuildResult {
   candidateClusters: number;
   summariesCreated: number;
   factsLinked: number;
+  /** AT1: clusters skipped because the LLM-synthesized summary landed on a
+   *  rejected value (plan §3 containment — per-cluster catch, not a whole-
+   *  phase abort). Member re-parenting writes are unaffected by construction
+   *  (same id + same content = guard-exempt), so this only ever counts
+   *  summary-creation refusals. */
+  rejected: number;
 }
 
 export async function buildDag(
@@ -121,7 +128,7 @@ export async function buildDag(
   facts: MemoryEntry[],
   opts: DagSummaryOptions,
 ): Promise<DagBuildResult> {
-  const result: DagBuildResult = { candidateClusters: 0, summariesCreated: 0, factsLinked: 0 };
+  const result: DagBuildResult = { candidateClusters: 0, summariesCreated: 0, factsLinked: 0, rejected: 0 };
 
   const unparented = facts.filter(
     (f) => f.dag_level === 1 && !f.dag_parent_id && f.tags.includes('extracted'),
@@ -152,7 +159,20 @@ export async function buildDag(
     summaryEntry.descendant_count = cluster.members.length;
     summaryEntry.earliest_at = memberCreatedAts[0];
     summaryEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
-    writeEntry(hippoRoot, summaryEntry);
+    // AT1 (plan §3 containment): a refused LLM-synthesized summary skips
+    // ONLY this cluster — the sleep cycle continues to the next one. The
+    // member re-parenting writes below never run for a skipped cluster
+    // (there is no summary id to parent them under).
+    try {
+      writeEntry(hippoRoot, summaryEntry);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        result.rejected++;
+        console.error(`[buildDag] cluster "${cluster.label}" skipped: summary matches a rejected value`);
+        continue;
+      }
+      throw err;
+    }
     result.summariesCreated++;
 
     for (const member of cluster.members) {
@@ -302,6 +322,10 @@ export interface EntityProfilesBuildResult {
   // independent-review MED #3 fold: surface failure counter so operators
   // see LLM null / rate-limit / 401 signal (parity with DagRebuildResult.failed).
   failed: number;
+  /** AT1: clusters skipped because the profile summary landed on a rejected
+   *  value (plan §3 containment). Kept distinct from `failed` (LLM null /
+   *  rate-limit) — a tombstone hit is a deliberate refusal, not an error. */
+  rejected: number;
 }
 
 /**
@@ -325,6 +349,7 @@ export async function buildEntityProfiles(
     profilesCreated: 0,
     l2sLinked: 0,
     failed: 0,
+    rejected: 0,
   };
 
   // Only L2 with no L3 parent yet (avoid re-clustering already-profiled L2s).
@@ -375,7 +400,19 @@ export async function buildEntityProfiles(
       profileEntry.earliest_at = memberCreatedAts[0];
       profileEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
       profileEntry.dag_level_3_built_at = nowIso;
-      writeEntry(hippoRoot, profileEntry);
+      // AT1 (plan §3 containment): per-cluster catch — skip this cluster,
+      // count, log once. The member re-linking writes below never run for a
+      // skipped cluster (mirrors buildDag above).
+      try {
+        writeEntry(hippoRoot, profileEntry);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          result.rejected++;
+          console.error(`[buildEntityProfiles] cluster "${cluster.label}" skipped: profile matches a rejected value`);
+          continue;
+        }
+        throw err;
+      }
       result.profilesCreated++;
 
       for (const member of cluster.members) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -25,7 +25,7 @@ const { DatabaseSync } = require('node:sqlite') as {
   DatabaseSync: new (path: string) => DatabaseSyncLike;
 };
 
-const CURRENT_SCHEMA_VERSION = 40;
+const CURRENT_SCHEMA_VERSION = 41;
 
 /**
  * Context passed to migrations that need to know WHERE the store lives.
@@ -2264,6 +2264,48 @@ const MIGRATIONS: Migration[] = [
           memory_ids_json TEXT NOT NULL      -- ids actually credited by this outcome event
         );
         CREATE INDEX IF NOT EXISTS idx_recall_trace_outcomes_trace ON recall_trace_outcomes(trace_id);
+      `);
+    },
+  },
+  {
+    version: 41,
+    up: (db) => {
+      // AT1 rejected-value tombstone (docs/plans/2026-08-15-at1-rejected-value-tombstone.md).
+      // Additive table, template = v40 above. A human who rejects a fact gets
+      // a durable say: the write-path guard in upsertEntryRow refuses any
+      // write that would re-introduce a value whose normalized digest
+      // matches a row here.
+      //
+      // No raw content and no preview stored. Follows the raw_archive
+      // redaction precedent (raw-archive.ts payload is {redacted:true, ...}):
+      // a rejected value may itself be a secret or PII ("never store my key
+      // again") — persisting it in the tombstone would defeat the point. The
+      // human sees the content at reject time (CLI echoes it); afterwards
+      // `reason` is the human-readable identity.
+      //
+      // No FK on source_memory_id (v40 precedent above: tombstone outlives
+      // the row it was sourced from) — provenance only.
+      //
+      // Reserved-word check on column names (skill-episode lesson, rule 10):
+      // tenant/digest/reason/rejected/source/normalized/chars are non-reserved.
+      //
+      // No min_compatible_binary bump — a deliberate tradeoff (plan §2,
+      // flagged to the ship gate). An old binary sharing a synced store
+      // writes WITHOUT the guard until upgraded; documented in
+      // MEMORY_ENVELOPE.md rather than hard-locking every old binary out of
+      // the store, which is disproportionate for the dominant single-user
+      // single-binary deployment.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS rejected_values (
+          tenant_id  TEXT NOT NULL,
+          digest     TEXT NOT NULL,            -- sha256/64 of normalized content
+          reason     TEXT,                     -- human-supplied; the only description stored
+          rejected_by TEXT,                    -- actor ('user:<id>' / 'cli' / ...)
+          rejected_at TEXT NOT NULL,
+          source_memory_id TEXT,               -- provenance only; NO FK (tombstone outlives the row)
+          normalized_chars INTEGER,            -- weak sanity aid for humans listing tombstones
+          PRIMARY KEY (tenant_id, digest)
+        ) WITHOUT ROWID;
       `);
     },
   },

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,5 +1,6 @@
 import { MemoryEntry, Layer, EmotionalValence, createMemory } from './memory.js';
 import { writeEntry } from './store.js';
+import { RejectedValueError } from './rejection.js';
 
 export interface ExtractedFact {
   content: string;
@@ -97,6 +98,7 @@ export function storeExtractedFacts(
   );
 
   const entries: MemoryEntry[] = [];
+  let rejected = 0;
 
   for (const fact of facts) {
     const tags = ['extracted', ...inheritedTags, ...fact.tags];
@@ -109,8 +111,23 @@ export function storeExtractedFacts(
       extracted_from: source.id,
     });
 
-    writeEntry(hippoRoot, entry);
+    // AT1 containment: a refusal is per-VALUE — one rejected fact must not
+    // drop the rest of this batch. writeEntry has already audited the
+    // refusal (reject_refusal) before rethrowing, so skip-and-count here.
+    try {
+      writeEntry(hippoRoot, entry);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        rejected++;
+        continue;
+      }
+      throw err;
+    }
     entries.push(entry);
+  }
+
+  if (rejected > 0) {
+    console.error(`storeExtractedFacts: skipped ${rejected} rejected value(s)`);
   }
 
   return entries;

--- a/src/importers.ts
+++ b/src/importers.ts
@@ -12,6 +12,7 @@ import { textOverlap } from './search.js';
 import { getGlobalRoot, initGlobal } from './shared.js';
 import { remember, archiveRaw, isPrivateScope, type Context } from './api.js';
 import { openHippoDb, closeHippoDb } from './db.js';
+import { RejectedValueError } from './rejection.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -21,6 +22,10 @@ export interface ImportResult {
   total: number;     // entries found in source
   imported: number;  // actually imported (after dedup)
   skipped: number;   // skipped as duplicates or too short
+  /** AT1: refused by the rejection-value guard — kept distinct from
+   *  `skipped` (dedup) so a tombstoned value is distinguishable from a
+   *  plain duplicate in import summaries (plan §3 containment, round-2 low). */
+  rejected: number;
   /** K1 vault import: rows archived this run (changed + source-deleted). In a
    *  dryRun this is the would-be count (a true deletion-sync preview). */
   archived?: number;
@@ -87,6 +92,7 @@ export function importEntries(
   let total = 0;
   let imported = 0;
   let skipped = 0;
+  let rejected = 0;
   const entries: MemoryEntry[] = [];
 
   for (const raw of chunks) {
@@ -137,18 +143,27 @@ export function importEntries(
       tenantId: options.global ? undefined : options.tenantId,
     });
 
-    entries.push(entry);
-
     if (!options.dryRun) {
-      writeEntry(targetRoot, entry);
+      // AT1 (plan §3 containment): a rejection refuses one CHUNK, not the
+      // whole import batch. Caught per-item so siblings still land.
+      try {
+        writeEntry(targetRoot, entry);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          rejected++;
+          continue;
+        }
+        throw err;
+      }
       // Add to existing so subsequent chunks dedup against freshly imported ones
       existing.push(entry);
     }
 
+    entries.push(entry);
     imported++;
   }
 
-  return { total, imported, skipped, entries };
+  return { total, imported, skipped, rejected, entries };
 }
 
 // ---------------------------------------------------------------------------
@@ -503,7 +518,7 @@ export function importMarkdown(filePath: string, options: ImportOptions): Import
     bySlug.set(sectionSlug, list);
   }
 
-  let totalResult: ImportResult = { total: 0, imported: 0, skipped: 0, entries: [] };
+  let totalResult: ImportResult = { total: 0, imported: 0, skipped: 0, rejected: 0, entries: [] };
 
   for (const [slug, chunks] of bySlug.entries()) {
     const sectionTags = slug ? ['imported', slug] : ['imported'];
@@ -512,6 +527,7 @@ export function importMarkdown(filePath: string, options: ImportOptions): Import
       total: totalResult.total + result.total,
       imported: totalResult.imported + result.imported,
       skipped: totalResult.skipped + result.skipped,
+      rejected: totalResult.rejected + result.rejected,
       entries: [...totalResult.entries, ...result.entries],
     };
   }
@@ -738,7 +754,7 @@ export function importVault(folderPath: string, options: ImportOptions): ImportR
   const resolvedStore = realpathOrResolve(hippoRoot);
   const resolvedFolder = realpathOrResolve(folderPath);
   if (resolvedFolder === resolvedStore || resolvedFolder.startsWith(resolvedStore + path.sep)) {
-    return { total: 0, imported: 0, skipped: 0, archived: 0, entries: [] };
+    return { total: 0, imported: 0, skipped: 0, rejected: 0, archived: 0, entries: [] };
   }
 
   const ctx: Context = {
@@ -790,6 +806,7 @@ export function importVault(folderPath: string, options: ImportOptions): ImportR
   let total = 0;
   let imported = 0;
   let skipped = 0;
+  let rejected = 0;
   let archived = 0;
   const entries: MemoryEntry[] = [];
 
@@ -903,15 +920,29 @@ export function importVault(folderPath: string, options: ImportOptions): ImportR
     });
     // dryRun preview: count what WOULD import, but make no writes (codex P2).
     if (!dryRun) {
-      const result = remember(ctx, {
-        content: body,
-        kind: 'raw',
-        artifactRef,
-        owner: 'agent:vault-import',
-        scope: scope ?? undefined,
-        tags,
-      });
-      echo.id = result.id;
+      // AT1 (plan §3 containment): a rejected note must not abort the rest
+      // of the vault scan (deletion-sync pass included). The priors above
+      // are already archived by this point — same self-heal story as any
+      // other crash between archiveRaw and remember() (comment above): a
+      // re-run with the file still rejected hits the same refusal again,
+      // loud each time via the rejected count.
+      try {
+        const result = remember(ctx, {
+          content: body,
+          kind: 'raw',
+          artifactRef,
+          owner: 'agent:vault-import',
+          scope: scope ?? undefined,
+          tags,
+        });
+        echo.id = result.id;
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          rejected++;
+          continue;
+        }
+        throw err;
+      }
     }
     entries.push(echo);
     imported++;
@@ -929,7 +960,7 @@ export function importVault(folderPath: string, options: ImportOptions): ImportR
     }
   }
 
-  return { total, imported, skipped, archived, entries };
+  return { total, imported, skipped, rejected, archived, entries };
 }
 
 /** Local tolerant JSON-array parse for the loader's `tags_json` column. The

--- a/src/importers.ts
+++ b/src/importers.ts
@@ -12,7 +12,7 @@ import { textOverlap } from './search.js';
 import { getGlobalRoot, initGlobal } from './shared.js';
 import { remember, archiveRaw, isPrivateScope, type Context } from './api.js';
 import { openHippoDb, closeHippoDb } from './db.js';
-import { RejectedValueError } from './rejection.js';
+import { RejectedValueError, checkRejectionGuard } from './rejection.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -95,75 +95,97 @@ export function importEntries(
   let rejected = 0;
   const entries: MemoryEntry[] = [];
 
-  for (const raw of chunks) {
-    const trimmed = raw.trim();
-    if (trimmed.length > 1000) {
-      console.error(`Warning: imported memory truncated from ${trimmed.length} to 1000 chars`);
-    }
-    const chunk = trimmed.slice(0, 1000);
-
-    // Skip empty or too-short chunks
-    if (!chunk || chunk.length < 10) {
-      skipped++;
-      continue;
-    }
-
-    total++;
-
-    // Dedup check: textOverlap > 0.7 with any existing memory = skip
-    let isDuplicate = false;
-    for (const existing_entry of existing) {
-      if (textOverlap(chunk, existing_entry.content) > 0.7) {
-        isDuplicate = true;
-        break;
+  // AT1 P2 fix: a dry-run preview never called writeEntry, so it never
+  // checked tombstones either — every non-duplicate chunk counted as
+  // `imported` even when a real run would refuse it, making the preview's
+  // `rejected` count silently 0. Probe (read-only) via the same guard
+  // writeEntry uses internally, without ever writing.
+  const dryRunDb = options.dryRun ? openHippoDb(targetRoot) : null;
+  try {
+    for (const raw of chunks) {
+      const trimmed = raw.trim();
+      if (trimmed.length > 1000) {
+        console.error(`Warning: imported memory truncated from ${trimmed.length} to 1000 chars`);
       }
-    }
+      const chunk = trimmed.slice(0, 1000);
 
-    if (isDuplicate) {
-      skipped++;
-      continue;
-    }
+      // Skip empty or too-short chunks
+      if (!chunk || chunk.length < 10) {
+        skipped++;
+        continue;
+      }
 
-    // A3: kind defaults to 'distilled'. ChatGPT/Claude/Cursor exports are curated
-    // user pastes, not raw transcripts from a system of record, so distilled is
-    // correct here. E1.3 (Slack ingestion) shipped 2026-04-29 in src/connectors/slack/
-    // and sets kind: 'raw' + routes deletions through archiveRawMemory() — these
-    // importers stay 'distilled' per the original reasoning. See MEMORY_ENVELOPE.md.
-    // L9: the dedup read above is scoped by options.tenantId — the WRITE
-    // must match, or scoped-dedup-passes-then-default-tenant-write breaks
-    // the per-tenant contract. Mirror the dedup-read guard: global=true
-    // → host-wide write to global store (tenantId irrelevant, createMemory
-    // defaults to 'default'). global=false → write to the same tenant as
-    // the dedup read.
-    const entry = createMemory(chunk, {
-      layer: Layer.Episodic,
-      tags: allTags,
-      source,
-      confidence: 'observed',
-      tenantId: options.global ? undefined : options.tenantId,
-    });
+      total++;
 
-    if (!options.dryRun) {
-      // AT1 (plan §3 containment): a rejection refuses one CHUNK, not the
-      // whole import batch. Caught per-item so siblings still land.
-      try {
-        writeEntry(targetRoot, entry);
-      } catch (err) {
-        if (err instanceof RejectedValueError) {
-          rejected++;
-          continue;
+      // Dedup check: textOverlap > 0.7 with any existing memory = skip
+      let isDuplicate = false;
+      for (const existing_entry of existing) {
+        if (textOverlap(chunk, existing_entry.content) > 0.7) {
+          isDuplicate = true;
+          break;
         }
-        throw err;
       }
-      // Add to existing so subsequent chunks dedup against freshly imported ones
-      existing.push(entry);
+
+      if (isDuplicate) {
+        skipped++;
+        continue;
+      }
+
+      // A3: kind defaults to 'distilled'. ChatGPT/Claude/Cursor exports are curated
+      // user pastes, not raw transcripts from a system of record, so distilled is
+      // correct here. E1.3 (Slack ingestion) shipped 2026-04-29 in src/connectors/slack/
+      // and sets kind: 'raw' + routes deletions through archiveRawMemory() — these
+      // importers stay 'distilled' per the original reasoning. See MEMORY_ENVELOPE.md.
+      // L9: the dedup read above is scoped by options.tenantId — the WRITE
+      // must match, or scoped-dedup-passes-then-default-tenant-write breaks
+      // the per-tenant contract. Mirror the dedup-read guard: global=true
+      // → host-wide write to global store (tenantId irrelevant, createMemory
+      // defaults to 'default'). global=false → write to the same tenant as
+      // the dedup read.
+      const entry = createMemory(chunk, {
+        layer: Layer.Episodic,
+        tags: allTags,
+        source,
+        confidence: 'observed',
+        tenantId: options.global ? undefined : options.tenantId,
+      });
+
+      if (options.dryRun) {
+        if (dryRunDb) {
+          try {
+            checkRejectionGuard(dryRunDb, entry.tenantId ?? 'default', entry.id, entry.content);
+          } catch (err) {
+            if (err instanceof RejectedValueError) {
+              rejected++;
+              continue;
+            }
+            throw err;
+          }
+        }
+      } else {
+        // AT1 (plan §3 containment): a rejection refuses one CHUNK, not the
+        // whole import batch. Caught per-item so siblings still land.
+        try {
+          writeEntry(targetRoot, entry);
+        } catch (err) {
+          if (err instanceof RejectedValueError) {
+            rejected++;
+            continue;
+          }
+          throw err;
+        }
+        // Add to existing so subsequent chunks dedup against freshly imported ones
+        existing.push(entry);
+      }
+
+      entries.push(entry);
+      imported++;
     }
 
-    entries.push(entry);
-    imported++;
+    return { total, imported, skipped, rejected, entries };
+  } finally {
+    if (dryRunDb) closeHippoDb(dryRunDb);
   }
-
-  return { total, imported, skipped, rejected, entries };
 }
 
 // ---------------------------------------------------------------------------
@@ -810,142 +832,163 @@ export function importVault(folderPath: string, options: ImportOptions): ImportR
   let archived = 0;
   const entries: MemoryEntry[] = [];
 
-  for (const relpath of relpaths) {
-    total++;
-    const artifactRef = `vault:${vaultName}:${relpath}`;
-    seen.add(artifactRef);
+  // AT1 P2 fix: dry-run never called remember(), so it never probed
+  // tombstones — every note that reached the write step counted as
+  // `imported` even when a real run would refuse it. Probe (read-only) via
+  // the same guard remember()/writeEntry uses, without ever writing.
+  const dryRunDb = dryRun ? openHippoDb(hippoRoot) : null;
+  try {
+    for (const relpath of relpaths) {
+      total++;
+      const artifactRef = `vault:${vaultName}:${relpath}`;
+      seen.add(artifactRef);
 
-    // Content-hash is computed from the RAW file bytes (deterministic; no
-    // Date/random in the content path) so idempotency survives frontmatter
-    // edits identically to body edits.
-    let rawFileContent: string;
-    try {
-      rawFileContent = fs.readFileSync(path.join(folderPath, relpath), 'utf8');
-    } catch {
-      // File vanished between enumeration and read (TOCTOU), or a transient
-      // IO/permission error. Skip this one file rather than aborting the whole
-      // import (incl. the deletion-sync pass); an idempotent re-run picks it up.
-      skipped++;
-      continue;
-    }
-    const hash = createHash('sha256').update(rawFileContent).digest('hex');
-    const hashTag = `content-hash:${hash}`;
-
-    // Load every live raw row for this ref (>1 only after a concurrent double-
-    // insert). The idempotency decision happens below, AFTER the full tag set is
-    // built, so it can compare the complete envelope rather than a subset.
-    const priors = existing.get(artifactRef) ?? [];
-
-    const { fm, body } = parseFrontmatter(rawFileContent);
-
-    // Empty / frontmatter-only note: nothing storable (createMemory enforces a
-    // min content length). The note's CONTENT was deleted at source, so this is a
-    // content-deletion: archive any prior row(s) - the old body must not stay live
-    // and searchable after the source no longer holds it (codex R12 P2) - then
-    // skip the write. Archiving here is safe precisely because we then skip
-    // remember() entirely: there is no archive-then-throw-on-empty-body hazard
-    // (the original reason this branch did not archive). The note stays in `seen`
-    // so deletion-sync does not double-process it.
-    if (body.trim().length < 3) {
-      for (const p of priors) {
-        archived++; // count even in dryRun so the preview reflects the removal
-        if (!dryRun) archiveRaw(ctx, p.id, `emptied:${artifactRef}`);
-      }
-      skipped++;
-      continue;
-    }
-
-    // Build the FULL tag envelope this import would write, BEFORE the idempotency
-    // decision. De-duplicate (createMemory stores tags verbatim, so a collision
-    // between, e.g., a frontmatter tag and an extraTag would otherwise produce a
-    // duplicate). Order-preserving.
-    const frontmatterTags = [
-      ...frontmatterList(fm['tags']),
-      ...frontmatterList(fm['aliases']).map((a) => `alias:${a}`),
-    ];
-    const wikilinkTags = parseWikilinks(body).map((t) => `wikilink-candidate:${t}`);
-    const tags = Array.from(
-      new Set([
-        'source:vault',
-        `vault:${vaultName}`,
-        hashTag,
-        ...frontmatterTags,
-        ...wikilinkTags,
-        ...extraTags,
-      ]),
-    );
-
-    // Unchanged iff EVERY live raw row carries the EXACT same tag set AND scope.
-    // Comparing the COMPLETE set (not the content-hash + a subset of extra tags)
-    // means every envelope change registers: content (via the content-hash tag),
-    // frontmatter, wikilinks, an ADDED extra tag, or a REMOVED one - the earlier
-    // piecemeal checks missed scope (R10 P2) then tag removal (R11 P2). Set
-    // equality is order-independent and both sides are deduped. (`length > 0`
-    // guard: a never-seen file must import, not skip; archiving ALL priors on a
-    // mismatch also clears any concurrent-double-insert duplicates.)
-    const wantTags = new Set(tags);
-    const envelopeUnchanged =
-      priors.length > 0 &&
-      priors.every((p) => {
-        if ((p.scope ?? null) !== scope) return false;
-        const priorTags = parseJsonArrayLoose(p.tags_json);
-        return priorTags.length === wantTags.size && priorTags.every((t) => wantTags.has(t));
-      });
-    if (envelopeUnchanged) {
-      // Unchanged file + envelope → skip (idempotent re-import).
-      skipped++;
-      continue;
-    }
-
-    // Changed file → archive EVERY old raw row for this ref (normally one; >1
-    // only after a concurrent double-insert), then append the new one. NEVER
-    // supersede (would yield kind='distilled'). archiveRaw commits + closes its
-    // handle before remember() runs, so there is no double-live row; a crash
-    // between them self-heals (file re-imported as fresh raw next run).
-    for (const p of priors) {
-      archived++; // count the would-be archive even in dryRun (true preview)
-      if (!dryRun) archiveRaw(ctx, p.id, `changed:${artifactRef}`);
-    }
-
-    // remember() owns the actual write. We build an `echo` of the SAME content +
-    // tags via createMemory purely for the ImportResult, then reconcile its id to
-    // remember()'s real row id so entries[] reflects the row that landed.
-    const echo = createMemory(body, {
-      kind: 'raw',
-      tags,
-      scope,
-      owner: 'agent:vault-import',
-      artifact_ref: artifactRef,
-      tenantId,
-    });
-    // dryRun preview: count what WOULD import, but make no writes (codex P2).
-    if (!dryRun) {
-      // AT1 (plan §3 containment): a rejected note must not abort the rest
-      // of the vault scan (deletion-sync pass included). The priors above
-      // are already archived by this point — same self-heal story as any
-      // other crash between archiveRaw and remember() (comment above): a
-      // re-run with the file still rejected hits the same refusal again,
-      // loud each time via the rejected count.
+      // Content-hash is computed from the RAW file bytes (deterministic; no
+      // Date/random in the content path) so idempotency survives frontmatter
+      // edits identically to body edits.
+      let rawFileContent: string;
       try {
-        const result = remember(ctx, {
-          content: body,
-          kind: 'raw',
-          artifactRef,
-          owner: 'agent:vault-import',
-          scope: scope ?? undefined,
-          tags,
-        });
-        echo.id = result.id;
-      } catch (err) {
-        if (err instanceof RejectedValueError) {
-          rejected++;
-          continue;
-        }
-        throw err;
+        rawFileContent = fs.readFileSync(path.join(folderPath, relpath), 'utf8');
+      } catch {
+        // File vanished between enumeration and read (TOCTOU), or a transient
+        // IO/permission error. Skip this one file rather than aborting the whole
+        // import (incl. the deletion-sync pass); an idempotent re-run picks it up.
+        skipped++;
+        continue;
       }
+      const hash = createHash('sha256').update(rawFileContent).digest('hex');
+      const hashTag = `content-hash:${hash}`;
+
+      // Load every live raw row for this ref (>1 only after a concurrent double-
+      // insert). The idempotency decision happens below, AFTER the full tag set is
+      // built, so it can compare the complete envelope rather than a subset.
+      const priors = existing.get(artifactRef) ?? [];
+
+      const { fm, body } = parseFrontmatter(rawFileContent);
+
+      // Empty / frontmatter-only note: nothing storable (createMemory enforces a
+      // min content length). The note's CONTENT was deleted at source, so this is a
+      // content-deletion: archive any prior row(s) - the old body must not stay live
+      // and searchable after the source no longer holds it (codex R12 P2) - then
+      // skip the write. Archiving here is safe precisely because we then skip
+      // remember() entirely: there is no archive-then-throw-on-empty-body hazard
+      // (the original reason this branch did not archive). The note stays in `seen`
+      // so deletion-sync does not double-process it.
+      if (body.trim().length < 3) {
+        for (const p of priors) {
+          archived++; // count even in dryRun so the preview reflects the removal
+          if (!dryRun) archiveRaw(ctx, p.id, `emptied:${artifactRef}`);
+        }
+        skipped++;
+        continue;
+      }
+
+      // Build the FULL tag envelope this import would write, BEFORE the idempotency
+      // decision. De-duplicate (createMemory stores tags verbatim, so a collision
+      // between, e.g., a frontmatter tag and an extraTag would otherwise produce a
+      // duplicate). Order-preserving.
+      const frontmatterTags = [
+        ...frontmatterList(fm['tags']),
+        ...frontmatterList(fm['aliases']).map((a) => `alias:${a}`),
+      ];
+      const wikilinkTags = parseWikilinks(body).map((t) => `wikilink-candidate:${t}`);
+      const tags = Array.from(
+        new Set([
+          'source:vault',
+          `vault:${vaultName}`,
+          hashTag,
+          ...frontmatterTags,
+          ...wikilinkTags,
+          ...extraTags,
+        ]),
+      );
+
+      // Unchanged iff EVERY live raw row carries the EXACT same tag set AND scope.
+      // Comparing the COMPLETE set (not the content-hash + a subset of extra tags)
+      // means every envelope change registers: content (via the content-hash tag),
+      // frontmatter, wikilinks, an ADDED extra tag, or a REMOVED one - the earlier
+      // piecemeal checks missed scope (R10 P2) then tag removal (R11 P2). Set
+      // equality is order-independent and both sides are deduped. (`length > 0`
+      // guard: a never-seen file must import, not skip; archiving ALL priors on a
+      // mismatch also clears any concurrent-double-insert duplicates.)
+      const wantTags = new Set(tags);
+      const envelopeUnchanged =
+        priors.length > 0 &&
+        priors.every((p) => {
+          if ((p.scope ?? null) !== scope) return false;
+          const priorTags = parseJsonArrayLoose(p.tags_json);
+          return priorTags.length === wantTags.size && priorTags.every((t) => wantTags.has(t));
+        });
+      if (envelopeUnchanged) {
+        // Unchanged file + envelope → skip (idempotent re-import).
+        skipped++;
+        continue;
+      }
+
+      // Changed file → archive EVERY old raw row for this ref (normally one; >1
+      // only after a concurrent double-insert), then append the new one. NEVER
+      // supersede (would yield kind='distilled'). archiveRaw commits + closes its
+      // handle before remember() runs, so there is no double-live row; a crash
+      // between them self-heals (file re-imported as fresh raw next run).
+      for (const p of priors) {
+        archived++; // count the would-be archive even in dryRun (true preview)
+        if (!dryRun) archiveRaw(ctx, p.id, `changed:${artifactRef}`);
+      }
+
+      // remember() owns the actual write. We build an `echo` of the SAME content +
+      // tags via createMemory purely for the ImportResult, then reconcile its id to
+      // remember()'s real row id so entries[] reflects the row that landed.
+      const echo = createMemory(body, {
+        kind: 'raw',
+        tags,
+        scope,
+        owner: 'agent:vault-import',
+        artifact_ref: artifactRef,
+        tenantId,
+      });
+      // dryRun preview: count what WOULD import, but make no writes (codex P2).
+      if (!dryRun) {
+        // AT1 (plan §3 containment): a rejected note must not abort the rest
+        // of the vault scan (deletion-sync pass included). The priors above
+        // are already archived by this point — same self-heal story as any
+        // other crash between archiveRaw and remember() (comment above): a
+        // re-run with the file still rejected hits the same refusal again,
+        // loud each time via the rejected count.
+        try {
+          const result = remember(ctx, {
+            content: body,
+            kind: 'raw',
+            artifactRef,
+            owner: 'agent:vault-import',
+            scope: scope ?? undefined,
+            tags,
+          });
+          echo.id = result.id;
+        } catch (err) {
+          if (err instanceof RejectedValueError) {
+            rejected++;
+            continue;
+          }
+          throw err;
+        }
+      } else if (dryRunDb) {
+        // AT1 P2 fix: probe the tombstone without writing so the preview's
+        // `rejected` count matches what a real run would refuse.
+        try {
+          checkRejectionGuard(dryRunDb, tenantId, echo.id, echo.content);
+        } catch (err) {
+          if (err instanceof RejectedValueError) {
+            rejected++;
+            continue;
+          }
+          throw err;
+        }
+      }
+      entries.push(echo);
+      imported++;
     }
-    entries.push(echo);
-    imported++;
+  } finally {
+    if (dryRunDb) closeHippoDb(dryRunDb);
   }
 
   // Deletion-sync: any artifactRef present in the Map but NOT seen this run is a

--- a/src/importers.ts
+++ b/src/importers.ts
@@ -24,8 +24,14 @@ export interface ImportResult {
   skipped: number;   // skipped as duplicates or too short
   /** AT1: refused by the rejection-value guard — kept distinct from
    *  `skipped` (dedup) so a tombstoned value is distinguishable from a
-   *  plain duplicate in import summaries (plan §3 containment, round-2 low). */
-  rejected: number;
+   *  plain duplicate in import summaries (plan §3 containment, round-2 low).
+   *  AT1 P2 fix (codex, published-surface compat): optional, not required —
+   *  `ImportResult` is re-exported from the package root (index.ts), and a
+   *  required field breaks any existing consumer constructing the pre-AT1
+   *  shape. Every producer in this file still always sets a real number;
+   *  `?? 0` at read sites (this file's own accumulation, cli.ts's summary
+   *  prints) tolerates a caller-supplied object that omits it. */
+  rejected?: number;
   /** K1 vault import: rows archived this run (changed + source-deleted). In a
    *  dryRun this is the would-be count (a true deletion-sync preview). */
   archived?: number;
@@ -549,7 +555,9 @@ export function importMarkdown(filePath: string, options: ImportOptions): Import
       total: totalResult.total + result.total,
       imported: totalResult.imported + result.imported,
       skipped: totalResult.skipped + result.skipped,
-      rejected: totalResult.rejected + result.rejected,
+      // AT1 P2 fix: `rejected` is now optional on ImportResult (compat) — tolerate
+      // undefined on either side of the accumulation.
+      rejected: (totalResult.rejected ?? 0) + (result.rejected ?? 0),
       entries: [...totalResult.entries, ...result.entries],
     };
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1160,6 +1160,13 @@ async function executeTool(
       const result = resolveConflict(hippoRoot, conflictId, keepId, forget, tenantId, {
         rejectLoserValue: rejectLoser,
         reason,
+        // P2 fix: resolveConflict's opts.rejectedBy defaults to 'cli' when
+        // omitted — this call site never passed it, so the tombstone's
+        // rejected_by AND the conflict_resolve audit's actor both landed as
+        // 'cli' even though the caller was MCP. ctx.actor carries the
+        // auth-resolved actor for HTTP-MCP (see McpContext above); stdio
+        // callers pass no ctx, so 'mcp' is the honest fallback there.
+        rejectedBy: ctx?.actor ?? 'mcp',
       });
       if (!result) return 'Could not resolve. Check the conflict ID and --keep value.';
       const action = rejectLoser ? 'rejected (tombstoned) and removed' : forget ? 'deleted' : 'weakened';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -31,6 +31,7 @@ import { recall as apiRecall, remember as apiRemember, outcome as apiOutcome, dr
 import { resolveProjectIdentity, classifyOriginProject } from '../project-identity.js';
 import { computePredictionBaserate } from '../predictions.js';
 import { appendAuditEvent } from '../audit.js';
+import { RejectedValueError } from '../rejection.js';
 import { createHash } from 'node:crypto';
 import {
   detectAnchoring,
@@ -370,6 +371,8 @@ const TOOLS = [
         conflict_id: { type: 'number', description: 'The conflict ID to resolve' },
         keep: { type: 'string', description: 'ID of the memory to keep' },
         forget: { type: 'boolean', description: 'Delete the loser instead of weakening (default: false)' },
+        rejectLoser: { type: 'boolean', description: 'Tombstone the loser\'s value too, so it refuses re-ingestion (implies removal; default: false)' },
+        reason: { type: 'string', description: 'Reason recorded on the tombstone when rejectLoser is set (default: a conflict-context string)' },
       },
       required: ['conflict_id', 'keep'],
     },
@@ -1112,6 +1115,7 @@ async function executeTool(
       const lessons = extractLessons(gitLog, config.gitLearnPatterns);
       let added = 0;
       let skipped = 0;
+      let rejected = 0;
       for (const lesson of lessons) {
         if (deduplicateLesson(hippoRoot, lesson, 0.7, tenantId)) { skipped++; continue; }
         const entry = createMemory(lesson, {
@@ -1122,10 +1126,18 @@ async function executeTool(
           baseHalfLifeDays: config.defaultHalfLifeDays,
           tenantId,
         });
-        writeEntry(hippoRoot, entry);
+        // AT1 (plan §3 containment): a refused lesson must not crash the
+        // MCP learn call or lose the rest of the git log scan.
+        try {
+          writeEntry(hippoRoot, entry);
+        } catch (err) {
+          if (err instanceof RejectedValueError) { rejected++; continue; }
+          throw err;
+        }
         added++;
       }
-      return `Git learn: ${added} new, ${skipped} duplicates skipped (scanned ${days} days)`;
+      const rejectedSuffix = rejected > 0 ? `, ${rejected} rejected values skipped` : '';
+      return `Git learn: ${added} new, ${skipped} duplicates skipped${rejectedSuffix} (scanned ${days} days)`;
     }
 
     case 'hippo_conflicts': {
@@ -1140,10 +1152,17 @@ async function executeTool(
       const conflictId = Number(args.conflict_id);
       const keepId = String(args.keep || '');
       const forget = Boolean(args.forget);
+      // AT1: optional rejectLoser + reason, threaded straight through to
+      // resolveConflict's opts (plan §5 — mirrors the CLI's --reject-loser).
+      const rejectLoser = Boolean(args.rejectLoser);
+      const reason = typeof args.reason === 'string' ? args.reason : undefined;
       if (isNaN(conflictId) || !keepId) return 'Required: conflict_id and keep.';
-      const result = resolveConflict(hippoRoot, conflictId, keepId, forget, tenantId);
+      const result = resolveConflict(hippoRoot, conflictId, keepId, forget, tenantId, {
+        rejectLoserValue: rejectLoser,
+        reason,
+      });
       if (!result) return 'Could not resolve. Check the conflict ID and --keep value.';
-      const action = forget ? 'deleted' : 'weakened';
+      const action = rejectLoser ? 'rejected (tombstoned) and removed' : forget ? 'deleted' : 'weakened';
       return `Resolved conflict ${conflictId}: kept ${keepId}, ${action} ${result.loserId}`;
     }
 

--- a/src/reject-flow.ts
+++ b/src/reject-flow.ts
@@ -72,6 +72,13 @@ export function rejectValue(opts: RejectFlowOpts): RejectFlowResult {
   if (opts.memoryId === undefined && opts.value === undefined) {
     throw new Error('reject requires either a memory id or --value.');
   }
+  if (opts.memoryId !== undefined && opts.value !== undefined) {
+    // P2 fix: the CLI's flag parser already refuses both forms together;
+    // the shared flow itself didn't enforce it, so a direct api caller
+    // passing both silently got the memoryId path with `value` ignored —
+    // surprising for a caller who thought they were rejecting `value`.
+    throw new Error('reject accepts either a memory id or --value, not both.');
+  }
   if (opts.value !== undefined && normalizeValueForRejection(opts.value).length === 0) {
     // Direct api callers can pass strings the CLI flag parser would have
     // refused; an empty-normalized tombstone would refuse nothing meaningful
@@ -209,6 +216,15 @@ export function unrejectValue(
   digestOrPrefix: string,
   actor: string,
 ): UnrejectOutcome {
+  // P2 fix: an empty/blank prefix startsWith-matches EVERY digest (every
+  // string starts with ''), which would previously fall through to the
+  // ambiguous-candidates branch and list the whole tombstone set instead of
+  // failing loud on the actually-invalid input. Reject before the DB round
+  // trip.
+  if (digestOrPrefix.trim().length === 0) {
+    return { status: 'not_found' };
+  }
+
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {

--- a/src/reject-flow.ts
+++ b/src/reject-flow.ts
@@ -18,7 +18,7 @@ import { archiveRawMemory } from './raw-archive.js';
 import {
   initStore,
   deleteEntryCore,
-  removeEntryMirrors,
+  purgeMirrorBestEffort,
   writeIndexMirror,
   buildIndexFromDb,
 } from './store.js';
@@ -172,17 +172,12 @@ export function rejectValue(opts: RejectFlowOpts): RejectFlowResult {
     // best-effort mirror purge per removed id, reaper-backstop stamp for
     // raw ids, one index mirror rewrite.
     for (const id of removedIds) {
-      let mirrorOk = false;
-      try {
-        removeEntryMirrors(opts.hippoRoot, id);
-        mirrorOk = true;
-      } catch (mirrorErr) {
-        console.error(
-          `hippo reject: mirror cleanup failed for ${id} (will retry via reaper on next open): ${
-            mirrorErr instanceof Error ? mirrorErr.message : String(mirrorErr)
-          }`,
-        );
-      }
+      // AT1 fix: purgeMirrorBestEffort retries once, then — for non-raw ids,
+      // which cleanupArchivedMirrors' reaper never scans — reports the
+      // EXPLICIT leftover path(s) instead of the false "will retry via
+      // reaper" claim. See its own doc comment (store.ts, near
+      // removeEntryMirrors) for the full rationale.
+      const mirrorOk = purgeMirrorBestEffort(opts.hippoRoot, id, removedRawIds.includes(id), 'hippo reject');
       if (mirrorOk && removedRawIds.includes(id)) {
         db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
           new Date().toISOString(),

--- a/src/reject-flow.ts
+++ b/src/reject-flow.ts
@@ -1,0 +1,248 @@
+/**
+ * AT1 rejected-value tombstone — shared reject/unreject/list flow.
+ * docs/plans/2026-08-15-at1-rejected-value-tombstone.md (T2, plan §4).
+ *
+ * The CLI (`hippo reject`/`rejections`/`unreject`) and the Context-based
+ * `api.reject`/`api.unreject`/`api.listRejections` surfaces both need the
+ * SAME multi-step transaction + post-commit mirror-purge flow. Extracted
+ * here (leaf module) so neither duplicates it.
+ *
+ * Module direction: this file imports from store.ts, rejection.ts, and
+ * raw-archive.ts. Nothing imports FROM this file except cli.ts and api.ts,
+ * so it introduces no cycle.
+ */
+
+import { openHippoDb, closeHippoDb } from './db.js';
+import { appendAuditEvent } from './audit.js';
+import { archiveRawMemory } from './raw-archive.js';
+import {
+  initStore,
+  deleteEntryCore,
+  removeEntryMirrors,
+  writeIndexMirror,
+  buildIndexFromDb,
+} from './store.js';
+import {
+  rejectionDigest,
+  normalizeValueForRejection,
+  insertRejectedValue,
+  deleteRejectedValue,
+  listRejectedValues,
+  type RejectedValueRow,
+} from './rejection.js';
+
+export interface RejectFlowOpts {
+  hippoRoot: string;
+  tenantId: string;
+  actor: string;
+  reason: string;
+  /** By-id form: reject the CURRENT content of an existing memory. */
+  memoryId?: string;
+  /** Pre-emptive form: reject a value not currently stored (or already gone). */
+  value?: string;
+}
+
+export interface RejectFlowResult {
+  digest: string;
+  /** The rejected content, for the CLI's at-reject-time echo (plan §2: the
+   *  tombstone itself stores no content — this is the only place it's seen
+   *  again after this call returns). */
+  content: string;
+  /** Every live row removed this call (all tenant rows whose normalized
+   *  digest matched — not just the id passed, per the K1/R7 duplicate
+   *  lesson). */
+  removedIds: string[];
+  /** Subset of removedIds that were kind='raw' (archived, not deleted). */
+  removedRawIds: string[];
+}
+
+/**
+ * `hippo reject` / `api.reject` core flow. ONE connection, one transaction:
+ * insert the tombstone, enumerate + remove every live tenant row whose
+ * normalized digest matches (kind-aware), one aggregate `reject_value`
+ * audit, COMMIT. Then post-commit (mirrors the existing purge+reaper
+ * pattern verbatim from api.archiveRaw, api.ts:1913-1938): best-effort
+ * mirror purge per removed id, `mirror_cleaned_at` stamps for raw ids, one
+ * index mirror rewrite.
+ */
+export function rejectValue(opts: RejectFlowOpts): RejectFlowResult {
+  if (!opts.reason.trim()) {
+    throw new Error('reject requires a non-empty --reason (the tombstone stores no content; reason is its only identity).');
+  }
+  if (opts.memoryId === undefined && opts.value === undefined) {
+    throw new Error('reject requires either a memory id or --value.');
+  }
+  if (opts.value !== undefined && normalizeValueForRejection(opts.value).length === 0) {
+    // Direct api callers can pass strings the CLI flag parser would have
+    // refused; an empty-normalized tombstone would refuse nothing meaningful
+    // and pollute the listing.
+    throw new Error('reject --value requires non-empty content.');
+  }
+
+  initStore(opts.hippoRoot);
+  const db = openHippoDb(opts.hippoRoot);
+  try {
+    let content: string;
+    if (opts.memoryId !== undefined) {
+      const row = db
+        .prepare(`SELECT content, tenant_id FROM memories WHERE id = ?`)
+        .get(opts.memoryId) as { content: string; tenant_id: string } | undefined;
+      if (!row || row.tenant_id !== opts.tenantId) {
+        throw new Error(`memory not found: ${opts.memoryId}`);
+      }
+      content = row.content;
+    } else {
+      content = opts.value!;
+    }
+
+    const digest = rejectionDigest(content);
+    const now = new Date().toISOString();
+    const removedIds: string[] = [];
+    const removedRawIds: string[] = [];
+
+    db.exec('BEGIN');
+    try {
+      insertRejectedValue(db, {
+        tenantId: opts.tenantId,
+        digest,
+        reason: opts.reason,
+        rejectedBy: opts.actor,
+        rejectedAt: now,
+        sourceMemoryId: opts.memoryId ?? null,
+        normalizedChars: normalizeValueForRejection(content).length,
+      });
+
+      // O(N) scan over the tenant's rows (plan §4): human-triggered command
+      // on ~1-5k-row stores — acceptable, documented. A digest column on
+      // memories is the escape if stores grow 100x; not needed now.
+      const rows = db
+        .prepare(`SELECT id, kind, content FROM memories WHERE tenant_id = ?`)
+        .all(opts.tenantId) as Array<{ id: string; kind: string; content: string }>;
+      for (const row of rows) {
+        if (rejectionDigest(row.content) !== digest) continue;
+        if (row.kind === 'raw') {
+          // Append-only trigger respected — archiveRawMemory is the only
+          // legitimate removal path for kind='raw', and its inner SAVEPOINT
+          // composes safely inside this BEGIN/COMMIT.
+          archiveRawMemory(db, row.id, { reason: opts.reason, who: opts.actor });
+          removedRawIds.push(row.id);
+        } else {
+          // suppressForgetAudit: the aggregate reject_value row below is the
+          // trail for these removals, not N individual forget rows (plan
+          // §4, round-3 advisory 2 — mirrors api.ts:1873-1877).
+          deleteEntryCore(db, row.id, { actor: opts.actor, suppressForgetAudit: true });
+        }
+        removedIds.push(row.id);
+      }
+
+      try {
+        appendAuditEvent(db, {
+          tenantId: opts.tenantId,
+          actor: opts.actor,
+          op: 'reject_value',
+          targetId: opts.memoryId,
+          metadata: { digest, removedIds, count: removedIds.length },
+        });
+      } catch {
+        // Best-effort — mirrors store.ts's private audit() semantics. This
+        // runs INSIDE the still-open transaction (COMMIT is the next
+        // statement): a swallowed audit failure lets the tombstone +
+        // removals commit without the trail row, rather than rolling the
+        // whole reject back over bookkeeping.
+      }
+
+      db.exec('COMMIT');
+    } catch (err) {
+      try {
+        db.exec('ROLLBACK');
+      } catch {
+        // already rolled back
+      }
+      throw err;
+    }
+
+    // Post-commit, db handle still open (same pattern as api.archiveRaw):
+    // best-effort mirror purge per removed id, reaper-backstop stamp for
+    // raw ids, one index mirror rewrite.
+    for (const id of removedIds) {
+      let mirrorOk = false;
+      try {
+        removeEntryMirrors(opts.hippoRoot, id);
+        mirrorOk = true;
+      } catch (mirrorErr) {
+        console.error(
+          `hippo reject: mirror cleanup failed for ${id} (will retry via reaper on next open): ${
+            mirrorErr instanceof Error ? mirrorErr.message : String(mirrorErr)
+          }`,
+        );
+      }
+      if (mirrorOk && removedRawIds.includes(id)) {
+        db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
+          new Date().toISOString(),
+          id,
+        );
+      }
+    }
+    if (removedIds.length > 0) {
+      writeIndexMirror(opts.hippoRoot, buildIndexFromDb(db));
+    }
+
+    return { digest, content, removedIds, removedRawIds };
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+export type UnrejectOutcome =
+  | { status: 'ok'; digest: string; reason: string | null }
+  | { status: 'not_found' }
+  | { status: 'ambiguous'; candidates: RejectedValueRow[] };
+
+/**
+ * `hippo unreject` / `api.unreject` — resolve a unique tombstone by digest
+ * (or prefix), delete it, audit `unreject_value`. The only v1 escape hatch
+ * (plan §4): no per-write force flag.
+ */
+export function unrejectValue(
+  hippoRoot: string,
+  tenantId: string,
+  digestOrPrefix: string,
+  actor: string,
+): UnrejectOutcome {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    const all = listRejectedValues(db, tenantId);
+    const matches = all.filter((r) => r.digest.startsWith(digestOrPrefix));
+    if (matches.length === 0) return { status: 'not_found' };
+    if (matches.length > 1) return { status: 'ambiguous', candidates: matches };
+
+    const target = matches[0]!;
+    deleteRejectedValue(db, tenantId, target.digest);
+    try {
+      appendAuditEvent(db, {
+        tenantId,
+        actor,
+        op: 'unreject_value',
+        targetId: target.sourceMemoryId ?? undefined,
+        metadata: { digest: target.digest, reason: target.reason },
+      });
+    } catch {
+      // Best-effort, same as reject's audit call above.
+    }
+    return { status: 'ok', digest: target.digest, reason: target.reason };
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+/** `hippo rejections` / `api.listRejections` — list tombstones for a tenant. */
+export function listRejectionsForTenant(hippoRoot: string, tenantId: string): RejectedValueRow[] {
+  initStore(hippoRoot);
+  const db = openHippoDb(hippoRoot);
+  try {
+    return listRejectedValues(db, tenantId);
+  } finally {
+    closeHippoDb(db);
+  }
+}

--- a/src/rejection.ts
+++ b/src/rejection.ts
@@ -204,11 +204,23 @@ export function checkRejectionGuard(
   // ULIDs, this lookup only classifies new-row vs same-id re-persist for the
   // id the caller is already writing, and the tombstone lookup above is the
   // tenant-scoped decision. Matches deleteEntry's own by-id SELECT.
-  const storedRow = db.prepare(`SELECT content FROM memories WHERE id = ?`).get(entryId) as
-    | { content: string }
+  //
+  // P2 fix: also read tenant_id. Content-digest-only comparison let a
+  // same-id upsert that ONLY changes tenantId slip through as an "unchanged
+  // re-persist" — content C sitting quietly (never rejected) in tenant A
+  // could be re-tagged into tenant B, and since C's digest already matched
+  // this row's stored digest, the guard exempted it even though B is the
+  // tenant that rejected C (that is WHY `tombstone` above is non-null: the
+  // lookup already ran under the INCOMING/destination tenantId). A tenant
+  // change on the SAME id is therefore always a content introduction into
+  // the destination tenant, exactly as if the row were new there.
+  const storedRow = db.prepare(`SELECT content, tenant_id FROM memories WHERE id = ?`).get(entryId) as
+    | { content: string; tenant_id: string }
     | undefined;
   const isNewRow = storedRow === undefined;
-  const isContentIntroduction = isNewRow || rejectionDigest(storedRow.content) !== incomingDigest;
+  const tenantChanged = !isNewRow && storedRow.tenant_id !== tenantId;
+  const isContentIntroduction =
+    isNewRow || tenantChanged || rejectionDigest(storedRow.content) !== incomingDigest;
   if (!isContentIntroduction) return; // unchanged same-id re-persist — exempt by construction
 
   throw new RejectedValueError({

--- a/src/rejection.ts
+++ b/src/rejection.ts
@@ -1,0 +1,221 @@
+/**
+ * AT1 rejected-value tombstone — core invariant.
+ * docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+ *
+ * Exact-normalized-value semantics: a human who rejects a fact can refuse
+ * byte-stable re-ingestion of the same value across remember/capture/import/
+ * sync surfaces. Paraphrase/semantic matching is explicitly out of scope
+ * (documented limitation, plan "Design").
+ *
+ * Kept db-agnostic (helpers take a `DatabaseSyncLike` handle) and does NOT
+ * import from store.ts — store.ts imports from here, and the reverse would
+ * be a cycle.
+ */
+
+import { createHash } from 'node:crypto';
+import type { DatabaseSyncLike } from './db.js';
+
+/**
+ * Normalize content for rejection-digest comparisons: Unicode NFC →
+ * lowercase → collapse whitespace runs to a single space → trim. No
+ * punctuation stripping — over-normalization creates false refusals, which
+ * are worse than misses (plan §1).
+ */
+export function normalizeValueForRejection(content: string): string {
+  return content.normalize('NFC').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Full sha256 hex (64 chars) of the normalized content. Reuses the strong-
+ * identity convention (importers.ts:814 content-hash tag), NOT the privacy-
+ * lossy 16-char convention (recall-trace query hashing) — a tombstone lookup
+ * key needs collision resistance, not redaction (plan §1).
+ */
+export function rejectionDigest(content: string): string {
+  return createHash('sha256').update(normalizeValueForRejection(content)).digest('hex');
+}
+
+/**
+ * Thrown by the write-path guard (checkRejectionGuard, called from
+ * upsertEntryRow) when an incoming write would introduce a value matching a
+ * tombstoned digest. Carries enough context for the transaction-owner catch
+ * blocks (writeEntry, api.supersede) to write a post-rollback
+ * `reject_refusal` audit row via `auditRejectionRefusal` (plan §3).
+ */
+export class RejectedValueError extends Error {
+  readonly digest: string;
+  readonly tenantId: string;
+  readonly entryId: string;
+  readonly reason: string | null;
+  readonly rejectedAt: string;
+
+  constructor(opts: {
+    digest: string;
+    tenantId: string;
+    entryId: string;
+    reason: string | null;
+    rejectedAt: string;
+  }) {
+    super(
+      `Memory value refused: matches a rejected value (digest ${opts.digest.slice(0, 12)}..., ` +
+        `reason: ${opts.reason ?? 'none given'}). Run "hippo unreject" to allow it again.`,
+    );
+    this.name = 'RejectedValueError';
+    this.digest = opts.digest;
+    this.tenantId = opts.tenantId;
+    this.entryId = opts.entryId;
+    this.reason = opts.reason;
+    this.rejectedAt = opts.rejectedAt;
+  }
+}
+
+export interface RejectedValueRow {
+  tenantId: string;
+  digest: string;
+  reason: string | null;
+  rejectedBy: string | null;
+  rejectedAt: string;
+  sourceMemoryId: string | null;
+  normalizedChars: number | null;
+}
+
+interface RawRejectedValueRow {
+  tenant_id: string;
+  digest: string;
+  reason: string | null;
+  rejected_by: string | null;
+  rejected_at: string;
+  source_memory_id: string | null;
+  normalized_chars: number | null;
+}
+
+function rowToRejectedValue(row: RawRejectedValueRow): RejectedValueRow {
+  return {
+    tenantId: row.tenant_id,
+    digest: row.digest,
+    reason: row.reason,
+    rejectedBy: row.rejected_by,
+    rejectedAt: row.rejected_at,
+    sourceMemoryId: row.source_memory_id,
+    normalizedChars: row.normalized_chars,
+  };
+}
+
+/**
+ * Look up a tombstone by tenant + digest. One indexed point query — the
+ * guard's common-case cost, a miss ends the guard (plan §3).
+ */
+export function findRejectedValue(
+  db: DatabaseSyncLike,
+  tenantId: string,
+  digest: string,
+): RejectedValueRow | null {
+  const row = db
+    .prepare(
+      `SELECT tenant_id, digest, reason, rejected_by, rejected_at, source_memory_id, normalized_chars
+       FROM rejected_values WHERE tenant_id = ? AND digest = ?`,
+    )
+    .get(tenantId, digest) as RawRejectedValueRow | undefined;
+  return row ? rowToRejectedValue(row) : null;
+}
+
+/**
+ * Insert (or refresh) a tombstone row. Caller owns the transaction — used by
+ * the T2 `reject` verb and `resolveConflict`'s `rejectLoserValue` path.
+ */
+export function insertRejectedValue(
+  db: DatabaseSyncLike,
+  opts: {
+    tenantId: string;
+    digest: string;
+    reason: string;
+    rejectedBy: string;
+    rejectedAt: string;
+    sourceMemoryId?: string | null;
+    normalizedChars: number;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO rejected_values(tenant_id, digest, reason, rejected_by, rejected_at, source_memory_id, normalized_chars)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(tenant_id, digest) DO UPDATE SET
+       reason = excluded.reason,
+       rejected_by = excluded.rejected_by,
+       rejected_at = excluded.rejected_at,
+       source_memory_id = excluded.source_memory_id,
+       normalized_chars = excluded.normalized_chars`,
+  ).run(
+    opts.tenantId,
+    opts.digest,
+    opts.reason,
+    opts.rejectedBy,
+    opts.rejectedAt,
+    opts.sourceMemoryId ?? null,
+    opts.normalizedChars,
+  );
+}
+
+/**
+ * Delete a tombstone by tenant + exact digest — the T2 `unreject` verb, the
+ * only v1 escape hatch (plan §4).
+ */
+export function deleteRejectedValue(db: DatabaseSyncLike, tenantId: string, digest: string): boolean {
+  const result = db.prepare(`DELETE FROM rejected_values WHERE tenant_id = ? AND digest = ?`).run(tenantId, digest);
+  return (result.changes ?? 0) > 0;
+}
+
+/** List tombstones for a tenant, newest first — the T2 `rejections` verb. */
+export function listRejectedValues(db: DatabaseSyncLike, tenantId: string): RejectedValueRow[] {
+  const rows = db
+    .prepare(
+      `SELECT tenant_id, digest, reason, rejected_by, rejected_at, source_memory_id, normalized_chars
+       FROM rejected_values WHERE tenant_id = ? ORDER BY rejected_at DESC, digest ASC`,
+    )
+    .all(tenantId) as RawRejectedValueRow[];
+  return rows.map(rowToRejectedValue);
+}
+
+/**
+ * The write-path guard's check helper, called from `upsertEntryRow`
+ * (store.ts). Fires when the incoming content's digest matches a tombstone
+ * AND the write *introduces* that content: the row is new, OR the stored
+ * row's content digest differs from the incoming one — an UPSERT editing a
+ * same-id row TO a rejected value is a content introduction and must be
+ * refused. Unchanged same-id re-persists (recall boost, decay, star toggle)
+ * are exempt by construction (plan §3).
+ *
+ * Ordering minimizes queries on the common (miss) path: (a) caller has
+ * already computed nothing yet — this does the digest + point lookup first;
+ * (b) a miss returns immediately (ONE indexed point query); (c) only on a
+ * tombstone hit does it SELECT the stored row's content to classify
+ * new-row vs content-introduction (+1 query, rare path).
+ */
+export function checkRejectionGuard(
+  db: DatabaseSyncLike,
+  tenantId: string,
+  entryId: string,
+  content: string,
+): void {
+  const incomingDigest = rejectionDigest(content);
+  const tombstone = findRejectedValue(db, tenantId, incomingDigest);
+  if (!tombstone) return; // miss ends the guard — the overwhelmingly common case
+
+  // Deliberately id-only (no tenant filter): memory ids are globally unique
+  // ULIDs, this lookup only classifies new-row vs same-id re-persist for the
+  // id the caller is already writing, and the tombstone lookup above is the
+  // tenant-scoped decision. Matches deleteEntry's own by-id SELECT.
+  const storedRow = db.prepare(`SELECT content FROM memories WHERE id = ?`).get(entryId) as
+    | { content: string }
+    | undefined;
+  const isNewRow = storedRow === undefined;
+  const isContentIntroduction = isNewRow || rejectionDigest(storedRow.content) !== incomingDigest;
+  if (!isContentIntroduction) return; // unchanged same-id re-persist — exempt by construction
+
+  throw new RejectedValueError({
+    digest: incomingDigest,
+    tenantId,
+    entryId,
+    reason: tombstone.reason,
+    rejectedAt: tombstone.rejectedAt,
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -212,6 +212,10 @@ const VALID_AUDIT_OPS: ReadonlySet<AuditOp> = new Set<AuditOp>([
   'customer_note_supersede', // E2 — emitted by saveCustomerNote on a supersession
   'customer_note_close',   // E2 — emitted by closeCustomerNote
   'mv_rescue',             // LC2-E3 — emitted by consolidate() per rescue; lockstep with AuditOp union + cli.ts VALID_AUDIT_OPS
+  'reject_value',          // AT1 — emitted by `hippo reject`; lockstep with AuditOp union + cli.ts VALID_AUDIT_OPS
+  'reject_refusal',        // AT1 — emitted when the rejection guard refuses a write; lockstep
+  'unreject_value',        // AT1 — emitted by `hippo unreject`; lockstep
+  'conflict_resolve',      // AT1 — emitted by resolveConflict on every resolution path; lockstep
 ]);
 
 // Cap on GET /v1/audit?limit=. Matches docs/api.md (when written) and is large

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -492,10 +492,23 @@ export function listPeers(
  * admission gate (transfer score, not-already-global) and was withheld SOLELY
  * by the secret veto — i.e. it counts shares actually prevented, not secret
  * rows merely present. Filled identically under `dryRun`.
+ *
+ * AT1: `stats.rejectedSkipped` (optional) is incremented once per candidate
+ * refused by the GLOBAL store's rejection tombstone (RejectedValueError from
+ * shareMemory -> writeEntry). Unlike secretSkipped, this can only be
+ * detected by attempting the write — `dryRun` returns candidates before the
+ * write loop runs, so `rejectedSkipped` stays at its initial value under
+ * `dryRun` (candidates that WOULD be refused are not distinguished in the
+ * dry-run preview).
  */
 export function autoShare(
   localRoot: string,
-  options: { minScore?: number; dryRun?: boolean; tenantId?: string; stats?: { secretSkipped: number } } = {},
+  options: {
+    minScore?: number;
+    dryRun?: boolean;
+    tenantId?: string;
+    stats?: { secretSkipped: number; rejectedSkipped?: number };
+  } = {},
 ): MemoryEntry[] {
   const { minScore = 0.6, dryRun = false } = options;
 
@@ -535,11 +548,36 @@ export function autoShare(
   if (dryRun) return candidates;
 
   const shared: MemoryEntry[] = [];
+  // AT1 containment (docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+  // plan §3 — sync/promote/share copy paths must not let ONE rejected
+  // candidate kill the batch): shareMemory -> writeEntry hits the LIVE guard
+  // against the GLOBAL store's tombstones. A matching candidate throws
+  // RejectedValueError, which (uncaught) would abort this whole loop and,
+  // via api.ts's sleep pipeline, the entire autoShare sleep phase. Mirrors
+  // syncGlobalToLocal's per-item catch just above in this file. writeEntry's
+  // own catch already writes the reject_refusal audit before rethrowing
+  // (plan §3) — do not double-audit here, just count and continue.
+  let rejectedSkipped = 0;
   for (const entry of candidates) {
-    // skipEmbed: batching invariant, this is a batch producer, so it embeds
-    // once via embedAll() below rather than once per row inside shareMemory.
-    const result = shareMemory(localRoot, entry.id, { force: true, skipEmbed: true });
-    if (result) shared.push(result);
+    try {
+      // skipEmbed: batching invariant, this is a batch producer, so it embeds
+      // once via embedAll() below rather than once per row inside shareMemory.
+      const result = shareMemory(localRoot, entry.id, { force: true, skipEmbed: true });
+      if (result) shared.push(result);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        rejectedSkipped++;
+        if (options.stats) options.stats.rejectedSkipped = (options.stats.rejectedSkipped ?? 0) + 1;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (rejectedSkipped > 0) {
+    console.error(
+      `autoShare: skipped ${rejectedSkipped} candidate(s) refused by the global store's rejection tombstone`,
+    );
   }
 
   if (shared.length > 0) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -23,6 +23,7 @@ import { search, hybridSearch, SearchResult } from './search.js';
 import { evalNow } from './ablation.js';
 import { deriveOriginProject, classifyOriginProject, resolveGlobalRootDir } from './project-identity.js';
 import { detectSecret } from './secret-detect.js';
+import { RejectedValueError } from './rejection.js';
 import { embedMemory, embedAll } from './embeddings.js';
 
 /**
@@ -572,6 +573,12 @@ export function syncGlobalToLocal(
   // only stamps when the field is missing).
   const currentName = deriveOriginProject(path.dirname(path.resolve(localRoot)));
   let count = 0;
+  // AT1 (plan §3 containment, the roadmap threat this whole feature targets
+  // — a locally-rejected value must not silently resurrect via sync down
+  // from global): per-item catch, no signature change (bare number return;
+  // see the syncGlobalToLocal callers in cli.ts + tests). Counted locally
+  // and printed as one summary line, same pattern as learnFromMemoryMd.
+  let rejected = 0;
 
   for (const entry of globalEntries) {
     // Skip if already present by ID
@@ -582,8 +589,20 @@ export function syncGlobalToLocal(
       classifyOriginProject(entry.origin_project, currentName) === 'cross-project'
     ) continue;
 
-    writeEntry(localRoot, entry);
+    try {
+      writeEntry(localRoot, entry);
+    } catch (err) {
+      if (err instanceof RejectedValueError) {
+        rejected++;
+        continue;
+      }
+      throw err;
+    }
     count++;
+  }
+
+  if (rejected > 0) {
+    console.error(`syncGlobalToLocal: skipped ${rejected} rejected value(s) (run \`hippo unreject\` on the local store to allow).`);
   }
 
   // Batch producer: one embedAll() on the destination rather than an

--- a/src/sleep-redact.ts
+++ b/src/sleep-redact.ts
@@ -52,6 +52,8 @@ export interface RedactSleepCtx {
  *   - secretSkipped (v1.25.0 — sibling of `shared`, produced by the same
  *     autoShare call; same per-invocation class, deliberately NOT given a
  *     divergent rule)
+ *   - rejectedSkipped (AT1 — secretSkipped's own sibling, same autoShare
+ *     call, same per-invocation class)
  *   - details (text descriptions, no aggregate numerics)
  */
 export function redactSleepResultForCaller(

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,19 @@ import { tokenize } from './search.js';
 import { appendAuditEvent, type AuditOp } from './audit.js';
 import { resolveTenantId } from './tenant.js';
 import { deriveOriginProject, originFromSource } from './project-identity.js';
+import {
+  checkRejectionGuard,
+  RejectedValueError,
+  rejectionDigest,
+  normalizeValueForRejection,
+  insertRejectedValue,
+} from './rejection.js';
+// AT1 (plan §5): resolveConflict's kind-aware loser removal needs
+// archiveRawMemory for kind='raw' losers. raw-archive.ts imports
+// markSummaryDirtyInTx from this module — both imports are used only
+// inside function bodies (never at module-evaluation time), so the cycle
+// is the standard safe mutual-function-reference shape under NodeNext ESM.
+import { archiveRawMemory } from './raw-archive.js';
 
 /**
  * Emit an audit event for a mutation against `db`. Wrapped so a broken audit
@@ -50,6 +63,28 @@ function audit(
     // Audit must never crash a mutation. Failures here mean the audit_log
     // table is broken; the mutation has already succeeded.
   }
+}
+
+/**
+ * Refusal audit for the AT1 rejection guard (plan §3). Written by the
+ * transaction OWNER post-rollback — writeEntry's catch (no outer tx exists
+ * there, so this lands in a fresh implicit transaction) and api.supersede's
+ * catch (after its own ROLLBACK) — never inside a scope the caller's own
+ * rollback could claw back. Best-effort `audit()` semantics: never throws.
+ */
+export function auditRejectionRefusal(
+  db: ReturnType<typeof openHippoDb>,
+  err: RejectedValueError,
+  actor: string,
+): void {
+  audit(
+    db,
+    'reject_refusal',
+    err.entryId,
+    { digest: err.digest, reason: err.reason },
+    actor,
+    err.tenantId,
+  );
 }
 
 export interface IndexEntry {
@@ -900,10 +935,32 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
 
   db.exec('BEGIN');
   try {
+    // AT1 (plan §3, round-3 redesign): run the guard LIVE per row rather
+    // than bypassing it. bootstrapLegacyStore is exactly the channel through
+    // which a stale/never-purged markdown mirror could resurrect a rejected
+    // value; a skip-and-count here closes that structurally, independent of
+    // mirror state. The refusal audit is written INLINE inside this
+    // still-open loop transaction (plain audit() — nothing is rolled back
+    // on a per-row skip, so the post-rollback auditRejectionRefusal helper
+    // is the wrong tool here).
+    let rejectedCount = 0;
     for (const entry of legacyEntries) {
       // v39: legacy markdown carries no origin_project; stamp from the store
       // location so bootstrapped rows stay visible to ambient context.
-      upsertEntryRow(db, stampOriginProjectForImport(hippoRoot, entry));
+      const stamped = stampOriginProjectForImport(hippoRoot, entry);
+      try {
+        upsertEntryRow(db, stamped);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          rejectedCount++;
+          audit(db, 'reject_refusal', err.entryId, { digest: err.digest, reason: err.reason }, 'cli', err.tenantId);
+          continue;
+        }
+        throw err;
+      }
+    }
+    if (rejectedCount > 0) {
+      console.error(`bootstrapLegacyStore: skipped ${rejectedCount} rejected value(s) found in legacy mirrors`);
     }
 
     const legacyIndex = loadLegacyIndexFile(hippoRoot);
@@ -994,7 +1051,21 @@ function loadLegacyStatsFile(hippoRoot: string): Record<string, unknown> {
   }
 }
 
-function upsertEntryRow(db: ReturnType<typeof openHippoDb>, entry: MemoryEntry): void {
+/**
+ * `bypassRejectionGuard` (AT1, plan §3): ONLY `batchWriteAndDelete`'s call
+ * site passes `true` — consolidation merge/auto-promote writes are LLM
+ * paraphrase rollups of already-guarded leaf facts; the guard belongs on
+ * leaf inserts. Every other caller (writeEntryDbOnly, bootstrapLegacyStore,
+ * rebuildIndex) leaves this false and the guard runs live.
+ */
+function upsertEntryRow(
+  db: ReturnType<typeof openHippoDb>,
+  entry: MemoryEntry,
+  bypassRejectionGuard = false,
+): void {
+  if (!bypassRejectionGuard) {
+    checkRejectionGuard(db, entry.tenantId ?? 'default', entry.id, entry.content);
+  }
   db.prepare(`
     INSERT INTO memories(
       id, created, last_retrieved, retrieval_count, strength, half_life_days, layer,
@@ -1116,7 +1187,8 @@ function deleteFtsRow(db: ReturnType<typeof openHippoDb>, id: string): void {
   }
 }
 
-function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
+// AT1: exported for the same reason as writeIndexMirror above.
+export function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
   const rows = db.prepare(`SELECT id, created, last_retrieved, strength, layer, tags_json, pinned FROM memories ORDER BY created ASC, id ASC`).all() as Array<{
     id: string;
     created: string;
@@ -1172,7 +1244,11 @@ function buildStatsFromDb(db: ReturnType<typeof openHippoDb>): Record<string, un
   };
 }
 
-function writeIndexMirror(hippoRoot: string, index: HippoIndex): void {
+// AT1: exported so src/reject-flow.ts can replicate deleteEntry's exact
+// post-commit "removeEntryMirrors then rewrite the index once" sequence for
+// the reject verb's (possibly multi-row) removal, without duplicating
+// buildIndexFromDb's query.
+export function writeIndexMirror(hippoRoot: string, index: HippoIndex): void {
   fs.writeFileSync(path.join(hippoRoot, 'index.json'), JSON.stringify(index, null, 2), 'utf8');
 }
 
@@ -1317,6 +1393,15 @@ export function writeEntry(
     writeEntryDbOnly(db, stamped, opts);
     opts?.afterCommit?.();
     writeEntryMirrors(hippoRoot, db, stamped);
+  } catch (error) {
+    // AT1 (plan §3): writeEntryDbOnly's own SAVEPOINT has already unwound by
+    // the time this catch runs, so the refusal audit lands post-rollback in
+    // a fresh implicit transaction — then rethrow so the caller sees the
+    // refusal.
+    if (error instanceof RejectedValueError) {
+      auditRejectionRefusal(db, error, opts?.actor ?? 'cli');
+    }
+    throw error;
   } finally {
     closeHippoDb(db);
   }
@@ -1632,11 +1717,58 @@ export function loadChildrenOf(
 }
 
 /**
+ * AT1 (plan §4, round-2 fix, designed from source): db-scoped delete core.
+ * `deleteEntry` used to open+close its OWN connection, which meant it could
+ * never compose inside a caller's transaction (unlike writeEntry/
+ * writeEntryDbOnly, which already split this way). Split identically: row-
+ * meta SELECT, `DELETE FROM memories`, FTS delete, `forget` audit, DAG
+ * dirty-mark. NO filesystem I/O — the caller's own transaction may still be
+ * rolled back, and mirror writes must only happen post-commit.
+ *
+ * `opts.suppressForgetAudit` (default false, off): T2's reject path sets
+ * this so removed non-raw rows do NOT each emit a `forget` row — a single
+ * aggregate `reject_value` audit row is the trail for that path instead.
+ * Default keeps `deleteEntry` byte-identical to its pre-split behavior.
+ *
+ * Returns `{tenantId, dagParentId}` for the removed row, or `null` if no row
+ * with `id` existed.
+ */
+export function deleteEntryCore(
+  db: ReturnType<typeof openHippoDb>,
+  id: string,
+  opts?: { actor?: string; suppressForgetAudit?: boolean },
+): { tenantId: string; dagParentId: string | null } | null {
+  const row = db
+    .prepare(`SELECT id, tenant_id, dag_parent_id FROM memories WHERE id = ?`)
+    .get(id) as { id?: string; tenant_id?: string; dag_parent_id?: string | null } | undefined;
+  if (!row?.id) return null;
+
+  db.prepare(`DELETE FROM memories WHERE id = ?`).run(id);
+  deleteFtsRow(db, id);
+  if (!opts?.suppressForgetAudit) {
+    audit(db, 'forget', id, undefined, opts?.actor ?? 'cli', row.tenant_id);
+  }
+  // v0.30 / E2 — DAG live-coupling: forget of a child under a level-2
+  // summary marks parent dirty. Non-atomic with the DELETE (no SAVEPOINT
+  // wrapper here, same as pre-split deleteEntry); markSummaryDirtyInTx is
+  // idempotent so any future child mutation re-marks parent if this fails.
+  // Acceptable degradation, mirrors the pre-split audit best-effort posture.
+  if (row.dag_parent_id) {
+    markSummaryDirtyInTx(db, row.dag_parent_id, row.tenant_id ?? 'default', opts?.actor ?? 'cli');
+  }
+  return { tenantId: row.tenant_id ?? 'default', dagParentId: row.dag_parent_id ?? null };
+}
+
+/**
  * Delete an entry from SQLite and mirrors.
  *
  * `opts.actor` defaults to 'cli'. The api.* layer threads `ctx.actor` so HTTP
  * callers land with `api_key:<key_id>` in the audit log without a duplicate
  * emit from the api wrapper.
+ *
+ * Thin wrapper over `deleteEntryCore` (open → core → mirrors → close);
+ * behavior is byte-identical to the pre-split implementation for every
+ * existing caller.
  */
 export function deleteEntry(
   hippoRoot: string,
@@ -1646,24 +1778,11 @@ export function deleteEntry(
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    const row = db
-      .prepare(`SELECT id, tenant_id, dag_parent_id FROM memories WHERE id = ?`)
-      .get(id) as { id?: string; tenant_id?: string; dag_parent_id?: string | null } | undefined;
-    if (!row?.id) return false;
+    const result = deleteEntryCore(db, id, opts);
+    if (!result) return false;
 
-    db.prepare(`DELETE FROM memories WHERE id = ?`).run(id);
-    deleteFtsRow(db, id);
     removeEntryMirrors(hippoRoot, id);
     writeIndexMirror(hippoRoot, buildIndexFromDb(db));
-    audit(db, 'forget', id, undefined, opts?.actor ?? 'cli', row.tenant_id);
-    // v0.30 / E2 — DAG live-coupling: forget of a child under a level-2
-    // summary marks parent dirty. Non-atomic with the DELETE (deleteEntry
-    // has no SAVEPOINT wrapper); markSummaryDirtyInTx is idempotent so any
-    // future child mutation re-marks parent if this fails. Acceptable
-    // degradation, mirrors deleteEntry's existing audit best-effort posture.
-    if (row.dag_parent_id) {
-      markSummaryDirtyInTx(db, row.dag_parent_id, row.tenant_id ?? 'default', opts?.actor ?? 'cli');
-    }
     return true;
   } finally {
     closeHippoDb(db);
@@ -1711,7 +1830,14 @@ export function batchWriteAndDelete(
     // context (codex gating review P1).
     const stampedWrites = toWrite.map((e) => stampOriginProject(hippoRoot, e));
     for (const entry of stampedWrites) {
-      upsertEntryRow(db, entry);
+      // AT1 (plan §3): bypass the rejection guard here. Consolidation
+      // merge/auto-promote writes are LLM paraphrase rollups of
+      // already-guarded leaf facts — refusing a paraphrase mid-batch would
+      // abort the whole consolidation transaction, and the digest would
+      // almost never match anyway (false confidence, not protection). The
+      // guard belongs on leaf inserts, which write through writeEntry /
+      // writeEntryDbOnly and stay guarded (bypassRejectionGuard defaults false).
+      upsertEntryRow(db, entry, true);
       // Hook for writes: child upserted under a level-2 summary marks parent dirty.
       if (entry.dag_parent_id) {
         dirtyParents.add(entry.dag_parent_id);
@@ -1856,9 +1982,27 @@ export function rebuildIndex(hippoRoot: string): HippoIndex {
     if (legacyEntries.length > 0) {
       db.exec('BEGIN');
       try {
+        // AT1 (plan §3, round-3 redesign): same guard-with-per-row-skip as
+        // bootstrapLegacyStore — rebuildIndex is the other channel through
+        // which a stale markdown mirror could resurrect a rejected value.
+        // Refusal audit written INLINE (nothing rolls back on a skip).
+        let rejectedCount = 0;
         for (const entry of legacyEntries) {
           // v39: same store-derived origin stamp as bootstrapLegacyStore.
-          upsertEntryRow(db, stampOriginProjectForImport(hippoRoot, entry));
+          const stamped = stampOriginProjectForImport(hippoRoot, entry);
+          try {
+            upsertEntryRow(db, stamped);
+          } catch (err) {
+            if (err instanceof RejectedValueError) {
+              rejectedCount++;
+              audit(db, 'reject_refusal', err.entryId, { digest: err.digest, reason: err.reason }, 'cli', err.tenantId);
+              continue;
+            }
+            throw err;
+          }
+        }
+        if (rejectedCount > 0) {
+          console.error(`rebuildIndex: skipped ${rejectedCount} rejected value(s) found in legacy mirrors`);
         }
         db.exec('COMMIT');
       } catch (err) {
@@ -2440,9 +2584,32 @@ export function replaceDetectedConflicts(
 }
 
 /**
+ * AT1 (plan §5): additive-optional opts for resolveConflict.
+ * `rejectLoserValue` implies removal of the loser regardless of
+ * `forgetLoser` — you cannot tombstone a value and leave it live.
+ */
+export interface ResolveConflictOpts {
+  /** Tombstone the loser's normalized digest + kind-aware remove it. */
+  rejectLoserValue?: boolean;
+  /** Actor for the tombstone + the new conflict_resolve audit row. Defaults to 'cli'. */
+  rejectedBy?: string;
+  /** Reason recorded on the tombstone (and passed to archiveRawMemory if the
+   *  loser is kind='raw'). Defaults to a conflict-context string. */
+  reason?: string;
+}
+
+/**
  * Resolve a conflict by keeping one memory and weakening the other.
  * Sets conflict status to 'resolved' and halves the loser's half-life.
- * If --forget is used, the loser is deleted entirely.
+ * If --forget is used, the loser is removed entirely (kind-aware: raw rows
+ * are archived via archiveRawMemory, others deleted via deleteEntryCore —
+ * AT1 fix for the pre-existing crash where a raw loser aborted the whole
+ * resolve transaction against the append-only trigger). `opts.rejectLoserValue`
+ * additionally tombstones the loser's normalized digest so it cannot be
+ * re-asserted later.
+ *
+ * Every resolution path (weaken / forget / reject) emits a `conflict_resolve`
+ * audit row (AT1 — previously resolveConflict wrote zero audit rows on any path).
  *
  * Returns the resolved conflict, or null if not found.
  */
@@ -2452,6 +2619,7 @@ export function resolveConflict(
   keepId: string,
   forgetLoser: boolean = false,
   tenantId?: string,
+  opts?: ResolveConflictOpts,
 ): { conflict: MemoryConflict; loserId: string } | null {
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
@@ -2497,9 +2665,50 @@ export function resolveConflict(
     db.prepare(`UPDATE memory_conflicts SET status = 'resolved', updated_at = datetime('now') WHERE id = ?`)
       .run(conflictId);
 
-    if (forgetLoser) {
-      // Delete the losing memory
-      db.prepare(`DELETE FROM memories WHERE id = ?${memScope}`).run(loserId, ...memArgs);
+    // AT1 (plan §5): removal (forgetLoser OR rejectLoserValue — a tombstoned
+    // value cannot be left live) is now kind-aware. The old bare
+    // `DELETE FROM memories WHERE id = ?` aborted the whole transaction when
+    // the loser was kind='raw' (append-only trigger fires); route through
+    // the same helpers the reject verb uses (both db-scoped, both compose
+    // inside this BEGIN/COMMIT). loserRemoved / loserWasRaw drive both the
+    // conflicts_with_json skip below and the post-commit mirror purge.
+    let loserRemoved = false;
+    let loserWasRaw = false;
+    let rejectedDigest: string | undefined;
+    const removeLoser = forgetLoser || opts?.rejectLoserValue === true;
+
+    if (removeLoser) {
+      const loserRow = db
+        .prepare(`SELECT kind, content, tenant_id FROM memories WHERE id = ?${memScope}`)
+        .get(loserId, ...memArgs) as { kind: string; content: string; tenant_id: string } | undefined;
+
+      if (loserRow) {
+        const actor = opts?.rejectedBy ?? 'cli';
+        const reason = opts?.reason ?? `resolveConflict ${conflictId}: kept ${keepId}`;
+
+        if (opts?.rejectLoserValue) {
+          rejectedDigest = rejectionDigest(loserRow.content);
+          insertRejectedValue(db, {
+            tenantId: loserRow.tenant_id ?? 'default',
+            digest: rejectedDigest,
+            reason,
+            rejectedBy: actor,
+            rejectedAt: new Date().toISOString(),
+            sourceMemoryId: loserId,
+            normalizedChars: normalizeValueForRejection(loserRow.content).length,
+          });
+        }
+
+        if (loserRow.kind === 'raw') {
+          archiveRawMemory(db, loserId, { reason, who: actor });
+          loserWasRaw = true;
+        } else {
+          deleteEntryCore(db, loserId, { actor, suppressForgetAudit: true });
+        }
+        loserRemoved = true;
+      }
+      // loserRow undefined = tenant-scope mismatch (or already gone); matches
+      // the old tenant-scoped DELETE's silent 0-rows-affected behavior.
     } else {
       // Halve the loser's half-life (weakens it over time)
       db.prepare(`UPDATE memories SET half_life_days = MAX(1, half_life_days / 2), updated_at = datetime('now') WHERE id = ?${memScope}`)
@@ -2515,7 +2724,7 @@ export function resolveConflict(
         .run(JSON.stringify(cleaned), keepId, ...memArgs);
     }
 
-    if (!forgetLoser) {
+    if (!loserRemoved) {
       const loserRow = db.prepare(`SELECT conflicts_with_json FROM memories WHERE id = ?${memScope}`).get(loserId, ...memArgs) as { conflicts_with_json: string } | undefined;
       if (loserRow) {
         const refs: string[] = JSON.parse(loserRow.conflicts_with_json || '[]');
@@ -2525,8 +2734,52 @@ export function resolveConflict(
       }
     }
 
+    // AT1: the missing audit (plan §5 — resolveConflict wrote ZERO audit_log
+    // rows on any path before this). Every path — weaken, forget, reject —
+    // lands exactly one conflict_resolve row.
+    audit(
+      db,
+      'conflict_resolve',
+      keepId,
+      {
+        conflictId,
+        keepId,
+        loserId,
+        disposition: loserRemoved ? (loserWasRaw ? 'archived_raw' : 'deleted') : 'weakened',
+        rejected: Boolean(opts?.rejectLoserValue),
+        rejectedDigest,
+      },
+      opts?.rejectedBy ?? 'cli',
+      tenantId,
+    );
+
     db.exec('COMMIT');
     syncMirrorFiles(hippoRoot, db);
+
+    // AT1 (plan §5): mirror purge + reaper stamp for the rejectLoserValue
+    // path only — same post-commit pattern as the reject verb
+    // (src/reject-flow.ts), reusing removeEntryMirrors + the raw_archive
+    // reaper bookkeeping. The plain forgetLoser path is left byte-identical
+    // to its pre-AT1 behavior (syncMirrorFiles above is all it ever did).
+    if (opts?.rejectLoserValue && loserRemoved) {
+      let mirrorOk = false;
+      try {
+        removeEntryMirrors(hippoRoot, loserId);
+        mirrorOk = true;
+      } catch (mirrorErr) {
+        console.error(
+          `resolveConflict: mirror cleanup failed for ${loserId} (will retry via reaper on next open): ${
+            mirrorErr instanceof Error ? mirrorErr.message : String(mirrorErr)
+          }`,
+        );
+      }
+      if (mirrorOk && loserWasRaw) {
+        db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
+          new Date().toISOString(),
+          loserId,
+        );
+      }
+    }
 
     return { conflict: { ...conflict, status: 'resolved' }, loserId };
   } catch (error) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -926,6 +926,69 @@ export function removeEntryMirrors(hippoRoot: string, id: string): void {
   }
 }
 
+/**
+ * AT1 mirror-purge honesty fix (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
+ * the candidate markdown mirror paths still on disk for `id`, computed the
+ * same way `removeEntryMirrors` walks them (one per layer: buffer/episodic/
+ * semantic), filtered to the ones that still `fs.existsSync`. Used to report
+ * an EXPLICIT path when a best-effort purge fails and no reaper exists to
+ * retry it — plain `removeEntryMirrors` returns void, giving no way to name
+ * which file is stuck.
+ */
+export function getExistingEntryMirrorPaths(hippoRoot: string, id: string): string[] {
+  return [Layer.Buffer, Layer.Episodic, Layer.Semantic]
+    .map((layer) => path.join(layerDir(hippoRoot, layer), `${id}.md`))
+    .filter((file) => fs.existsSync(file));
+}
+
+/**
+ * AT1 fix: best-effort markdown-mirror purge shared by `reject-flow.ts`'s
+ * `rejectValue` and `resolveConflict`'s post-commit purge. Both used to log
+ * "will retry via reaper on next open" for EVERY failure, but the reaper
+ * (`cleanupArchivedMirrors`, raw-archive-mirror-cleanup.ts) only scans
+ * `raw_archive` — that message was false for a non-raw id, which has no
+ * reaper at all.
+ *
+ * Retries the unlink once synchronously (the common real-world failure is a
+ * transient lock/AV-scanner false positive, not a permanent one). On a
+ * second failure: raw ids still get the honest reaper message (true); non-raw
+ * ids get the EXPLICIT leftover file path(s) and a manual-delete instruction,
+ * since nothing will ever retry them automatically.
+ *
+ * Returns true if the mirror ended up purged (first or second attempt).
+ */
+export function purgeMirrorBestEffort(
+  hippoRoot: string,
+  id: string,
+  isRaw: boolean,
+  logPrefix: string,
+): boolean {
+  try {
+    removeEntryMirrors(hippoRoot, id);
+    return true;
+  } catch {
+    try {
+      removeEntryMirrors(hippoRoot, id);
+      return true;
+    } catch (secondErr) {
+      const msg = secondErr instanceof Error ? secondErr.message : String(secondErr);
+      if (isRaw) {
+        console.error(
+          `${logPrefix}: mirror cleanup failed for ${id} (will retry via reaper on next open): ${msg}`,
+        );
+      } else {
+        const leftover = getExistingEntryMirrorPaths(hippoRoot, id);
+        const pathsNote = leftover.length > 0 ? leftover.join(', ') : `${id}.md (path unresolved)`;
+        console.error(
+          `${logPrefix}: mirror cleanup failed for ${id} - no automatic retry exists for this file, ` +
+          `delete it manually: ${pathsNote} (${msg})`,
+        );
+      }
+      return false;
+    }
+  }
+}
+
 function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: string): boolean {
   const countRow = db.prepare(`SELECT COUNT(*) AS count FROM memories`).get() as { count?: number } | undefined;
   const memoryCount = Number(countRow?.count ?? 0);
@@ -2803,17 +2866,12 @@ export function resolveConflict(
     // purge+reaper pattern as the reject verb (src/reject-flow.ts) and
     // api.archiveRaw — reusing removeEntryMirrors + raw_archive bookkeeping.
     if (loserRemoved) {
-      let mirrorOk = false;
-      try {
-        removeEntryMirrors(hippoRoot, loserId);
-        mirrorOk = true;
-      } catch (mirrorErr) {
-        console.error(
-          `resolveConflict: mirror cleanup failed for ${loserId} (will retry via reaper on next open): ${
-            mirrorErr instanceof Error ? mirrorErr.message : String(mirrorErr)
-          }`,
-        );
-      }
+      // AT1 fix: purgeMirrorBestEffort retries once, then — for non-raw ids,
+      // which cleanupArchivedMirrors' reaper never scans — reports the
+      // EXPLICIT leftover path(s) instead of the false "will retry via
+      // reaper" claim. See its own doc comment (store.ts, near
+      // removeEntryMirrors) for the full rationale.
+      const mirrorOk = purgeMirrorBestEffort(hippoRoot, loserId, loserWasRaw, 'resolveConflict');
       if (mirrorOk && loserWasRaw) {
         db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
           new Date().toISOString(),

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,7 @@ import {
   rejectionDigest,
   normalizeValueForRejection,
   insertRejectedValue,
+  findRejectedValue,
 } from './rejection.js';
 // AT1 (plan §5): resolveConflict's kind-aware loser removal needs
 // archiveRawMemory for kind='raw' losers. raw-archive.ts imports
@@ -929,6 +930,16 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
   const countRow = db.prepare(`SELECT COUNT(*) AS count FROM memories`).get() as { count?: number } | undefined;
   const memoryCount = Number(countRow?.count ?? 0);
   if (memoryCount > 0) return false;
+  // AT1 P2 fix: memoryCount alone is not a reliable "already bootstrapped"
+  // signal once the rejection guard exists. If EVERY legacy mirror row is
+  // rejected, memories stays at 0 rows even after a successful bootstrap
+  // pass, so the memoryCount>0 gate above never trips — every subsequent
+  // initStore() call would re-run this whole function: re-scan the legacy
+  // mirrors, re-attempt (and re-refuse, re-auditing) every row, and
+  // re-INSERT the legacy consolidation_runs rows with no dedup, duplicating
+  // them on each open. A dedicated meta flag marks bootstrap as
+  // attempted-and-settled regardless of how many rows actually landed.
+  if (getMeta(db, 'legacy_bootstrap_completed', '0') === '1') return false;
 
   const legacyEntries = loadLegacyEntriesFromMarkdown(hippoRoot);
   if (legacyEntries.length === 0) return false;
@@ -991,6 +1002,9 @@ function bootstrapLegacyStore(db: ReturnType<typeof openHippoDb>, hippoRoot: str
       );
     }
 
+    // AT1 P2 fix: stamp completion regardless of how many rows actually
+    // landed (all-rejected included) — see the gate comment above.
+    setMeta(db, 'legacy_bootstrap_completed', '1');
     db.exec('COMMIT');
   } catch (error) {
     db.exec('ROLLBACK');
@@ -1053,10 +1067,13 @@ function loadLegacyStatsFile(hippoRoot: string): Record<string, unknown> {
 
 /**
  * `bypassRejectionGuard` (AT1, plan §3): ONLY `batchWriteAndDelete`'s call
- * site passes `true` — consolidation merge/auto-promote writes are LLM
- * paraphrase rollups of already-guarded leaf facts; the guard belongs on
- * leaf inserts. Every other caller (writeEntryDbOnly, bootstrapLegacyStore,
- * rebuildIndex) leaves this false and the guard runs live.
+ * site passes `true`. Consolidation merges are DETERMINISTIC CONCATENATION
+ * (mergeContents, consolidate.ts:736-751), not LLM paraphrase — the bypass
+ * is safe because the producer (consolidate.ts's merge pass) now checks the
+ * merged content's rejection digest against the tenant's tombstones BEFORE
+ * ever assembling a batch to write, and skips the merge entirely on a hit.
+ * Every other caller (writeEntryDbOnly, bootstrapLegacyStore, rebuildIndex)
+ * leaves this false and the guard runs live.
  */
 function upsertEntryRow(
   db: ReturnType<typeof openHippoDb>,
@@ -1187,7 +1204,13 @@ function deleteFtsRow(db: ReturnType<typeof openHippoDb>, id: string): void {
   }
 }
 
-// AT1: exported for the same reason as writeIndexMirror above.
+/**
+ * Derive the current `HippoIndex` (entries + last-retrieval/trace lockstep
+ * meta) from SQLite, the source of truth. Exported (AT1) for the same
+ * reason as `writeIndexMirror` below: `src/reject-flow.ts` needs to rebuild
+ * the index mirror post-commit after a (possibly multi-row) reject removal,
+ * without duplicating this query.
+ */
 export function buildIndexFromDb(db: ReturnType<typeof openHippoDb>): HippoIndex {
   const rows = db.prepare(`SELECT id, created, last_retrieved, strength, layer, tags_json, pinned FROM memories ORDER BY created ASC, id ASC`).all() as Array<{
     id: string;
@@ -1244,10 +1267,13 @@ function buildStatsFromDb(db: ReturnType<typeof openHippoDb>): Record<string, un
   };
 }
 
-// AT1: exported so src/reject-flow.ts can replicate deleteEntry's exact
-// post-commit "removeEntryMirrors then rewrite the index once" sequence for
-// the reject verb's (possibly multi-row) removal, without duplicating
-// buildIndexFromDb's query.
+/**
+ * Write the `index.json` mirror file for a given (already-derived) index.
+ * Exported (AT1) so `src/reject-flow.ts` can replicate `deleteEntry`'s exact
+ * post-commit "removeEntryMirrors then rewrite the index once" sequence for
+ * the reject verb's (possibly multi-row) removal, without duplicating
+ * `buildIndexFromDb`'s query.
+ */
 export function writeIndexMirror(hippoRoot: string, index: HippoIndex): void {
   fs.writeFileSync(path.join(hippoRoot, 'index.json'), JSON.stringify(index, null, 2), 'utf8');
 }
@@ -1725,9 +1751,11 @@ export function loadChildrenOf(
  * dirty-mark. NO filesystem I/O — the caller's own transaction may still be
  * rolled back, and mirror writes must only happen post-commit.
  *
- * `opts.suppressForgetAudit` (default false, off): T2's reject path sets
- * this so removed non-raw rows do NOT each emit a `forget` row — a single
- * aggregate `reject_value` audit row is the trail for that path instead.
+ * `opts.suppressForgetAudit` (default false, off): two AT1 callers set this
+ * so a removed non-raw row does NOT ALSO emit a `forget` row, because each
+ * already writes its own aggregate audit trail — `src/reject-flow.ts`'s
+ * `rejectValue` (single `reject_value` row covering every same-digest row
+ * removed) and `resolveConflict` (`conflict_resolve` row per resolution).
  * Default keeps `deleteEntry` byte-identical to its pre-split behavior.
  *
  * Returns `{tenantId, dagParentId}` for the removed row, or `null` if no row
@@ -1830,13 +1858,17 @@ export function batchWriteAndDelete(
     // context (codex gating review P1).
     const stampedWrites = toWrite.map((e) => stampOriginProject(hippoRoot, e));
     for (const entry of stampedWrites) {
-      // AT1 (plan §3): bypass the rejection guard here. Consolidation
-      // merge/auto-promote writes are LLM paraphrase rollups of
-      // already-guarded leaf facts — refusing a paraphrase mid-batch would
-      // abort the whole consolidation transaction, and the digest would
-      // almost never match anyway (false confidence, not protection). The
-      // guard belongs on leaf inserts, which write through writeEntry /
-      // writeEntryDbOnly and stay guarded (bypassRejectionGuard defaults false).
+      // AT1 (plan §3, corrected): bypass the rejection guard here.
+      // Consolidation merges are DETERMINISTIC CONCATENATION (mergeContents,
+      // consolidate.ts:736-751) of already-guarded leaf facts, not an LLM
+      // paraphrase — refusing mid-batch would abort the whole consolidation
+      // transaction. The bypass is safe because consolidate.ts's merge pass
+      // now checks the merged content's rejection digest against the
+      // tenant's tombstones BEFORE ever pushing a merge into pendingWrites,
+      // skipping that merge entirely on a hit — the producer-side check is
+      // the fix, this bypass just stays out of its way. The guard belongs
+      // on leaf inserts, which write through writeEntry / writeEntryDbOnly
+      // and stay guarded (bypassRejectionGuard defaults false).
       upsertEntryRow(db, entry, true);
       // Hook for writes: child upserted under a level-2 summary marks parent dirty.
       if (entry.dag_parent_id) {
@@ -2756,12 +2788,21 @@ export function resolveConflict(
     db.exec('COMMIT');
     syncMirrorFiles(hippoRoot, db);
 
-    // AT1 (plan §5): mirror purge + reaper stamp for the rejectLoserValue
-    // path only — same post-commit pattern as the reject verb
-    // (src/reject-flow.ts), reusing removeEntryMirrors + the raw_archive
-    // reaper bookkeeping. The plain forgetLoser path is left byte-identical
-    // to its pre-AT1 behavior (syncMirrorFiles above is all it ever did).
-    if (opts?.rejectLoserValue && loserRemoved) {
+    // AT1 P1b fix: mirror purge + reaper stamp for EVERY removed loser, not
+    // just the rejectLoserValue path. Pre-AT1, the plain forgetLoser path on
+    // a raw loser crashed outright (bare DELETE FROM memories hit the
+    // append-only trigger) — there is no legacy "successful forget, no
+    // purge" behavior to preserve for that case. Post-AT1's kind-aware
+    // removal (archiveRawMemory / deleteEntryCore above) makes plain
+    // --forget succeed on every kind, but until this fix the mirror was
+    // only purged when rejectLoserValue was ALSO set: a plain raw --forget
+    // left its markdown mirror orphaned (the reaper still catches it
+    // eventually, since archiveRawMemory's own raw_archive insert leaves
+    // mirror_cleaned_at NULL) and a plain non-raw --forget left its mirror
+    // orphaned FOREVER (no reaper exists for non-raw rows). Same post-commit
+    // purge+reaper pattern as the reject verb (src/reject-flow.ts) and
+    // api.archiveRaw — reusing removeEntryMirrors + raw_archive bookkeeping.
+    if (loserRemoved) {
       let mirrorOk = false;
       try {
         removeEntryMirrors(hippoRoot, loserId);
@@ -3148,9 +3189,33 @@ export function applyRebuildResult(
     db.exec('SAVEPOINT rebuild_summary');
     try {
       const nowIso = new Date().toISOString();
+
+      // AT1 P1a fix (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
+      // applyRebuildResult's bumpRebuildCount branch wrote patch.content via
+      // a direct UPDATE, bypassing the rejection guard entirely (the guard
+      // lives in upsertEntryRow's INSERT path, which this function never
+      // calls). A rebuild that regenerates byte-identical content to an
+      // already-rejected value (e.g. deterministic summarization of an
+      // unchanged child set) would silently re-assert it every sleep cycle.
+      // Check BEFORE choosing which UPDATE to run — only the
+      // bumpRebuildCount branch ever writes content, so a miss or a
+      // zero-child call is a no-op here (one indexed point query, guarded
+      // path only).
+      const tombstone = patch.bumpRebuildCount
+        ? findRejectedValue(db, summary.tenantId, rejectionDigest(patch.content))
+        : null;
+      // On a hit: do NOT write the new content. Fall through to the SAME
+      // metadata-only behavior the zero-child branch already has —
+      // descendant_count/earliest_at/latest_at update + summary_dirty
+      // cleared, no content write, no rebuild_count bump. Clearing dirty
+      // (rather than leaving it set) is deliberate: leaving it dirty would
+      // make every following sleep cycle re-attempt and re-refuse the
+      // identical rebuild forever (the DAG-loop this fix closes).
+      const applyContentWrite = patch.bumpRebuildCount && !tombstone;
+
       // ONE prepared UPDATE per branch. Test #8 inspects the SQL string.
       // v0.30 / E5: widened dag_level=2 -> IN (2, 3) on both branches.
-      const sql = patch.bumpRebuildCount
+      const sql = applyContentWrite
         ? `UPDATE memories
               SET content = ?,
                   descendant_count = ?,
@@ -3175,7 +3240,7 @@ export function applyRebuildResult(
               AND summary_dirty = 1
               AND kind != 'archived'`;
 
-      const result = patch.bumpRebuildCount
+      const result = applyContentWrite
         ? db.prepare(sql).run(
             patch.content,
             patch.descendant_count,
@@ -3193,22 +3258,58 @@ export function applyRebuildResult(
             summary.tenantId,
           );
 
+      // Return-value semantics (documented per plan follow-up): `changed`
+      // reflects whether THIS call's UPDATE (content or metadata-only)
+      // affected a row — NOT whether patch.content specifically landed. On
+      // a refusal, metadata still applies, so changed=true here even though
+      // content did not change. This is a deliberate choice: the caller
+      // (dag.ts rebuildDirtySummaries) treats changed=false as "race lost,
+      // silently retry next cycle" — returning false on a refusal would
+      // retry the same doomed LLM rebuild forever. Returning true settles
+      // this cycle (dirty cleared) at the cost of the refused rebuild also
+      // counting toward the caller's `rebuilt` stat, which is the lesser
+      // evil and mirrors the pre-existing zero-child branch's own semantics
+      // (it already returns changed=true for a metadata-only update).
       const changed = (result.changes ?? 0) > 0;
+
+      if (tombstone && changed) {
+        // Best-effort refusal audit, written INLINE inside this still-open
+        // SAVEPOINT — nothing here rolls back on a refusal (the metadata
+        // UPDATE above already committed to this savepoint), so the
+        // post-rollback auditRejectionRefusal helper (writeEntry/supersede's
+        // tool) is the wrong one here; a direct audit() call is correct and
+        // commits with the rest of this savepoint.
+        audit(
+          db,
+          'reject_refusal',
+          summary.id,
+          { digest: tombstone.digest, reason: tombstone.reason },
+          patch.actor,
+          summary.tenantId,
+        );
+        console.error(
+          `applyRebuildResult: refused rebuild content for ${summary.id} — matches a rejected value ` +
+            `(digest ${tombstone.digest.slice(0, 12)}...); metadata updated, content unchanged`,
+        );
+      }
 
       if (changed) {
         // FTS sync — bare UPDATE on memories does NOT update memories_fts.
         // R1 HIGH must-fix from plan-eng-r1. Construct the patched entry in
         // memory and reuse the existing syncFtsRow helper (delete-then-insert).
         // earliest_at/latest_at preserve null semantics (R2 must-fix).
+        // AT1: content stays summary.content (unchanged) when the write was
+        // refused — applyContentWrite is false, so patch.content was never
+        // written to the row FTS must mirror.
         const patchedEntry: MemoryEntry = {
           ...summary,
-          content: patch.content,
+          content: applyContentWrite ? patch.content : summary.content,
           descendant_count: patch.descendant_count,
           earliest_at: patch.earliest_at,
           latest_at: patch.latest_at,
           summary_dirty: 0,
-          last_rebuilt_at: patch.bumpRebuildCount ? nowIso : summary.last_rebuilt_at,
-          rebuild_count: patch.bumpRebuildCount
+          last_rebuilt_at: applyContentWrite ? nowIso : summary.last_rebuilt_at,
+          rebuild_count: applyContentWrite
             ? (summary.rebuild_count ?? 0) + 1
             : summary.rebuild_count,
         };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1919,7 +1919,14 @@ export function batchWriteAndDelete(
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
   try {
-    db.exec('BEGIN');
+    // BEGIN IMMEDIATE (codex delta-review P2): the AT1 tombstone probes below
+    // READ before the first write. Under a deferred BEGIN, that read pins a
+    // WAL snapshot; a concurrent writer (e.g. `hippo reject`) committing
+    // between probe and first upsert would make the later write-lock upgrade
+    // fail with SQLITE_BUSY and roll back the ENTIRE batch — the exact race
+    // the probe exists to contain. Taking the write lock up front serializes
+    // the probe and the writes on one consistent snapshot.
+    db.exec('BEGIN IMMEDIATE');
     // v0.30 / E2 — DAG live-coupling: BEFORE deletes, snapshot dag_parent_id
     // for every doomed row so we can mark parents dirty post-COMMIT. Done
     // inside the same BEGIN so the SELECT sees pre-delete state.
@@ -1966,20 +1973,32 @@ export function batchWriteAndDelete(
     const skippedWriteIds = new Set<string>();
     for (const entry of stampedWrites) {
       const entryTenantId = entry.tenantId ?? 'default';
-      const incomingDigest = rejectionDigest(entry.content);
-      const tombstone = findRejectedValue(db, entryTenantId, incomingDigest);
-      if (tombstone) {
-        batchRejectedSkips++;
-        skippedWriteIds.add(entry.id);
-        audit(
-          db,
-          'reject_refusal',
-          entry.id,
-          { digest: incomingDigest, reason: tombstone.reason },
-          'sleep-batch',
-          entryTenantId,
-        );
-        continue;
+      // Codex delta-review P2 fix: reuse checkRejectionGuard rather than a
+      // bare tombstone probe — the guard's content-INTRODUCTION
+      // classification must apply here too. A tombstone can legitimately
+      // coexist with a live same-content row (resolveConflict deliberately
+      // excludes keepId from its sweep; unreject-then-re-reject windows), and
+      // an unconditional skip would starve that row of decay/replay metadata
+      // updates forever. The guard throws only when the write is new-row or
+      // changes content TO the rejected value; unchanged same-id re-persists
+      // pass through, exactly as on the writeEntry path.
+      try {
+        checkRejectionGuard(db, entryTenantId, entry.id, entry.content);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          batchRejectedSkips++;
+          skippedWriteIds.add(entry.id);
+          audit(
+            db,
+            'reject_refusal',
+            entry.id,
+            { digest: err.digest, reason: err.reason },
+            'sleep-batch',
+            entryTenantId,
+          );
+          continue;
+        }
+        throw err;
       }
       // AT1 (plan §3, corrected): bypass the rejection guard here.
       // Consolidation merges are DETERMINISTIC CONCATENATION (mergeContents,

--- a/src/store.ts
+++ b/src/store.ts
@@ -917,8 +917,17 @@ function writeMarkdownMirror(hippoRoot: string, entry: MemoryEntry): void {
   fs.writeFileSync(path.join(dir, `${entry.id}.md`), serializeEntry(entry), 'utf8');
 }
 
+// AT1 P1 fix (codex): `writeMarkdownMirror` writes ANY layer's mirror,
+// including `trace/<id>.md` for Layer.Trace rows (auto-promoted traces,
+// consolidate.ts) — but this enumeration only walked
+// Buffer/Episodic/Semantic. A rejected/forgotten trace row's markdown
+// content survived on disk while the purge (and `hippo reject`/plain
+// `forget`) reported success, and a stale trace mirror is exactly the
+// resurrection channel bootstrapLegacyStore/rebuildIndex guard against.
+// Fixes BOTH the AT1 reject-flow purge and the pre-existing plain-`forget`
+// gap for trace rows (deleteEntry has always called this same function).
 export function removeEntryMirrors(hippoRoot: string, id: string): void {
-  for (const layer of [Layer.Buffer, Layer.Episodic, Layer.Semantic]) {
+  for (const layer of [Layer.Buffer, Layer.Episodic, Layer.Semantic, Layer.Trace]) {
     const file = path.join(layerDir(hippoRoot, layer), `${id}.md`);
     if (fs.existsSync(file)) {
       fs.unlinkSync(file);
@@ -936,7 +945,11 @@ export function removeEntryMirrors(hippoRoot: string, id: string): void {
  * which file is stuck.
  */
 export function getExistingEntryMirrorPaths(hippoRoot: string, id: string): string[] {
-  return [Layer.Buffer, Layer.Episodic, Layer.Semantic]
+  // AT1 P1 fix (codex): same missing Layer.Trace as removeEntryMirrors above
+  // — kept in lockstep with it since this function's whole purpose is
+  // walking the mirror paths "the same way removeEntryMirrors walks them"
+  // (see its own doc comment).
+  return [Layer.Buffer, Layer.Episodic, Layer.Semantic, Layer.Trace]
     .map((layer) => path.join(layerDir(hippoRoot, layer), `${id}.md`))
     .filter((file) => fs.existsSync(file));
 }
@@ -1137,6 +1150,18 @@ function loadLegacyStatsFile(hippoRoot: string): Record<string, unknown> {
  * ever assembling a batch to write, and skips the merge entirely on a hit.
  * Every other caller (writeEntryDbOnly, bootstrapLegacyStore, rebuildIndex)
  * leaves this false and the guard runs live.
+ *
+ * AT1 P1 fix (codex, batch-transaction rejection race): the producer check
+ * above runs on a DIFFERENT connection BEFORE this transaction opens — a
+ * `hippo reject X` that commits in that window is invisible to it. This
+ * parameter's contract is UNCHANGED (still the sole bypass, still trusted
+ * by the producer-side check for the common case); what changed is that
+ * `batchWriteAndDelete` no longer trusts it BLINDLY. It now runs its own
+ * in-transaction point-probe (same connection, same digest lookup this
+ * function's guard would have done) immediately before each upsert and
+ * skips — rather than writes — any entry whose content matches a tombstone
+ * that landed after the producer's check. See batchWriteAndDelete for the
+ * skip logic.
  */
 function upsertEntryRow(
   db: ReturnType<typeof openHippoDb>,
@@ -1920,7 +1945,42 @@ export function batchWriteAndDelete(
     // origin would make freshly consolidated memories vanish from ambient
     // context (codex gating review P1).
     const stampedWrites = toWrite.map((e) => stampOriginProject(hippoRoot, e));
+    // AT1 P1 fix (codex, batch-transaction rejection race): the producer-side
+    // check (e.g. consolidate.ts's merge pass) runs BEFORE this transaction,
+    // on a different connection. A `hippo reject X` that commits in that
+    // window is invisible to it — a queued same-id write of X already
+    // sitting in `toWrite` (decay/replay re-persist, or a merge built before
+    // the reject) would silently re-INSERT the just-rejected row via the
+    // blind bypass. Fix: one indexed point probe per batch entry, on THIS
+    // connection, INSIDE this transaction — closes the race regardless of
+    // which write class hits it. N is small per sleep, so the extra query
+    // per entry is cheap.
+    //
+    // Skip, don't throw: the batch must still complete for every OTHER
+    // entry. Skipping is correct for every write class here — a merge
+    // summary skip just means that rollup is absent this cycle (its source
+    // facts stay merely demoted, recoverable next sleep); a skipped
+    // demotion/replay re-persist of a rejected-removed row means it stays
+    // gone, which is the entire point of the tombstone.
+    let batchRejectedSkips = 0;
+    const skippedWriteIds = new Set<string>();
     for (const entry of stampedWrites) {
+      const entryTenantId = entry.tenantId ?? 'default';
+      const incomingDigest = rejectionDigest(entry.content);
+      const tombstone = findRejectedValue(db, entryTenantId, incomingDigest);
+      if (tombstone) {
+        batchRejectedSkips++;
+        skippedWriteIds.add(entry.id);
+        audit(
+          db,
+          'reject_refusal',
+          entry.id,
+          { digest: incomingDigest, reason: tombstone.reason },
+          'sleep-batch',
+          entryTenantId,
+        );
+        continue;
+      }
       // AT1 (plan §3, corrected): bypass the rejection guard here.
       // Consolidation merges are DETERMINISTIC CONCATENATION (mergeContents,
       // consolidate.ts:736-751) of already-guarded leaf facts, not an LLM
@@ -1928,10 +1988,11 @@ export function batchWriteAndDelete(
       // transaction. The bypass is safe because consolidate.ts's merge pass
       // now checks the merged content's rejection digest against the
       // tenant's tombstones BEFORE ever pushing a merge into pendingWrites,
-      // skipping that merge entirely on a hit — the producer-side check is
-      // the fix, this bypass just stays out of its way. The guard belongs
-      // on leaf inserts, which write through writeEntry / writeEntryDbOnly
-      // and stay guarded (bypassRejectionGuard defaults false).
+      // skipping that merge entirely on a hit, AND because the point-probe
+      // immediately above closes the race window between that producer
+      // check and this COMMIT. The guard itself still belongs on leaf
+      // inserts, which write through writeEntry / writeEntryDbOnly and stay
+      // guarded (bypassRejectionGuard defaults false).
       upsertEntryRow(db, entry, true);
       // Hook for writes: child upserted under a level-2 summary marks parent dirty.
       if (entry.dag_parent_id) {
@@ -1950,8 +2011,17 @@ export function batchWriteAndDelete(
     }
     db.exec('COMMIT');
 
-    // Sync mirrors once after all DB writes
+    if (batchRejectedSkips > 0) {
+      console.error(
+        `batchWriteAndDelete: skipped ${batchRejectedSkips} write(s) whose content matches a rejected value (tombstone hit during the batch transaction)`,
+      );
+    }
+
+    // Sync mirrors once after all DB writes. Entries skipped above were
+    // never inserted — writing their markdown mirror would resurrect the
+    // exact content the skip just kept out of the DB.
     for (const entry of stampedWrites) {
+      if (skippedWriteIds.has(entry.id)) continue;
       writeMarkdownMirror(hippoRoot, entry);
     }
     for (const id of toDeleteIds) {
@@ -2770,6 +2840,12 @@ export function resolveConflict(
     let loserRemoved = false;
     let loserWasRaw = false;
     let rejectedDigest: string | undefined;
+    // AT1 P1 fix (codex): same-tenant duplicates of the loser's content that
+    // rejectLoserValue also removes (see below) — separate from loserId so
+    // the audit + post-commit mirror purge can cover ALL of them, not just
+    // loserId.
+    const extraRemovedIds: string[] = [];
+    const extraRemovedRawIds: string[] = [];
     const removeLoser = forgetLoser || opts?.rejectLoserValue === true;
 
     if (removeLoser) {
@@ -2792,6 +2868,33 @@ export function resolveConflict(
             sourceMemoryId: loserId,
             normalizedChars: normalizeValueForRejection(loserRow.content).length,
           });
+
+          // AT1 P1 fix (codex): reject-flow.ts's `rejectValue` removes ALL
+          // live same-tenant rows whose normalized digest matches, not just
+          // the one id passed — but this branch only ever removed loserId,
+          // leaving same-TENANT duplicates live while their shared content
+          // was tombstoned. Same O(N) scan pattern as reject-flow.ts (human-
+          // triggered command, tenant's row count is human-scale). CRITICAL
+          // BOUNDARY: tenant-scoped ONLY — tombstones are tenant-scoped by
+          // design, so a same-content row in ANOTHER tenant is legitimately
+          // live and must NOT be touched here. `keepId` is excluded even if
+          // its content coincidentally matches: the human explicitly chose
+          // to keep it in this same resolution, and this branch must not
+          // undo that choice in the same transaction.
+          const loserTenantId = loserRow.tenant_id ?? 'default';
+          const dupRows = db
+            .prepare(`SELECT id, kind, content FROM memories WHERE tenant_id = ? AND id != ? AND id != ?`)
+            .all(loserTenantId, loserId, keepId) as Array<{ id: string; kind: string; content: string }>;
+          for (const dup of dupRows) {
+            if (rejectionDigest(dup.content) !== rejectedDigest) continue;
+            if (dup.kind === 'raw') {
+              archiveRawMemory(db, dup.id, { reason, who: actor });
+              extraRemovedRawIds.push(dup.id);
+            } else {
+              deleteEntryCore(db, dup.id, { actor, suppressForgetAudit: true });
+            }
+            extraRemovedIds.push(dup.id);
+          }
         }
 
         if (loserRow.kind === 'raw') {
@@ -2843,6 +2946,10 @@ export function resolveConflict(
         disposition: loserRemoved ? (loserWasRaw ? 'archived_raw' : 'deleted') : 'weakened',
         rejected: Boolean(opts?.rejectLoserValue),
         rejectedDigest,
+        // AT1 P1 fix: every row this call removed, not just loserId — the
+        // same-tenant duplicate sweep above (extraRemovedIds) needs an
+        // audit trail too.
+        removedIds: loserRemoved ? [loserId, ...extraRemovedIds] : [],
       },
       opts?.rejectedBy ?? 'cli',
       tenantId,
@@ -2866,17 +2973,24 @@ export function resolveConflict(
     // purge+reaper pattern as the reject verb (src/reject-flow.ts) and
     // api.archiveRaw — reusing removeEntryMirrors + raw_archive bookkeeping.
     if (loserRemoved) {
-      // AT1 fix: purgeMirrorBestEffort retries once, then — for non-raw ids,
-      // which cleanupArchivedMirrors' reaper never scans — reports the
-      // EXPLICIT leftover path(s) instead of the false "will retry via
-      // reaper" claim. See its own doc comment (store.ts, near
-      // removeEntryMirrors) for the full rationale.
-      const mirrorOk = purgeMirrorBestEffort(hippoRoot, loserId, loserWasRaw, 'resolveConflict');
-      if (mirrorOk && loserWasRaw) {
-        db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
-          new Date().toISOString(),
-          loserId,
-        );
+      // AT1 P1 fix: loop over loserId AND every same-tenant duplicate the
+      // rejectLoserValue sweep above removed (extraRemovedIds) — previously
+      // only loserId's mirror was purged, leaving duplicate mirrors orphaned
+      // despite their rows being gone.
+      for (const removedId of [loserId, ...extraRemovedIds]) {
+        const isRaw = removedId === loserId ? loserWasRaw : extraRemovedRawIds.includes(removedId);
+        // AT1 fix: purgeMirrorBestEffort retries once, then — for non-raw ids,
+        // which cleanupArchivedMirrors' reaper never scans — reports the
+        // EXPLICIT leftover path(s) instead of the false "will retry via
+        // reaper" claim. See its own doc comment (store.ts, near
+        // removeEntryMirrors) for the full rationale.
+        const mirrorOk = purgeMirrorBestEffort(hippoRoot, removedId, isRaw, 'resolveConflict');
+        if (mirrorOk && isRaw) {
+          db.prepare(`UPDATE raw_archive SET mirror_cleaned_at = ? WHERE memory_id = ?`).run(
+            new Date().toISOString(),
+            removedId,
+          );
+        }
       }
     }
 

--- a/tests/a3-envelope-migration.test.ts
+++ b/tests/a3-envelope-migration.test.ts
@@ -8,13 +8,13 @@ import { writeEntry, readEntry, initStore } from '../src/store.js';
 
 describe('A3 envelope migration v14+v15', () => {
   it('CURRENT_SCHEMA_VERSION is 21 (v14 + v15 hardening + v16 tenant_id + v17 slack tables + v18 B3 dlPFC depth + v19 slack_dlq columns + v20 GDPR Path A redact backfill + v21 raw_archive.mirror_cleaned_at)', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
   });
 
   it('fresh db migrates to v21', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a3-'));
     const db = openHippoDb(home);
-    expect(getSchemaVersion(db)).toBe(40);
+    expect(getSchemaVersion(db)).toBe(41);
     closeHippoDb(db);
     rmSync(home, { recursive: true, force: true });
   });

--- a/tests/a5-tenant-migration.test.ts
+++ b/tests/a5-tenant-migration.test.ts
@@ -9,8 +9,8 @@ describe('A5 schema migration v16: tenant_id columns', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-a5-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
-      expect(getCurrentSchemaVersion()).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
+      expect(getCurrentSchemaVersion()).toBe(41);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/auth-role-migration.test.ts
+++ b/tests/auth-role-migration.test.ts
@@ -16,14 +16,14 @@ import { createApiKey, validateApiKey } from '../src/auth.js';
 
 describe('v1.12.0 migration v26: api_keys.role', () => {
   it('CURRENT_SCHEMA_VERSION is 26', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
   });
 
   it('fresh DB has api_keys.role column with DEFAULT admin', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-v26-fresh-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
       const cols = db.prepare(`PRAGMA table_info(api_keys)`).all() as Array<{ name: string; type: string; dflt_value: string | null; notnull: number }>;
       const role = cols.find((c) => c.name === 'role');
       expect(role).toBeDefined();

--- a/tests/b3-goal-stack-migration.test.ts
+++ b/tests/b3-goal-stack-migration.test.ts
@@ -9,8 +9,8 @@ describe('B3 schema migration v18', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-b3-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
-      expect(getCurrentSchemaVersion()).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
+      expect(getCurrentSchemaVersion()).toBe(41);
     } finally {
       closeHippoDb(db);
       rmSync(home, { recursive: true, force: true });

--- a/tests/dag-summary-metadata.test.ts
+++ b/tests/dag-summary-metadata.test.ts
@@ -36,13 +36,13 @@ describe('schema v25 — DAG summary metadata', () => {
   afterEach(() => safeRmSync(root));
 
   it('current schema version is 25', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
   });
 
   it('fresh init brings DB to v25 with the three new columns', () => {
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
       const cols = db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name?: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('descendant_count');

--- a/tests/db-migration-v27-self-heal.test.ts
+++ b/tests/db-migration-v27-self-heal.test.ts
@@ -74,7 +74,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db, 'schema_version')).toBe('40');
+      expect(getMeta(db, 'schema_version')).toBe('41');
     } finally {
       closeHippoDb(db);
     }
@@ -134,7 +134,7 @@ describe('migration v27 self-heal — partial-applied v16 state', () => {
       const tables = tableNames(db2);
       expect(tables).toContain('api_keys');
       expect(tables).toContain('audit_log');
-      expect(getMeta(db2, 'schema_version')).toBe('40');
+      expect(getMeta(db2, 'schema_version')).toBe('41');
     } finally {
       closeHippoDb(db2);
     }

--- a/tests/graph-schema.test.ts
+++ b/tests/graph-schema.test.ts
@@ -25,7 +25,7 @@ describe('graph schema v37 (E3.3)', () => {
   afterEach(() => { try { rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ } });
 
   it('CURRENT_SCHEMA_VERSION is 38', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
   });
 
   it('creates entities + relations + graph_extraction_queue tables', () => {

--- a/tests/pr2-session-continuity.test.ts
+++ b/tests/pr2-session-continuity.test.ts
@@ -36,8 +36,8 @@ describe('schema v5+v6 migration', () => {
     initStore(tmpDir);
     const db = openHippoDb(tmpDir);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
-      expect(getCurrentSchemaVersion()).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
+      expect(getCurrentSchemaVersion()).toBe(41);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/recall-trace-migration.test.ts
+++ b/tests/recall-trace-migration.test.ts
@@ -30,8 +30,8 @@ describe('LC1 schema migration v40', () => {
     const home = mkdtempSync(join(tmpdir(), 'hippo-lc1-mig-'));
     const db = openHippoDb(home);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
-      expect(getCurrentSchemaVersion()).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
+      expect(getCurrentSchemaVersion()).toBe(41);
       const tables = tableNames(db);
       expect(tables).toContain('recall_traces');
       expect(tables).toContain('recall_trace_results');
@@ -149,7 +149,7 @@ describe('LC1 schema migration v40', () => {
     // Re-open triggers runMigrations, which should re-run v40.
     db = openHippoDb(home);
     try {
-      expect(getMeta(db, 'schema_version')).toBe('40');
+      expect(getMeta(db, 'schema_version')).toBe('41');
       const tables = tableNames(db);
       expect(tables).toContain('recall_traces');
       expect(tables).toContain('recall_trace_results');

--- a/tests/rejection-acceptance.test.ts
+++ b/tests/rejection-acceptance.test.ts
@@ -33,6 +33,8 @@ import {
 import { cmdCapture } from '../src/capture.js';
 import { syncGlobalToLocal } from '../src/shared.js';
 import * as api from '../src/api.js';
+import { consolidate } from '../src/consolidate.js';
+import { importEntries } from '../src/importers.js';
 
 function tmpHome(prefix: string = 'hippo-rejection-acceptance-'): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -368,6 +370,110 @@ describe('AT1 case 6: AT5 paired case — reject removes a value from recall, pe
 
       const afterReattempt = api.recall(ctx(home), { query: 'zynthkey', limit: 5 });
       expect(afterReattempt.results.some((r) => r.content === wContent)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 consolidation-loop fix: merge tombstone check', () => {
+  it('a rejected would-be-merged content digest makes consolidate skip that merge: no semantic row with that digest, sources not demoted/deleted, skip counted', async () => {
+    const home = tmpHome('hippo-rejection-acceptance-consolidate-');
+    try {
+      initStore(home);
+      // Disable replay: it independently rehearses (and half-life-boosts)
+      // survivors regardless of the merge pass, which would confound the
+      // "sources not demoted" half_life_days assertion below.
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      // longText is the longer of the two, so mergeContents' length-sort
+      // deterministically picks it as the 2-entry merge base.
+      const shortText = 'migrate the billing database before the next release window';
+      const longText = 'migrate the billing database before the next release window with full backups enabled';
+      const e1 = createMemory(shortText, { layer: Layer.Episodic });
+      const e2 = createMemory(longText, { layer: Layer.Episodic });
+      writeEntry(home, e1);
+      writeEntry(home, e2);
+
+      const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
+      const mergedDigest = rejectionDigest(mergedContent);
+      const db = openHippoDb(home);
+      try {
+        insertRejectedValue(db, {
+          tenantId: 'default',
+          digest: mergedDigest,
+          reason: 'pre-rejected merge rollup',
+          rejectedBy: 'test',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection(mergedContent).length,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = await consolidate(home, { dryRun: false });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('skipped 1 merge(s) whose content matches a rejected value'),
+      );
+      errorSpy.mockRestore();
+
+      expect(result.semanticCreated).toBe(0);
+
+      const allAfter = loadAllEntries(home);
+      // No row anywhere carries the rejected merge digest.
+      expect(allAfter.some((e) => rejectionDigest(e.content) === mergedDigest)).toBe(false);
+
+      // Sources survive, UNMERGED: still present, still episodic, half-life
+      // untouched (the demotion loop never ran for this cluster).
+      const e1After = allAfter.find((e) => e.id === e1.id);
+      const e2After = allAfter.find((e) => e.id === e2.id);
+      expect(e1After).toBeDefined();
+      expect(e2After).toBeDefined();
+      expect(e1After!.layer).toBe(Layer.Episodic);
+      expect(e2After!.layer).toBe(Layer.Episodic);
+      expect(e1After!.half_life_days).toBe(e1.half_life_days);
+      expect(e2After!.half_life_days).toBe(e2.half_life_days);
+
+      const dbAfter = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(dbAfter, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+      } finally {
+        closeHippoDb(dbAfter);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 P2 fix: import dry-run tombstone accuracy', () => {
+  it('importEntries dry-run counts a tombstoned chunk as rejected (not imported), writes nothing, and agrees with a real run', () => {
+    const home = tmpHome('hippo-rejection-acceptance-import-dryrun-');
+    try {
+      initStore(home);
+      const rejectedChunk = 'never re-import this specific chunk of text again please';
+      const otherChunk = 'a completely different unrelated chunk of text here';
+      api.reject(ctx(home), { value: rejectedChunk, reason: 'pre-emptive dry-run test tombstone' });
+
+      const dryResult = importEntries([rejectedChunk, otherChunk], 'import:test', [], {
+        hippoRoot: home,
+        dryRun: true,
+      });
+      expect(dryResult.rejected).toBe(1);
+      expect(dryResult.imported).toBe(1);
+      expect(loadAllEntries(home).length).toBe(0); // dry-run writes nothing
+
+      const realResult = importEntries([rejectedChunk, otherChunk], 'import:test', [], {
+        hippoRoot: home,
+        dryRun: false,
+      });
+      expect(realResult.rejected).toBe(1);
+      expect(realResult.imported).toBe(1);
+      const contents = loadAllEntries(home).map((e) => e.content);
+      expect(contents).not.toContain(rejectedChunk);
+      expect(contents).toContain(otherChunk);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/rejection-acceptance.test.ts
+++ b/tests/rejection-acceptance.test.ts
@@ -20,7 +20,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'no
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
-import { initStore, writeEntry, readEntry, loadAllEntries, rebuildIndex } from '../src/store.js';
+import { initStore, writeEntry, readEntry, loadAllEntries, rebuildIndex, appendSessionEvent } from '../src/store.js';
 import { createMemory, Layer } from '../src/memory.js';
 import { queryAuditEvents } from '../src/audit.js';
 import {
@@ -31,7 +31,7 @@ import {
   findRejectedValue,
 } from '../src/rejection.js';
 import { cmdCapture } from '../src/capture.js';
-import { syncGlobalToLocal } from '../src/shared.js';
+import { syncGlobalToLocal, autoShare } from '../src/shared.js';
 import * as api from '../src/api.js';
 import { consolidate } from '../src/consolidate.js';
 import { importEntries } from '../src/importers.js';
@@ -476,6 +476,210 @@ describe('AT1 P2 fix: import dry-run tombstone accuracy', () => {
       expect(contents).toContain(otherChunk);
     } finally {
       rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 codex-P1 fix 1: auto-promoted trace tombstone check', () => {
+  it('reject an auto-promoted trace -> next consolidate does not recreate it: skip counted, one reject_refusal audit, no trace row', async () => {
+    const home = tmpHome('hippo-rejection-acceptance-trace-');
+    try {
+      initStore(home);
+      const sid = 'test-session-rejected-trace';
+      appendSessionEvent(home, 'default', {
+        session_id: sid, event_type: 'action', content: 'read config.ts', source: 'agent',
+      });
+      appendSessionEvent(home, 'default', {
+        session_id: sid,
+        event_type: 'session_complete',
+        content: 'success',
+        source: 'agent',
+        metadata: { summary: 'rotated the deploy key' },
+      });
+
+      const firstResult = await consolidate(home, { now: new Date() });
+      expect(firstResult.promotedTraces).toBe(1);
+
+      const traceBefore = loadAllEntries(home).find((e) => e.layer === Layer.Trace);
+      expect(traceBefore).toBeDefined();
+
+      api.reject(ctx(home), { memoryId: traceBefore!.id, reason: 'trace content was wrong' });
+      expect(readEntry(home, traceBefore!.id)).toBeNull();
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const secondResult = await consolidate(home, { now: new Date() });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('skipped 1 auto-promoted trace'),
+      );
+      errorSpy.mockRestore();
+
+      // Not recreated, and not counted as promoted.
+      expect(secondResult.promotedTraces).toBe(0);
+      const tracesAfter = loadAllEntries(home).filter((e) => e.layer === Layer.Trace);
+      expect(tracesAfter).toHaveLength(0);
+
+      const db = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+        expect(refusals[0]!.metadata.sourceSessionId).toBe(sid);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant', () => {
+  it('a tombstone in the tenant createMemory actually stamps (default) blocks the merge, even though the cluster is a different tenant', async () => {
+    const home = tmpHome('hippo-rejection-acceptance-merge-tenant-');
+    try {
+      initStore(home);
+      // Disable replay: see the sibling "consolidation-loop fix" test above.
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      const shortText = 'rotate the staging tls certificates before expiry';
+      const longText = 'rotate the staging tls certificates before expiry and notify the on-call channel';
+      const e1 = createMemory(shortText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      const e2 = createMemory(longText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      writeEntry(home, e1);
+      writeEntry(home, e2);
+
+      const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
+      const mergedDigest = rejectionDigest(mergedContent);
+
+      // Tombstone lives in 'default' — the tenant createMemory's semantic
+      // entry actually stamps (it is never passed a tenantId option) — NOT
+      // the cluster's own 'tenant-a'.
+      const db = openHippoDb(home);
+      try {
+        insertRejectedValue(db, {
+          tenantId: 'default',
+          digest: mergedDigest,
+          reason: 'pre-rejected in the actual destination tenant',
+          rejectedBy: 'test',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection(mergedContent).length,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = await consolidate(home, { dryRun: false });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('skipped 1 merge(s) whose content matches a rejected value'),
+      );
+      errorSpy.mockRestore();
+
+      expect(result.semanticCreated).toBe(0);
+      const allAfter = loadAllEntries(home);
+      expect(allAfter.some((e) => rejectionDigest(e.content) === mergedDigest)).toBe(false);
+
+      const dbAfter = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(dbAfter, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+      } finally {
+        closeHippoDb(dbAfter);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a tombstone ONLY in the source tenant (not the destination) does not falsely block the merge', async () => {
+    const home = tmpHome('hippo-rejection-acceptance-merge-tenant-');
+    try {
+      initStore(home);
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      const shortText = 'archive the quarterly billing export before cleanup';
+      const longText = 'archive the quarterly billing export before cleanup and confirm checksum';
+      const e1 = createMemory(shortText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      const e2 = createMemory(longText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      writeEntry(home, e1);
+      writeEntry(home, e2);
+
+      const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
+      const mergedDigest = rejectionDigest(mergedContent);
+
+      // Tombstone lives ONLY in 'tenant-a' (the cluster's source tenant) —
+      // the write actually lands in 'default', so this must NOT block.
+      const db = openHippoDb(home);
+      try {
+        insertRejectedValue(db, {
+          tenantId: 'tenant-a',
+          digest: mergedDigest,
+          reason: 'rejected in the source tenant only',
+          rejectedBy: 'test',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection(mergedContent).length,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const result = await consolidate(home, { dryRun: false });
+
+      expect(result.semanticCreated).toBe(1);
+      const allAfter = loadAllEntries(home);
+      const semantic = allAfter.find((e) => e.layer === Layer.Semantic && e.content === mergedContent);
+      expect(semantic).toBeDefined();
+      expect(semantic!.tenantId).toBe('default');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 codex-P1 fix 3: autoShare per-candidate rejection containment', () => {
+  it('one rejected + one clean candidate: the sleep-facing autoShare call completes, the clean one shares, the rejected one is counted', () => {
+    const localRoot = tmpHome('hippo-rejection-acceptance-autoshare-local-');
+    const globalRoot = tmpHome('hippo-rejection-acceptance-autoshare-global-');
+    const prevHippoHome = process.env.HIPPO_HOME;
+    try {
+      initStore(localRoot);
+      initStore(globalRoot);
+      // autoShare -> shareMemory resolves its destination via
+      // getGlobalRoot()/HIPPO_HOME (same pattern as shared.test.ts's
+      // promoteToGlobal describe block).
+      process.env.HIPPO_HOME = globalRoot;
+
+      const rejectedContent = 'never re-share this specific finding to the global store again';
+      const cleanContent = 'a completely different clean finding worth sharing globally';
+      const rejectedEntry = createMemory(rejectedContent, { layer: Layer.Episodic });
+      const cleanEntry = createMemory(cleanContent, { layer: Layer.Episodic });
+      writeEntry(localRoot, rejectedEntry);
+      writeEntry(localRoot, cleanEntry);
+
+      // Reject in the GLOBAL store — the store shareMemory -> writeEntry
+      // actually writes into.
+      api.reject(ctx(globalRoot), { value: rejectedContent, reason: 'must not be shared globally' });
+
+      const stats = { secretSkipped: 0, rejectedSkipped: 0 };
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const shared = autoShare(localRoot, { minScore: 0, stats });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('skipped 1 candidate(s) refused'),
+      );
+      errorSpy.mockRestore();
+
+      // The clean candidate shared; the rejected one did not abort the batch.
+      expect(shared.length).toBe(1);
+      expect(shared[0]!.content).toBe(cleanContent);
+      expect(stats.rejectedSkipped).toBe(1);
+
+      const globalContents = loadAllEntries(globalRoot).map((e) => e.content);
+      expect(globalContents).toContain(cleanContent);
+      expect(globalContents).not.toContain(rejectedContent);
+    } finally {
+      if (prevHippoHome === undefined) delete process.env.HIPPO_HOME;
+      else process.env.HIPPO_HOME = prevHippoHome;
+      rmSync(localRoot, { recursive: true, force: true });
+      rmSync(globalRoot, { recursive: true, force: true });
     }
   });
 });

--- a/tests/rejection-acceptance.test.ts
+++ b/tests/rejection-acceptance.test.ts
@@ -480,6 +480,46 @@ describe('AT1 P2 fix: import dry-run tombstone accuracy', () => {
   });
 });
 
+describe('AT1 P2 fix: capture dry-run tombstone accuracy', () => {
+  it('capture dry-run reports a tombstoned extraction as rejected and writes nothing, agreeing with a real run', () => {
+    const home = tmpHome('hippo-rejection-acceptance-capture-dryrun-');
+    try {
+      initStore(home);
+      // Digit signal so audit.ts's isContentWorthStoring specificity gate
+      // (hasNoSpecificity) doesn't filter these before they ever reach the
+      // rejection guard — same fixture-construction rule as case 1 above.
+      const rejectedContent = 'use bearer tokens for outbound api calls to port 8443';
+      api.reject(ctx(home), { value: rejectedContent, reason: 'pre-emptive dry-run capture tombstone' });
+
+      const fixturePath = join(home, 'capture-dryrun-fixture.txt');
+      writeFileSync(
+        fixturePath,
+        [
+          `decision: ${rejectedContent}`,
+          'decision: rotate deploy keys every 90 days',
+        ].join('\n'),
+        'utf8',
+      );
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      cmdCapture(home, { source: 'file', filePath: fixturePath, dryRun: true, global: false });
+      const dryLogs = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      logSpy.mockRestore();
+
+      expect(dryLogs).toContain(', 1 rejected)');
+      expect(loadAllEntries(home).length).toBe(0); // dry-run writes nothing
+
+      // Real run agrees: the tombstoned item is refused, the sibling lands.
+      cmdCapture(home, { source: 'file', filePath: fixturePath, dryRun: false, global: false });
+      const contents = loadAllEntries(home).map((e) => e.content);
+      expect(contents).not.toContain(rejectedContent);
+      expect(contents.some((c) => c.includes('rotate deploy keys'))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('AT1 codex-P1 fix 1: auto-promoted trace tombstone check', () => {
   it('reject an auto-promoted trace -> next consolidate does not recreate it: skip counted, one reject_refusal audit, no trace row', async () => {
     const home = tmpHome('hippo-rejection-acceptance-trace-');

--- a/tests/rejection-acceptance.test.ts
+++ b/tests/rejection-acceptance.test.ts
@@ -1,0 +1,375 @@
+/**
+ * AT1 T3 acceptance-critical tests: docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+ * §7 (tests) + the six cases assigned to T3.
+ *
+ * Real DB, per the project convention (mirrors tests/rejection-guard.test.ts
+ * and tests/rejection-verbs.test.ts, which already cover guard mechanics,
+ * verbs, and resolveConflict — none of that is repeated here).
+ *
+ * Six cases:
+ *   1. Acceptance (roadmap-verbatim): reject-by-id then capture re-assertion.
+ *   2. Refused supersede: CAS rollback + one reject_refusal audit row.
+ *   3. Copy-path: syncGlobalToLocal skips a locally-rejected value.
+ *   4. Rebuild resurrection pin: a stale markdown mirror cannot resurrect.
+ *   5. Migration v41 idempotence (fresh re-open + a v40-shaped upgrade).
+ *   6. AT5 paired case: reject removes a value from recall, permanently.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
+import { initStore, writeEntry, readEntry, loadAllEntries, rebuildIndex } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { queryAuditEvents } from '../src/audit.js';
+import {
+  RejectedValueError,
+  rejectionDigest,
+  normalizeValueForRejection,
+  insertRejectedValue,
+  findRejectedValue,
+} from '../src/rejection.js';
+import { cmdCapture } from '../src/capture.js';
+import { syncGlobalToLocal } from '../src/shared.js';
+import * as api from '../src/api.js';
+
+function tmpHome(prefix: string = 'hippo-rejection-acceptance-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function ctx(hippoRoot: string, tenantId: string = 'default'): api.Context {
+  return { hippoRoot, tenantId, actor: { subject: 'cli', role: 'admin' } };
+}
+
+describe('AT1 case 1: acceptance (roadmap-verbatim)', () => {
+  it('reject X by id -> capture re-assertion refused, 2 siblings written, one reject_refusal audit row, extraction does not throw; supersession unchanged', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+
+      // Seed X, then reject it by id — removes the row and tombstones its digest.
+      const xContent = 'use bearer tokens for outbound api calls';
+      const x = createMemory(xContent, { layer: Layer.Episodic });
+      writeEntry(home, x);
+      api.reject(ctx(home), { memoryId: x.id, reason: 'no longer approved for outbound calls' });
+      expect(readEntry(home, x.id)).toBeNull();
+
+      // A transcript re-asserting X among 3 extractable decision items.
+      const fixturePath = join(home, 'transcript-fixture.txt');
+      writeFileSync(
+        fixturePath,
+        [
+          `decision: ${xContent}`,
+          // Siblings need a specificity signal (number/proper-noun/path/code)
+          // per audit.ts's isContentWorthStoring gate (hasNoSpecificity) — a
+          // vague under-40-char sentence with no digits gets filtered before
+          // it ever reaches the rejection guard, which would silently turn
+          // this into a 1-item extraction instead of the intended 3.
+          'decision: cache dns lookups for 5 minutes',
+          'decision: rotate deploy keys every 90 days',
+        ].join('\n'),
+        'utf8',
+      );
+
+      expect(() =>
+        cmdCapture(home, { source: 'file', filePath: fixturePath, dryRun: false, global: false }),
+      ).not.toThrow();
+
+      const contents = loadAllEntries(home).map((e) => e.content);
+      expect(contents).not.toContain(xContent);
+      expect(contents.some((c) => c.includes('cache dns lookups'))).toBe(true);
+      expect(contents.some((c) => c.includes('rotate deploy keys'))).toBe(true);
+
+      const db = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+      } finally {
+        closeHippoDb(db);
+      }
+
+      // Supersession unchanged for non-rejected values: api.supersede.
+      const u = createMemory('unrelated baseline for api supersede', { layer: Layer.Episodic });
+      writeEntry(home, u);
+      const supersedeResult = api.supersede(ctx(home), u.id, 'unrelated baseline, revised');
+      expect(supersedeResult.ok).toBe(true);
+      expect(readEntry(home, u.id)!.superseded_by).toBe(supersedeResult.newId);
+      expect(readEntry(home, supersedeResult.newId)!.content).toBe('unrelated baseline, revised');
+
+      // cmdSupersede-style 2-write flow (cli.ts's cmdSupersede pattern,
+      // replicated inline — cmdSupersede itself is not exported): mutate
+      // old.superseded_by then writeEntry both rows.
+      const v = createMemory('second unrelated baseline', { layer: Layer.Episodic });
+      writeEntry(home, v);
+      const vNew = createMemory('second unrelated baseline, revised', { layer: Layer.Episodic });
+      v.superseded_by = vNew.id;
+      expect(() => {
+        writeEntry(home, v);
+        writeEntry(home, vNew);
+      }).not.toThrow();
+      expect(readEntry(home, v.id)!.superseded_by).toBe(vNew.id);
+      expect(readEntry(home, vNew.id)!.content).toBe('second unrelated baseline, revised');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 case 2: refused supersede audit surface', () => {
+  it('api.supersede onto a rejected successor value throws, CAS rolls back (superseded_by unchanged), one reject_refusal audit row', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const old = createMemory('supersede baseline content', { layer: Layer.Episodic });
+      writeEntry(home, old);
+
+      const yContent = 'rejected successor content for supersede';
+      api.reject(ctx(home), { value: yContent, reason: 'pre-emptively rejected successor' });
+
+      expect(() => api.supersede(ctx(home), old.id, yContent)).toThrow(RejectedValueError);
+
+      // CAS rolled back: the old row's superseded_by pointer is untouched.
+      const stored = readEntry(home, old.id);
+      expect(stored).not.toBeNull();
+      expect(stored!.superseded_by).toBeNull();
+
+      const db = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+        expect(refusals[0]!.metadata.digest).toBe(rejectionDigest(yContent));
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 case 3: copy-path refusal (syncGlobalToLocal)', () => {
+  it('global store holds Z; local store rejects Z; sync skips Z, syncs siblings, and counts the skip', () => {
+    const globalRoot = tmpHome('hippo-rejection-acceptance-global-');
+    const localRoot = tmpHome('hippo-rejection-acceptance-local-');
+    try {
+      initStore(globalRoot);
+      initStore(localRoot);
+
+      const zContent = 'value rejected locally but present globally';
+      const z = createMemory(zContent, { layer: Layer.Episodic });
+      const s1 = createMemory('sibling one synced from global', { layer: Layer.Episodic });
+      const s2 = createMemory('sibling two synced from global', { layer: Layer.Episodic });
+      writeEntry(globalRoot, z);
+      writeEntry(globalRoot, s1);
+      writeEntry(globalRoot, s2);
+
+      api.reject(ctx(localRoot), { value: zContent, reason: 'rejected locally, must not sync from global' });
+
+      // mockRestore() (unlike a bare unspy) also clears recorded call
+      // history, so every assertion against errorSpy must run BEFORE it —
+      // restore happens last, after the spy has served its purpose.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const count = syncGlobalToLocal(localRoot, globalRoot);
+      expect(count).toBe(2); // siblings only — Z was skipped, not counted as copied
+
+      const localContents = loadAllEntries(localRoot).map((e) => e.content);
+      expect(localContents).not.toContain(zContent);
+      expect(localContents).toContain('sibling one synced from global');
+      expect(localContents).toContain('sibling two synced from global');
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('skipped 1 rejected value'));
+      errorSpy.mockRestore();
+    } finally {
+      rmSync(globalRoot, { recursive: true, force: true });
+      rmSync(localRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 case 4: rebuild resurrection pin', () => {
+  it('a stale markdown mirror of a rejected raw row is skipped on rebuildIndex, not resurrected', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+
+      // Sentinel row so `memories` never drops to zero once rawEntry is
+      // archived below. bootstrapLegacyStore (run from every initStore()
+      // prologue, including the ones inside readEntry/rebuildIndex) only
+      // scans legacy mirrors when memoryCount === 0 — without this sentinel,
+      // the store would re-enter that path on every subsequent open as long
+      // as the stale mirror sits on disk, each time re-running (and
+      // re-auditing) the guard skip. The sentinel isolates the assertion to
+      // rebuildIndex's own dedicated per-row guard loop, which is what this
+      // test targets.
+      const sentinel = createMemory('unrelated sentinel entry keeps memories non-empty', {
+        layer: Layer.Episodic,
+      });
+      writeEntry(home, sentinel);
+
+      const rawContent = 'raw transcript content later rejected and archived';
+      const rawEntry = createMemory(rawContent, { layer: Layer.Episodic, kind: 'raw' });
+      writeEntry(home, rawEntry);
+
+      const mirrorPath = join(home, Layer.Episodic, `${rawEntry.id}.md`);
+      expect(existsSync(mirrorPath)).toBe(true);
+      const mirrorSnapshot = readFileSync(mirrorPath, 'utf8');
+
+      api.reject(ctx(home), { memoryId: rawEntry.id, reason: 'raw content rejected' });
+      expect(readEntry(home, rawEntry.id)).toBeNull();
+      // Post-commit purge removed the mirror (reuses the api.archiveRaw pattern).
+      expect(existsSync(mirrorPath)).toBe(false);
+
+      // Construct the resurrection precondition explicitly: a mirror the
+      // purge missed (best-effort purge failure, or a not-yet-synced copy).
+      writeFileSync(mirrorPath, mirrorSnapshot, 'utf8');
+
+      const dbBefore = openHippoDb(home);
+      let refusalsBefore: number;
+      try {
+        refusalsBefore = queryAuditEvents(dbBefore, { tenantId: 'default', op: 'reject_refusal' }).length;
+      } finally {
+        closeHippoDb(dbBefore);
+      }
+
+      rebuildIndex(home);
+
+      // Value stays absent — the guard skipped the stale-mirror re-insert.
+      expect(readEntry(home, rawEntry.id)).toBeNull();
+
+      const dbAfter = openHippoDb(home);
+      try {
+        const refusalsAfter = queryAuditEvents(dbAfter, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusalsAfter.length).toBe(refusalsBefore + 1);
+      } finally {
+        closeHippoDb(dbAfter);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 case 5: migration v41 idempotence', () => {
+  it('fresh store stays at schema_version 41 across re-open; rejected_values data survives', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const digest = rejectionDigest('idempotence-check value');
+
+      const db1 = openHippoDb(home);
+      try {
+        expect(getSchemaVersion(db1)).toBe(41);
+        insertRejectedValue(db1, {
+          tenantId: 'default',
+          digest,
+          reason: 'idempotence check',
+          rejectedBy: 'test',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection('idempotence-check value').length,
+        });
+      } finally {
+        closeHippoDb(db1);
+      }
+
+      // Re-open: runMigrations runs again (it is invoked unconditionally from
+      // openHippoDb) but migration.version=41 <= currentVersion=41 is
+      // skipped — a no-op that must not disturb existing data.
+      const db2 = openHippoDb(home);
+      try {
+        expect(getSchemaVersion(db2)).toBe(41);
+        const row = findRejectedValue(db2, 'default', digest);
+        expect(row).not.toBeNull();
+        expect(row!.reason).toBe('idempotence check');
+      } finally {
+        closeHippoDb(db2);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a v40-shaped store (schema_version rolled back, rejected_values dropped) upgrades cleanly to 41 on re-open, without touching min_compatible_binary', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+
+      let minCompatBefore: string | undefined;
+      const db1 = openHippoDb(home);
+      try {
+        expect(getSchemaVersion(db1)).toBe(41);
+        minCompatBefore = (
+          db1.prepare(`SELECT value FROM meta WHERE key = 'min_compatible_binary'`).get() as
+            | { value?: string }
+            | undefined
+        )?.value;
+
+        // Simulate a v40-shaped store: roll the version marker back and drop
+        // the v41 table, leaving everything else (including
+        // min_compatible_binary) untouched.
+        db1.exec(`DROP TABLE IF EXISTS rejected_values`);
+        db1.prepare(`UPDATE meta SET value = '40' WHERE key = 'schema_version'`).run();
+      } finally {
+        closeHippoDb(db1);
+      }
+
+      const db2 = openHippoDb(home); // re-open re-runs runMigrations
+      try {
+        expect(getSchemaVersion(db2)).toBe(41);
+        expect(() =>
+          insertRejectedValue(db2, {
+            tenantId: 'default',
+            digest: rejectionDigest('post-upgrade value'),
+            reason: 'post-upgrade check',
+            rejectedBy: 'test',
+            rejectedAt: new Date().toISOString(),
+            normalizedChars: normalizeValueForRejection('post-upgrade value').length,
+          }),
+        ).not.toThrow();
+
+        const minCompatAfter = (
+          db2.prepare(`SELECT value FROM meta WHERE key = 'min_compatible_binary'`).get() as
+            | { value?: string }
+            | undefined
+        )?.value;
+        expect(minCompatAfter).toBe(minCompatBefore);
+      } finally {
+        closeHippoDb(db2);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AT1 case 6: AT5 paired case — reject removes a value from recall, permanently', () => {
+  it('reject removes a value from recall; re-remember attempt is refused; recall stays clean', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const wContent = 'do not use the deprecated zynthkey rotation script for staging credentials';
+      const remembered = api.remember(ctx(home), { content: wContent });
+
+      const before = api.recall(ctx(home), { query: 'zynthkey', limit: 5 });
+      expect(before.results.some((r) => r.id === remembered.id)).toBe(true);
+
+      api.reject(ctx(home), { memoryId: remembered.id, reason: 'staging creds process changed' });
+
+      const afterReject = api.recall(ctx(home), { query: 'zynthkey', limit: 5 });
+      expect(afterReject.results.some((r) => r.content === wContent)).toBe(false);
+
+      let caught: unknown = null;
+      try {
+        api.remember(ctx(home), { content: wContent });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(RejectedValueError);
+
+      const afterReattempt = api.recall(ctx(home), { query: 'zynthkey', limit: 5 });
+      expect(afterReattempt.results.some((r) => r.content === wContent)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/rejection-guard.test.ts
+++ b/tests/rejection-guard.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
-import { initStore, writeEntry, readEntry, batchWriteAndDelete } from '../src/store.js';
+import { initStore, writeEntry, readEntry, batchWriteAndDelete, applyRebuildResult } from '../src/store.js';
 import { createMemory, Layer } from '../src/memory.js';
 import { queryAuditEvents } from '../src/audit.js';
 import {
@@ -156,6 +156,122 @@ describe('AT1 rejection guard', () => {
       } finally {
         closeHippoDb(db);
       }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('applyRebuildResult refuses a rebuild patch matching a rejected value: old content survives, dirty cleared, one reject_refusal audit, no loop on second run (P1a fix)', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const summary = createMemory('old summary content', {
+        layer: Layer.Semantic,
+        dag_level: 2,
+        confidence: 'inferred',
+      });
+      writeEntry(home, summary);
+
+      const rejectedContent = 'rebuilt content that was already rejected';
+      reject(home, rejectedContent, 'known-bad rebuild output');
+
+      // Force the summary dirty — rebuildDirtySummaries' normal trigger is a
+      // child write under it; this test drives applyRebuildResult directly.
+      const dbSetup = openHippoDb(home);
+      try {
+        dbSetup.prepare(`UPDATE memories SET summary_dirty = 1 WHERE id = ?`).run(summary.id);
+      } finally {
+        closeHippoDb(dbSetup);
+      }
+
+      const loaded = readEntry(home, summary.id)!;
+      const changed = applyRebuildResult(home, loaded, {
+        content: rejectedContent,
+        descendant_count: 3,
+        earliest_at: '2026-08-01T00:00:00Z',
+        latest_at: '2026-08-02T00:00:00Z',
+        bumpRebuildCount: true,
+        zeroChildren: false,
+        actor: 'sleep',
+      });
+
+      // Documented return-value semantics: metadata still applied → true,
+      // even though content was refused.
+      expect(changed).toBe(true);
+
+      const after = readEntry(home, summary.id)!;
+      expect(after.content).toBe('old summary content');
+      expect(after.summary_dirty).toBe(0);
+      expect(after.rebuild_count).toBe(0);
+      expect(after.descendant_count).toBe(3); // metadata DID apply
+
+      const db = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+        expect(refusals[0]!.targetId).toBe(summary.id);
+      } finally {
+        closeHippoDb(db);
+      }
+
+      // No loop: dirty is cleared, so a second attempt against the
+      // now-current row (summary_dirty=1 no longer matches) is a race-loser
+      // no-op — no second refusal audit.
+      const secondPass = applyRebuildResult(home, after, {
+        content: rejectedContent,
+        descendant_count: 3,
+        earliest_at: '2026-08-01T00:00:00Z',
+        latest_at: '2026-08-02T00:00:00Z',
+        bumpRebuildCount: true,
+        zeroChildren: false,
+        actor: 'sleep',
+      });
+      expect(secondPass).toBe(false);
+
+      const db2 = openHippoDb(home);
+      try {
+        const refusals2 = queryAuditEvents(db2, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals2.length).toBe(1); // still just one — no loop
+      } finally {
+        closeHippoDb(db2);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a same-id upsert that only changes tenantId is refused when the destination tenant rejected the unchanged content (P2 fix)', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      // Content lives quietly in tenant A — never rejected there.
+      const entry = createMemory('shared content across a tenant move', { layer: Layer.Episodic });
+      entry.tenantId = 'tenant-a';
+      writeEntry(home, entry);
+      expect(readEntry(home, entry.id, 'tenant-a')).not.toBeNull();
+
+      // Tenant B rejects the SAME (byte-identical) content.
+      const db = openHippoDb(home);
+      try {
+        insertRejectedValue(db, {
+          tenantId: 'tenant-b',
+          digest: rejectionDigest('shared content across a tenant move'),
+          reason: 'rejected in tenant B',
+          rejectedBy: 'cli',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection('shared content across a tenant move').length,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+
+      // Same id, SAME content — only tenantId changes A -> B.
+      const moved = { ...entry, tenantId: 'tenant-b' };
+      expect(() => writeEntry(home, moved)).toThrow(RejectedValueError);
+
+      // The row stays in tenant A, untouched.
+      expect(readEntry(home, entry.id, 'tenant-a')!.content).toBe('shared content across a tenant move');
+      expect(readEntry(home, entry.id, 'tenant-b')).toBeNull();
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/rejection-guard.test.ts
+++ b/tests/rejection-guard.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
+import { initStore, writeEntry, readEntry, batchWriteAndDelete } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { queryAuditEvents } from '../src/audit.js';
+import {
+  insertRejectedValue,
+  rejectionDigest,
+  normalizeValueForRejection,
+  RejectedValueError,
+} from '../src/rejection.js';
+
+function tmpHome(): string {
+  return mkdtempSync(join(tmpdir(), 'hippo-rejection-'));
+}
+
+function reject(home: string, text: string, reason: string): string {
+  const digest = rejectionDigest(text);
+  const db = openHippoDb(home);
+  try {
+    insertRejectedValue(db, {
+      tenantId: 'default',
+      digest,
+      reason,
+      rejectedBy: 'cli',
+      rejectedAt: new Date().toISOString(),
+      normalizedChars: normalizeValueForRejection(text).length,
+    });
+  } finally {
+    closeHippoDb(db);
+  }
+  return digest;
+}
+
+describe('AT1 rejection guard', () => {
+  it('fresh store migrates to schema_version 41', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const db = openHippoDb(home);
+      try {
+        expect(getSchemaVersion(db)).toBe(41);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('guarded new-row write of a rejected value throws RejectedValueError', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      reject(home, 'secret api key: sk-12345', 'leaked credential');
+
+      const entry = createMemory('secret api key: sk-12345', { layer: Layer.Episodic });
+      expect(() => writeEntry(home, entry)).toThrow(RejectedValueError);
+      expect(readEntry(home, entry.id)).toBeNull();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('same-id content-change onto a rejected value throws and leaves the original row untouched', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const original = createMemory('original safe content', { layer: Layer.Episodic });
+      writeEntry(home, original);
+
+      const rejectedText = 'now a rejected value';
+      reject(home, rejectedText, 'bad edit');
+
+      const edited = { ...original, content: rejectedText };
+      expect(() => writeEntry(home, edited)).toThrow(RejectedValueError);
+
+      const stored = readEntry(home, original.id);
+      expect(stored!.content).toBe('original safe content');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('unchanged same-id re-persist of an already-tombstoned value succeeds (exempt by construction)', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const entry = createMemory('boosted fact', { layer: Layer.Episodic });
+      writeEntry(home, entry); // lands before any tombstone exists
+
+      // Reject the SAME value the row already holds (e.g. a reject created
+      // after the row existed). A recall-boost re-persist of the unchanged
+      // content must not be refused.
+      reject(home, 'boosted fact', 'created after the row existed');
+
+      const boosted = { ...entry, retrieval_count: entry.retrieval_count + 1 };
+      expect(() => writeEntry(home, boosted)).not.toThrow();
+      expect(readEntry(home, entry.id)!.retrieval_count).toBe(entry.retrieval_count + 1);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('batchWriteAndDelete bypasses the rejection guard (consolidation rollups)', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const rollupText = 'rollup text that happens to match a tombstone';
+      reject(home, rollupText, 'coincidental digest match');
+
+      const entry = createMemory(rollupText, { layer: Layer.Semantic });
+      expect(() => batchWriteAndDelete(home, [entry], [])).not.toThrow();
+      expect(readEntry(home, entry.id)!.content).toBe(rollupText);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('normalization variants (case, whitespace) are refused by the same tombstone', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      reject(home, 'The Sky Is Blue', 'canonical form rejected');
+
+      const variants = ['the sky is blue', '  the   sky is   blue  ', 'THE SKY IS BLUE'];
+      for (const variant of variants) {
+        const entry = createMemory(variant, { layer: Layer.Episodic });
+        expect(() => writeEntry(home, entry)).toThrow(RejectedValueError);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a refused writeEntry leaves exactly one reject_refusal audit row and no memory row', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const text = 'never store my key again';
+      const digest = reject(home, text, 'secret');
+
+      const entry = createMemory(text, { layer: Layer.Episodic });
+      expect(() => writeEntry(home, entry)).toThrow(RejectedValueError);
+      expect(readEntry(home, entry.id)).toBeNull();
+
+      const db = openHippoDb(home);
+      try {
+        const rows = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(rows.length).toBe(1);
+        expect(rows[0]!.targetId).toBe(entry.id);
+        expect(rows[0]!.metadata.digest).toBe(digest);
+      } finally {
+        closeHippoDb(db);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/rejection-guard.test.ts
+++ b/tests/rejection-guard.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openHippoDb, closeHippoDb, getSchemaVersion } from '../src/db.js';
-import { initStore, writeEntry, readEntry, batchWriteAndDelete, applyRebuildResult } from '../src/store.js';
+import { initStore, writeEntry, readEntry, deleteEntry, batchWriteAndDelete, applyRebuildResult } from '../src/store.js';
 import { createMemory, Layer } from '../src/memory.js';
 import { queryAuditEvents } from '../src/audit.js';
 import {
@@ -105,16 +105,43 @@ describe('AT1 rejection guard', () => {
     }
   });
 
-  it('batchWriteAndDelete bypasses the rejection guard (consolidation rollups)', () => {
+  it('batchWriteAndDelete probes for a rejected value in-transaction and skips a re-persist that races a reject, instead of resurrecting it (P1 batch-transaction race fix)', () => {
     const home = tmpHome();
     try {
       initStore(home);
-      const rollupText = 'rollup text that happens to match a tombstone';
-      reject(home, rollupText, 'coincidental digest match');
+      const raceText = 'batch race content rejected between the producer check and the batch commit';
+      const entry = createMemory(raceText, { layer: Layer.Semantic });
+      writeEntry(home, entry);
 
-      const entry = createMemory(rollupText, { layer: Layer.Semantic });
-      expect(() => batchWriteAndDelete(home, [entry], [])).not.toThrow();
-      expect(readEntry(home, entry.id)!.content).toBe(rollupText);
+      // The queued write standing in for a stale toWrite/pendingWrites entry
+      // (e.g. consolidate's decay-pass strength refresh) captured BEFORE the
+      // reject below commits — same id, same content, about to reach
+      // batchWriteAndDelete's guard-bypassed upsert AFTER the row is gone.
+      // This is the exact race the producer-side check alone cannot close:
+      // the producer runs on a different connection before this transaction
+      // opens.
+      const queuedRePersist = { ...entry, retrieval_count: entry.retrieval_count + 1 };
+
+      // The race: remove the row and tombstone its digest — exactly what
+      // `hippo reject` does (reject-flow.ts), done here directly at the
+      // store/rejection.ts layer to match this file's existing convention.
+      deleteEntry(home, entry.id);
+      const digest = reject(home, raceText, 'rejected mid-race, between producer check and batch commit');
+      expect(readEntry(home, entry.id)).toBeNull();
+
+      expect(() => batchWriteAndDelete(home, [queuedRePersist], [])).not.toThrow();
+      expect(readEntry(home, entry.id)).toBeNull(); // stays gone — not resurrected
+
+      const db = openHippoDb(home);
+      try {
+        const refusals = queryAuditEvents(db, { tenantId: 'default', op: 'reject_refusal' });
+        expect(refusals.length).toBe(1);
+        expect(refusals[0]!.targetId).toBe(entry.id);
+        expect(refusals[0]!.metadata.digest).toBe(digest);
+        expect(refusals[0]!.actor).toBe('sleep-batch');
+      } finally {
+        closeHippoDb(db);
+      }
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/rejection-verbs.test.ts
+++ b/tests/rejection-verbs.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { createMemory } from '../src/memory.js';
+import { createMemory, Layer } from '../src/memory.js';
 import {
   initStore,
   writeEntry,
@@ -105,6 +105,27 @@ describe('api.reject / api.unreject / api.listRejections', () => {
     const a = createMemory('needs a reason', { tags: [] });
     writeEntry(tmpDir, a);
     expect(() => api.reject(ctx(), { memoryId: a.id, reason: '' })).toThrow();
+  });
+
+  it('reject throws when both memoryId and value are given (P2 fix)', () => {
+    const a = createMemory('both forms supplied at once', { tags: [] });
+    writeEntry(tmpDir, a);
+    expect(() =>
+      api.reject(ctx(), { memoryId: a.id, value: 'a different value entirely', reason: 'ambiguous' }),
+    ).toThrow();
+  });
+
+  it('unreject throws on a blank digest/prefix instead of matching every tombstone (P2 fix)', () => {
+    const a = createMemory('to be rejected for the blank-unreject test', { tags: [] });
+    writeEntry(tmpDir, a);
+    api.reject(ctx(), { memoryId: a.id, reason: 'setup for blank-unreject test' });
+    expect(api.listRejections(ctx()).length).toBe(1);
+
+    expect(() => api.unreject(ctx(), '')).toThrow();
+    expect(() => api.unreject(ctx(), '   ')).toThrow();
+    // The tombstone must survive an accidental blank call, not get wiped by
+    // an empty-string startsWith-matches-everything prefix scan.
+    expect(api.listRejections(ctx()).length).toBe(1);
   });
 });
 
@@ -203,6 +224,93 @@ describe('resolveConflict AT1 wiring', () => {
       expect(events[0]!.metadata.disposition).toBe('archived_raw');
     } finally {
       closeHippoDb(db);
+    }
+  });
+
+  it('raw loser via PLAIN resolve --forget (no --reject-loser) purges its mirror + stamps mirror_cleaned_at (P1b fix)', () => {
+    const a = createMemory('keeper content for raw mirror-purge conflict', { tags: ['x'] });
+    const rawLoser = createMemory('raw loser content for the mirror-purge test', { tags: ['x'], kind: 'raw' });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, rawLoser);
+    const mirrorPath = path.join(tmpDir, Layer.Episodic, `${rawLoser.id}.md`);
+    expect(fs.existsSync(mirrorPath)).toBe(true);
+
+    replaceDetectedConflicts(tmpDir, [{
+      memory_a_id: a.id,
+      memory_b_id: rawLoser.id,
+      reason: 'raw conflict for mirror-purge test',
+      score: 0.85,
+    }]);
+    const conflicts = listMemoryConflicts(tmpDir, 'open');
+    const conflictId = conflicts[0]!.id;
+
+    // Plain --forget, deliberately WITHOUT rejectLoserValue — before P1b the
+    // post-commit purge gate required rejectLoserValue too, so this path
+    // left the raw mirror orphaned (only the reaper would eventually catch
+    // it; a non-raw loser would never be caught at all).
+    resolveConflict(tmpDir, conflictId, a.id, true, 'default');
+    expect(readEntry(tmpDir, rawLoser.id)).toBeNull();
+    expect(fs.existsSync(mirrorPath)).toBe(false);
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const row = db
+        .prepare(`SELECT mirror_cleaned_at FROM raw_archive WHERE memory_id = ?`)
+        .get(rawLoser.id) as { mirror_cleaned_at: string | null } | undefined;
+      expect(row?.mirror_cleaned_at).toBeTruthy();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('rejectLoserValue on a RAW loser: tombstone written, raw archived (not deleted), no crash — previously untested combination (GDPR pairing)', () => {
+    const a = createMemory('keeper content for raw+reject conflict', { tags: ['x'] });
+    const rawLoser = createMemory('raw loser content later rejected via the reject-loser path', {
+      tags: ['x'],
+      kind: 'raw',
+    });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, rawLoser);
+    replaceDetectedConflicts(tmpDir, [{
+      memory_a_id: a.id,
+      memory_b_id: rawLoser.id,
+      reason: 'raw+reject conflict',
+      score: 0.85,
+    }]);
+    const conflicts = listMemoryConflicts(tmpDir, 'open');
+    const conflictId = conflicts[0]!.id;
+
+    expect(() =>
+      resolveConflict(tmpDir, conflictId, a.id, false, 'default', {
+        rejectLoserValue: true,
+        reason: 'raw loser rejected via GDPR-adjacent path',
+      }),
+    ).not.toThrow();
+
+    // Archived, not hard-deleted: the row is gone from `memories` but a
+    // raw_archive row exists (append-only trigger respected).
+    expect(readEntry(tmpDir, rawLoser.id)).toBeNull();
+    const db = openHippoDb(tmpDir);
+    try {
+      const archiveRow = db.prepare(`SELECT memory_id FROM raw_archive WHERE memory_id = ?`).get(rawLoser.id);
+      expect(archiveRow).not.toBeUndefined();
+    } finally {
+      closeHippoDb(db);
+    }
+
+    // Tombstone written: re-remembering the raw loser's content is refused.
+    expect(() =>
+      api.remember(ctx(), { content: 'raw loser content later rejected via the reject-loser path' }),
+    ).toThrow(RejectedValueError);
+
+    const db2 = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db2, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      expect(events[0]!.metadata.disposition).toBe('archived_raw');
+      expect(events[0]!.metadata.rejected).toBe(true);
+    } finally {
+      closeHippoDb(db2);
     }
   });
 });

--- a/tests/rejection-verbs.test.ts
+++ b/tests/rejection-verbs.test.ts
@@ -1,0 +1,237 @@
+/**
+ * AT1 T2 smoke tests: reject/unreject/rejections (api.ts + src/reject-flow.ts)
+ * and resolveConflict's rejectLoserValue + audit wiring.
+ * docs/plans/2026-08-15-at1-rejected-value-tombstone.md
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createMemory } from '../src/memory.js';
+import {
+  initStore,
+  writeEntry,
+  readEntry,
+  listMemoryConflicts,
+  replaceDetectedConflicts,
+  resolveConflict,
+} from '../src/store.js';
+import { queryAuditEvents } from '../src/audit.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import * as api from '../src/api.js';
+import { RejectedValueError } from '../src/rejection.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-reject-verbs-'));
+  initStore(tmpDir);
+});
+
+function ctx(tenantId: string = 'default'): api.Context {
+  return { hippoRoot: tmpDir, tenantId, actor: { subject: 'cli', role: 'admin' } };
+}
+
+describe('api.reject / api.unreject / api.listRejections', () => {
+  it('reject by id removes the row + all same-digest duplicates, one reject_value audit, zero forget audits', () => {
+    const a = createMemory('duplicate offending value', { tags: ['x'] });
+    const b = createMemory('DUPLICATE OFFENDING VALUE', { tags: ['y'] }); // same normalized digest
+    const unrelated = createMemory('unrelated safe value', { tags: ['z'] });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, b);
+    writeEntry(tmpDir, unrelated);
+
+    const result = api.reject(ctx(), { memoryId: a.id, reason: 'test rejection' });
+    expect(result.removedIds.slice().sort()).toEqual([a.id, b.id].sort());
+
+    expect(readEntry(tmpDir, a.id)).toBeNull();
+    expect(readEntry(tmpDir, b.id)).toBeNull();
+    expect(readEntry(tmpDir, unrelated.id)).not.toBeNull();
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const rejectEvents = queryAuditEvents(db, { tenantId: 'default', op: 'reject_value' });
+      expect(rejectEvents.length).toBe(1);
+      expect(rejectEvents[0]!.metadata.digest).toBe(result.digest);
+      expect(rejectEvents[0]!.metadata.count).toBe(2);
+
+      const forgetEvents = queryAuditEvents(db, { tenantId: 'default', op: 'forget' });
+      expect(forgetEvents.length).toBe(0);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('rejections lists the tombstone', () => {
+    const a = createMemory('to be rejected', { tags: [] });
+    writeEntry(tmpDir, a);
+    api.reject(ctx(), { memoryId: a.id, reason: 'listed test' });
+
+    const rows = api.listRejections(ctx());
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.reason).toBe('listed test');
+    expect(rows[0]!.sourceMemoryId).toBe(a.id);
+  });
+
+  it('re-remember of the rejected value is refused', () => {
+    const a = createMemory('refuse me please', { tags: [] });
+    writeEntry(tmpDir, a);
+    api.reject(ctx(), { memoryId: a.id, reason: 'refused' });
+
+    expect(() => api.remember(ctx(), { content: 'refuse me please' })).toThrow(RejectedValueError);
+  });
+
+  it('unreject then re-remember succeeds', () => {
+    const a = createMemory('temporarily rejected', { tags: [] });
+    writeEntry(tmpDir, a);
+    const rejectResult = api.reject(ctx(), { memoryId: a.id, reason: 'temp' });
+
+    const unrejectResult = api.unreject(ctx(), rejectResult.digest);
+    expect(unrejectResult.ok).toBe(true);
+    expect(api.listRejections(ctx()).length).toBe(0);
+
+    expect(() => api.remember(ctx(), { content: 'temporarily rejected' })).not.toThrow();
+  });
+
+  it('reject --value pre-emptive path: zero removals, still refuses a later write', () => {
+    const result = api.reject(ctx(), { value: 'never seen before value', reason: 'pre-emptive' });
+    expect(result.removedIds.length).toBe(0);
+
+    expect(() => api.remember(ctx(), { content: 'never seen before value' })).toThrow(RejectedValueError);
+  });
+
+  it('reject requires a non-empty reason', () => {
+    const a = createMemory('needs a reason', { tags: [] });
+    writeEntry(tmpDir, a);
+    expect(() => api.reject(ctx(), { memoryId: a.id, reason: '' })).toThrow();
+  });
+});
+
+describe('resolveConflict AT1 wiring', () => {
+  function seedConflict(): { aId: string; bId: string; conflictId: number } {
+    const a = createMemory('Always use semicolons in PowerShell', { tags: ['x'] });
+    const b = createMemory('Use && to chain commands in PowerShell', { tags: ['x'] });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, b);
+    replaceDetectedConflicts(tmpDir, [{
+      memory_a_id: a.id,
+      memory_b_id: b.id,
+      reason: 'contradictory chaining advice',
+      score: 0.85,
+    }]);
+    const conflicts = listMemoryConflicts(tmpDir, 'open');
+    return { aId: a.id, bId: b.id, conflictId: conflicts[0]!.id };
+  }
+
+  it('legacy 5-arg call shape still works and now writes a conflict_resolve audit (previously zero)', () => {
+    const { aId, conflictId } = seedConflict();
+    const result = resolveConflict(tmpDir, conflictId, aId, false, 'default'); // 5 args, no opts
+    expect(result).not.toBeNull();
+    expect(result!.conflict.status).toBe('resolved');
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      expect(events[0]!.metadata.disposition).toBe('weakened');
+      expect(events[0]!.metadata.rejected).toBe(false);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('resolveConflict --forget writes a conflict_resolve audit with disposition=deleted', () => {
+    const { aId, bId, conflictId } = seedConflict();
+    resolveConflict(tmpDir, conflictId, aId, true, 'default');
+    expect(readEntry(tmpDir, bId)).toBeNull();
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      expect(events[0]!.metadata.disposition).toBe('deleted');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('rejectLoserValue tombstones + removes the loser; re-remember of its content is refused', () => {
+    const { aId, bId, conflictId } = seedConflict();
+    const result = resolveConflict(tmpDir, conflictId, aId, false, 'default', {
+      rejectLoserValue: true,
+      reason: 'loser rejected',
+    });
+    expect(result).not.toBeNull();
+    expect(readEntry(tmpDir, bId)).toBeNull();
+
+    expect(() =>
+      api.remember(ctx(), { content: 'Use && to chain commands in PowerShell' }),
+    ).toThrow(RejectedValueError);
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      expect(events[0]!.metadata.rejected).toBe(true);
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  it('raw loser via resolve --forget no longer throws (kind-aware removal)', () => {
+    const a = createMemory('keeper content for raw conflict', { tags: ['x'] });
+    const rawLoser = createMemory('raw loser content', { tags: ['x'], kind: 'raw' });
+    writeEntry(tmpDir, a);
+    writeEntry(tmpDir, rawLoser);
+    replaceDetectedConflicts(tmpDir, [{
+      memory_a_id: a.id,
+      memory_b_id: rawLoser.id,
+      reason: 'raw conflict',
+      score: 0.85,
+    }]);
+    const conflicts = listMemoryConflicts(tmpDir, 'open');
+    const conflictId = conflicts[0]!.id;
+
+    expect(() => resolveConflict(tmpDir, conflictId, a.id, true, 'default')).not.toThrow();
+    expect(readEntry(tmpDir, rawLoser.id)).toBeNull();
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      expect(events[0]!.metadata.disposition).toBe('archived_raw');
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+});
+
+describe('cmdSupersede write-order contract (code-review round-1 high)', () => {
+  it('a refused successor write leaves the old row without a dangling superseded_by pointer', () => {
+    // Replicates cmdSupersede's REORDERED two-write flow (cli.ts): the
+    // successor is written FIRST so the rejection guard fires before any
+    // mutation of the old row. The old ordering committed
+    // old.superseded_by = newEntry.id before the guarded write, leaving a
+    // dangling pointer to an id that was never created.
+    const old = createMemory('the old belief to correct', { tags: ['s'] });
+    writeEntry(tmpDir, old);
+
+    api.reject(ctx(), { value: 'the corrected but rejected belief', reason: 'known-bad correction' });
+
+    const newEntry = createMemory('the corrected but rejected belief', {
+      tags: ['s'],
+      confidence: 'verified',
+    });
+
+    // Successor write first: refused, and nothing has been mutated.
+    expect(() => writeEntry(tmpDir, newEntry)).toThrow(RejectedValueError);
+
+    // The old row must be untouched: no dangling pointer, still live.
+    const oldAfter = readEntry(tmpDir, old.id);
+    expect(oldAfter).not.toBeNull();
+    expect(oldAfter!.superseded_by).toBeNull();
+    // And the successor id must not exist.
+    expect(readEntry(tmpDir, newEntry.id)).toBeNull();
+  });
+});

--- a/tests/rejection-verbs.test.ts
+++ b/tests/rejection-verbs.test.ts
@@ -63,6 +63,20 @@ describe('api.reject / api.unreject / api.listRejections', () => {
     }
   });
 
+  it('reject purges the trace-layer markdown mirror (P1 fix: removeEntryMirrors previously skipped Layer.Trace)', () => {
+    const trace = createMemory('trace: read config.ts -> rotated the deploy key -> success', {
+      layer: Layer.Trace,
+      trace_outcome: 'success',
+    });
+    writeEntry(tmpDir, trace);
+    const mirrorPath = path.join(tmpDir, Layer.Trace, `${trace.id}.md`);
+    expect(fs.existsSync(mirrorPath)).toBe(true);
+
+    api.reject(ctx(), { memoryId: trace.id, reason: 'trace content was wrong' });
+    expect(readEntry(tmpDir, trace.id)).toBeNull();
+    expect(fs.existsSync(mirrorPath)).toBe(false);
+  });
+
   it('rejections lists the tombstone', () => {
     const a = createMemory('to be rejected', { tags: [] });
     writeEntry(tmpDir, a);
@@ -198,6 +212,42 @@ describe('resolveConflict AT1 wiring', () => {
     } finally {
       closeHippoDb(db);
     }
+  });
+
+  it('rejectLoserValue removes a same-tenant same-digest duplicate but leaves an identical-content row in ANOTHER tenant untouched (P1 fix)', () => {
+    const { aId, bId, conflictId } = seedConflict();
+    const loserContent = 'Use && to chain commands in PowerShell';
+
+    // Same-tenant duplicate of the loser's content — must be swept up too.
+    const dup = createMemory(loserContent, { tags: ['dup'] });
+    writeEntry(tmpDir, dup);
+
+    // Identical content in a DIFFERENT tenant — tombstones are tenant-scoped
+    // by design; this row must survive untouched.
+    const otherTenantDup = createMemory(loserContent, { tags: ['dup'], tenantId: 'other-tenant' });
+    writeEntry(tmpDir, otherTenantDup);
+
+    const result = resolveConflict(tmpDir, conflictId, aId, false, 'default', {
+      rejectLoserValue: true,
+      reason: 'loser + same-tenant duplicates rejected',
+    });
+    expect(result).not.toBeNull();
+
+    expect(readEntry(tmpDir, bId)).toBeNull();
+    expect(readEntry(tmpDir, dup.id)).toBeNull();
+    expect(readEntry(tmpDir, otherTenantDup.id, 'other-tenant')).not.toBeNull();
+
+    const db = openHippoDb(tmpDir);
+    try {
+      const events = queryAuditEvents(db, { tenantId: 'default', op: 'conflict_resolve' });
+      expect(events.length).toBe(1);
+      const removedIds = events[0]!.metadata.removedIds as string[];
+      expect(removedIds.slice().sort()).toEqual([bId, dup.id].sort());
+    } finally {
+      closeHippoDb(db);
+    }
+
+    expect(() => api.remember(ctx(), { content: loserContent })).toThrow(RejectedValueError);
   });
 
   it('raw loser via resolve --forget no longer throws (kind-aware removal)', () => {

--- a/tests/v039-gdpr-path-a.test.ts
+++ b/tests/v039-gdpr-path-a.test.ts
@@ -34,10 +34,10 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
   });
 
   it('1. schema v20: getCurrentSchemaVersion() returns 20', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
     } finally {
       closeHippoDb(db);
     }
@@ -107,7 +107,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(40);
+      expect(getSchemaVersion(db2)).toBe(41);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-legacy-1') as { payload_json: string };
@@ -150,7 +150,7 @@ describe('v0.39 GDPR Path A redaction + migration v20', () => {
 
     const db2 = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db2)).toBe(40);
+      expect(getSchemaVersion(db2)).toBe(41);
       const row = db2
         .prepare(`SELECT payload_json FROM raw_archive WHERE memory_id = ?`)
         .get('m-malformed-1') as { payload_json: string };

--- a/tests/v039-slack-hardening.test.ts
+++ b/tests/v039-slack-hardening.test.ts
@@ -43,10 +43,10 @@ describe('v0.39 commit 3 — Slack hardening + migration v19', () => {
 
   // 1. Migration v19 schema additions present.
   it('migration v19: slack_dlq has team_id, bucket, retry_count, signature, slack_timestamp', () => {
-    expect(getCurrentSchemaVersion()).toBe(40);
+    expect(getCurrentSchemaVersion()).toBe(41);
     const db = openHippoDb(root);
     try {
-      expect(getSchemaVersion(db)).toBe(40);
+      expect(getSchemaVersion(db)).toBe(41);
       const cols = db.prepare(`PRAGMA table_info(slack_dlq)`).all() as Array<{ name: string }>;
       const names = cols.map((c) => c.name);
       expect(names).toContain('team_id');


### PR DESCRIPTION
## Summary
ROADMAP.md Part V **AT1 [critical, next]**: durable value-keyed suppression on human rejection. A digest-keyed, per-store/per-tenant `rejected_values` tombstone refuses byte-stable re-assertion of a rejected value across every write surface, with audited refusals and an `unreject` escape hatch.

Full design + 3-round plan-gate trail: `docs/plans/2026-08-15-at1-rejected-value-tombstone.md` (dev-framework-rl episode 01M025CW434ZAPVSFC61BGFGCT).

- Migration v41 (`rejected_values`, no content stored, no min_compatible_binary bump: tradeoff documented)
- Guard at the single INSERT choke point, content-introduction semantics; sole bypass = consolidation batch writer; recovery paths run the guard with per-row skip (structural mirror-resurrection closure)
- `hippo reject <id>|--value` / `rejections` / `unreject` (+ api trio); post-commit mirror purge reusing the mirror_cleaned_at reaper
- `resolveConflict`: kind-aware loser removal (fixes pre-existing raw-loser crash) + previously-missing audit (`conflict_resolve` on every path) + opt-in `--reject-loser`
- `cmdSupersede` reordered successor-first (no dangling `superseded_by` on refusal)
- Containment at every multi-item write loop; single-item surfaces fail loud; connector refusals permanently ack idempotency
- AT5 paired recall case included in tests

## Test plan
- [x] 25 new tests (guard truth table / verbs + resolveConflict + write-order regression / roadmap-verbatim acceptance incl. capture containment, refused-supersede audit, sync refusal, rebuild pin, migration idempotence, AT5 recall case)
- [x] Full suite: 2932 pass; 18 historical schema-pin assertions updated 40->41 (mechanical, every migration does this); 1 known pre-existing worker-RPC flake documented
- [x] E2E drive on compiled dist: reject -> normalization-variant refusal with reason -> unreject
- [ ] CI green on this PR (draft; review gates running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NUZVRXZRWfGiztx9JHYQt