### PR TITLE
Hardening pass: AT1 follow-ups (tenant landing, MCP actor, refused stat, lazy handle, test determinism)

### DIFF
--- a/docs/plans/2026-08-15-hardening-at1-followups.md
+++ b/docs/plans/2026-08-15-hardening-at1-followups.md
@@ -1,0 +1,75 @@
+# Hardening pass: AT1 follow-ups (episode 01M02X45JWXGB0HTS9VQPFMZB0)
+
+Status: Revised r2 (plan-eng-critic r1 fail 68; both must-fixes + both lows applied)
+Base: origin/master 35815a0 (v1.31.0). Branch: fix/hardening-at1-followups. Worktree: C:/Users/skf_s/hippo-wt-hard.
+Source: .devrl-backlog.md Candidates (filed from AT1 episode 01M025CW434ZAPVSFC61BGFGCT) + AT1 ship-check flaky-test classification.
+
+One correctness core (T1) + four riders (T2-T5). One PR, one commit per task.
+
+## T1 - Cross-tenant consolidation landing (correctness core)
+
+**Defect (verified 2026-08-15):** consolidate.ts:136 `loadAllEntries` is host-wide. The merge pass (:659-686) filters episodic survivors and clusters purely by `textOverlap` - clusters can span tenants, and `mergeContents` concatenates cross-tenant content into one semantic row. `createMemory` at :709 omits `tenantId`, so the row stamps 'default' (memory.ts:535). The trace pass (:334-380) fetches sessions under `consolidationTenant = resolveTenantId({})` (:342) but `createMemory` at :371 also omits `tenantId`. Two consequences beyond the filed leak:
+- Trace idempotency ghost: `traceExistsForSession` (:347) checks under `consolidationTenant`; the trace landed in 'default', so for any non-default tenant the check never hits and the trace regenerates every sleep.
+- The AT1 tombstone checks (:390-396, :727-737) already key off the BUILT entry's tenantId, so they follow this fix automatically - no tombstone changes needed.
+
+**Fix:**
+1. Merge pass: partition `mergeCandidates` by `tenantId` before the overlap loop (`Map<tenant, MemoryEntry[]>`); run the existing cluster loop per partition; pass the partition tenant into `createMemory` (`tenantId` option exists, memory.ts:481). Cross-tenant clusters become impossible by construction.
+2. Trace pass: pass `tenantId: consolidationTenant` into `createMemory` at :371.
+
+**Consumer audit (done at plan time, grill carry-forward):** recall/assemble/search are tenant-scoped per request - rows landing in the source tenant become visible to the CORRECT tenant (today they are visible to the wrong one and invisible to the right one). shared.ts is tenant-aware end-to-end (shareMemory host-passed tenantId :369-379; D4 global filtering :429-447). dag.ts already tenant-partitions L3 building (dag.ts:363-368 acknowledges the mixed-L3 default problem this fix reduces). No consumer depends on 'default' landing. Single-tenant stores: every row is 'default', one partition, byte-identical behavior.
+
+**Tests:** (a) two tenants with overlapping episodic content -> two separate merged rows, each in its source tenant, no content mixing (assert both directions); (b) single-tenant merge unchanged (existing suites are the pin); (c) trace lands in `consolidationTenant` when HIPPO_TENANT is non-default; (d) trace idempotency: second consolidate under non-default tenant creates NO second trace (regression pin for the ghost); (e) merge-tombstone + trace-tombstone checks still fire under the new landing tenant (adjust AT1 destination-tenant tests if they pinned 'default' landing).
+
+**Executor check (grill amendment):** the extraction pass (consolidate 1.6/1.7) is a sibling producer - read how extract.ts storeExtractedFacts stamps tenant on extracted-fact rows. Same defect (rows land in 'default' from non-default sources) -> fold in ONLY if the fix is the same one-line createMemory/threading shape; anything larger gets filed as a backlog candidate, not absorbed.
+
+## T2 - MCP actor threading (5 sites)
+
+**Defect:** server.ts:498, :839, :878, :942, :985 build ApiContext with hardcoded `adminActor('mcp')`; McpContext.actor (:110, a string, auth-resolved for HTTP-MCP) is ignored. Attribution only: api.ts:101 "Role checks happen at the request layer"; every api.ts use of `ctx.actor` is `.subject` into audit rows/writeEntry actor (api.ts:249, :977, :1088...). The house pattern exists at :1169 (`rejectedBy: ctx?.actor ?? 'mcp'`).
+
+**Fix:** at all 5 sites: `actor: adminActor(ctx?.actor ?? 'mcp')` - subject becomes the auth-resolved actor under HTTP-MCP, stdio keeps 'mcp'. Role semantics unchanged by construction (still adminActor). Verify each site actually has `ctx` in scope (executeTool signature :441 `ctx?: McpContext`).
+Precondition check at execute: read adminActor's signature in api.ts first - if it does not take a subject parameter, use the correct actor constructor the resolve path / http layer uses instead; do NOT invent a new one.
+
+**Tests:** executeTool with a ctx carrying actor 'user:alice' -> audit_log rows for remember/outcome record subject 'user:alice'; without ctx -> 'mcp' (existing behavior pin).
+
+## T3 - consolidateDb lazy open (perf hygiene)
+
+**Defect (advisory reframed at discover):** consolidate.ts:318 opens the shared handle unconditionally on every non-dry-run sleep even when the cycle has zero auto-promote sessions and zero merge clusters. The filed "defer until MERGE_MIN_CLUSTER" is stale - the handle also serves the auto-promote tombstone checks (:390-396), which run before any cluster sizing.
+
+**Fix:** memoized lazy getter (`getConsolidateDb(): Database` opening on first call; `null` until used; dryRun still never opens). The finally (:785) closes only if opened. All `if (consolidateDb)` guards become calls through the getter at the existing sites (each already gated on !dryRun by construction).
+Risk note: the getter must be a closure over the same handle variable the finally reads - no double-open, no leak on throw between first use and finally.
+
+**Tests:** behavioral pin - no-op sleep completes clean and every existing tombstone suite stays green. Asserting "db never opened" directly is optional: only if a test-only counter or existing debug detail line makes it cheap; do not build observation machinery for a perf-hygiene rider.
+
+## T4 - rebuilt-vs-refused stat split (observability)
+
+**Defect:** store.ts:3452-3463 documents deliberately returning changed=true on a tombstone refusal so the caller's `rebuilt` stat also counts refusals (accepted at AT1 as lesser evil vs infinite retry).
+
+**Fix:** return `{ changed, refused }` from applyRebuildResult. Caller enumeration (plan-eng-critic r1, verified by grep): dag.ts:250 and :285 (rebuildDirtySummaries), PLUS four direct test call sites asserting the current boolean return - tests/rejection-guard.test.ts:215-227 (`expect(changed).toBe(true)`) and :247-256 (`expect(secondPass).toBe(false)`); tests/dag-rebuild-summaries.test.ts:408-417 (`expect(ok).toBe(true)`) and :499-513 (`expect(ok).toBe(false)`). All four assertions MUST be updated to the new shape (`.changed`) in the SAME T4 commit - not discovered via a red test run. dag.ts rebuildDirtySummaries splits counters: refusals increment `refused`, not `rebuilt`; surface `refused` in the summary line/result the same way `rebuilt` is surfaced. Retry semantics unchanged (dirty still cleared, no behavior change - counters only).
+
+**Parallel-surface check (audit rule 2, grill amendment):** grep every consumer of rebuildDirtySummaries' result and the sleep-stats print surfaces (cli sleep command, api sleep, MCP tool, SleepResult threading a la AT1's rejectedSkipped) BEFORE wiring; either surface `refused` at all of them or state in the commit which surface deliberately carries it and why the others do not.
+
+**Tests:** rebuild hitting a tombstone increments refused and not rebuilt; clean rebuild increments rebuilt only.
+
+## T5 - memory-value-wiring wall-clock flake (test determinism)
+
+**Defect (mechanism hypothesis, to be reproduced before fixing; corrected per plan-eng-critic r1):** tests/memory-value-wiring.test.ts:62 pins `NOW = 2026-08-10T12:00:00Z` - a date now in the real past. `condemnedEntry` (:81-100) overrides `created` AND `last_retrieved` to the ancient date, so those are already pinned. The fields genuinely left at REAL now are `valid_from` (memory.ts:526, never overridden) and the entry's initial stored `strength` (computed once inside createMemory via calculateStrength with default real-now, memory.ts:539, BEFORE the override spread applies). Any decay/scoring math touching those yields wall-clock-dependent values, flipping strength assertions (e.g. :427/:439). AT1 observed: fails in full suite, passes in isolation - which a pure NOW-vs-wall-clock mechanism does NOT explain (isolation would fail too). The hypothesis is therefore INCOMPLETE: cross-test interference (shared dir, env/config bleed, suite-length timing) is live. The executor must reproduce and pin the actual mechanism (run the file + the failing case with evidence, in isolation AND in suite) before touching assertions.
+
+**Fix (root cause, not tolerance):** make the file's clock basis single-sourced - condemnedEntry overrides EVERY time field createMemory stamps (`valid_from` + re-derive the initial `strength` post-override; `last_retrieved` is already handled), and/or NOW derives from a fixed offset of a single frozen reference used everywhere. Loosening `=== 1.0` to a tolerance is BANNED unless the executor demonstrates the clock cannot be fully injected; if so, record why in the commit.
+
+**Tests:** the file itself; run it 3x in isolation AND once inside the full suite; all green.
+
+## Shared constraints
+
+- No schema change, no migration, no version-const bump in this pass (release = patch bump at ship, 8-manifest lockstep per check-manifest-versions.mjs).
+- Additive public surface only: applyRebuildResult return-shape change is internal (store.ts private helper for dag.ts); verify it is not exported from index.ts before treating as internal.
+- Tests: real DB (house convention), vitest; touched suites + full suite before review.
+- Commit messages: no em dashes; Write-to-file + `git commit -F`.
+- [PROBATION] memories in scope: feedback_codex_review_base_aware (use --base for committed-work reviews, delta-scope re-reviews, 900s+ timeouts), feedback_exposure_audit_mechanism_not_data (T1/T2 classify by mechanism), multitenant-join-table-composite-fks (T1 tests), feedback_background_logs_full_copy_no_tail (suite runs capture BOTH streams to file).
+
+## Out of scope
+
+- Write-path consolidation refactor (shared mutation primitives) - next episode, deliberately after this pass.
+- Per-tenant consolidation loop for auto-trace (docs/plans/2026-05-02-continuity-tables-tenant-scope.md) - T1 fixes landing/mixing, not the single-tenant session-window design.
+- A5 v2 sub-2 tenant-scoping residue beyond the two createMemory sites.
+- mergeContents paraphrase/summary quality - unchanged.
+- dag.ts L3 entity profiles: verified ALREADY tenant-scoped (byTenant partition + tenantId threaded into createMemory at dag.ts:397, "HIGH #1 fold") - no open edge, nothing to file (plan-eng-critic r1 correction; the :363-368 comment describes the pre-fix problem).

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -24,7 +24,7 @@ import {
 } from './store.js';
 import { textOverlap, markRetrieved } from './search.js';
 import { compareEntryIdentity } from './compare.js';
-import { openHippoDb, closeHippoDb } from './db.js';
+import { openHippoDb, closeHippoDb, type DatabaseSyncLike } from './db.js';
 import { rejectionDigest, findRejectedValue } from './rejection.js';
 import { loadPhysicsState, savePhysicsState, refreshParticleProperties } from './physics-state.js';
 import { simulate, type ForceContext } from './physics.js';
@@ -88,6 +88,10 @@ export interface ConsolidationResult {
   summariesRebuilt: number;
   summariesRebuildFailed: number;
   summariesZeroChildSkipped: number;
+  // Hardening pass: tombstone-refused rebuilds split out of `rebuilt` so the
+  // stat no longer silently absorbs refusals (metadata still applied, dirty
+  // still cleared - counters only; see applyRebuildResult's return contract).
+  summariesRebuildRefused: number;
   summariesRebuildCapped: boolean;
   // v0.30 / E5 — L3 entity-profile build count
   entityProfilesCreated: number;
@@ -122,6 +126,7 @@ export async function consolidate(
     summariesRebuilt: 0,
     summariesRebuildFailed: 0,
     summariesZeroChildSkipped: 0,
+    summariesRebuildRefused: 0,
     summariesRebuildCapped: false,
     entityProfilesCreated: 0,
     dryRun,
@@ -291,22 +296,29 @@ export async function consolidate(
   }
 
   // AT1 rejection-guard db handle (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
-  // opened ONCE for the whole non-dry-run consolidate, covering BOTH the
-  // auto-promote pass (1.4, immediately below) and the merge pass (3,
-  // further down) — both build deterministic content that batchWriteAndDelete
-  // writes through the guard's bypass, so both need a producer-side
-  // tombstone check before pushing to pendingWrites. A single handle here
-  // replaces what used to be a per-pass open. Dry-run never reaches the
-  // bypass (no batchWriteAndDelete call), so there is nothing for a handle
-  // to protect against — stays null and every `if (consolidateDb)` below is
-  // a no-op.
+  // covers BOTH the auto-promote pass (1.4, immediately below) and the merge
+  // pass (3, further down) — both build deterministic content that
+  // batchWriteAndDelete writes through the guard's bypass, so both need a
+  // producer-side tombstone check before pushing to pendingWrites.
   //
-  // AT1 P2 fix (codex, handle-leak restructure): the open must be followed
-  // IMMEDIATELY by the try whose finally closes it, covering every phase
-  // that can touch consolidateDb — not just the merge pass. Previously the
+  // T3 fix (2026-08-15 hardening pass, perf hygiene): memoized lazy getter,
+  // not an eager open. The handle only serves these two tombstone checks —
+  // a sleep with zero promotable sessions and zero merge clusters never
+  // reaches either use site, so opening it unconditionally on every
+  // non-dry-run sleep paid a db-open cost for nothing. dryRun still never
+  // opens (getConsolidateDb short-circuits before touching the handle).
+  // Every `if (consolidateDb)` guard below becomes `const consolidateDb =
+  // getConsolidateDb();` at its use site — same semantics, opened on first
+  // real use. consolidateDbOpened (not just a truthy handle check) is the
+  // single source of truth for "was this ever opened", so the finally below
+  // closes it exactly once and never double-opens.
+  //
+  // AT1 P2 fix (codex, handle-leak restructure): the getter's lifetime must
+  // start IMMEDIATELY before the try whose finally closes it, covering every
+  // phase that can touch it — not just the merge pass. Previously the
   // try/finally wrapped only section 3 (merge pass); an exception thrown by
   // auto-promote (1.4), replay (1.5), batch extraction (1.6), the DAG
-  // passes (1.7-1.9), or physics (2) would propagate past the open handle
+  // passes (1.7-1.9), or physics (2) would propagate past an open handle
   // with nothing to close it. No behavior change on the happy path — each
   // of those phases already best-effort catches its own exceptions today
   // (physics has its own try/catch below; each DAG pass wraps its own
@@ -315,7 +327,16 @@ export async function consolidate(
   // NOT re-indented (mechanical wrap only, kept surgical): every statement
   // between this try and its finally (below, at the end of the merge pass)
   // stays at its original indentation.
-  const consolidateDb = dryRun ? null : openHippoDb(hippoRoot);
+  let consolidateDbHandle: DatabaseSyncLike | null = null;
+  let consolidateDbOpened = false;
+  const getConsolidateDb = (): DatabaseSyncLike | null => {
+    if (dryRun) return null;
+    if (!consolidateDbOpened) {
+      consolidateDbHandle = openHippoDb(hippoRoot);
+      consolidateDbOpened = true;
+    }
+    return consolidateDbHandle;
+  };
   // Declared here (not at the merge pass, its point of use) so it survives
   // this try/finally — a `let` declared INSIDE the try would go out of
   // scope before the `if (mergesSkippedRejected > 0)` check that reads it
@@ -376,6 +397,13 @@ export async function consolidate(
           source_session_id: session.session_id,
           tags: ['auto-promoted'],
           source: 'auto-promote',
+          // T1 fix (2026-08-15 hardening pass): stamp the trace into the SAME
+          // tenant traceExistsForSession (:347, above) checks under. Before
+          // this, createMemory omitted tenantId and the trace always landed
+          // 'default' (memory.ts:535) while the idempotency check ran under
+          // consolidationTenant — for any non-default tenant that check never
+          // hit, and the trace regenerated every sleep.
+          tenantId: consolidationTenant,
         },
       );
 
@@ -387,6 +415,7 @@ export async function consolidate(
       // stamped tenantId (read off `trace` after createMemory — never guess
       // the tenant) + the built content's digest. A hit skips the push
       // entirely: not counted as promoted, not added to survivors.
+      const consolidateDb = getConsolidateDb();
       if (consolidateDb) {
         const traceDigest = rejectionDigest(trace.content);
         const tombstone = findRejectedValue(consolidateDb, trace.tenantId, traceDigest);
@@ -550,10 +579,12 @@ export async function consolidate(
       result.summariesRebuilt = rebuildResult.rebuilt;
       result.summariesRebuildFailed = rebuildResult.failed;
       result.summariesZeroChildSkipped = rebuildResult.zeroChildSkipped;
+      result.summariesRebuildRefused = rebuildResult.refused;
       result.summariesRebuildCapped = rebuildResult.capped;
-      if (rebuildResult.rebuilt > 0 || rebuildResult.zeroChildSkipped > 0 || rebuildResult.failed > 0) {
+      if (rebuildResult.rebuilt > 0 || rebuildResult.zeroChildSkipped > 0 || rebuildResult.failed > 0 || rebuildResult.refused > 0) {
         const parts: string[] = [];
         if (rebuildResult.rebuilt > 0) parts.push(`${rebuildResult.rebuilt} rebuilt`);
+        if (rebuildResult.refused > 0) parts.push(`${rebuildResult.refused} refused`);
         if (rebuildResult.zeroChildSkipped > 0) parts.push(`${rebuildResult.zeroChildSkipped} zero-child-skipped`);
         if (rebuildResult.failed > 0) parts.push(`${rebuildResult.failed} failed`);
         if (rebuildResult.capped) parts.push(`CAPPED@${cap}`);
@@ -661,6 +692,20 @@ export async function consolidate(
   );
   const used = new Set<string>();
 
+  // T1 fix (2026-08-15 hardening pass): partition by tenantId BEFORE the
+  // overlap loop so a cluster can never span tenants. Previously textOverlap
+  // clustered across the whole host-wide `survivors` list with no tenant
+  // boundary, and mergeContents concatenated cross-tenant content into one
+  // row. Map preserves insertion order, so single-tenant stores (every row
+  // 'default') get exactly one partition and iterate in the same order as
+  // before this fix — byte-identical behavior there.
+  const mergeCandidatesByTenant = new Map<string, MemoryEntry[]>();
+  for (const entry of mergeCandidates) {
+    const bucket = mergeCandidatesByTenant.get(entry.tenantId);
+    if (bucket) bucket.push(entry);
+    else mergeCandidatesByTenant.set(entry.tenantId, [entry]);
+  }
+
   // AT1 consolidation-loop fix (docs/plans/2026-08-15-at1-rejected-value-tombstone.md):
   // reuses the single consolidateDb handle opened once above (before the
   // auto-promote pass, 1.4) for the whole non-dry-run consolidate — see that
@@ -670,16 +715,17 @@ export async function consolidate(
   // declared up at the try's opening above 1.4, not here — it has to
   // survive the try/finally that now wraps this whole section; see the
   // handle-leak restructure comment there.)
-    for (let i = 0; i < mergeCandidates.length; i++) {
-      if (used.has(mergeCandidates[i].id)) continue;
+  for (const [mergeTenant, tenantCandidates] of mergeCandidatesByTenant) {
+    for (let i = 0; i < tenantCandidates.length; i++) {
+      if (used.has(tenantCandidates[i].id)) continue;
 
-      const cluster: MemoryEntry[] = [mergeCandidates[i]];
+      const cluster: MemoryEntry[] = [tenantCandidates[i]];
 
-      for (let j = i + 1; j < mergeCandidates.length; j++) {
-        if (used.has(mergeCandidates[j].id)) continue;
-        const overlap = textOverlap(mergeCandidates[i].content, mergeCandidates[j].content);
+      for (let j = i + 1; j < tenantCandidates.length; j++) {
+        if (used.has(tenantCandidates[j].id)) continue;
+        const overlap = textOverlap(tenantCandidates[i].content, tenantCandidates[j].content);
         if (overlap >= MERGE_OVERLAP_THRESHOLD) {
-          cluster.push(mergeCandidates[j]);
+          cluster.push(tenantCandidates[j]);
         }
       }
 
@@ -692,18 +738,11 @@ export async function consolidate(
 
       // AT1 P2 fix: build the semantic entry FIRST — createMemory is cheap
       // and pure — so the tombstone check below runs under the tenant the
-      // row will ACTUALLY land in. The prior version checked
-      // cluster[0].tenantId, but createMemory (below) is never passed a
-      // tenantId option, so it always stamps its own default ('default',
-      // see memory.ts) regardless of the cluster's source tenant — the
-      // check was consulting a tenant's tombstones that the write was never
-      // going to land in (a false negative on the real destination, and a
-      // possible false-block on the source tenant's unrelated tombstones).
-      // This fix only makes the CHECK match wherever the row actually
-      // lands; it deliberately does NOT change that destination — merge
-      // rows always landing in 'default' regardless of source tenant is a
-      // real, pre-existing cross-tenant question, tracked separately as an
-      // AT1 follow-up (not this fix's scope) rather than folded in here.
+      // row will ACTUALLY land in.
+      // T1 fix: createMemory now receives tenantId: mergeTenant (the
+      // partition's tenant — every member of `cluster` shares it by
+      // construction), so the row lands in its source tenant instead of
+      // always 'default'.
       let semantic: MemoryEntry | null = null;
       if (!dryRun) {
         semantic = createMemory(mergedContent, {
@@ -713,6 +752,7 @@ export async function consolidate(
           schema_fit: 0.7,
           source: 'consolidation',
           confidence: 'inferred',
+          tenantId: mergeTenant,
         });
       }
 
@@ -724,6 +764,7 @@ export async function consolidate(
       // bypass safe. A hit skips the WHOLE cluster: sources stay unmerged —
       // not demoted, not deleted — so a later sleep gets another chance if
       // the tombstone is lifted.
+      const consolidateDb = getConsolidateDb();
       if (consolidateDb && semantic) {
         const mergeDigest = rejectionDigest(semantic.content);
         const tombstone = findRejectedValue(consolidateDb, semantic.tenantId, mergeDigest);
@@ -781,8 +822,9 @@ export async function consolidate(
         }
       }
     }
+  }
   } finally {
-    if (consolidateDb) closeHippoDb(consolidateDb);
+    if (consolidateDbHandle) closeHippoDb(consolidateDbHandle);
   }
 
   if (mergesSkippedRejected > 0) {

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -398,7 +398,8 @@ export async function consolidate(
           tags: ['auto-promoted'],
           source: 'auto-promote',
           // T1 fix (2026-08-15 hardening pass): stamp the trace into the SAME
-          // tenant traceExistsForSession (:347, above) checks under. Before
+          // tenant the traceExistsForSession idempotency check (above) runs
+          // under. Before
           // this, createMemory omitted tenantId and the trace always landed
           // 'default' (memory.ts:535) while the idempotency check ran under
           // consolidationTenant — for any non-default tenant that check never

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -198,6 +198,7 @@ export async function buildDag(
 export interface DagRebuildResult {
   attempted: number;            // summaries we tried (<= cap)
   rebuilt: number;              // successful regenerations
+  refused: number;              // tombstone-hit refusals — dirty cleared, content NOT written (T4 split from `rebuilt`)
   zeroChildSkipped: number;     // dirty-cleared without LLM (descendants all gone)
   failed: number;               // LLM null, fetch error, or applyRebuildResult throw
   capped: boolean;              // true if queue had more than cap entries
@@ -213,7 +214,12 @@ export interface DagRebuildResult {
  *
  * Race-loser handling: applyRebuildResult's UPDATE WHERE includes
  * AND summary_dirty=1, so concurrent sleep's second writer returns
- * changed=false. Silent skip (neither rebuilt++ nor failed++).
+ * changed=false. Silent skip (neither rebuilt++ nor refused++ nor failed++).
+ *
+ * T4: applyRebuildResult returns { changed, refused } — a tombstone hit
+ * (rebuild content matches a previously-rejected value) increments
+ * `refused`, not `rebuilt`. Dirty still clears either way; only the stat
+ * split changed (docs/plans/2026-08-15-hardening-at1-followups.md T4).
  */
 export async function rebuildDirtySummaries(
   hippoRoot: string,
@@ -227,6 +233,7 @@ export async function rebuildDirtySummaries(
   const result: DagRebuildResult = {
     attempted: queue.length,
     rebuilt: 0,
+    refused: 0,
     zeroChildSkipped: 0,
     failed: 0,
     capped,
@@ -247,7 +254,7 @@ export async function rebuildDirtySummaries(
 
       if (children.length === 0) {
         // Zero-child case: clear dirty + zero counts, no LLM call, no rebuild_count bump.
-        const changed = applyRebuildResult(hippoRoot, summary, {
+        const { changed } = applyRebuildResult(hippoRoot, summary, {
           content: summary.content,
           descendant_count: 0,
           earliest_at: null,
@@ -257,7 +264,9 @@ export async function rebuildDirtySummaries(
           actor: 'sleep',
         });
         if (changed) result.zeroChildSkipped++;
-        // changed=false → race lost / row vanished; silently skip
+        // changed=false → race lost / row vanished; silently skip. `refused`
+        // is always false here — applyRebuildResult only checks the
+        // tombstone when bumpRebuildCount is true (store.ts:3398).
         continue;
       }
 
@@ -282,7 +291,7 @@ export async function rebuildDirtySummaries(
       }
 
       const childCreatedAts = children.map((c) => c.created).sort();
-      const changed = applyRebuildResult(hippoRoot, summary, {
+      const { changed, refused } = applyRebuildResult(hippoRoot, summary, {
         content: newContent,
         descendant_count: children.length,
         earliest_at: childCreatedAts[0],
@@ -291,8 +300,13 @@ export async function rebuildDirtySummaries(
         zeroChildren: false,
         actor: 'sleep',
       });
-      if (changed) result.rebuilt++;
-      // changed=false → race lost; not failure, not success, silently skip
+      if (refused) {
+        result.refused++;
+      } else if (changed) {
+        result.rebuilt++;
+      }
+      // changed=false (refused also false) → race lost; not failure, not
+      // success, silently skip
     } catch (err) {
       // Per-summary failure isolation — one throw doesn't abort the queue.
       // independent-review MED #2 fold: log enough to triage in production

--- a/src/dag.ts
+++ b/src/dag.ts
@@ -134,58 +134,90 @@ export async function buildDag(
     (f) => f.dag_level === 1 && !f.dag_parent_id && f.tags.includes('extracted'),
   );
 
-  const clusters = clusterFacts(unparented);
-  const eligibleClusters = clusters.filter((c) => c.members.length >= 3);
-  result.candidateClusters = eligibleClusters.length;
+  // Hardening follow-up (mirrors consolidate.ts's mergeCandidatesByTenant,
+  // T1): partition unparented facts by tenantId BEFORE clustering so a
+  // cluster can never mix facts from different tenants into one
+  // LLM-synthesized summary. Map preserves insertion order, so
+  // single-tenant stores (every row 'default') get exactly one partition
+  // and iterate in the same order as before this fix — byte-identical
+  // behavior there.
+  const unparentedByTenant = new Map<string, MemoryEntry[]>();
+  for (const fact of unparented) {
+    const bucket = unparentedByTenant.get(fact.tenantId);
+    if (bucket) bucket.push(fact);
+    else unparentedByTenant.set(fact.tenantId, [fact]);
+  }
 
-  for (const cluster of eligibleClusters) {
-    const summary = await generateDagSummary(
-      cluster.label,
-      cluster.members.map((m) => m.content),
-      opts,
-    );
-    if (!summary) continue;
+  for (const [factTenant, tenantFacts] of unparentedByTenant) {
+    const clusters = clusterFacts(tenantFacts);
+    const eligibleClusters = clusters.filter((c) => c.members.length >= 3);
+    result.candidateClusters += eligibleClusters.length;
 
-    const memberCreatedAts = cluster.members.map((m) => m.created).sort();
-    const summaryEntry = createMemory(summary, {
-      layer: Layer.Semantic,
-      tags: [...cluster.entityTags, 'dag-summary'],
-      confidence: 'inferred',
-      dag_level: 2,
-    });
-    // Schema v25: cache descendant_count + earliest/latest_at on the summary
-    // row so DAG-aware recall (docs/plans/2026-05-05-dag-recall.md Task 2)
-    // can reason about scope without walking the children.
-    summaryEntry.descendant_count = cluster.members.length;
-    summaryEntry.earliest_at = memberCreatedAts[0];
-    summaryEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
-    // AT1 (plan §3 containment): a refused LLM-synthesized summary skips
-    // ONLY this cluster — the sleep cycle continues to the next one. The
-    // member re-parenting writes below never run for a skipped cluster
-    // (there is no summary id to parent them under).
-    try {
-      writeEntry(hippoRoot, summaryEntry);
-    } catch (err) {
-      if (err instanceof RejectedValueError) {
-        result.rejected++;
-        console.error(`[buildDag] cluster "${cluster.label}" skipped: summary matches a rejected value`);
-        continue;
+    for (const cluster of eligibleClusters) {
+      const summary = await generateDagSummary(
+        cluster.label,
+        cluster.members.map((m) => m.content),
+        opts,
+      );
+      if (!summary) continue;
+
+      const memberCreatedAts = cluster.members.map((m) => m.created).sort();
+      // Every member of `cluster` shares factTenant by construction (the
+      // tenant partition above), so the summary lands in the same tenant
+      // as the facts it summarizes instead of always 'default'
+      // (memory.ts:535 defaults tenantId when the option is omitted).
+      const summaryEntry = createMemory(summary, {
+        layer: Layer.Semantic,
+        tags: [...cluster.entityTags, 'dag-summary'],
+        confidence: 'inferred',
+        dag_level: 2,
+        tenantId: factTenant,
+      });
+      // Schema v25: cache descendant_count + earliest/latest_at on the summary
+      // row so DAG-aware recall (docs/plans/2026-05-05-dag-recall.md Task 2)
+      // can reason about scope without walking the children.
+      summaryEntry.descendant_count = cluster.members.length;
+      summaryEntry.earliest_at = memberCreatedAts[0];
+      summaryEntry.latest_at = memberCreatedAts[memberCreatedAts.length - 1];
+      // AT1 (plan §3 containment): a refused LLM-synthesized summary skips
+      // ONLY this cluster — the sleep cycle continues to the next one. The
+      // member re-parenting writes below never run for a skipped cluster
+      // (there is no summary id to parent them under).
+      //
+      // The tombstone check itself is tenant-scoped for free: writeEntry ->
+      // writeEntryDbOnly -> upsertEntryRow calls
+      // checkRejectionGuard(db, entry.tenantId ?? 'default', ...)
+      // (store.ts:1172), reading tenantId off the entry being written. Now
+      // that summaryEntry carries factTenant instead of the implicit
+      // 'default', the guard consults that tenant's tombstones — no
+      // separate check needed here (unlike consolidate.ts's merge pass,
+      // which pre-checks via findRejectedValue because it writes through
+      // batchWriteAndDelete's bypassRejectionGuard path instead of
+      // writeEntry).
+      try {
+        writeEntry(hippoRoot, summaryEntry);
+      } catch (err) {
+        if (err instanceof RejectedValueError) {
+          result.rejected++;
+          console.error(`[buildDag] cluster "${cluster.label}" skipped: summary matches a rejected value`);
+          continue;
+        }
+        throw err;
       }
-      throw err;
-    }
-    result.summariesCreated++;
+      result.summariesCreated++;
 
-    for (const member of cluster.members) {
-      const updated: MemoryEntry = { ...member, dag_parent_id: summaryEntry.id };
-      writeEntry(hippoRoot, updated);
-      result.factsLinked++;
+      for (const member of cluster.members) {
+        const updated: MemoryEntry = { ...member, dag_parent_id: summaryEntry.id };
+        writeEntry(hippoRoot, updated);
+        result.factsLinked++;
+      }
+      // v0.30 / E3 — cancel the cascade of dirty-marks fired by member
+      // writeEntry calls (E2 hook on writeEntryDbOnly at store.ts:1214).
+      // The summary we just built IS fresh, no rebuild needed. Without this,
+      // E3 in the SAME sleep cycle would re-rebuild every new summary
+      // (2x LLM cost). plan-eng-r1 HIGH must-fix.
+      clearSummaryDirtyAfterBuild(hippoRoot, summaryEntry.id, summaryEntry.tenantId, 'buildDag');
     }
-    // v0.30 / E3 — cancel the cascade of dirty-marks fired by member
-    // writeEntry calls (E2 hook on writeEntryDbOnly at store.ts:1214).
-    // The summary we just built IS fresh, no rebuild needed. Without this,
-    // E3 in the SAME sleep cycle would re-rebuild every new summary
-    // (2x LLM cost). plan-eng-r1 HIGH must-fix.
-    clearSummaryDirtyAfterBuild(hippoRoot, summaryEntry.id, summaryEntry.tenantId, 'buildDag');
   }
 
   return result;

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -109,6 +109,12 @@ export function storeExtractedFacts(
       confidence: 'inferred',
       source: source.source,
       extracted_from: source.id,
+      // T1 executor check (2026-08-15 hardening pass): same defect as the
+      // consolidate.ts merge/trace passes — createMemory with no tenantId
+      // option stamps 'default' (memory.ts:535) regardless of the source
+      // entry's own tenant. Thread it through so extracted facts land in
+      // the same tenant as the episodic memory they were extracted from.
+      tenantId: source.tenantId,
     });
 
     // AT1 containment: a refusal is per-VALUE — one rejected fact must not

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -675,7 +675,8 @@ async function executeTool(
       // v0.32 / J3.2 — auto-injection of reference-class baserate hint
       // when the query carries a forward-prediction phrase. Read from
       // apiResult.planningFallacyHint (already computed inside api.recall
-      // with actor='mcp' threaded through ctx.actor.subject). The hint is
+      // with the caller identity threaded through ctx.actor.subject -
+      // auth-resolved actor under HTTP-MCP, 'mcp' for stdio). The hint is
       // pipeline-INVARIANT — same (hippoRoot, tenantId, query) inputs
       // produce the same hint regardless of which downstream search
       // pipeline (api.recall band vs physics/hybrid) renders the memory
@@ -932,10 +933,11 @@ async function executeTool(
       const tags: string[] = [];
       if (args.error) tags.push('error');
       if (args.tag) tags.push(String(args.tag));
-      // Route through api.ts so audit_log captures actor='mcp' uniformly with
-      // CLI/REST. api.ts.remember writes the memory + audit row in one
-      // transaction-friendly path; we re-read the entry to surface the
-      // half-life used in the MCP human-readable response.
+      // Route through api.ts so audit_log captures the caller identity
+      // uniformly with CLI/REST: the auth-resolved ctx.actor under HTTP-MCP,
+      // 'mcp' for stdio (no ctx). api.ts.remember writes the memory + audit
+      // row in one transaction-friendly path; we re-read the entry to surface
+      // the half-life used in the MCP human-readable response.
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
@@ -976,8 +978,9 @@ async function executeTool(
       const ids = lastRecalledIds.get(clientKey) ?? [];
       if (ids.length === 0) return 'No recent recalls to apply outcome to.';
 
-      // Route through src/api.ts so audit_log captures actor='mcp' and
-      // tenant scoping is enforced uniformly (same surface as recall/remember).
+      // Route through src/api.ts so audit_log captures the caller identity
+      // (auth-resolved ctx.actor under HTTP-MCP, 'mcp' for stdio) and tenant
+      // scoping is enforced uniformly (same surface as recall/remember).
       // outcome() also handles cross-tenant id skip silently.
       const apiCtx: ApiContext = {
         hippoRoot,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -495,7 +495,7 @@ async function executeTool(
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
-        actor: adminActor('mcp'),
+        actor: adminActor(ctx?.actor ?? 'mcp'),
       };
       // Route through api.recall for audit + (when requested) continuity block.
       // api.recall already applies the same default-deny / exact-match rules
@@ -836,7 +836,7 @@ async function executeTool(
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
-        actor: adminActor('mcp'),
+        actor: adminActor(ctx?.actor ?? 'mcp'),
       };
       const explicitScope = typeof args.scope === 'string' && args.scope.length > 0
         ? String(args.scope)
@@ -875,7 +875,7 @@ async function executeTool(
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
-        actor: adminActor('mcp'),
+        actor: adminActor(ctx?.actor ?? 'mcp'),
       };
       const r = apiDrillDown(apiCtx, summaryId, {
         ...(Number.isFinite(limit) && limit > 0 ? { limit } : {}),
@@ -939,7 +939,7 @@ async function executeTool(
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
-        actor: adminActor('mcp'),
+        actor: adminActor(ctx?.actor ?? 'mcp'),
       };
       const result = apiRemember(apiCtx, {
         content: text,
@@ -982,7 +982,7 @@ async function executeTool(
       const apiCtx: ApiContext = {
         hippoRoot,
         tenantId,
-        actor: adminActor('mcp'),
+        actor: adminActor(ctx?.actor ?? 'mcp'),
       };
       const { applied } = apiOutcome(apiCtx, ids, good);
       return `Applied ${good ? 'positive' : 'negative'} outcome to ${applied} memories`;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -597,7 +597,7 @@ async function executeTool(
       // EVAL-ONLY ablation (see ablation.ts): skip persistence under the recall
       // flag; ids below stay populated for outcome attribution.
       if (!isRecallBoostAblated()) {
-        for (const entry of retrieved) writeEntry(hippoRoot, entry);
+        for (const entry of retrieved) writeEntry(hippoRoot, entry, { actor: ctx?.actor ?? 'mcp' });
       }
       lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
@@ -623,7 +623,7 @@ async function executeTool(
             try {
               appendAuditEvent(dbForAudit, {
                 tenantId,
-                actor: 'mcp',
+                actor: ctx?.actor ?? 'mcp',
                 op: 'recall_anchor_detected_memory_dominance',
                 targetId: mcpAnchoringHint.memoryId,
                 metadata: {
@@ -639,7 +639,7 @@ async function executeTool(
             try {
               appendAuditEvent(dbForAudit, {
                 tenantId,
-                actor: 'mcp',
+                actor: ctx?.actor ?? 'mcp',
                 op: 'recall_anchor_detected_query_repeat',
                 targetId: mcpAnchoringHint.memoryId,
                 metadata: { memory_id: mcpAnchoringHint.memoryId },
@@ -658,7 +658,7 @@ async function executeTool(
           try {
             appendAuditEvent(dbForAudit, {
               tenantId,
-              actor: 'mcp',
+              actor: ctx?.actor ?? 'mcp',
               op: 'recall_anchor_skipped_no_session',
               targetId: undefined,
               metadata: {
@@ -715,7 +715,8 @@ async function executeTool(
       // planningFallacyHint), this depends on MCP's OWN returned top-K and the
       // scope-filtered candidate pool (entries) it was drawn from, so MCP
       // computes its own hint here. Soft warning only. Gated by
-      // HIPPO_AVAILABILITY=off; audit emission is pipeline-local (actor='mcp').
+      // HIPPO_AVAILABILITY=off; audit emission is pipeline-local (actor =
+      // auth-resolved ctx.actor under HTTP-MCP, 'mcp' for stdio).
       let mcpAvailabilityHint: AvailabilityHint | null = null;
       if (process.env.HIPPO_AVAILABILITY !== 'off') {
         mcpAvailabilityHint = detectAvailabilityBias({
@@ -727,7 +728,7 @@ async function executeTool(
           try {
             appendAuditEvent(dbForAudit, {
               tenantId,
-              actor: 'mcp',
+              actor: ctx?.actor ?? 'mcp',
               op: 'recall_availability_detected',
               metadata: {
                 recent_fraction: mcpAvailabilityHint.recentFraction,
@@ -912,7 +913,7 @@ async function executeTool(
       // (single source of truth, no caller-site drift).
       const classTag = String(args.class_tag || '').trim();
       if (!classTag) return 'No class_tag provided. Usage: pass class_tag matching a class used in past predictions (e.g. "migration-effort").';
-      const baserate = computePredictionBaserate(hippoRoot, tenantId, classTag, 'mcp');
+      const baserate = computePredictionBaserate(hippoRoot, tenantId, classTag, ctx?.actor ?? 'mcp');
       if (baserate.nClosed === 0) {
         return `No closed predictions in class "${classTag}" yet. Create one via hippo_predict (or 'hippo predict ...' CLI) and close it with hippo_predict_close once the actual outcome is known. Base rates need closed predictions with numeric actual_value to compute.`;
       }
@@ -1059,7 +1060,7 @@ async function executeTool(
       // EVAL-ONLY ablation (see ablation.ts): skip persistence under the recall
       // flag; ids below stay populated for outcome attribution.
       if (!isRecallBoostAblated()) {
-        for (const entry of retrieved) writeEntry(hippoRoot, entry);
+        for (const entry of retrieved) writeEntry(hippoRoot, entry, { actor: ctx?.actor ?? 'mcp' });
       }
       lastRecalledIds.set(resolveClientKey(ctx), retrieved.map((e) => e.id));
 
@@ -1132,7 +1133,7 @@ async function executeTool(
         // AT1 (plan §3 containment): a refused lesson must not crash the
         // MCP learn call or lose the rest of the git log scan.
         try {
-          writeEntry(hippoRoot, entry);
+          writeEntry(hippoRoot, entry, { actor: ctx?.actor ?? 'mcp' });
         } catch (err) {
           if (err instanceof RejectedValueError) { rejected++; continue; }
           throw err;

--- a/src/store.ts
+++ b/src/store.ts
@@ -3365,14 +3365,17 @@ export interface RebuildPatch {
  * WHERE includes `AND summary_dirty = 1` so concurrent sleep's race-loser
  * becomes a no-op (no rebuild_count bump, no audit row).
  *
- * Returns true on actual rebuild (changes > 0), false on race-loss /
- * unknown id / archived / wrong dag_level.
+ * Returns `{ changed, refused }`. `changed` is true when this call's UPDATE
+ * (content or metadata-only) affected a row; false on race-loss / unknown id
+ * / archived / wrong dag_level. `refused` is true only when a tombstone hit
+ * suppressed the content write AND the metadata UPDATE still landed — see
+ * the return-semantics comment below for the full contract.
  */
 export function applyRebuildResult(
   hippoRoot: string,
   summary: MemoryEntry,
   patch: RebuildPatch,
-): boolean {
+): { changed: boolean; refused: boolean } {
   assertTenantId('applyRebuildResult', summary.tenantId);
   initStore(hippoRoot);
   const db = openHippoDb(hippoRoot);
@@ -3449,24 +3452,31 @@ export function applyRebuildResult(
             summary.tenantId,
           );
 
-      // Return-value semantics (documented per plan follow-up): `changed`
-      // reflects whether THIS call's UPDATE (content or metadata-only)
-      // affected a row — NOT whether patch.content specifically landed. On
-      // a refusal, metadata still applies, so changed=true here even though
-      // content did not change. This is a deliberate choice: the caller
+      // Return-value semantics (v0.30/T4 split): `changed` reflects whether
+      // THIS call's UPDATE (content or metadata-only) affected a row — NOT
+      // whether patch.content specifically landed. On a refusal, metadata
+      // still applies, so changed=true even though content did not change.
+      // This preserves the pre-T4 no-infinite-retry choice: the caller
       // (dag.ts rebuildDirtySummaries) treats changed=false as "race lost,
       // silently retry next cycle" — returning false on a refusal would
-      // retry the same doomed LLM rebuild forever. Returning true settles
-      // this cycle (dirty cleared) at the cost of the refused rebuild also
-      // counting toward the caller's `rebuilt` stat, which is the lesser
-      // evil and mirrors the pre-existing zero-child branch's own semantics
-      // (it already returns changed=true for a metadata-only update).
+      // retry the same doomed LLM rebuild forever, so changed=true settles
+      // this cycle (dirty cleared) regardless of refusal.
+      // `refused` is the T4 addition: true only when a tombstone hit AND
+      // the metadata UPDATE landed (changed=true) — a refusal that loses
+      // the race to a concurrent writer reports refused=false too, since
+      // nothing from this call took effect. Before T4, a refusal also
+      // counted toward the caller's `rebuilt` stat because `changed` alone
+      // could not distinguish it; the caller now increments `refused`
+      // instead of `rebuilt` when this is true, so the stat reflects what
+      // happened without changing dirty-clearing or retry behavior.
       const changed = (result.changes ?? 0) > 0;
+      const refused = Boolean(tombstone) && changed;
 
       if (tombstone && changed) {
-        // Best-effort refusal audit, written INLINE inside this still-open
-        // SAVEPOINT — nothing here rolls back on a refusal (the metadata
-        // UPDATE above already committed to this savepoint), so the
+        // refused === true here (same condition, narrowed for the tombstone.*
+        // access below). Best-effort refusal audit, written INLINE inside
+        // this still-open SAVEPOINT — nothing here rolls back on a refusal
+        // (the metadata UPDATE above already committed to this savepoint), so the
         // post-rollback auditRejectionRefusal helper (writeEntry/supersede's
         // tool) is the wrong one here; a direct audit() call is correct and
         // commits with the rest of this savepoint.
@@ -3524,7 +3534,7 @@ export function applyRebuildResult(
       }
 
       db.exec('RELEASE SAVEPOINT rebuild_summary');
-      return changed;
+      return { changed, refused };
     } catch (e) {
       try {
         db.exec('ROLLBACK TO SAVEPOINT rebuild_summary');

--- a/tests/consolidate-lazy-db.test.ts
+++ b/tests/consolidate-lazy-db.test.ts
@@ -1,0 +1,113 @@
+/**
+ * T3 test: docs/plans/2026-08-15-hardening-at1-followups.md
+ *
+ * Defect (perf hygiene, not correctness): consolidate.ts opened the shared
+ * consolidateDb handle unconditionally on every non-dry-run sleep, even one
+ * with zero auto-promote candidates and zero merge clusters. Fix: memoized
+ * lazy getter, opened on first real use, closed in the finally only if it
+ * was actually opened.
+ *
+ * Behavioral pin per the plan: no direct "db never opened" assertion (no
+ * test-only counter exists to make that cheap, and the plan says not to
+ * build observation machinery for a perf-hygiene rider) — instead, confirm
+ * a no-op sleep still completes clean, and that a real merge-tombstone
+ * scenario (the AT1 guard this handle exists for) still behaves identically
+ * under the lazy getter.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry, loadAllEntries } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { consolidate } from '../src/consolidate.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { insertRejectedValue, normalizeValueForRejection, rejectionDigest } from '../src/rejection.js';
+
+function tmpHome(prefix: string = 'hippo-consolidate-lazy-db-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+describe('T3: consolidateDb lazy open', () => {
+  it('a no-op sleep (no entries, no promotable sessions, no merge clusters) completes clean', async () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const result = await consolidate(home, { dryRun: false, now: new Date() });
+      expect(result.merged).toBe(0);
+      expect(result.semanticCreated).toBe(0);
+      expect(result.promotedTraces).toBe(0);
+      expect(loadAllEntries(home)).toHaveLength(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('a real merge cluster still opens the handle and the AT1 tombstone check still fires under the lazy getter', async () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      const shortText = 'renew the expiring vpn certificate before the weekend';
+      const longText = 'renew the expiring vpn certificate before the weekend and alert the network team';
+      const e1 = createMemory(shortText, { layer: Layer.Episodic });
+      const e2 = createMemory(longText, { layer: Layer.Episodic });
+      writeEntry(home, e1);
+      writeEntry(home, e2);
+
+      const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
+      const mergedDigest = rejectionDigest(mergedContent);
+      const db = openHippoDb(home);
+      try {
+        insertRejectedValue(db, {
+          tenantId: 'default',
+          digest: mergedDigest,
+          reason: 'pre-rejected merge rollup (lazy-open regression pin)',
+          rejectedBy: 'test',
+          rejectedAt: new Date().toISOString(),
+          normalizedChars: normalizeValueForRejection(mergedContent).length,
+        });
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = await consolidate(home, { dryRun: false });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('skipped 1 merge(s) whose content matches a rejected value'),
+      );
+      errorSpy.mockRestore();
+
+      expect(result.semanticCreated).toBe(0);
+      const allAfter = loadAllEntries(home);
+      expect(allAfter.some((e) => rejectionDigest(e.content) === mergedDigest)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('dry-run never opens the handle: no-op even when a merge cluster exists', async () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      const shortText = 'back up the primary database before the migration';
+      const longText = 'back up the primary database before the migration and verify checksums';
+      const e1 = createMemory(shortText, { layer: Layer.Episodic });
+      const e2 = createMemory(longText, { layer: Layer.Episodic });
+      writeEntry(home, e1);
+      writeEntry(home, e2);
+
+      const result = await consolidate(home, { dryRun: true });
+      // Dry-run previews the merge without writing (getConsolidateDb short
+      // circuits to null before it ever calls openHippoDb).
+      expect(result.dryRun).toBe(true);
+      expect(loadAllEntries(home)).toHaveLength(2);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/consolidate-tenant-landing.test.ts
+++ b/tests/consolidate-tenant-landing.test.ts
@@ -1,0 +1,167 @@
+/**
+ * T1 tests: docs/plans/2026-08-15-hardening-at1-followups.md
+ *
+ * Defect: consolidate.ts's merge pass clustered episodic entries purely by
+ * textOverlap with no tenant boundary, and both the merge pass and the
+ * trace pass called createMemory without a tenantId, so every
+ * consolidation-produced row landed in 'default' regardless of its
+ * source(s). Fix: partition the merge pass by tenantId before clustering
+ * and thread tenantId through both createMemory calls (consolidate.ts) and
+ * extract.ts's storeExtractedFacts (same one-line defect, folded in per the
+ * plan's executor check).
+ *
+ * Real DB, per the project convention (rejection-acceptance.test.ts covers
+ * the tombstone-interaction cases; this file covers plain landing).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, writeEntry, loadAllEntries, appendSessionEvent } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { consolidate } from '../src/consolidate.js';
+import { storeExtractedFacts, type ExtractedFact } from '../src/extract.js';
+
+function tmpHome(prefix: string = 'hippo-consolidate-tenant-landing-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+describe('T1 (a): merge pass partitions by tenant before clustering', () => {
+  it('two tenants with byte-identical overlapping episodic content produce two separate merged rows, each in its own source tenant, never mixed into one', async () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      // Disable replay: it independently rehearses survivors and would
+      // confound nothing here, but matches house convention for merge tests.
+      writeFileSync(join(home, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+
+      // Deliberately IDENTICAL text pair in both tenants. textOverlap has no
+      // tenant awareness, so before the fix all 4 entries clustered together
+      // (identical text => maximum overlap) into ONE row with
+      // "[Consolidated pattern from 4 related memories]" landing in
+      // 'default'. After the fix, tenant partition happens first: each
+      // tenant's own 2 entries cluster on their own into a
+      // "[Consolidated from 2 related memories]" row in that tenant.
+      const shortText = 'rotate the staging tls certificates before expiry';
+      const longText = 'rotate the staging tls certificates before expiry and notify the on-call channel';
+
+      const aShort = createMemory(shortText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      const aLong = createMemory(longText, { layer: Layer.Episodic, tenantId: 'tenant-a' });
+      const bShort = createMemory(shortText, { layer: Layer.Episodic, tenantId: 'tenant-b' });
+      const bLong = createMemory(longText, { layer: Layer.Episodic, tenantId: 'tenant-b' });
+      writeEntry(home, aShort);
+      writeEntry(home, aLong);
+      writeEntry(home, bShort);
+      writeEntry(home, bLong);
+
+      const result = await consolidate(home, { dryRun: false });
+
+      // Two separate 2-entry merges, not one 4-entry merge.
+      expect(result.semanticCreated).toBe(2);
+      expect(result.merged).toBe(4);
+
+      const allAfter = loadAllEntries(home);
+      const semanticRows = allAfter.filter((e) => e.layer === Layer.Semantic);
+      expect(semanticRows).toHaveLength(2);
+
+      const byTenant = new Map(semanticRows.map((e) => [e.tenantId, e]));
+      expect(byTenant.has('tenant-a')).toBe(true);
+      expect(byTenant.has('tenant-b')).toBe(true);
+      expect(byTenant.has('default')).toBe(false);
+
+      // Both directions: neither row is the 4-way "pattern from 4" bulleted
+      // form a cross-tenant cluster would have produced.
+      for (const row of semanticRows) {
+        expect(row.content).toContain('[Consolidated from 2 related memories]');
+        expect(row.content).not.toContain('pattern from 4');
+      }
+
+      // Sources demoted (not deleted) under their OWN tenant — cross-check
+      // no source crossed into the other tenant's row.
+      const aSources = allAfter.filter((e) => e.tenantId === 'tenant-a' && e.layer === Layer.Episodic);
+      const bSources = allAfter.filter((e) => e.tenantId === 'tenant-b' && e.layer === Layer.Episodic);
+      expect(aSources).toHaveLength(2);
+      expect(bSources).toHaveLength(2);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('T1 (c)+(d): trace pass lands in the resolved tenant and stays idempotent there', () => {
+  it('an auto-promoted trace lands in HIPPO_TENANT (not default), and a second sleep does not regenerate it', async () => {
+    const home = tmpHome();
+    const prevTenant = process.env.HIPPO_TENANT;
+    try {
+      initStore(home);
+      process.env.HIPPO_TENANT = 'tenant-x';
+
+      const sid = 'test-session-tenant-x';
+      appendSessionEvent(home, 'tenant-x', {
+        session_id: sid, event_type: 'action', content: 'rotate the deploy key', source: 'agent',
+      });
+      appendSessionEvent(home, 'tenant-x', {
+        session_id: sid,
+        event_type: 'session_complete',
+        content: 'success',
+        source: 'agent',
+        metadata: { summary: 'rotated the deploy key' },
+      });
+
+      const firstResult = await consolidate(home, { now: new Date() });
+      expect(firstResult.promotedTraces).toBe(1);
+
+      const allAfterFirst = loadAllEntries(home);
+      const traces = allAfterFirst.filter((e) => e.layer === Layer.Trace);
+      expect(traces).toHaveLength(1);
+      // (c): the trace landed under the resolved tenant, not 'default' —
+      // this is the fix; before it, createMemory omitted tenantId and every
+      // trace stamped 'default' regardless of HIPPO_TENANT.
+      expect(traces[0]!.tenantId).toBe('tenant-x');
+
+      // (d): idempotency ghost regression pin. traceExistsForSession checks
+      // under consolidationTenant ('tenant-x'). Before the fix the trace
+      // itself lived in 'default', so that check never matched under a
+      // non-default tenant and every sleep regenerated a duplicate trace.
+      const secondResult = await consolidate(home, { now: new Date() });
+      expect(secondResult.promotedTraces).toBe(0);
+
+      const allAfterSecond = loadAllEntries(home);
+      const tracesAfterSecond = allAfterSecond.filter((e) => e.layer === Layer.Trace);
+      expect(tracesAfterSecond).toHaveLength(1);
+    } finally {
+      if (prevTenant === undefined) delete process.env.HIPPO_TENANT;
+      else process.env.HIPPO_TENANT = prevTenant;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('T1 executor check: extract.ts storeExtractedFacts has the same defect, folded in', () => {
+  it('extracted facts inherit the source entry tenant instead of stamping default', () => {
+    const home = tmpHome();
+    try {
+      initStore(home);
+      const source = createMemory('Alice prefers dark mode and vim keybindings', {
+        layer: Layer.Episodic,
+        tenantId: 'tenant-extract',
+      });
+      writeEntry(home, source);
+
+      const facts: ExtractedFact[] = [
+        { content: 'Alice prefers dark mode', tags: ['speaker:alice'], valence: 'neutral' },
+      ];
+      const stored = storeExtractedFacts(home, source, facts);
+
+      expect(stored).toHaveLength(1);
+      expect(stored[0]!.tenantId).toBe('tenant-extract');
+
+      const persisted = loadAllEntries(home).find((e) => e.id === stored[0]!.id);
+      expect(persisted).toBeDefined();
+      expect(persisted!.tenantId).toBe('tenant-extract');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/dag-rebuild-summaries.test.ts
+++ b/tests/dag-rebuild-summaries.test.ts
@@ -24,6 +24,7 @@ import { createMemory, Layer, type MemoryEntry } from '../src/memory.js';
 import { rebuildDirtySummaries, buildDag, generateDagSummary } from '../src/dag.js';
 import { consolidate } from '../src/consolidate.js';
 import { archiveRawMemory } from '../src/raw-archive.js';
+import { insertRejectedValue, rejectionDigest, normalizeValueForRejection } from '../src/rejection.js';
 
 /**
  * Build a fetcher that returns the same synthetic content for every call.
@@ -58,6 +59,26 @@ function forceMarkDirty(hippoRoot: string, summaryId: string): void {
   const db = openHippoDb(hippoRoot);
   try {
     db.prepare(`UPDATE memories SET summary_dirty = 1 WHERE id = ?`).run(summaryId);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Insert a tombstone matching `content`'s rejection digest, so a later
+ * rebuild that regenerates the identical content gets refused (T4 tests).
+ */
+function rejectValue(hippoRoot: string, tenantId: string, content: string): void {
+  const db = openHippoDb(hippoRoot);
+  try {
+    insertRejectedValue(db, {
+      tenantId,
+      digest: rejectionDigest(content),
+      reason: 'T4 refused-stat test fixture',
+      rejectedBy: 'test',
+      rejectedAt: new Date().toISOString(),
+      normalizedChars: normalizeValueForRejection(content).length,
+    });
   } finally {
     db.close();
   }
@@ -405,7 +426,7 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
     expect(sql).toContain('AND summary_dirty = 1'); // race-loser guard
 
     // Smoke test the function actually applies the patch in one round-trip
-    const ok = applyRebuildResult(hippoRoot, summary, {
+    const result = applyRebuildResult(hippoRoot, summary, {
       content: 'one-shot-content-xyzabc',
       descendant_count: 0,
       earliest_at: null,
@@ -414,7 +435,8 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
       zeroChildren: false,
       actor: 'test',
     });
-    expect(ok).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(result.refused).toBe(false); // no tombstone in play — clean rebuild
 
     const db = openHippoDb(hippoRoot);
     try {
@@ -501,7 +523,7 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
     writeEntry(hippoRoot, summary);
     // Note: we do NOT force-mark dirty — simulate the race-loser by leaving clean
 
-    const ok = applyRebuildResult(hippoRoot, summary, {
+    const result = applyRebuildResult(hippoRoot, summary, {
       content: 'should-not-land',
       descendant_count: 5,
       earliest_at: '2026-05-25T10:00:00Z',
@@ -510,7 +532,8 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
       zeroChildren: false,
       actor: 'test',
     });
-    expect(ok).toBe(false);
+    expect(result.changed).toBe(false);
+    expect(result.refused).toBe(false); // race-loser, not a refusal — no tombstone hit
 
     const db = openHippoDb(hippoRoot);
     try {
@@ -583,4 +606,73 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
       }
     }
   }, 240_000); // 1500-row real-DB seed is intentionally slow on low-power CI/dev hosts; passes in ~90s solo but full-suite fork-pool contention can double it
+
+  it('test #13: T4 — tombstone-hit rebuild increments refused, not rebuilt (dirty still clears, content unchanged)', async () => {
+    const summary = makeSummary('original summary content');
+    writeEntry(hippoRoot, summary);
+    const child = makeChild(summary.id, 'fact for refused rebuild');
+    writeEntry(hippoRoot, child);
+    forceMarkDirty(hippoRoot, summary.id);
+
+    const rejectedContent = 'this-exact-content-was-already-rejected-XYZ';
+    rejectValue(hippoRoot, summary.tenantId, rejectedContent);
+
+    // Fetcher regenerates content byte-identical to the tombstoned value —
+    // the deterministic-summarization scenario the AT1 P1a fix guards.
+    const fetcher = makeOkFetcher(rejectedContent);
+    const result = await rebuildDirtySummaries(hippoRoot, {
+      apiKey: 'test-key',
+      fetcher,
+      cap: 20,
+    });
+
+    expect(result.attempted).toBe(1);
+    expect(result.refused).toBe(1);
+    expect(result.rebuilt).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.zeroChildSkipped).toBe(0);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const row = db.prepare(`
+        SELECT content, summary_dirty, rebuild_count, descendant_count FROM memories WHERE id = ?
+      `).get(summary.id) as any;
+      // Content NOT overwritten — the tombstone refused it.
+      expect(row.content).toBe('original summary content');
+      // Dirty still clears — no infinite retry loop (the pre-existing
+      // no-infinite-retry choice T4 keeps).
+      expect(row.summary_dirty).toBe(0);
+      expect(row.rebuild_count ?? 0).toBe(0);
+      // Metadata still applies alongside the refusal.
+      expect(row.descendant_count).toBe(1);
+
+      const refusalAudit = db.prepare(`
+        SELECT COUNT(*) AS n FROM audit_log WHERE op = 'reject_refusal' AND target_id = ?
+      `).get(summary.id) as { n: number };
+      expect(refusalAudit.n).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('test #14: T4 — clean rebuild (no tombstone hit) increments rebuilt, refused stays zero', async () => {
+    const summary = makeSummary('stale summary content');
+    writeEntry(hippoRoot, summary);
+    const child = makeChild(summary.id, 'fact for clean rebuild');
+    writeEntry(hippoRoot, child);
+    forceMarkDirty(hippoRoot, summary.id);
+
+    const fetcher = makeOkFetcher('fresh-regenerated-summary-content-T4');
+    const result = await rebuildDirtySummaries(hippoRoot, {
+      apiKey: 'test-key',
+      fetcher,
+      cap: 20,
+    });
+
+    expect(result.attempted).toBe(1);
+    expect(result.rebuilt).toBe(1);
+    expect(result.refused).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.zeroChildSkipped).toBe(0);
+  });
 });

--- a/tests/dag-rebuild-summaries.test.ts
+++ b/tests/dag-rebuild-summaries.test.ts
@@ -518,6 +518,74 @@ describe('v0.30 / E3 — sleep-cycle rebuildDirtySummaries', () => {
     expect(rebuildResult.rebuilt).toBe(0);
   });
 
+  it('T-followup (hardening pass, docs/plans/2026-08-15-hardening-at1-followups.md): buildDag partitions unparented facts by tenant — two tenants sharing a speaker: tag produce two per-tenant summaries, never one cross-tenant summary in default', async () => {
+    // Deliberately the SAME entity tag ('speaker:alice') across both
+    // tenants so that without the tenant partition, clusterFacts's jaccard
+    // match on entityTags would merge all 6 facts into one 6-member cluster
+    // whose LLM-synthesized summary then landed in 'default' regardless of
+    // source (memory.ts:535's implicit default when createMemory isn't
+    // passed a tenantId). Mirrors T1(a)'s cross-tenant shape
+    // (tests/consolidate-tenant-landing.test.ts) but for the DAG producer
+    // (dag.ts buildDag) instead of consolidate.ts's merge pass.
+    const aFacts = ['alice did X', 'alice said Y', 'alice noted Z'].map((c) =>
+      createMemory(c, {
+        layer: Layer.Episodic,
+        dag_level: 1,
+        tags: ['extracted', 'speaker:alice'],
+        tenantId: 'tenant-a',
+      }),
+    );
+    const bFacts = ['alice ran P', 'alice flagged Q', 'alice closed R'].map((c) =>
+      createMemory(c, {
+        layer: Layer.Episodic,
+        dag_level: 1,
+        tags: ['extracted', 'speaker:alice'],
+        tenantId: 'tenant-b',
+      }),
+    );
+    for (const f of [...aFacts, ...bFacts]) writeEntry(hippoRoot, f);
+
+    const fetcher = makeOkFetcher('synthetic-tenant-partitioned-summary');
+    // Host-wide input, exactly like consolidate.ts:543's `extractedFacts`
+    // (survivors filtered host-wide, no tenant slicing by the caller) —
+    // buildDag itself must do the tenant separation, not its caller.
+    const result = await buildDag(hippoRoot, [...aFacts, ...bFacts], {
+      apiKey: 'test-key',
+      fetcher,
+    });
+
+    // Two separate per-tenant clusters, not one 6-member cross-tenant cluster.
+    expect(result.candidateClusters).toBe(2);
+    expect(result.summariesCreated).toBe(2);
+    expect(result.factsLinked).toBe(6);
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      const summaries = db.prepare(
+        `SELECT id, tenant_id FROM memories WHERE dag_level = 2 AND tags_json LIKE '%dag-summary%'`,
+      ).all() as Array<{ id: string; tenant_id: string }>;
+      expect(summaries).toHaveLength(2);
+      const tenants = summaries.map((s) => s.tenant_id).sort();
+      expect(tenants).toEqual(['tenant-a', 'tenant-b']);
+      expect(tenants).not.toContain('default');
+
+      // Each tenant's 3 members must be re-parented under THAT tenant's own
+      // summary — no member crossed into the other tenant's cluster.
+      const summaryByTenant = new Map(summaries.map((s) => [s.tenant_id, s.id]));
+      for (const [tenantId, facts] of [['tenant-a', aFacts], ['tenant-b', bFacts]] as const) {
+        const rows = db.prepare(
+          `SELECT dag_parent_id FROM memories WHERE tenant_id = ? AND dag_level = 1`,
+        ).all(tenantId) as Array<{ dag_parent_id: string }>;
+        expect(rows).toHaveLength(facts.length);
+        for (const row of rows) {
+          expect(row.dag_parent_id).toBe(summaryByTenant.get(tenantId));
+        }
+      }
+    } finally {
+      db.close();
+    }
+  });
+
   it('test #11: race-loser no-op — pre-cleared dirty flag → applyRebuildResult returns false, no audit, no rebuild_count bump', () => {
     const summary = makeSummary('s11-summary-content');
     writeEntry(hippoRoot, summary);

--- a/tests/mcp-assemble.test.ts
+++ b/tests/mcp-assemble.test.ts
@@ -51,7 +51,7 @@ describe('mcp hippo_assemble', () => {
   it('hippo_assemble is in the tools catalogue', async () => {
     const res = await handleMcpRequest(
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const tools = (res as { result?: { tools?: Array<{ name?: string }> } }).result?.tools ?? [];
     expect(tools.map((t) => t.name)).toContain('hippo_assemble');
@@ -70,7 +70,7 @@ describe('mcp hippo_assemble', () => {
       writeEntry(home, e);
     }
     const res = await callTool(2, 'hippo_assemble', { session_id: 'sess-mcp' }, {
-      hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' },
+      hippoRoot: home, tenantId: 'default', actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('sess-mcp');
@@ -80,14 +80,14 @@ describe('mcp hippo_assemble', () => {
 
   it('rejects empty session_id', async () => {
     const res = await callTool(3, 'hippo_assemble', { session_id: '' }, {
-      hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' },
+      hippoRoot: home, tenantId: 'default', actor: 'mcp',
     });
     expect(extractText(res).toLowerCase()).toContain('no session_id');
   });
 
   it('clean empty result for unknown session', async () => {
     const res = await callTool(4, 'hippo_assemble', { session_id: 'sess-nope' }, {
-      hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' },
+      hippoRoot: home, tenantId: 'default', actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('0 items');

--- a/tests/mcp-context-scope.test.ts
+++ b/tests/mcp-context-scope.test.ts
@@ -60,7 +60,7 @@ describe('mcp hippo_context scope filter', () => {
     const res = await callTool(0, 'hippo_context', { budget: 0 }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
 
     expect(extractText(res)).toBe('Done.');
@@ -82,7 +82,7 @@ describe('mcp hippo_context scope filter', () => {
     const res = await callTool(1, 'hippo_context', {}, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).not.toContain('private memory secret');
@@ -103,7 +103,7 @@ describe('mcp hippo_context scope filter', () => {
     const res = await callTool(2, 'hippo_context', { scope: 'slack:private:Csecret' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('Private task');
@@ -123,7 +123,7 @@ describe('mcp hippo_context scope filter', () => {
     const res = await callTool(3, 'hippo_context', {}, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).not.toContain('BRAVO deploykey fact from another project');
@@ -144,7 +144,7 @@ describe('mcp hippo_context scope filter', () => {
     const res = await callTool(4, 'hippo_context', {}, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).not.toContain('sk_vendor_deadbeef123456');

--- a/tests/mcp-drill.test.ts
+++ b/tests/mcp-drill.test.ts
@@ -65,7 +65,7 @@ describe('mcp hippo_drill', () => {
   it('hippo_drill is registered in the tools catalogue', async () => {
     const res = await handleMcpRequest(
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const tools = (res as { result?: { tools?: Array<{ name?: string }> } }).result?.tools ?? [];
     const names = tools.map((t) => t.name);
@@ -94,7 +94,7 @@ describe('mcp hippo_drill', () => {
     const res = await callTool(2, 'hippo_drill', { summary_id: summary.id }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain(summary.id);
@@ -112,7 +112,7 @@ describe('mcp hippo_drill', () => {
     const res = await callTool(3, 'hippo_drill', { summary_id: leaf.id }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text.toLowerCase()).toContain('leaf row');
@@ -130,7 +130,7 @@ describe('mcp hippo_drill', () => {
     const res = await callTool(4, 'hippo_drill', { summary_id: summary.id }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text.toLowerCase()).toContain('no drillable summary');
@@ -140,7 +140,7 @@ describe('mcp hippo_drill', () => {
     const res = await callTool(5, 'hippo_drill', { summary_id: '' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text.toLowerCase()).toContain('no summary_id');
@@ -150,7 +150,7 @@ describe('mcp hippo_drill', () => {
     const res = await callTool(6, 'hippo_drill', { summary_id: 'missing', depth: 1.5 }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     expect(extractText(res)).toContain('depth must be an integer');
   });

--- a/tests/mcp-predict-baserate.test.ts
+++ b/tests/mcp-predict-baserate.test.ts
@@ -27,7 +27,7 @@ function callTool(
   reqId: number,
   name: string,
   args: Record<string, unknown>,
-  ctx: { hippoRoot: string; tenantId: string; actor: { subject: string; role: 'admin' | 'member' }; clientKey?: string },
+  ctx: { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
 ) {
   return handleMcpRequest(
     {
@@ -75,7 +75,7 @@ describe('mcp hippo_predict_baserate (J3, v0.31)', () => {
     const res = await callTool(1, 'hippo_predict_baserate', { class_tag: 'mcp-test' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
 
@@ -93,7 +93,7 @@ describe('mcp hippo_predict_baserate (J3, v0.31)', () => {
     const res = await callTool(2, 'hippo_predict_baserate', { class_tag: 'never-seen' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     expect(text).toContain('No closed predictions');
@@ -105,7 +105,7 @@ describe('mcp hippo_predict_baserate (J3, v0.31)', () => {
     const res = await callTool(3, 'hippo_predict_baserate', {}, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     expect(text).toContain('No class_tag');

--- a/tests/mcp-recall-anchoring.test.ts
+++ b/tests/mcp-recall-anchoring.test.ts
@@ -29,11 +29,11 @@ function callTool(
   reqId: number,
   name: string,
   args: Record<string, unknown>,
-  ctx: { hippoRoot: string; tenantId: string; actor: { subject: string; role: 'admin' | 'member' }; clientKey?: string },
+  ctx: { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
 ) {
   return handleMcpRequest(
     { jsonrpc: '2.0', id: reqId, method: 'tools/call', params: { name, arguments: args } },
-    ctx as unknown as { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
+    ctx,
   );
 }
 
@@ -83,7 +83,7 @@ describe('mcp hippo_recall anchoringHint (J1, v0.33)', () => {
   });
 
   it('R2 fires after >=3 recalls with same query on same session (memory_dominance + suppressedByInterference bumped)', async () => {
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     // Three recalls with DIFFERENT queries on the same session — same top
     // memory should win each time and trigger R2 on the 3rd.
     await callTool(1, 'hippo_recall', { query: 'frobnicate baz quux', session_id: 'sess1' }, ctx);
@@ -102,14 +102,14 @@ describe('mcp hippo_recall anchoringHint (J1, v0.33)', () => {
   });
 
   it('does NOT render anchoring block on the first recall (no history yet)', async () => {
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     const res = await callTool(1, 'hippo_recall', { query: 'frobnicate baz quux', session_id: 'sess1' }, ctx);
     const text = extractText(res);
     expect(text).not.toContain('## Anchoring hint');
   });
 
   it('emits recall_anchor_skipped_no_session when session_id is absent', async () => {
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     expect(countAuditOps(home, 'recall_anchor_skipped_no_session')).toBe(0);
     await callTool(1, 'hippo_recall', { query: 'frobnicate baz quux' }, ctx);
     expect(countAuditOps(home, 'recall_anchor_skipped_no_session')).toBe(1);
@@ -117,7 +117,7 @@ describe('mcp hippo_recall anchoringHint (J1, v0.33)', () => {
 
   it('does NOT render anchoring block when HIPPO_ANCHORING=off', async () => {
     process.env.HIPPO_ANCHORING = 'off';
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     // Repeat 3 distinct queries — would normally fire R2.
     await callTool(1, 'hippo_recall', { query: 'frobnicate baz quux', session_id: 'sess1' }, ctx);
     await callTool(2, 'hippo_recall', { query: 'frobnicate baz different words', session_id: 'sess1' }, ctx);

--- a/tests/mcp-recall-autodebias.test.ts
+++ b/tests/mcp-recall-autodebias.test.ts
@@ -29,7 +29,7 @@ function callTool(
   reqId: number,
   name: string,
   args: Record<string, unknown>,
-  ctx: { hippoRoot: string; tenantId: string; actor: { subject: string; role: 'admin' | 'member' }; clientKey?: string },
+  ctx: { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
 ) {
   return handleMcpRequest(
     {
@@ -38,7 +38,7 @@ function callTool(
       method: 'tools/call',
       params: { name, arguments: args },
     },
-    ctx as unknown as { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
+    ctx,
   );
 }
 
@@ -78,7 +78,7 @@ describe('mcp hippo_recall planningFallacyHint text block (J3.2 v0.32)', () => {
 
   it('prepends "## Planning fallacy hint" block when query matches forward-claim AND class resolves', async () => {
     seedBaserate(home);
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     const res = await callTool(1, 'hippo_recall', { query: 'migration effort will take 3 days' }, ctx);
     const text = extractText(res);
     expect(text).toContain('## Planning fallacy hint');
@@ -90,7 +90,7 @@ describe('mcp hippo_recall planningFallacyHint text block (J3.2 v0.32)', () => {
 
   it('does NOT prepend the hint block when query has no forward-claim phrase', async () => {
     seedBaserate(home);
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     const res = await callTool(1, 'hippo_recall', { query: 'show me the auth flow' }, ctx);
     const text = extractText(res);
     expect(text).not.toContain('## Planning fallacy hint');
@@ -99,7 +99,7 @@ describe('mcp hippo_recall planningFallacyHint text block (J3.2 v0.32)', () => {
   it('does NOT prepend the hint block when HIPPO_AUTODEBIAS=off', async () => {
     seedBaserate(home);
     process.env.HIPPO_AUTODEBIAS = 'off';
-    const ctx = { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp' as const, role: 'admin' as const } };
+    const ctx = { hippoRoot: home, tenantId: 'default', actor: 'mcp' };
     const res = await callTool(1, 'hippo_recall', { query: 'migration effort will take 3 days' }, ctx);
     const text = extractText(res);
     expect(text).not.toContain('## Planning fallacy hint');

--- a/tests/mcp-recall-continuity.test.ts
+++ b/tests/mcp-recall-continuity.test.ts
@@ -62,7 +62,7 @@ describe('mcp hippo_recall include_continuity', () => {
     const res = await callTool(1, 'hippo_recall', { query: 'deploys' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).not.toContain('## Continuity');
@@ -97,7 +97,7 @@ describe('mcp hippo_recall include_continuity', () => {
     }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('## Continuity');
@@ -123,7 +123,7 @@ describe('mcp hippo_recall include_continuity', () => {
     }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('## Continuity');
@@ -148,7 +148,7 @@ describe('mcp hippo_recall include_continuity', () => {
     }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp', role: 'admin' },
+      actor: 'mcp',
     });
     const text = extractText(res);
     expect(text).toContain('Private task');

--- a/tests/mcp-recall-fresh-tail-policy.test.ts
+++ b/tests/mcp-recall-fresh-tail-policy.test.ts
@@ -78,7 +78,7 @@ describe('mcp hippo_recall fresh-tail policy F5 (v1.6.5)', () => {
       await callTool(
         'hippo_recall',
         { query: 'event', fresh_tail_count: 3 },
-        { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+        { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
       );
     } catch (err) {
       thrown = err;
@@ -104,7 +104,7 @@ describe('mcp hippo_recall fresh-tail policy F5 (v1.6.5)', () => {
     const res = await callTool(
       'hippo_recall',
       { query: 'event', fresh_tail_count: 3, fresh_tail_session_id: 'sess-A' },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const r = res as {
       error?: { code: number; message: string };
@@ -124,7 +124,7 @@ describe('mcp hippo_recall fresh-tail policy F5 (v1.6.5)', () => {
     const res = await callTool(
       'hippo_recall',
       { query: 'event', fresh_tail_count: 3 },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const r = res as {
       error?: { code: number; message: string };

--- a/tests/mcp-recall-goal-boost.test.ts
+++ b/tests/mcp-recall-goal-boost.test.ts
@@ -59,7 +59,7 @@ describe('MCP hippo_recall session_id goal-stack boost (v1.7.4)', () => {
   afterEach(() => rmSync(home, { recursive: true, force: true }));
 
   it('session_id schema field is accepted (no validation error) and reaches the boost', async () => {
-    const ctx = { hippoRoot: home, tenantId, actor: { subject: 'mcp', role: 'admin' } };
+    const ctx = { hippoRoot: home, tenantId, actor: 'mcp' };
     remember({ hippoRoot: home, tenantId, actor: { subject: 'test', role: 'admin' } }, {
       content: 'auth bug fix details',
       tags: ['fix-auth'],
@@ -87,7 +87,7 @@ describe('MCP hippo_recall session_id goal-stack boost (v1.7.4)', () => {
   });
 
   it('without session_id, no boost runs and goal_recall_log stays empty (v1.7.3 baseline)', async () => {
-    const ctx = { hippoRoot: home, tenantId, actor: { subject: 'mcp', role: 'admin' } };
+    const ctx = { hippoRoot: home, tenantId, actor: 'mcp' };
     remember({ hippoRoot: home, tenantId, actor: { subject: 'test', role: 'admin' } }, {
       content: 'auth bug fix details',
       tags: ['fix-auth'],

--- a/tests/mcp-recall-scorer-window.test.ts
+++ b/tests/mcp-recall-scorer-window.test.ts
@@ -74,7 +74,7 @@ describe('MCP hippo_recall scorer_window (v1.7.2 T4)', () => {
     const result = await callTool(
       'hippo_recall',
       { query: 'alpha', budget: 5000, scorer_window: 2 },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const text =
       (result as { result?: { content: Array<{ text: string }> } }).result
@@ -88,7 +88,7 @@ describe('MCP hippo_recall scorer_window (v1.7.2 T4)', () => {
       await callTool(
         'hippo_recall',
         { query: 'alpha', scorer_window: 0 },
-        { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+        { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
       );
     } catch (err) {
       thrown = err;
@@ -117,7 +117,7 @@ describe('MCP hippo_recall scorer_window (v1.7.2 T4)', () => {
     const result = await callTool(
       'hippo_recall',
       { query: 'alpha', budget: 5000, scorer_window: 2, fresh_tail_count: 5 },
-      { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+      { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
     );
     const text =
       (result as { result?: { content: Array<{ text: string }> } }).result
@@ -137,7 +137,7 @@ describe('MCP hippo_recall scorer_window (v1.7.2 T4)', () => {
       await callTool(
         'hippo_recall',
         { query: 'alpha', scorer_window: 'abc' },
-        { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+        { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
       );
     } catch (err) {
       thrown = err;

--- a/tests/mcp-recall-suppression-summary.test.ts
+++ b/tests/mcp-recall-suppression-summary.test.ts
@@ -42,7 +42,7 @@ function callTool(
   reqId: number,
   name: string,
   args: Record<string, unknown>,
-  ctx: { hippoRoot: string; tenantId: string; actor: { subject: string; role: 'admin' | 'member' }; clientKey?: string },
+  ctx: { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
 ) {
   return handleMcpRequest(
     {
@@ -51,7 +51,7 @@ function callTool(
       method: 'tools/call',
       params: { name, arguments: args },
     },
-    ctx as unknown as { hippoRoot: string; tenantId: string; actor: string; clientKey?: string },
+    ctx,
   );
 }
 
@@ -90,7 +90,7 @@ describe('mcp hippo_recall Cutoff suppressionSummary (C5, v1.12.13 + v1.13.3)', 
     const res = await callTool(1, 'hippo_recall', { query: 'omega', budget: 200 }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     // v1.13.3: format is "## Cutoff\nShowing N of M candidates; ..." (was
@@ -115,7 +115,7 @@ describe('mcp hippo_recall Cutoff suppressionSummary (C5, v1.12.13 + v1.13.3)', 
     const res = await callTool(2, 'hippo_recall', { query: 'omega', budget: 200 }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     // Extract Cutoff totalCandidates value via regex.
@@ -138,7 +138,7 @@ describe('mcp hippo_recall Cutoff suppressionSummary (C5, v1.12.13 + v1.13.3)', 
     const res = await callTool(3, 'hippo_recall', { query: 'nothing' }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     expect(text).not.toMatch(/## Cutoff/);
@@ -162,7 +162,7 @@ describe('mcp hippo_recall Cutoff suppressionSummary (C5, v1.12.13 + v1.13.3)', 
     const res = await callTool(4, 'hippo_recall', { query: 'omega', budget: 200 }, {
       hippoRoot: home,
       tenantId: 'default',
-      actor: { subject: 'mcp:test', role: 'admin' },
+      actor: 'mcp:test',
     });
     const text = extractText(res);
     const cutoffIdx = text.indexOf('## Cutoff');

--- a/tests/memory-value-wiring.test.ts
+++ b/tests/memory-value-wiring.test.ts
@@ -83,21 +83,39 @@ function condemnedEntry(
   opts: { layer?: Layer; tenantId?: string; tags?: string[]; confidence?: MemoryEntry['confidence'] } = {},
 ): MemoryEntry {
   const created = ancientDate(3650);
-  return {
-    ...createMemory(content, {
-      layer: opts.layer ?? Layer.Semantic,
-      tenantId: opts.tenantId,
-      tags: opts.tags,
-      confidence: opts.confidence,
-    }),
+  const base = createMemory(content, {
+    layer: opts.layer ?? Layer.Semantic,
+    tenantId: opts.tenantId,
+    tags: opts.tags,
+    confidence: opts.confidence,
+  });
+  const overridden: MemoryEntry = {
+    ...base,
     created,
     last_retrieved: created,
+    valid_from: created,
     half_life_days: 1,
     retrieval_count: 0,
     outcome_positive: 0,
     outcome_negative: 0,
     pinned: false,
   };
+  // T5 fix (AT1 in-suite flake): single-source the stored `strength` to the
+  // same frozen clock basis as every other field above, instead of trusting
+  // createMemory's own computed value. createMemory (memory.ts:539) derives
+  // its initial strength via calculateStrength(entry) with NO explicit
+  // `now`, which defaults to a SECOND, separate evalNow() call -- distinct
+  // from the one that stamped created/last_retrieved a few lines earlier
+  // (memory.ts:494). Any real clock tick between those two reads makes
+  // daysSince a tiny positive epsilon instead of exactly 0, so `base.strength`
+  // can land at 0.999999999... instead of 1.0 (confirmed empirically: ~0.1%
+  // of calls landed non-unity in a 200k-iteration stress repro -- rare in
+  // isolation, likelier under full-suite worker contention, matching the
+  // observed isolation-pass/suite-fail split). Re-deriving here against
+  // `created` itself as `now` makes daysSince exactly 0 by definition
+  // (last_retrieved === created above): strength is exactly 1.0 with zero
+  // dependency on the real clock.
+  return { ...overridden, strength: calculateStrength(overridden, new Date(created)) };
 }
 
 function auditRescueRows(hippoRoot: string, tenantId: string) {

--- a/tests/rejection-acceptance.test.ts
+++ b/tests/rejection-acceptance.test.ts
@@ -573,7 +573,11 @@ describe('AT1 codex-P1 fix 1: auto-promoted trace tombstone check', () => {
 });
 
 describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant', () => {
-  it('a tombstone in the tenant createMemory actually stamps (default) blocks the merge, even though the cluster is a different tenant', async () => {
+  // T1 landing fix (2026-08-15 hardening pass, consolidate.ts): merge rows
+  // now stamp the CLUSTER'S OWN tenant, not always 'default' — both cases
+  // below were written against the pre-fix 'default' landing and are
+  // updated here to the new landing tenant (plan test point e).
+  it('a tombstone in the cluster tenant blocks the merge, now that merge rows land in their source tenant', async () => {
     const home = tmpHome('hippo-rejection-acceptance-merge-tenant-');
     try {
       initStore(home);
@@ -590,13 +594,12 @@ describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant'
       const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
       const mergedDigest = rejectionDigest(mergedContent);
 
-      // Tombstone lives in 'default' — the tenant createMemory's semantic
-      // entry actually stamps (it is never passed a tenantId option) — NOT
-      // the cluster's own 'tenant-a'.
+      // Tombstone lives in 'tenant-a' — the cluster's own tenant, and (post
+      // T1 fix) the tenant createMemory's semantic entry actually stamps.
       const db = openHippoDb(home);
       try {
         insertRejectedValue(db, {
-          tenantId: 'default',
+          tenantId: 'tenant-a',
           digest: mergedDigest,
           reason: 'pre-rejected in the actual destination tenant',
           rejectedBy: 'test',
@@ -620,7 +623,7 @@ describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant'
 
       const dbAfter = openHippoDb(home);
       try {
-        const refusals = queryAuditEvents(dbAfter, { tenantId: 'default', op: 'reject_refusal' });
+        const refusals = queryAuditEvents(dbAfter, { tenantId: 'tenant-a', op: 'reject_refusal' });
         expect(refusals.length).toBe(1);
       } finally {
         closeHippoDb(dbAfter);
@@ -630,7 +633,7 @@ describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant'
     }
   });
 
-  it('a tombstone ONLY in the source tenant (not the destination) does not falsely block the merge', async () => {
+  it('a tombstone in an unrelated tenant does not falsely block the merge', async () => {
     const home = tmpHome('hippo-rejection-acceptance-merge-tenant-');
     try {
       initStore(home);
@@ -646,14 +649,15 @@ describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant'
       const mergedContent = `[Consolidated from 2 related memories]\n\n${longText}`;
       const mergedDigest = rejectionDigest(mergedContent);
 
-      // Tombstone lives ONLY in 'tenant-a' (the cluster's source tenant) —
-      // the write actually lands in 'default', so this must NOT block.
+      // Tombstone lives in an unrelated tenant ('default') — the write now
+      // lands in 'tenant-a' (the cluster's own tenant), so this must NOT
+      // block.
       const db = openHippoDb(home);
       try {
         insertRejectedValue(db, {
-          tenantId: 'tenant-a',
+          tenantId: 'default',
           digest: mergedDigest,
-          reason: 'rejected in the source tenant only',
+          reason: 'rejected in an unrelated tenant only',
           rejectedBy: 'test',
           rejectedAt: new Date().toISOString(),
           normalizedChars: normalizeValueForRejection(mergedContent).length,
@@ -668,7 +672,7 @@ describe('AT1 codex-P1 fix 2: merge tombstone check uses the destination tenant'
       const allAfter = loadAllEntries(home);
       const semantic = allAfter.find((e) => e.layer === Layer.Semantic && e.content === mergedContent);
       expect(semantic).toBeDefined();
-      expect(semantic!.tenantId).toBe('default');
+      expect(semantic!.tenantId).toBe('tenant-a');
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/rejection-guard.test.ts
+++ b/tests/rejection-guard.test.ts
@@ -212,7 +212,7 @@ describe('AT1 rejection guard', () => {
       }
 
       const loaded = readEntry(home, summary.id)!;
-      const changed = applyRebuildResult(home, loaded, {
+      const result1 = applyRebuildResult(home, loaded, {
         content: rejectedContent,
         descendant_count: 3,
         earliest_at: '2026-08-01T00:00:00Z',
@@ -222,9 +222,11 @@ describe('AT1 rejection guard', () => {
         actor: 'sleep',
       });
 
-      // Documented return-value semantics: metadata still applied → true,
-      // even though content was refused.
-      expect(changed).toBe(true);
+      // Documented return-value semantics (T4 split): metadata still
+      // applied → changed=true, even though content was refused; refused=true
+      // is the T4 signal the caller uses to NOT count this as a rebuild.
+      expect(result1.changed).toBe(true);
+      expect(result1.refused).toBe(true);
 
       const after = readEntry(home, summary.id)!;
       expect(after.content).toBe('old summary content');
@@ -244,7 +246,7 @@ describe('AT1 rejection guard', () => {
       // No loop: dirty is cleared, so a second attempt against the
       // now-current row (summary_dirty=1 no longer matches) is a race-loser
       // no-op — no second refusal audit.
-      const secondPass = applyRebuildResult(home, after, {
+      const result2 = applyRebuildResult(home, after, {
         content: rejectedContent,
         descendant_count: 3,
         earliest_at: '2026-08-01T00:00:00Z',
@@ -253,7 +255,11 @@ describe('AT1 rejection guard', () => {
         zeroChildren: false,
         actor: 'sleep',
       });
-      expect(secondPass).toBe(false);
+      expect(result2.changed).toBe(false);
+      // Race-loser, not a refusal: the row's summary_dirty no longer matches
+      // the WHERE clause, so nothing from this call landed — refused stays
+      // false even though the tombstone still exists.
+      expect(result2.refused).toBe(false);
 
       const db2 = openHippoDb(home);
       try {

--- a/tests/scope-filter-generic-private.test.ts
+++ b/tests/scope-filter-generic-private.test.ts
@@ -50,7 +50,7 @@ function callMcpTool(
       method: 'tools/call',
       params: { name, arguments: args },
     },
-    { hippoRoot: home, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' } },
+    { hippoRoot: home, tenantId: 'default', actor: 'mcp' },
   );
 }
 

--- a/tests/v039-mcp-tenant-isolation.test.ts
+++ b/tests/v039-mcp-tenant-isolation.test.ts
@@ -313,6 +313,16 @@ describe('v039 mcp tenant + client-key isolation', () => {
       const outcomeEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'outcome' });
       const aliceOutcome = outcomeEvents.find((e) => e.actor === 'user:alice');
       expect(aliceOutcome).toBeDefined();
+
+      // Codex review-stage P2 pin: the recall branch's SIDE EFFECTS (retrieval
+      // persist via writeEntry, anchoring/availability audits) must carry the
+      // same resolved actor as the primary call - a single authenticated
+      // recall must never fan audit rows out across multiple principals
+      // ('user:alice' primary + 'cli' writeEntry default + hardcoded 'mcp').
+      const allAlphaEvents = queryAuditEvents(db, { tenantId: 'alpha' });
+      const principals = new Set(allAlphaEvents.map((e) => e.actor));
+      expect(principals.has('cli')).toBe(false);
+      expect(principals.has('mcp')).toBe(false);
     } finally {
       closeHippoDb(db);
     }

--- a/tests/v039-mcp-tenant-isolation.test.ts
+++ b/tests/v039-mcp-tenant-isolation.test.ts
@@ -78,8 +78,8 @@ describe('v039 mcp tenant + client-key isolation', () => {
       { content: 'shared-canary lastRecalled keyed-by-clientKey alpha-tenant' },
     );
 
-    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:tokenA:1.2.3.4' };
-    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:tokenB:5.6.7.8' };
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenA:1.2.3.4' };
+    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenB:5.6.7.8' };
 
     // Both clients recall the same memory.
     await callTool(1, 'hippo_recall', { query: 'lastRecalled', budget: 1500 }, ctxA);
@@ -106,7 +106,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
     //
     // Probe that branch directly: clear B's set by giving a different
     // clientKey that has never recalled.
-    const ctxC = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:tokenC:never-recalled' };
+    const ctxC = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:tokenC:never-recalled' };
     const cOutcome = await callTool(3, 'hippo_outcome', { good: true }, ctxC);
     expect(extractText(cOutcome)).toMatch(/No recent recalls/i);
 
@@ -123,7 +123,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
       { content: 'audit-canary recall actor-mcp shape lock' },
     );
 
-    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:t:addr' };
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr' };
     await callTool(1, 'hippo_recall', { query: 'audit-canary', budget: 1500 }, ctx);
 
     const db = openHippoDb(home);
@@ -148,7 +148,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
 
   // ---- Test 3: MCP remember produces audit_log with actor='mcp' -------------
   it('hippo_remember via MCP routes through api.ts and writes audit_log with actor=mcp', async () => {
-    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:t:addr' };
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr' };
     const res = await callTool(
       1,
       'hippo_remember',
@@ -170,7 +170,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
 
   // ---- Test 3.5: hippo_outcome routes through api.ts (audit_log actor=mcp) -
   it('hippo_outcome via MCP routes through api.ts and writes audit_log with op=outcome actor=mcp', async () => {
-    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:t:addr-outcome' };
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:t:addr-outcome' };
     // Seed a memory + recall it so lastRecalledIds is populated for clientKey.
     apiRemember({ hippoRoot: home, tenantId: 'alpha', actor: { subject: 'cli', role: 'admin' } }, { content: 'outcome-canary memory for audit shape lock' });
     await callTool(1, 'hippo_recall', { query: 'outcome-canary' }, ctx);
@@ -196,7 +196,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
       { content: 'stdio-fallback canary backward-compat clientKey-undefined' },
     );
 
-    const ctxNoKey = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' } };
+    const ctxNoKey = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp' };
 
     // Recall sets the keyed Map under the stdio-${pid}:alpha fallback.
     const recallRes = await callTool(1, 'hippo_recall', { query: 'stdio-fallback', budget: 1500 }, ctxNoKey);
@@ -227,8 +227,8 @@ describe('v039 mcp tenant + client-key isolation', () => {
     const keyB = `http:${createHash('sha256').update(bearerB).digest('hex').slice(0, 16)}:${remoteAddr}`;
     expect(keyA).not.toBe(keyB);
 
-    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: keyA };
-    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: keyB };
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: keyA };
+    const ctxB = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: keyB };
 
     // Only A recalls.
     await callTool(1, 'hippo_recall', { query: 'cross-client', budget: 1500 }, ctxA);
@@ -255,7 +255,7 @@ describe('v039 mcp tenant + client-key isolation', () => {
     // through to the test — handleMcpRequest catches the executeTool throw
     // only in the HTTP handler, but here we're calling handleMcpRequest
     // directly, so the throw propagates. Wrap accordingly.
-    const ctxB = { hippoRoot: home, tenantId: 'bravo', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:bravo-token:1.2.3.4' };
+    const ctxB = { hippoRoot: home, tenantId: 'bravo', actor: 'mcp', clientKey: 'http:bravo-token:1.2.3.4' };
 
     let threwNotFound = false;
     try {
@@ -277,9 +277,79 @@ describe('v039 mcp tenant + client-key isolation', () => {
     }
 
     // Sanity: tenant A can still share its own memory.
-    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:alpha-token:1.2.3.4' };
+    const ctxA = { hippoRoot: home, tenantId: 'alpha', actor: 'mcp', clientKey: 'http:alpha-token:1.2.3.4' };
     const okRes = await callTool(2, 'hippo_share', { id: a.id, force: true }, ctxA);
     expect(extractText(okRes)).toMatch(/Shared \[mem_|Shared \[g_/);
+  });
+
+  // ---- Test 7: T2 — ctx.actor threads into audit_log subject ---------------
+  // server.ts's 5 ApiContext build sites used to hardcode adminActor('mcp'),
+  // ignoring McpContext.actor entirely. Fix: adminActor(ctx?.actor ?? 'mcp').
+  // Under HTTP-MCP ctx.actor carries the auth-resolved subject; this must
+  // show up as the audit_log actor for remember and outcome (recall already
+  // covered by Test 2's actor=mcp pin above, same code path).
+  it('hippo_remember and hippo_outcome via MCP thread ctx.actor into audit_log subject (T2)', async () => {
+    const ctx = { hippoRoot: home, tenantId: 'alpha', actor: 'user:alice', clientKey: 'http:alice:addr' };
+
+    const rememberRes = await callTool(
+      1,
+      'hippo_remember',
+      { text: 'T2-canary remember actor-threading user-alice' },
+      ctx,
+    );
+    expect(extractText(rememberRes)).toMatch(/Remembered \[mem_/);
+
+    await callTool(2, 'hippo_recall', { query: 'T2-canary' }, ctx);
+    const outcomeRes = await callTool(3, 'hippo_outcome', { good: true }, ctx);
+    expect(extractText(outcomeRes)).toMatch(/Applied positive outcome to \d+ memories/);
+
+    const db = openHippoDb(home);
+    try {
+      const rememberEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'remember' });
+      const aliceRemember = rememberEvents.find((e) => e.actor === 'user:alice');
+      expect(aliceRemember).toBeDefined();
+      expect(aliceRemember!.targetId).toMatch(/^mem_/);
+
+      const outcomeEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'outcome' });
+      const aliceOutcome = outcomeEvents.find((e) => e.actor === 'user:alice');
+      expect(aliceOutcome).toBeDefined();
+    } finally {
+      closeHippoDb(db);
+    }
+  });
+
+  // ---- Test 8: T2 — actor not supplied still falls back to 'mcp' -----------
+  // Pins ctx?.actor ?? 'mcp' directly (existing-behavior pin: stdio callers
+  // pass no ctx, and the fallback must stay 'mcp'). This deliberately does
+  // NOT call handleMcpRequest with the whole ctx argument omitted — on this
+  // dev machine findHippoRoot()'s cwd walk reaches the real global store at
+  // C:/Users/skf_s/.hippo before HIPPO_HOME's sandbox override applies
+  // (verified: C:/Users/skf_s/.hippo exists), so exercising the literal
+  // no-ctx branch here would write test rows into a real, non-test store.
+  // hippoRoot/tenantId are supplied instead (as in every other test in this
+  // file, skipping findHippoRoot entirely) with actor the only field left
+  // unset, which reaches the fix's `??` operator identically at runtime.
+  it('MCP context with actor omitted falls back to "mcp" in audit_log (ctx?.actor ?? "mcp" pin)', async () => {
+    const res = await handleMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'hippo_remember', arguments: { text: 'T2-canary fallback no-actor-supplied' } },
+      },
+      { hippoRoot: home, tenantId: 'alpha', clientKey: 'http:no-actor:addr' } as any,
+    );
+    expect(extractText(res)).toMatch(/Remembered \[mem_/);
+
+    const db = openHippoDb(home);
+    try {
+      const rememberEvents = queryAuditEvents(db, { tenantId: 'alpha', op: 'remember' });
+      const fallbackRemember = rememberEvents.find((e) => e.actor === 'mcp');
+      expect(fallbackRemember).toBeDefined();
+      expect(fallbackRemember!.targetId).toMatch(/^mem_/);
+    } finally {
+      closeHippoDb(db);
+    }
   });
 });
 

--- a/tests/v039-server-hardening.test.ts
+++ b/tests/v039-server-hardening.test.ts
@@ -366,7 +366,7 @@ describe('v039 server hardening', () => {
     );
 
     // Call MCP recall with no scope.
-    const ctx = { hippoRoot: root, tenantId: 'default', actor: { subject: 'mcp', role: 'admin' }, clientKey: 'http:t:test' };
+    const ctx = { hippoRoot: root, tenantId: 'default', actor: 'mcp', clientKey: 'http:t:test' };
     const res = await handleMcpRequest(
       {
         jsonrpc: '2.0',


### PR DESCRIPTION
Five hardening items batched from the AT1 episode's backlog, one correctness core + four riders. Plan (3-round-gated): docs/plans/2026-08-15-hardening-at1-followups.md

- T1 cross-tenant consolidation landing: merge pass, trace pass, extract.ts, and (execute-gate catch) DAG L2 buildDag all partitioned/threaded by tenant. Closes content mixing across tenants, wrong-tenant landing, and the non-default-tenant trace idempotency ghost.
- T2 MCP actor threading: 5 sites use the auth-resolved ctx.actor for audit attribution (role unchanged); exposed and fixed a 13-file pre-existing fixture-shape bug.
- T3 lazy consolidateDb open (perf hygiene).
- T4 applyRebuildResult {changed, refused} split, threaded to sleep-result surfaces; all 6 callers updated.
- T5 memory-value-wiring flake: root-caused (createMemory double clock read, ~0.1% non-unity strength over 200k iterations) and fixed by single-sourcing the clock basis; no tolerance widening.

Gates: plan-eng-critic 68 -> 90 (r2, zero must-fix); code-review-critic 60 -> 92 (r2, zero must-fix). Full suite 2975/2980 (single failure load-induced during an unrelated machine incident, re-ran green 4/4; 4 pre-existing skips). tsc clean.

## Test plan
- [x] Full suite (2975 pass, 1 load-flake reruled green, 4 pre-existing skips)
- [x] tsc --noEmit clean
- [x] New regression tests: tenant landing (merge/trace/extract/DAG), refused-stat split, MCP actor attribution, clock-basis determinism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NUZVRXZRWfGiztx9JHYQt