### PR TITLE
Fix cross-tenant data loss in deduplicateStore

### DIFF
--- a/docs/plans/2026-08-15-dedupe-tenant-partition.md
+++ b/docs/plans/2026-08-15-dedupe-tenant-partition.md
@@ -1,0 +1,33 @@
+# Dedupe tenant partition (episode 01M03MP0G3YDXBQXXWY7DP0PSC)
+
+Status: Draft (plan-eng-critic pending)
+Base: origin/master 9cb5616 (v1.32.0). Branch: fix/dedupe-tenant-partition. Worktree: C:/Users/skf_s/hippo-wt-dedupe.
+
+## Defect (proven, not hypothesized)
+
+src/dedupe.ts `deduplicateStore` (:72-136) loads ALL entries host-wide (:78) and its O(N^2) pair loop (:106-127) compares content with zero tenant checks, so a stronger tenant-A row absorbs a byte-identical tenant-B row and `deleteEntry` (:131) removes tenant-B's copy: cross-tenant DATA LOSS. Proven in the v1.32.0 episode's two-tenant E2E drive (tenant-b lost its merged semantic row + 2 episodic rows to tenant-a identicals). Pre-existing; exposed by v1.32.0's landing fix; known-issue note shipped in the v1.32.0 CHANGELOG.
+
+## Fix
+
+Inside `deduplicateStore`: group `entries` by `tenantId` (Map, insertion order - the house pattern from consolidate.ts `mergeCandidatesByTenant` and dag.ts `unparentedByTenant`); run the EXISTING survivor sort (:95-101) and pair loop per group; accumulate `removed`/`pairs` across groups. The v1.26.3 survivor total order (strength bucket desc -> retrieval_count desc -> compareEntryIdentity) is preserved unchanged WITHIN each tenant; cross-tenant pairs simply never form. Single-tenant stores: one group, byte-identical behavior (per-group sort of the only group = the current global sort).
+
+Both callers inherit with no signature change: api.ts:2878 (sleep `phases.deduplicateStore`, injected at :2795/:2808) and cli.ts:2772 (`hippo dedup`). `DedupPair` unchanged (tenant fields rejected at grill - not needed for the fix; the kept/removed ids resolve tenants if an operator ever needs them).
+
+Deliberate non-goal: cross-tenant dedupe is never correct - the tenant boundary is an isolation boundary (v39 scope isolation; v1.32.0 landing fix). The config-audit cron's "local-vs-global duplicates" pass is cross-STORE (different mechanism, untouched).
+
+Stale-objection note (plan-eng-critic r1): docs/design-decisions/2026-05-24-blocked-items.md D1 claims tenant-scoping deduplicateStore would destroy a "cross-tenant crossDups" feature. Verified false: the crossDups counter (api.ts:2887-2889) is cross-LAYER (semantic vs episodic; cli.ts prints it as "cross-layer duplicates"), not cross-tenant. No code depends on cross-tenant matches surviving; the v1.32.0 CHANGELOG labels cross-tenant dedupe a data-loss bug. Do not resurrect D1's objection.
+
+## Tests
+
+Existing: tests/dedupe-survivor-determinism.test.ts is the pin for the total order - must stay green untouched (single-tenant cases exercise the one-group path).
+New (same file or tests/dedupe-tenant-partition.test.ts): (a) byte-identical content in tenant-a and tenant-b -> ZERO removals, both rows survive; (b) duplicates WITHIN tenant-a next to an identical pair within tenant-b -> exactly one removal per tenant, survivors correct per the total order in each; (c) dryRun parity for (b).
+
+## Acceptance (E2E, the original repro)
+
+Re-run the v1.32.0 verify drive on the compiled CLI (scratch store, cwd outside any git repo, all output captured): two tenants x identical episodic pairs -> sleep -> BOTH tenants keep their merged semantic row; the dedupe summary reports zero cross-tenant removals. The v1.32.0 drive's failing observation (tenant-b stripped to one episodic row, no semantic) must flip.
+
+## Constraints
+
+- Single file (src/dedupe.ts) + tests; no schema change, no API change, no version bump in this pass.
+- Real-DB vitest; no em dashes; commit via Write + git commit -F.
+- Ship as v1.32.1 (patch: pure bugfix, no API surface change) at the human gate.

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -99,19 +99,17 @@ export function deduplicateStore(
   const finiteCount = (n: number | null | undefined): number =>
     Number.isFinite(n ?? 0) ? (n ?? 0) : 0;
 
+  // Shared across tenant groups: safe because memory ids are globally
+  // unique (crypto.randomUUID at creation), so an id in `removed` can never
+  // collide with another tenant's row, and deleteEntry below deletes by
+  // primary-key id alone.
   const removed = new Set<string>();
   const pairs: DedupPair[] = [];
 
   for (const tenantEntries of entriesByTenant.values()) {
-    // Total order so the survivor is a deterministic function of the entry
-    // multiset, not of load/ingest order: strength bucket desc
-    // (materially-stronger survives) -> retrieval_count desc (more-retrieved
-    // survives on a strength tie) -> compareEntryIdentity (content asc -> id
-    // asc), the cross-ingest-stable terminal key. Without a terminal key,
-    // freshly-ingested near-duplicates tie exactly (strength=1,
-    // retrieval_count=0) and the stable sort falls through to
-    // loadAllEntries's `created ASC, id ASC` order -- arrival order.
-    // Scoped per tenant group: the total order is within a tenant only,
+    // The v1.26.3 survivor total order (see the file-level docstring:
+    // strength bucket desc -> retrieval_count desc -> compareEntryIdentity),
+    // scoped per tenant group: the total order holds within a tenant only,
     // matching the partition above.
     tenantEntries.sort((a, b) => {
       const bucketDiff = strengthBucket(b.strength) - strengthBucket(a.strength);

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -20,6 +20,7 @@
 import { textOverlap } from './search.js';
 import { loadAllEntries, deleteEntry } from './store.js';
 import { compareEntryIdentity } from './compare.js';
+import type { MemoryEntry } from './memory.js';
 
 export interface DedupPair {
   kept: string;
@@ -77,14 +78,19 @@ export function deduplicateStore(
   const dryRun = options.dryRun ?? false;
   const entries = loadAllEntries(hippoRoot);
 
-  // Total order so the survivor is a deterministic function of the entry
-  // multiset, not of load/ingest order: strength bucket desc
-  // (materially-stronger survives) -> retrieval_count desc (more-retrieved
-  // survives on a strength tie) -> compareEntryIdentity (content asc -> id
-  // asc), the cross-ingest-stable terminal key. Without a terminal key,
-  // freshly-ingested near-duplicates tie exactly (strength=1,
-  // retrieval_count=0) and the stable sort falls through to
-  // loadAllEntries's `created ASC, id ASC` order -- arrival order.
+  // Tenant partition (mirrors consolidate.ts mergeCandidatesByTenant and
+  // dag.ts unparentedByTenant): group by tenantId BEFORE the sort so a
+  // duplicate pair can never form across tenants. Map preserves insertion
+  // order, so a single-tenant store (every row 'default') gets exactly one
+  // group and the sort plus pair loop below run byte-identical to the
+  // pre-fix global pass.
+  const entriesByTenant = new Map<string, MemoryEntry[]>();
+  for (const entry of entries) {
+    const bucket = entriesByTenant.get(entry.tenantId);
+    if (bucket) bucket.push(entry);
+    else entriesByTenant.set(entry.tenantId, [entry]);
+  }
+
   // finiteCount mirrors strengthBucket's non-finite hardening on the
   // retrieval leg: a NaN retrieval_count would make the comparator return
   // NaN and break the total order the same way a NaN bucket would.
@@ -92,37 +98,50 @@ export function deduplicateStore(
   // symmetry, not a live bug.
   const finiteCount = (n: number | null | undefined): number =>
     Number.isFinite(n ?? 0) ? (n ?? 0) : 0;
-  entries.sort((a, b) => {
-    const bucketDiff = strengthBucket(b.strength) - strengthBucket(a.strength);
-    if (bucketDiff !== 0) return bucketDiff;
-    const retrievalDiff = finiteCount(b.retrieval_count) - finiteCount(a.retrieval_count);
-    if (retrievalDiff !== 0) return retrievalDiff;
-    return compareEntryIdentity(a, b);
-  });
 
   const removed = new Set<string>();
   const pairs: DedupPair[] = [];
 
-  for (let i = 0; i < entries.length; i++) {
-    if (removed.has(entries[i].id)) continue;
-    for (let j = i + 1; j < entries.length; j++) {
-      if (removed.has(entries[j].id)) continue;
+  for (const tenantEntries of entriesByTenant.values()) {
+    // Total order so the survivor is a deterministic function of the entry
+    // multiset, not of load/ingest order: strength bucket desc
+    // (materially-stronger survives) -> retrieval_count desc (more-retrieved
+    // survives on a strength tie) -> compareEntryIdentity (content asc -> id
+    // asc), the cross-ingest-stable terminal key. Without a terminal key,
+    // freshly-ingested near-duplicates tie exactly (strength=1,
+    // retrieval_count=0) and the stable sort falls through to
+    // loadAllEntries's `created ASC, id ASC` order -- arrival order.
+    // Scoped per tenant group: the total order is within a tenant only,
+    // matching the partition above.
+    tenantEntries.sort((a, b) => {
+      const bucketDiff = strengthBucket(b.strength) - strengthBucket(a.strength);
+      if (bucketDiff !== 0) return bucketDiff;
+      const retrievalDiff = finiteCount(b.retrieval_count) - finiteCount(a.retrieval_count);
+      if (retrievalDiff !== 0) return retrievalDiff;
+      return compareEntryIdentity(a, b);
+    });
 
-      const similarity = textOverlap(entries[i].content, entries[j].content);
-      if (similarity <= threshold) continue;
+    for (let i = 0; i < tenantEntries.length; i++) {
+      if (removed.has(tenantEntries[i].id)) continue;
+      for (let j = i + 1; j < tenantEntries.length; j++) {
+        if (removed.has(tenantEntries[j].id)) continue;
 
-      removed.add(entries[j].id);
-      pairs.push({
-        kept: entries[i].id,
-        keptContent: entries[i].content,
-        keptLayer: entries[i].layer,
-        keptStrength: entries[i].strength ?? 0,
-        removed: entries[j].id,
-        removedContent: entries[j].content,
-        removedLayer: entries[j].layer,
-        removedStrength: entries[j].strength ?? 0,
-        similarity,
-      });
+        const similarity = textOverlap(tenantEntries[i].content, tenantEntries[j].content);
+        if (similarity <= threshold) continue;
+
+        removed.add(tenantEntries[j].id);
+        pairs.push({
+          kept: tenantEntries[i].id,
+          keptContent: tenantEntries[i].content,
+          keptLayer: tenantEntries[i].layer,
+          keptStrength: tenantEntries[i].strength ?? 0,
+          removed: tenantEntries[j].id,
+          removedContent: tenantEntries[j].content,
+          removedLayer: tenantEntries[j].layer,
+          removedStrength: tenantEntries[j].strength ?? 0,
+          similarity,
+        });
+      }
     }
   }
 

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -67,7 +67,11 @@ export function strengthBucket(strength: number | null | undefined): number {
 
 /**
  * Scan the store for near-duplicate memories and remove the weaker copy.
- * Two memories are duplicates if their content has > threshold Jaccard overlap.
+ * Two memories are duplicates if their content has > threshold Jaccard
+ * overlap AND they belong to the same tenant: the scan is partitioned by
+ * tenantId, so byte-identical content in two tenants is never a duplicate
+ * pair (the tenant boundary is an isolation boundary; cross-tenant removal
+ * was the v1.32.0 known-issue data-loss bug).
  * Keeps the one with higher strength (or more retrievals if tied).
  */
 export function deduplicateStore(

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -14,7 +14,9 @@
  * asc). Previously the strength/retrieval-count comparator could tie
  * exactly with no terminal key, so the survivor fell to load order
  * (arrival-order-dependent); see `strengthBucket` below for the bucket
- * encoding.
+ * encoding. As of the tenant-partition fix
+ * (docs/plans/2026-08-15-dedupe-tenant-partition.md) the order is scoped
+ * WITHIN each tenant group; cross-tenant pairs are never compared.
  */
 
 import { textOverlap } from './search.js';

--- a/tests/dedupe-tenant-partition.test.ts
+++ b/tests/dedupe-tenant-partition.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tenant partition for `deduplicateStore`
+ * (docs/plans/2026-08-15-dedupe-tenant-partition.md).
+ *
+ * Pins that a duplicate pair can never form across tenants. Before this fix
+ * `deduplicateStore` loaded all entries host-wide and ran one global sort +
+ * pair loop, so a stronger tenant-A row could absorb a byte-identical
+ * tenant-B row and delete it: cross-tenant data loss. The fix groups entries
+ * by tenantId (Map insertion order) before the sort, mirroring
+ * consolidate.ts's mergeCandidatesByTenant and dag.ts's unparentedByTenant,
+ * then runs the existing v1.26.3 survivor total order within each group.
+ *
+ * tests/dedupe-survivor-determinism.test.ts stays the single-tenant pin for
+ * the total order itself; this file is the tenant-partition regression
+ * suite, kept separate so the total-order pin file does not grow multi-
+ * tenant setup it does not otherwise need.
+ *
+ * Real-DB per project convention: each test isolates a fresh hippoRoot via
+ * mkdtempSync + initStore, following the tmpHome idiom in
+ * tests/dedupe-survivor-determinism.test.ts and tests/api-sleep.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore, loadAllEntries } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { remember, type Context } from '../src/api.js';
+import { deduplicateStore } from '../src/dedupe.js';
+
+function tmpHome(prefix: string): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  initStore(home);
+  return {
+    home,
+    restore: () => rmSync(home, { recursive: true, force: true }),
+  };
+}
+
+function ctxFor(home: string, tenantId: string): Context {
+  return { hippoRoot: home, tenantId, actor: { subject: 'test', role: 'admin' } };
+}
+
+function setStrength(home: string, id: string, strength: number): void {
+  const db = openHippoDb(home);
+  try {
+    db.prepare(`UPDATE memories SET strength = ? WHERE id = ?`).run(strength, id);
+  } finally {
+    closeHippoDb(db);
+  }
+}
+
+// Same probe pair as tests/dedupe-survivor-determinism.test.ts: 14 tokens per
+// entry, 13 shared, one word swapped ("this" -> "last"). Jaccard = 13/15 =
+// 0.8667 (> 0.7 dedupe threshold), computed against src/search.ts
+// textOverlap's tokenizer (lowercase, punctuation-stripped, length>1 tokens,
+// set-based Jaccard).
+const CONTENT_A =
+  'The quarterly finance report shows revenue grew steadily across all four regions this year';
+const CONTENT_B =
+  'The quarterly finance report shows revenue grew steadily across all four regions last year';
+
+// Byte-identical content used across two tenants for the zero-removal case.
+const SHARED_CONTENT =
+  'This exact sentence is shared by two different tenants in the store on purpose';
+
+describe('deduplicateStore tenant partition', () => {
+  it('(a) byte-identical content in tenant-a and tenant-b removes nothing; both rows survive', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-tenant-a-');
+    try {
+      const a = remember(ctxFor(home, 'tenant-a'), { content: SHARED_CONTENT });
+      const b = remember(ctxFor(home, 'tenant-b'), { content: SHARED_CONTENT });
+
+      const result = deduplicateStore(home);
+
+      expect(result.removed).toBe(0);
+      expect(result.pairs).toEqual([]);
+
+      const all = loadAllEntries(home);
+      expect(all.length).toBe(2);
+      const tenantAEntries = loadAllEntries(home, 'tenant-a');
+      const tenantBEntries = loadAllEntries(home, 'tenant-b');
+      expect(tenantAEntries.map((e) => e.id)).toEqual([a.id]);
+      expect(tenantBEntries.map((e) => e.id)).toEqual([b.id]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('(b) duplicates within EACH of two tenants: exactly one removal per tenant, survivor per the total order in each', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-tenant-b-');
+    try {
+      // tenant-a: CONTENT_A weak, CONTENT_B strong -> CONTENT_B survives.
+      const aWeak = remember(ctxFor(home, 'tenant-a'), { content: CONTENT_A });
+      const aStrong = remember(ctxFor(home, 'tenant-a'), { content: CONTENT_B });
+      setStrength(home, aWeak.id, 0.5);
+      setStrength(home, aStrong.id, 1.0);
+
+      // tenant-b: CONTENT_B weak, CONTENT_A strong -> CONTENT_A survives.
+      // Deliberately the mirror image of tenant-a's pair, so a leaked
+      // cross-tenant comparison (all four rows overlap pairwise > 0.7)
+      // would produce a different removal count and different survivors
+      // than the per-tenant-correct result asserted below.
+      const bWeak = remember(ctxFor(home, 'tenant-b'), { content: CONTENT_B });
+      const bStrong = remember(ctxFor(home, 'tenant-b'), { content: CONTENT_A });
+      setStrength(home, bWeak.id, 0.5);
+      setStrength(home, bStrong.id, 1.0);
+
+      const result = deduplicateStore(home);
+
+      expect(result.removed).toBe(2);
+      expect(result.pairs.length).toBe(2);
+
+      const tenantAPair = result.pairs.find((p) => p.removed === aWeak.id);
+      expect(tenantAPair).toBeDefined();
+      expect(tenantAPair?.kept).toBe(aStrong.id);
+      expect(tenantAPair?.keptContent).toBe(CONTENT_B);
+
+      const tenantBPair = result.pairs.find((p) => p.removed === bWeak.id);
+      expect(tenantBPair).toBeDefined();
+      expect(tenantBPair?.kept).toBe(bStrong.id);
+      expect(tenantBPair?.keptContent).toBe(CONTENT_A);
+
+      const tenantAEntries = loadAllEntries(home, 'tenant-a');
+      expect(tenantAEntries.map((e) => e.id)).toEqual([aStrong.id]);
+      const tenantBEntries = loadAllEntries(home, 'tenant-b');
+      expect(tenantBEntries.map((e) => e.id)).toEqual([bStrong.id]);
+    } finally {
+      restore();
+    }
+  });
+
+  it('(c) dryRun parity: two-tenant dryRun pairs equal what a subsequent real run deletes', () => {
+    const { home, restore } = tmpHome('hippo-dedupe-tenant-c-');
+    try {
+      const aWeak = remember(ctxFor(home, 'tenant-a'), { content: CONTENT_A });
+      const aStrong = remember(ctxFor(home, 'tenant-a'), { content: CONTENT_B });
+      setStrength(home, aWeak.id, 0.5);
+      setStrength(home, aStrong.id, 1.0);
+
+      const bWeak = remember(ctxFor(home, 'tenant-b'), { content: CONTENT_B });
+      const bStrong = remember(ctxFor(home, 'tenant-b'), { content: CONTENT_A });
+      setStrength(home, bWeak.id, 0.5);
+      setStrength(home, bStrong.id, 1.0);
+
+      const dry = deduplicateStore(home, { dryRun: true });
+      const real = deduplicateStore(home, { dryRun: false });
+
+      expect(dry.removed).toBe(2);
+      expect(real.removed).toBe(2);
+
+      const sortByRemoved = (p: { removed: string }[]) =>
+        [...p].sort((x, y) => x.removed.localeCompare(y.removed));
+      expect(sortByRemoved(dry.pairs).map((p) => p.removed)).toEqual(
+        sortByRemoved(real.pairs).map((p) => p.removed),
+      );
+      expect(sortByRemoved(dry.pairs).map((p) => p.removedContent)).toEqual(
+        sortByRemoved(real.pairs).map((p) => p.removedContent),
+      );
+      expect(sortByRemoved(dry.pairs).map((p) => p.keptContent)).toEqual(
+        sortByRemoved(real.pairs).map((p) => p.keptContent),
+      );
+
+      const tenantAEntries = loadAllEntries(home, 'tenant-a');
+      expect(tenantAEntries.map((e) => e.id)).toEqual([aStrong.id]);
+      const tenantBEntries = loadAllEntries(home, 'tenant-b');
+      expect(tenantBEntries.map((e) => e.id)).toEqual([bStrong.id]);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes the v1.32.0 known issue: deduplicateStore compared content across the whole store with no tenant boundary, so a stronger tenant-A row absorbed a byte-identical tenant-B row and tenant-B's copy was deleted (cross-tenant data loss, proven in the v1.32.0 two-tenant E2E drive).

Entries now group by tenantId before the sort; the v1.26.3 survivor total order and the pair loop run per tenant group. Duplicate pairs can never form across tenants. Single-tenant stores are byte-identical. Both callers (api.sleep dedupe phase, hippo dedup CLI) inherit with no signature change.

Plan (gated 92): docs/plans/2026-08-15-dedupe-tenant-partition.md. Code gate 92 (zero must-fix, both lows applied).

## Test plan
- [x] New dedupe-tenant-partition suite: identical content across tenants survives; mirror-image within-tenant duplicates dedupe once per tenant with correct survivors; dryRun parity
- [x] Survivor-determinism suite untouched, green
- [x] Full suite 2980/0/4, exit 0
- [x] E2E acceptance re-drive on the compiled CLI flipped the original repro: both tenants keep their merged semantic row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NUZVRXZRWfGiztx9JHYQt