### PR TITLE
fix: stop the capture extractor inverting and fragmenting rules (DF2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **The capture extractor stored prohibitions as their OPPOSITE (DF2).** Measured on 1.35.0: `"Never use --no-verify on git commits in this project."` was stored as `"use --no-verify on git commits in this project"`, and `"You must not commit the .env file"` as `"commit the .env file to this repository"` - then injected into later prompts as pinned rules meaning the reverse of what was written. Cause: every pattern was an unanchored keyword alternation with a fixed-width capture beginning AFTER the keyword, so the negation was discarded and the content ran past clause boundaries. Patterns now carry the keyword in its own group, preserved whenever it carries semantic sign (`never`, `always`, `must not`, `don't ever`) and dropped only for colon labels (`error:`, `decision:`) whose category is already recorded on the item. Content is bounded to its clause by a depth- and quote-aware scanner instead of counted to 200 characters.
+- **Acronyms count as specificity.** The vagueness gate tested `[A-Z][a-z]{2,}`, which cannot see `PR`, `CI`, `DB`, `API`, `S3` - the densest domain tokens in a technical memory. Once clause-bounding shortened captures, short technical rules fell under the 40-char gate and were silently dropped. Chat acronyms (`TODO`, `FYI`, `LGTM`, `IIRC`, ...) are excluded, so this does not widen what counts as worth storing.
+
+### Notes
+- **Rules captured before this version may be sign-inverted, and are not migrated.** If your store predates this release, `rule`-tagged rows written by session capture may say the opposite of the rule you stated - the inversion above was silent, so there is no marker to find them by. `hippo audit` cannot detect an inverted rule, and automatic repair is deliberately not attempted: rewriting stored user content on upgrade is riskier than leaving it. Review pinned rules with `hippo list --tag rule` and re-state any that read backwards. Re-capturing the same transcript writes a NEW correctly-signed row rather than matching the old one, so an inverted memory and its correction can coexist until you remove the old one.
+- Captures now keep their keyword, so a rule stored before and after this version will differ textually (`"run the suite twice"` vs `"always run the suite twice"`) and will not dedupe against each other.
+
 ## 1.35.0 - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.36.0 - 2026-08-23
 
 ### Fixed
 - **The capture extractor stored prohibitions as their OPPOSITE (DF2).** Measured on 1.35.0: `"Never use --no-verify on git commits in this project."` was stored as `"use --no-verify on git commits in this project"`, and `"You must not commit the .env file"` as `"commit the .env file to this repository"` - then injected into later prompts as pinned rules meaning the reverse of what was written. Cause: every pattern was an unanchored keyword alternation with a fixed-width capture beginning AFTER the keyword, so the negation was discarded and the content ran past clause boundaries. Patterns now carry the keyword in its own group, preserved whenever it carries semantic sign (`never`, `always`, `must not`, `don't ever`) and dropped only for colon labels (`error:`, `decision:`) whose category is already recorded on the item. Content is bounded to its clause by a depth- and quote-aware scanner instead of counted to 200 characters.

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -163,6 +163,47 @@ stripped would reintroduce the inversion this change removes. AT1 shipped
 2026-08-15, eight days before this, so the affected population is small.
 Recorded so a re-capture after upgrade reads as known, not mysterious.
 
+## KNOWN REMAINING LIMITATION, and why I stopped here
+
+**Defect:** a single-quoted literal longer than the pattern's 500-char
+capture window has its closing quote outside `full`, so the pairing check
+sees no closer, treats the opener as prose, and cuts at the first comma
+inside the literal. Measured on a 632-char input:
+`"Always pass '<600-char literal with a comma>' to the parser."` stores
+`"Always pass 'a"`. Normal-length literals are unaffected
+(`"Always pass 'a, b' to the parser"` is correct).
+
+**Why it is not fixed in this branch.** This is the sixth consecutive
+review round on one function, and the shape has not changed: every fix
+trades one text edge case for another.
+
+| Round | Defect | Severity |
+|---|---|---|
+| 1 | cut inside code delimiters | P1 |
+| 2 | every apostrophe opened quote mode forever | P1 |
+| 3 | ignoring apostrophes cut inside `'a, b'` | P1 |
+| 4 | word-boundary heuristic opened on elided forms | P2 |
+| 5 | pairing check fails when the closer is past the window | P2 |
+
+Severity is converging (P1 → P2) and the cases are narrowing, which is
+some evidence the approach can be finished. But five patches to a
+hand-rolled character scanner, each one surfacing a case the previous did
+not consider, is the three-strike pattern at scale. The honest read is
+that **prose-vs-code segmentation wants a real tokenizer, not another
+predicate**, and that is a separate episode with its own plan — not a
+sixth patch appended to a long one.
+
+**Why the branch is still worth shipping with this open.** The severe
+defect — prohibitions stored as their opposite — was fixed in the first
+commit and has been stable through every round since. The remaining
+limitation costs at most one malformed memory for an unusually long
+quoted literal, against a defect that inverted the meaning of every
+negation rule a user wrote. Shipping the first while tracking the second
+is the better trade; holding the inversion fix hostage to a tokenizer
+rewrite is not.
+
+Backlogged as its own item.
+
 ## Non-goals
 
 - Not touching `isContentWorthStoring` / `isFragment` (shared with capture's

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -163,46 +163,41 @@ stripped would reintroduce the inversion this change removes. AT1 shipped
 2026-08-15, eight days before this, so the affected population is small.
 Recorded so a re-capture after upgrade reads as known, not mysterious.
 
-## KNOWN REMAINING LIMITATION, and why I stopped here
+## Review-round history, and the correction I had to make about it
 
-**Defect:** a single-quoted literal longer than the pattern's 500-char
-capture window has its closing quote outside `full`, so the pairing check
-sees no closer, treats the opener as prose, and cuts at the first comma
-inside the literal. Measured on a 632-char input:
-`"Always pass '<600-char literal with a comma>' to the parser."` stores
-`"Always pass 'a"`. Normal-length literals are unaffected
-(`"Always pass 'a, b' to the parser"` is correct).
+Six codex rounds landed on `boundToClause`. After round 5 I told the operator
+the pattern itself was the finding - five patches to a hand-rolled scanner,
+each trading one text edge case for another - and stopped, recommending a
+tokenizer rewrite as a separate episode.
 
-**Why it is not fixed in this branch.** This is the sixth consecutive
-review round on one function, and the shape has not changed: every fix
-trades one text edge case for another.
+**That read was wrong, and the last round proves it.**
 
-| Round | Defect | Severity |
-|---|---|---|
-| 1 | cut inside code delimiters | P1 |
-| 2 | every apostrophe opened quote mode forever | P1 |
-| 3 | ignoring apostrophes cut inside `'a, b'` | P1 |
-| 4 | word-boundary heuristic opened on elided forms | P2 |
-| 5 | pairing check fails when the closer is past the window | P2 |
+| Round | Defect | Severity | Kind of fix |
+|---|---|---|---|
+| 1 | cut inside `build(x, y)` | P1 | predicate |
+| 2 | every apostrophe opened quote mode forever | P1 | predicate |
+| 3 | ignoring apostrophes cut inside `'a, b'` | P1 | predicate |
+| 4 | word-boundary heuristic opened on `'em` | P2 | predicate -> verified pairing |
+| 5 | closer past the 500-char content cap | P2 | **input plumbing, not a predicate** |
 
-Severity is converging (P1 → P2) and the cases are narrowing, which is
-some evidence the approach can be finished. But five patches to a
-hand-rolled character scanner, each one surfacing a case the previous did
-not consider, is the three-strike pattern at scale. The honest read is
-that **prose-vs-code segmentation wants a real tokenizer, not another
-predicate**, and that is a separate episode with its own plan — not a
-sixth patch appended to a long one.
+Round 5 was not a sixth heuristic. The patterns cap their content group at 500
+characters and handed *that truncated string* to the scanner, so a literal
+whose closing quote sat past the cap had no visible partner - the pairing check
+read the opener as prose and cut inside the literal. **No predicate could have
+fixed that**, because the closer was never in the scanner's input. Widening the
+input to the untruncated sentence makes pairing decidable; `boundToClause`
+already caps its OUTPUT at `maxLen`, so a wider input costs nothing.
 
-**Why the branch is still worth shipping with this open.** The severe
-defect — prohibitions stored as their opposite — was fixed in the first
-commit and has been stable through every round since. The remaining
-limitation costs at most one malformed memory for an unusually long
-quoted literal, against a defect that inverted the meaning of every
-negation rule a user wrote. Shipping the first while tracking the second
-is the better trade; holding the inversion fix hostage to a tokenizer
-rewrite is not.
+The lesson is about the stopping rule, not the scanner. Counting rounds is a
+bad convergence test: it treats a plumbing defect and a heuristic patch as the
+same evidence. **The signal to watch is what each fix IS.** Rounds 1-3 were
+predicates guessing at text shape, which is the treadmill. Round 4 replaced a
+guess with a verified property. Round 5 removed a blindness from the input.
+Those last two were the approach converging, and I read them as it failing.
 
-Backlogged as its own item.
+All six text classes are now verified together, each proven load-bearing by
+stashing the fix and watching the corpus go red: elided forms, paired literals,
+long literals past the cap, contractions, code delimiters, negations.
 
 ## Non-goals
 

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -163,41 +163,50 @@ stripped would reintroduce the inversion this change removes. AT1 shipped
 2026-08-15, eight days before this, so the affected population is small.
 Recorded so a re-capture after upgrade reads as known, not mysterious.
 
-## Review-round history, and the correction I had to make about it
+## Where the review rounds ended, and why
 
-Six codex rounds landed on `boundToClause`. After round 5 I told the operator
-the pattern itself was the finding - five patches to a hand-rolled scanner,
-each trading one text edge case for another - and stopped, recommending a
-tokenizer rewrite as a separate episode.
+Twelve codex rounds landed on the clause scanner. They stopped being about
+bugs and became a measurement of the problem, so the result is recorded as a
+boundary rather than a backlog item.
 
-**That read was wrong, and the last round proves it.**
+**The measured finding.** Quote role is not decidable from local context.
+Two inputs, byte-identical neighbours, opposite correct answers:
 
-| Round | Defect | Severity | Kind of fix |
-|---|---|---|---|
-| 1 | cut inside `build(x, y)` | P1 | predicate |
-| 2 | every apostrophe opened quote mode forever | P1 | predicate |
-| 3 | ignoring apostrophes cut inside `'a, b'` | P1 | predicate |
-| 4 | word-boundary heuristic opened on `'em` | P2 | predicate -> verified pairing |
-| 5 | closer past the 500-char content cap | P2 | **input plumbing, not a predicate** |
+    "Always run 'echo a, b ';then verify."          prev=" " next=";" after="t"
+    "Always keep 'em enabled, then set ';foo, ..."  prev=" " next=";" after="f"
 
-Round 5 was not a sixth heuristic. The patterns cap their content group at 500
-characters and handed *that truncated string* to the scanner, so a literal
-whose closing quote sat past the cap had no visible partner - the pairing check
-read the opener as prose and cut inside the literal. **No predicate could have
-fixed that**, because the closer was never in the scanner's input. Widening the
-input to the untruncated sentence makes pairing decidable; `boundToClause`
-already caps its OUTPUT at `maxLen`, so a wider input costs nothing.
+The first quote must close (it ends a quoted shell command); the second must
+not (it opens an unmatched token, and closing there swallows the clause
+boundary). The same holds for `prev="(" next="." after=letter`, a closer in
+`'a, ('.trim()` and an opener in `parse('.env`.
 
-The lesson is about the stopping rule, not the scanner. Counting rounds is a
-bad convergence test: it treats a plumbing defect and a heuristic patch as the
-same evidence. **The signal to watch is what each fix IS.** Rounds 1-3 were
-predicates guessing at text shape, which is the treadmill. Round 4 replaced a
-guess with a verified property. Round 5 removed a blindness from the input.
-Those last two were the approach converging, and I read them as it failing.
+Deciding these requires knowing whether an EARLIER quote was an elision or a
+real opener - global pairing rather than neighbour inspection - and pairing
+in turn needs a notion of what a literal "looks like", which is another
+heuristic. That is the wall, and it is a property of the input, not of any
+particular predicate.
 
-All six text classes are now verified together, each proven load-bearing by
-stashing the fix and watching the corpus go red: elided forms, paired literals,
-long literals past the cap, contractions, code delimiters, negations.
+**What the rounds actually bought.** Each one named a distinction that was
+missing rather than a condition:
+
+| Round | Distinction it named |
+|---|---|
+| 1 | separators inside code delimiters are not clause boundaries |
+| 2-4 | an apostrophe is not a quote; an elision has no partner |
+| 5 | the scanner was reading a TRUNCATED match, not the sentence |
+| 6 | group offsets must come from the engine, not from arithmetic |
+| 7-11 | punctuation splits: `, ; : ! ?` never join tokens, `. - _ /` do |
+| 12 | the residue is locally undecidable |
+
+**The engineering call.** The scanner favours the shapes that occur in real
+memory text - quoted shell commands, flags, filenames, contractions,
+possessives - and accepts the mirrored shapes as a bounded cost: a capture
+slightly too long or slightly too short. Never a semantic inversion, which
+is the defect this branch exists to remove and which master still has.
+
+Both accepted shapes are pinned by test 16 in
+`tests/df2-capture-coherence.test.ts`, asserting current behaviour so any
+future change to the predicate surfaces as a failure instead of drifting.
 
 ## Non-goals
 

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -146,6 +146,23 @@ a colon-terminated keyword's OWN colon read as a clause boundary, truncating
 the capture down to just the keyword. Hence two groups per pattern, with
 clause-scanning applied only to the content group.
 
+## Accepted limitation: AT1 tombstones predating this change
+
+Raised at review (confidence 75, below the blocking bar) and accepted rather
+than fixed. `checkRejectionGuard` digests the exact normalized content
+(`rejectionDigest`, sha256 over NFC-lowercased text). This change alters the
+captured content shape for RULE items — `"use --no-verify…"` becomes
+`"Never use --no-verify…"` — so a tombstone a user created against the
+OLD shape will not match the NEW capture, and that value becomes
+re-capturable once.
+
+Not fixed here because the alternatives are worse: rewriting stored
+tombstones is a data migration over user memory (the exact thing DF4/AT3's
+quarantine work exists to do carefully), and digesting content with keywords
+stripped would reintroduce the inversion this change removes. AT1 shipped
+2026-08-15, eight days before this, so the affected population is small.
+Recorded so a re-capture after upgrade reads as known, not mysterious.
+
 ## Non-goals
 
 - Not touching `isContentWorthStoring` / `isFragment` (shared with capture's

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -181,10 +181,18 @@ boundary). The same holds for `prev="(" next="." after=letter`, a closer in
 `'a, ('.trim()` and an opener in `parse('.env`.
 
 Deciding these requires knowing whether an EARLIER quote was an elision or a
-real opener - global pairing rather than neighbour inspection - and pairing
-in turn needs a notion of what a literal "looks like", which is another
-heuristic. That is the wall, and it is a property of the input, not of any
-particular predicate.
+real opener - global pairing rather than neighbour inspection.
+
+**Corrected by the ship-gate review.** Calling this "undecidable" was too
+strong. A small elision lexicon ('em, 'til, 'tis, 'cause, 'n) separates both
+pinned pairs: treat a known elision as never-an-opener, and the mirrored
+quote stops pairing with it. The genuinely undecidable residue is narrower -
+an UNKNOWN elision ahead of a quote-shaped token - and rarer than the first
+wording implied. The accurate word is UNRESOLVED, not unresolvable.
+
+They stay pinned rather than fixed because a lexicon is a different kind of
+change - data rather than logic - and belongs with the tokenizer question
+instead of being appended to a twelve-round predicate.
 
 **What the rounds actually bought.** Each one named a distinction that was
 missing rather than a condition:

--- a/docs/plans/2026-08-23-df2-capture-anchoring.md
+++ b/docs/plans/2026-08-23-df2-capture-anchoring.md
@@ -1,0 +1,205 @@
+# DF2 — Capture extractor: keyword-preserving, clause-bounded capture
+
+Status: Draft rev 3 (episode 01M0QG886DY90D7VVYTH6MKVET, plan stage)
+Roadmap: ROADMAP.md Part VI, DF2 [next]
+Base: origin/master 06adc90 (v1.35.0)
+
+**Every claim below carries a measured BEFORE and a measured AFTER.** Rev 1
+and rev 2 were each rejected for a claim measured only against the unpatched
+build; the post-state is now simulated and executed for the whole corpus.
+
+## The roadmap's stated cause is false (measured)
+
+Part VI blames hard-slicing before extraction (`capture.ts` ~424-434).
+Executed: the live fragment reproduces byte-identically from untruncated
+source, and identically under `.slice(0,500)` and `.slice(0,120)`.
+Truncation is not involved. The roadmap entry needs the same premise
+correction DF3's did.
+
+## Root cause: one mechanism, two symptoms
+
+All 16 patterns are a keyword alternation followed by a fixed-width capture
+**that begins after the keyword**:
+`/(?:never|always|must(?:\s+not)?|…)\s+(.{5,200})/i`.
+`extractFromPatterns` (capture.ts:98-116) takes `match[1]` and accepts on
+length alone.
+
+**Symptom 1 — the capture counts characters, so it overruns the clause.**
+**Symptom 2 — the keyword is discarded, so prohibitions inflect positive.**
+
+## Design (two changes; measured corpus below)
+
+### T1 — capture FROM the keyword, not after it
+
+Fixes Symptom 2: `never` / `must not` / `do not ever` survive into stored
+content, so a prohibition still reads as one.
+
+### T2 — bound the capture to the clause instead of 200 characters
+
+Stop at `,`/`;`/`:` + whitespace, or at a sentence terminator **that is
+followed by whitespace or end-of-string**.
+
+The whitespace requirement is load-bearing and was found by simulating the
+post-state: a bare `[.!?]` split truncates on periods *inside tokens*.
+Measured — `"You must never commit the .env file to the repository."` bounded
+on bare `.` yields `"must never commit the"`, which then FAILS the write gate
+and is silently dropped. Hippo memories are full of `.env`, `capture.ts`,
+`v1.35.0`. With the whitespace requirement it yields the full clause.
+
+The 200-char ceiling is RETAINED as an upper bound: the capture is
+clause-bounded **or** 200 characters, whichever comes first. Without it, a
+long span containing no clause terminator would grow past the 500-char
+ceiling in `extractFromPatterns` and the whole match would be **dropped**,
+where today it is truncated at 200 and stored — a silent behaviour change on
+abbreviation- or code-heavy prose. Round-3 critic finding; folded.
+
+Trailing cleanup extends `cleanExtract` to drop an unmatched trailing `)`
+left by clause-bounding. **Algorithm, stated to avoid a naive
+implementation:** count `(` and `)` in the captured string and strip trailing
+`)` only while closes exceed opens — never strip a trailing `)` that balances
+an opening one (measured: `"never got entries)"` → `"never got entries"`,
+while a balanced `"always run the suite (twice)"` is left intact).
+
+## Measured corpus — BEFORE and AFTER, with the write-gate verdict
+
+`isContentWorthStoring` run on the actual post-fix string, not assumed:
+
+| Case | Stored TODAY | Stored AFTER | gate |
+|---|---|---|---|
+| "Never use --no-verify on git commits in this project." | `"use --no-verify on git commits in th…"` **(inverted)** | `"Never use --no-verify on git commits…"` | pass |
+| "You must never commit the .env file to the repository." | `"never commit the .env file to the re…"` | `"must never commit the .env file to t…"` | pass |
+| "We should always run the suite twice locally before merging…" | `"run the suite twice locally before m…"` | `"always run the suite twice locally b…"` | pass |
+| "Never edit capture.ts and audit.ts in the same commit…" | `"edit capture.ts and audit.ts in the …"` | `"Never edit capture.ts and audit.ts i…"` | pass |
+| "…(two had never got entries), plus one documented exception." | `"got entries), plus one documented ex…"` **(fragment)** | `"never got entries"` | **fail → not stored** |
+| "I have never seen this test fail on master before, so it is…" | `"seen this test fail on master before"` | `"never seen this test fail on master …"` | pass |
+| "Never force push to main." | **NONE** | `"Never force push to main"` | pass |
+
+Two results in that table are behaviour changes worth naming explicitly,
+because rev 2 asserted the opposite of one of them:
+
+1. **Fragments now self-reject.** Clause-bounding makes an overrun capture
+   short and vague, and the *existing* write gate then rejects it. The two
+   mechanisms compose; no change to the gate is needed.
+2. **Short imperatives start being captured.** `"Never force push to main."`
+   is uncapturable today and captured after the fix. Cause, measured:
+   `hasProperNoun = /[A-Z][a-z]{2,}/` (audit.ts:66) matches the preserved
+   sentence-initial `"Never"`, so `hasNoSpecificity` returns false and the
+   gate accepts. Rev 2 claimed these would "still return none after this
+   fix" — **that claim was false**, caught by the round-2 critic.
+   The outcome is desirable (these are genuine rules) but it arrives via a
+   case-sensitivity quirk in the gate: the same rule typed lowercase is still
+   rejected (`isContentWorthStoring("never force push to main")` → false).
+   That quirk is pre-existing, out of scope here, and backlogged.
+
+## Scope limit, stated honestly
+
+T1+T2 make every capture **coherent and correctly signed**. They do **not**
+make the extractor judge rule-versus-narrative: "I have never seen this test
+fail" still captures, now as `"never seen this test fail on master before"` —
+a complete, correctly-signed clause instead of shrapnel with the negation
+stripped. That is the honest limit. Precision on rule-detection is a judgment
+problem, not a regex problem, and the DF3 episode is the evidence for not
+attempting it with heuristics (three attempts to widen a shared text
+predicate, three regressions). Backlogged.
+
+## REJECTED designs (both measured, both rejected on evidence)
+
+- **Clause-start anchoring** (rev 1). Would regress genuine captures:
+  `"We should always run the suite twice locally"` and `"You must never commit
+  the .env file"` are captured today and both would be dropped, because
+  ordinary rule phrasing puts the keyword after a subject and modal. Position
+  cannot separate `"We always run the suite twice"` (a practice) from `"I have
+  never seen this fail"` (narrative).
+- **Fixing `PREFERENCE_PATTERNS[0]`'s two-group shape here** (rev 2's T3).
+  Real defect — measured: `"Prefer using SQLite instead of Postgres for local
+  dev."` stores `"using SQLite"`, because only `match[1]` is ever read, and
+  `match[2]` runs to end-of-sentence (`"Postgres for local dev."`). The
+  connective is also non-capturing, so a faithful reconstruction needs a new
+  capture group. Two critic rounds found rev 2's specification of this
+  underdetermined. It is an independent defect in a different pattern set —
+  **removed from this plan and backlogged as its own item** rather than
+  carried as a third under-specified change.
+
+## Correction found during execute: label keywords must NOT be preserved
+
+T1 as planned said "preserve the keyword". Executing it uniformly surfaced a
+distinction the plan had not drawn, and it matters:
+
+- **Semantic keywords carry sign.** `never`, `must not`, `do not ever`,
+  `always`. Dropping them inverts the meaning — that is the entire point of
+  T1, so they must be preserved.
+- **Label keywords carry none.** `decision:`, `rule:`, `error:`,
+  `important:`, `the X is`. They only name a category, and the category is
+  already recorded in `item.category` / `tags`. Prefixing them onto the
+  content is duplication — and it broke two tests in
+  `tests/rejection-acceptance.test.ts`, because AT1's rejected-value guard
+  digests the **bare** content and a `"decision: "` prefix changes the hash.
+
+Discriminator implemented: a prefix ending in its own colon, or matching
+`the <word> is`, is dropped; everything else is preserved. Measured after:
+`"Error: the migration silently dropped…"` → `"the migration silently
+dropped…"`; `"Never use --no-verify…"` → `"Never use --no-verify…"`;
+rejection-acceptance back to 14/14.
+
+A second executor finding, also folded: a single combined capture group lets
+a colon-terminated keyword's OWN colon read as a clause boundary, truncating
+the capture down to just the keyword. Hence two groups per pattern, with
+clause-scanning applied only to the content group.
+
+## Non-goals
+
+- Not touching `isContentWorthStoring` / `isFragment` (shared with capture's
+  write gate; three DF3 regressions).
+- Not touching source truncation (measured irrelevant).
+- No cleanup of already-stored inverted/fragmented memories (producer only;
+  existing rows are DF4/AT3 quarantine territory).
+
+## Tests (real DB, no mocks; `extractFromText` is the exported seam)
+
+Each red-under-old case is confirmed by reverting the fix and observing the
+failure — never assumed.
+
+1. **Inversion pin:** `"Never use --no-verify…"` → content contains `never`.
+2. **Fragment self-rejects:** the `"(two had never got entries), plus one…"`
+   sentence → **no** stored item (clause-bound + existing gate).
+3. **Overrun stops at the clause:** `"I have never seen this test fail…, so
+   it is probably a flake."` → content excludes `"so it is"`.
+4. **Periods inside tokens survive:** `"Never edit capture.ts and audit.ts in
+   the same commit without running npm test."` → content contains
+   `capture.ts`. Red under a bare-`[.!?]` bound.
+5. **Genuine rules keep their keyword** — corpus measured capturable today:
+   the `must never commit the .env file` and `should always run the suite
+   twice` cases.
+6. **DECISION and ERROR sets:** one keyword-preserved case each (`"We decided
+   to pin the version…"`, `"The issue was that the reserve loop did not
+   dedupe…"`), asserting the new shape is intended for those sets too, not an
+   unexamined side effect of a uniform change.
+7. **Documented behaviour change:** `"Never force push to main."` → now
+   captured. Pins the rev-2 correction so it cannot silently regress.
+8. **Pattern-set coverage sweep:** a table-driven case per pattern ARRAY
+   (DECISION, RULE, ERROR, PREFERENCE) asserting each one's post-fix shape,
+   so the "uniform across all 16" claim is pinned rather than asserted from
+   three examples. Round-3 critic finding; folded.
+9. **Upper-bound retained:** a long clause-free span still yields a stored
+   (truncated) item rather than being dropped — pins the ceiling behaviour
+   above.
+10. **No-regression:** existing `tests/capture*.test.ts` green.
+
+## Acceptance
+
+- A prohibition is never stored as an instruction (1).
+- No stored capture runs past its clause (2, 3).
+- Tokens containing periods are not truncated (4).
+- Every rule capturable today is still captured, keyword intact (5, 6).
+- The short-imperative behaviour change is tested, not discovered (7).
+- Existing capture tests unchanged (8).
+
+## Risks
+
+- **Clause-bounding could over-truncate** a rule spanning a comma ("Never
+  force push, even on a feature branch"). Guard: test 5's corpus plus the
+  8-char floor. If a genuine rule truncates badly, bound on sentence
+  terminators only.
+- **Stored content shape changes** across all four pattern sets. Intended;
+  tests 5 and 6 pin the intended shape per set. No migration — existing rows
+  untouched.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.35.0",
+  "version": "1.36.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -104,7 +104,13 @@ function hasNoSpecificity(text: string): boolean {
   // "The rule is every PR needs two approvals, no exceptions." to "every PR
   // needs two approvals", which then fell under the 40-char vagueness gate
   // and was silently DROPPED - a rule that stored before this branch.
-  const hasAcronym = /\b[A-Z]{2,6}\b/.test(text);
+  // ...but an acronym only signals specificity when it stands out AGAINST
+  // ordinary prose. Without the lowercase requirement, any shouted phrase
+  // qualifies: "FIXED SIGNALS" passed the gate while the identical
+  // "fixed signals" was correctly rejected, so capitalization alone bought a
+  // bypass - into auditMemory and includeRecent as well, where junk would
+  // then occupy recent-context slots. Codex P2, r8.
+  const hasAcronym = /\b[A-Z]{2,6}\b/.test(text) && /[a-z]/.test(text);
   const hasPath = /[/\\.]/.test(text);
   const hasCode = /[`_{}()\[\]]/.test(text);
   if (hasNumber || hasProperNoun || hasPath || hasCode || hasAcronym) return false;

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -110,7 +110,15 @@ function hasNoSpecificity(text: string): boolean {
   // "fixed signals" was correctly rejected, so capitalization alone bought a
   // bypass - into auditMemory and includeRecent as well, where junk would
   // then occupy recent-context slots. Codex P2, r8.
-  const hasAcronym = /\b[A-Z]{2,6}\b/.test(text) && /[a-z]/.test(text);
+  // CHAT acronyms are not domain signal. Admitting any all-caps token let
+  // "LGTM ship it", "TODO fix this thing", "FYI all done here" through a gate
+  // that correctly rejected them before - and this gate is shared, so the
+  // effect is retroactive: junk rows already in a user's store were filtered
+  // out of recent-context slots and would have started occupying them, and
+  // `hippo audit` would have stopped flagging them. Found at the ship gate.
+  const CHAT_ACRONYMS = /^(?:TODO|FYI|LGTM|IIRC|IMO|IMHO|FWIW|TBD|BTW|ASAP|AFAIK|WIP|NB|PS)$/;
+  const domainAcronyms = (text.match(/\b[A-Z]{2,6}\b/g) ?? []).filter(a => !CHAT_ACRONYMS.test(a));
+  const hasAcronym = domainAcronyms.length > 0 && /[a-z]/.test(text);
   const hasPath = /[/\\.]/.test(text);
   const hasCode = /[`_{}()\[\]]/.test(text);
   if (hasNumber || hasProperNoun || hasPath || hasCode || hasAcronym) return false;

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -97,9 +97,17 @@ function hasNoSpecificity(text: string): boolean {
   const words = text.toLowerCase().split(/\s+/);
   const hasNumber = /\d/.test(text);
   const hasProperNoun = /[A-Z][a-z]{2,}/.test(text);
+  // An ACRONYM is specificity too, and this test could not see one: the
+  // proper-noun pattern needs lowercase after the capital, so "PR", "CI",
+  // "DB", "API", "S3" - the densest domain tokens in a technical memory -
+  // all read as vague. Surfaced by DF2: clause-bounding correctly shortened
+  // "The rule is every PR needs two approvals, no exceptions." to "every PR
+  // needs two approvals", which then fell under the 40-char vagueness gate
+  // and was silently DROPPED - a rule that stored before this branch.
+  const hasAcronym = /\b[A-Z]{2,6}\b/.test(text);
   const hasPath = /[/\\.]/.test(text);
   const hasCode = /[`_{}()\[\]]/.test(text);
-  if (hasNumber || hasProperNoun || hasPath || hasCode) return false;
+  if (hasNumber || hasProperNoun || hasPath || hasCode || hasAcronym) return false;
   return words.length < 8 && VAGUE_ONLY.test(text);
 }
 

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -157,7 +157,16 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
       if (ch === quote) quote = null;
       continue;
     }
-    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    // Only " and ` open a quote. An apostrophe is NOT treated as one: in
+    // prose it is overwhelmingly a contraction or possessive ("it's", "the
+    // user's config"), and treating it as an opening quote leaves the
+    // scanner in quote mode forever, disabling clause-bounding entirely for
+    // ordinary English. Measured before this: "Always ensure it's enabled,
+    // then restart the service." captured the whole trailing clause.
+    // Codex P1, second round. The cost of ignoring ' is that a comma inside
+    // a single-quoted code string bounds early — a SHORTER capture, which is
+    // the safe direction here.
+    if (ch === '"' || ch === '`') { quote = ch; continue; }
     if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
     if (ch === ')' || ch === ']' || ch === '}') { if (depth > 0) depth--; continue; }
     if (depth > 0) continue;

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -42,32 +42,54 @@ export interface ExtractedItem {
 }
 
 // Sentence-level patterns
+//
+// T1 (DF2): each pattern now carries TWO capture groups — group 1 is the
+// discriminating keyword (plus its trailing separator, verbatim), group 2 is
+// the content that follows it. Previously only the after-keyword content was
+// captured, so a negation like "never" / "must not" was discarded and a
+// prohibition inverted into an instruction ("Never use X" stored as "use X").
+// `extractFromPatterns` reassembles group1 + a clause-bounded group2 (T2, via
+// `boundToClause` below) rather than reading a single fixed-width group —
+// group 2's own reach is widened to {1,500} because the true stopping point
+// is now found by content, not counted characters. Keeping the keyword in
+// its own group (rather than folding it into one bigger capture) matters:
+// `boundToClause` must scan for a clause boundary only in group 2, never in
+// group 1 — several keywords end in their own colon ("error:", "rule:",
+// "decision:") which is not a clause boundary in the prose sense and would
+// wrongly truncate the capture down to just the keyword if scanned.
+// `PREFERENCE_PATTERNS[0]` is the one exception — its two-capture-group
+// shape means something different (two content spans either side of
+// "instead of"/"over"/"not") and is a separate, backlogged defect (see
+// docs/plans/2026-08-23-df2-capture-anchoring.md); left as-is.
 const DECISION_PATTERNS = [
-  /(?:we(?:'ve| have)?|i(?:'ve| have)?|let's)\s+decid(?:ed|e)\s+(?:to\s+)?(.{10,200})/i,
-  /(?:let's|we(?:'ll| will| should)?)\s+(?:go with|do|use|try|build|implement|switch to)\s+(.{5,200})/i,
-  /(?:going|went)\s+with\s+(.{5,200})/i,
-  /(?:the plan is|plan:)\s+(.{10,200})/i,
-  /decision:\s*(.{10,200})/i,
+  /(?:we(?:'ve| have)?|i(?:'ve| have)?|let's)\s+(decid(?:ed|e)\s+(?:to\s+)?)(.{1,500})/i,
+  /(?:let's|we(?:'ll| will| should)?)\s+((?:go with|do|use|try|build|implement|switch to)\s+)(.{1,500})/i,
+  /((?:going|went)\s+with\s+)(.{1,500})/i,
+  /((?:the plan is|plan:)\s+)(.{1,500})/i,
+  /(decision:\s*)(.{1,500})/i,
 ];
 
 const RULE_PATTERNS = [
-  /(?:never|always|must(?:\s+not)?|do(?:n't| not)\s+ever)\s+(.{5,200})/i,
-  /(?:the rule is|rule:)\s*(.{5,200})/i,
-  /(?:important|critical|remember):\s*(.{10,200})/i,
-  /(?:make sure|ensure)\s+(?:to\s+)?(.{10,200})/i,
+  /((?:never|always|must(?:\s+not)?|do(?:n't| not)\s+ever)\s+)(.{1,500})/i,
+  /((?:the rule is|rule:)\s*)(.{1,500})/i,
+  /((?:important|critical|remember):\s*)(.{1,500})/i,
+  /((?:make sure|ensure)\s+(?:to\s+)?)(.{1,500})/i,
 ];
 
 const ERROR_PATTERNS = [
-  /(?:error|bug|gotcha|watch out|careful|warning|caveat|trap):\s*(.{10,200})/i,
-  /(?:this broke|this breaks|this will break|broke because)\s+(.{5,200})/i,
-  /(?:the (?:issue|problem|fix) (?:is|was))\s+(.{10,200})/i,
-  /(?:don't forget|easy to miss):\s*(.{5,200})/i,
+  /((?:error|bug|gotcha|watch out|careful|warning|caveat|trap):\s*)(.{1,500})/i,
+  /((?:this broke|this breaks|this will break|broke because)\s+)(.{1,500})/i,
+  /((?:the (?:issue|problem|fix) (?:is|was))\s+)(.{1,500})/i,
+  /((?:don't forget|easy to miss):\s*)(.{1,500})/i,
 ];
 
+// PREFERENCE_PATTERNS[0] keeps its pre-DF2 two-capture-group shape
+// (match[1]-only, unbounded) — out of scope here, backlogged. See
+// extractFromPatterns' reference check against this exact array element.
 const PREFERENCE_PATTERNS = [
   /(?:prefer|use)\s+(.{5,100})\s+(?:instead of|over|not)\s+(.{3,100})/i,
-  /(?:don't use|avoid|skip)\s+(.{5,200})/i,
-  /(?:we(?:'re| are)\s+using|the stack is|we use)\s+(.{5,200})/i,
+  /((?:don't use|avoid|skip)\s+)(.{1,500})/i,
+  /((?:we(?:'re| are)\s+using|the stack is|we use)\s+)(.{1,500})/i,
 ];
 
 // Heading patterns that signal a following list of specs/requirements
@@ -88,11 +110,70 @@ function splitSentences(text: string): string[] {
     .filter((s) => s.length > 5);
 }
 
+/**
+ * T2 (DF2): bound a keyword+content capture to its clause instead of a fixed
+ * character count. `full` is `keywordPrefix + content` (already concatenated
+ * so the 200-char ceiling below applies to the whole stored string, not just
+ * the part after the keyword); `searchFrom` is `keywordPrefix.length`, so the
+ * clause/terminator scan only ever looks INSIDE `content` — several keywords
+ * end in their own colon ("error:", "rule:", "decision:") which must never
+ * be mistaken for a clause boundary in the prose that follows.
+ *
+ * Stops at the first `,`/`;`/`:` followed by whitespace, or at a sentence
+ * terminator `[.!?]` followed by whitespace or end-of-string — whichever
+ * comes first — and never past `maxLen` chars total.
+ *
+ * The whitespace requirement on the terminator is load-bearing: a bare
+ * `[.!?]` would split inside a token like `.env` / `capture.ts` / `v1.35.0`,
+ * turning a full clause into a fragment that then fails the write gate and
+ * is silently dropped (measured in the plan). The `maxLen` ceiling is also
+ * load-bearing: without it, a clause-free span can run past the 500-char
+ * gate in `extractFromPatterns` and the whole match is dropped, where today
+ * it is truncated and stored.
+ */
+function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
+  let cutEnd = full.length;
+  const tail = full.slice(searchFrom);
+
+  const clause = tail.match(/[,;:]\s/);
+  if (clause && clause.index !== undefined) {
+    const idx = searchFrom + clause.index;
+    if (idx < cutEnd) cutEnd = idx;
+  }
+
+  const terminator = tail.match(/[.!?](?=\s|$)/);
+  if (terminator && terminator.index !== undefined) {
+    const idx = searchFrom + terminator.index + 1;
+    if (idx < cutEnd) cutEnd = idx;
+  }
+
+  let bounded = full.slice(0, cutEnd);
+  if (bounded.length > maxLen) bounded = bounded.slice(0, maxLen);
+  return bounded;
+}
+
 function cleanExtract(raw: string): string {
-  return raw
+  let content = raw
     .replace(/^[:\s-]+/, '')
     .replace(/[.!?,;:\s]+$/, '')
     .trim();
+
+  // T2 trailing cleanup: clause-bounding can cut inside a parenthetical and
+  // leave an unmatched trailing ')' (e.g. "...(two had never got entries),"
+  // bounds to "never got entries)"). Strip a trailing ')' ONLY while closes
+  // outnumber opens in the string so far — a balanced parenthetical like
+  // "always run the suite (twice)" must be left intact.
+  while (content.endsWith(')')) {
+    const opens = (content.match(/\(/g) ?? []).length;
+    const closes = (content.match(/\)/g) ?? []).length;
+    if (closes <= opens) break;
+    content = content
+      .slice(0, -1)
+      .replace(/[.!?,;:\s]+$/, '')
+      .trim();
+  }
+
+  return content;
 }
 
 function extractFromPatterns(
@@ -104,9 +185,33 @@ function extractFromPatterns(
   for (const pat of patterns) {
     const match = sentence.match(pat);
     if (match) {
-      // Use the captured group if available, otherwise the full match
-      const raw = match[1] ?? match[0];
-      const content = cleanExtract(raw);
+      let bounded: string;
+      if (pat === PREFERENCE_PATTERNS[0]) {
+        // PREFERENCE_PATTERNS[0] is the one pattern left out of T1/T2 (see
+        // comment at its definition) — its match[1] keeps its pre-DF2,
+        // unbounded shape rather than going through clause-bounding.
+        bounded = match[1] ?? match[0];
+      } else {
+        // group1 = keyword + separator (verbatim, never clause-bounded);
+        // group2 = the content that follows it (clause-bounded below).
+        //
+        // T1 preserves the keyword only when it carries SEMANTIC SIGN — a
+        // negation or modality ("never", "must not", "do not ever",
+        // "always"). Dropping those inverts the meaning, which is the whole
+        // point of T1. A LABEL keyword ("decision:", "rule:", "error:",
+        // "important:") carries no sign: it only names the category, which
+        // is already recorded in `category`/`tags`, so prefixing it onto the
+        // content is duplication that also breaks value-keyed matching
+        // (AT1's rejected-value digest hashes the bare content).
+        // Discriminator: a label ends in its own colon, or is a "the X is"
+        // phrase.
+        const rawPrefix = match[1] ?? '';
+        const isLabelPrefix = /:\s*$/.test(rawPrefix) || /^\s*the\s+\w+\s+is\s*$/i.test(rawPrefix);
+        const keywordPrefix = isLabelPrefix ? '' : rawPrefix;
+        const afterKeyword = match[2] ?? match[0];
+        bounded = boundToClause(keywordPrefix + afterKeyword, keywordPrefix.length);
+      }
+      const content = cleanExtract(bounded);
       if (content.length >= 8 && content.length <= 500) {
         return { content, category, tags: [tag, 'captured'] };
       }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -157,16 +157,30 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
       if (ch === quote) quote = null;
       continue;
     }
-    // Only " and ` open a quote. An apostrophe is NOT treated as one: in
-    // prose it is overwhelmingly a contraction or possessive ("it's", "the
-    // user's config"), and treating it as an opening quote leaves the
-    // scanner in quote mode forever, disabling clause-bounding entirely for
-    // ordinary English. Measured before this: "Always ensure it's enabled,
-    // then restart the service." captured the whole trailing clause.
-    // Codex P1, second round. The cost of ignoring ' is that a comma inside
-    // a single-quoted code string bounds early — a SHORTER capture, which is
-    // the safe direction here.
+    // Quote handling has to tell an APOSTROPHE from a single-quoted
+    // LITERAL, because getting either wrong reintroduces the fragment
+    // defect this change exists to remove, and both fragments PASS the
+    // write gate (code punctuation reads as "specific"):
+    //   treat every ' as a quote  -> "Always ensure it's enabled, then
+    //     restart..." never leaves quote mode, bounding disabled entirely
+    //   treat no ' as a quote     -> "Always pass 'a, b' to the parser."
+    //     cuts at the comma and stores "Always pass 'a"
+    // Both were codex P1s on this branch, in consecutive rounds.
+    //
+    // Discriminator: a ' OPENS a literal only at a word boundary - preceded
+    // by start/whitespace/open-bracket AND followed by non-whitespace. An
+    // in-word apostrophe ("it's", "user's") has letters on both sides and is
+    // just a character.
     if (ch === '"' || ch === '`') { quote = ch; continue; }
+    if (ch === "'") {
+      const prev = i > 0 ? full[i - 1] : undefined;
+      const next = full[i + 1];
+      const atBoundary =
+        (prev === undefined || /[\s([{]/.test(prev)) &&
+        next !== undefined && !/\s/.test(next);
+      if (atBoundary) { quote = ch; }
+      continue;
+    }
     if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
     if (ch === ')' || ch === ']' || ch === '}') { if (depth > 0) depth--; continue; }
     if (depth > 0) continue;

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -138,15 +138,24 @@ function splitSentences(text: string): string[] {
  * end-of-string - never by a letter, which is what makes "user's" an
  * apostrophe rather than a partner.
  */
-function hasCloserAfter(full: string, from: number): boolean {
-  for (let j = full.indexOf("'", from); j !== -1; j = full.indexOf("'", j + 1)) {
-    const prev = full[j - 1];
+function lastCloserIndex(full: string): number {
+  // ONE pass, not one per apostrophe. The previous shape rescanned the whole
+  // remaining suffix at every boundary apostrophe, so a transcript full of
+  // elisions ("keep 'em", "wait 'til", ...) made extraction quadratic and
+  // could stall a moderately sized capture. Codex P2, r7.
+  //
+  // A closer is an apostrophe NOT followed by a letter or digit. The earlier
+  // rule also demanded non-whitespace BEFORE it, which rejected the genuine
+  // closer in "Always preserve 'a, b ' exactly" and re-cut inside the
+  // literal (codex P2, r7). What actually distinguishes a closer from an
+  // in-word apostrophe is only what FOLLOWS it: "user's" has a letter, a
+  // closer has space, punctuation, or end-of-string.
+  for (let j = full.length - 1; j >= 0; j--) {
+    if (full[j] !== "'") continue;
     const next = full[j + 1];
-    if (prev !== undefined && !/\s/.test(prev) && (next === undefined || !/[\p{L}\p{N}]/u.test(next))) {
-      return true;
-    }
+    if (next === undefined || !/[\p{L}\p{N}]/u.test(next)) return j;
   }
-  return false;
+  return -1;
 }
 
 function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
@@ -164,6 +173,7 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
   // So: a separator only ends the clause at bracket depth zero and outside
   // quotes. Unbalanced closers are tolerated (depth floors at 0) because
   // captured text often starts mid-expression.
+  const lastCloser = lastCloserIndex(full);
   let depth = 0;
   let quote: string | null = null;
   let cutEnd = full.length;
@@ -213,7 +223,7 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
       // So apply the SAME shape rule already used to open a literal, mirrored:
       // a closer has non-whitespace before it and whitespace/punctuation (not
       // a letter) after. "user's" fails it on both counts. Codex P2, r6.
-      if (atBoundary && hasCloserAfter(full, i + 1)) { quote = ch; }
+      if (atBoundary && lastCloser > i) { quote = ch; }
       continue;
     }
     if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -131,6 +131,24 @@ function splitSentences(text: string): string[] {
  * gate in `extractFromPatterns` and the whole match is dropped, where today
  * it is truncated and stored.
  */
+/**
+ * Does a plausible CLOSING single quote appear after `from`? Mirror of the
+ * opener rule in `boundToClause`: a closer sits tight against the literal it
+ * ends (non-whitespace before) and is followed by whitespace, punctuation, or
+ * end-of-string - never by a letter, which is what makes "user's" an
+ * apostrophe rather than a partner.
+ */
+function hasCloserAfter(full: string, from: number): boolean {
+  for (let j = full.indexOf("'", from); j !== -1; j = full.indexOf("'", j + 1)) {
+    const prev = full[j - 1];
+    const next = full[j + 1];
+    if (prev !== undefined && !/\s/.test(prev) && (next === undefined || !/[\p{L}\p{N}]/u.test(next))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
   // Scan for the first PROSE clause boundary after `searchFrom`.
   //
@@ -184,7 +202,18 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
       // is disabled for the rest of the capture. Requiring an actual closing
       // quote later in the string replaces a guess with a checkable fact -
       // an elided form simply has no partner. Codex P2, this round.
-      if (atBoundary && full.indexOf("'", i + 1) !== -1) { quote = ch; }
+      // ...and the partner must LOOK like a closer, not merely be another
+      // apostrophe. Distance cannot separate the two cases - both put a `'`
+      // far downstream:
+      //   "Always pass '<600-char literal>' to the parser"  -> the far ' IS
+      //     the closer, and pairing must succeed
+      //   "keep 'em enabled, then <520 chars> check user's config" -> the far
+      //     ' is in-word, and pairing against it re-opens quote mode on the
+      //     elision, disabling bounding for the rest of the capture
+      // So apply the SAME shape rule already used to open a literal, mirrored:
+      // a closer has non-whitespace before it and whitespace/punctuation (not
+      // a letter) after. "user's" fails it on both counts. Codex P2, r6.
+      if (atBoundary && hasCloserAfter(full, i + 1)) { quote = ch; }
       continue;
     }
     if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
@@ -241,7 +270,9 @@ function extractFromPatterns(
   tag: string
 ): ExtractedItem | null {
   for (const pat of patterns) {
-    const match = sentence.match(pat);
+    // `d` gives per-group offsets; see the contentStart comment below.
+    const dpat = pat.flags.includes('d') ? pat : new RegExp(pat.source, pat.flags + 'd');
+    const match = dpat.exec(sentence);
     if (match) {
       let bounded: string;
       if (pat === PREFERENCE_PATTERNS[0]) {
@@ -274,7 +305,14 @@ function extractFromPatterns(
         // no further predicate could have fixed it. boundToClause already
         // caps its OUTPUT at maxLen, so widening the input costs nothing and
         // makes pairing decidable on the whole sentence. Codex P2, round 5.
-        const contentStart = match.index !== undefined ? match.index + rawPrefix.length : -1;
+        // Group 2's REAL offset, read from the regex engine. Deriving it as
+        // `match.index + rawPrefix.length` assumes group 1 starts the match,
+        // but DECISION_PATTERNS carry an uncaptured subject ("we ", "let's ")
+        // ahead of it - so the offset landed inside the keyword and the
+        // widened slice duplicated text: "We decided to pin..." stored as
+        // "decided to to pin...". Real corruption of the commonest decision
+        // capture, shipped in the previous commit. Codex P1, r6.
+        const contentStart = match.indices?.[2]?.[0] ?? -1;
         const afterKeyword = contentStart >= 0 ? sentence.slice(contentStart) : (match[2] ?? match[0]);
         bounded = boundToClause(keywordPrefix + afterKeyword, keywordPrefix.length);
       }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -138,6 +138,10 @@ function splitSentences(text: string): string[] {
  * end-of-string - never by a letter, which is what makes "user's" an
  * apostrophe rather than a partner.
  */
+function isLetterOrDigit(ch: string | undefined): boolean {
+  return ch !== undefined && /[\p{L}\p{N}]/u.test(ch);
+}
+
 function lastCloserIndex(full: string): number {
   // ONE pass, not one per apostrophe. The previous shape rescanned the whole
   // remaining suffix at every boundary apostrophe, so a transcript full of
@@ -166,7 +170,7 @@ function lastCloserIndex(full: string): number {
     if (full[j] !== "'") continue;
     const prev = full[j - 1];
     const next = full[j + 1];
-    if (next !== undefined && /[\p{L}\p{N}]/u.test(next)) continue;
+    if (isLetterOrDigit(next)) continue;
     // "tight against content" excludes an OPENING delimiter: in
     // "call parse('--force" the paren is non-whitespace but the quote after
     // it is an opener, and treating it as a closer let an earlier elision
@@ -214,7 +218,18 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
     const ch = full[i];
 
     if (quote) {
-      if (ch === quote) quote = null;
+      // Closing uses the SAME shape test as opening. This was asymmetric:
+      // twelve rounds went into deciding when a quote OPENS a literal, while
+      // the close accepted any bare "'" - so the apostrophe in a possessive
+      // INSIDE a literal closed it early:
+      //   "Always pass 'user's a, b list' to the parser."
+      //     -> "Always pass 'user's a"   (master kept the whole literal)
+      // a mid-literal fragment that then PASSES the write gate, which is
+      // precisely the defect this branch exists to remove. Found by the
+      // ship-gate review after every earlier gate missed it.
+      if (ch === quote && (quote !== "'" || !isLetterOrDigit(full[i + 1]))) {
+        quote = null;
+      }
       continue;
     }
     // Quote handling has to tell an APOSTROPHE from a single-quoted
@@ -337,7 +352,15 @@ function extractFromPatterns(
         // Discriminator: a label ends in its own colon, or is a "the X is"
         // phrase.
         const rawPrefix = match[1] ?? '';
-        const isLabelPrefix = /:\s*$/.test(rawPrefix) || /^\s*the\s+\w+\s+(?:is|was)\s*$/i.test(rawPrefix);
+        // ONLY colon-terminated labels are dropped. Dropping "the X is/was"
+        // too left the residue starting with "to ", which isFragment then
+        // rejected outright - so "The plan is to ship on Friday" and "The fix
+        // was to bump the pool timeout" stored NOTHING, where every prior
+        // version stored them. Silent loss on two of the highest-traffic
+        // patterns, and invisible: an absent memory leaves no trace. The AT1
+        // rejected-value evidence only ever involved colon labels
+        // ("decision: "), so the narrower rule keeps that guarantee.
+        const isLabelPrefix = /:\s*$/.test(rawPrefix);
         const keywordPrefix = isLabelPrefix ? '' : rawPrefix;
         // Scan the UNTRUNCATED remainder, not match[2]. The patterns cap
         // their content group at 500 chars, so a quoted literal whose closer

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -144,24 +144,36 @@ function lastCloserIndex(full: string): number {
   // elisions ("keep 'em", "wait 'til", ...) made extraction quadratic and
   // could stall a moderately sized capture. Codex P2, r7.
   //
-  // Decided by what FOLLOWS the quote, and nothing else. Three revisions of
-  // this predicate each added a clause about the preceding character, and
-  // each one broke a shape the last had fixed:
-  //   r7  next is not a letter          -> accepted "'--force" as a closer
-  //   r8  ...and tight-before OR loose-after -> rejected "'a, b ',"
-  // Looking only forward separates all four shapes with one positive class,
-  // because the distinction is really opener-versus-closer, not spacing:
-  //   "user's"            next 's'  - a letter continues a word
-  //   "run '--force,"     next '-'  - punctuation that STARTS a token
-  //   "pass 'a, b' to"    next ' '  - whitespace ENDS the literal
-  //   "preserve 'a, b '," next ','  - clause punctuation ENDS it too
-  // A closer is followed by end-of-string, whitespace, or clause/closing
-  // punctuation. Anything that begins a token is an opener. The earlier
-  // letter-exclusion is subsumed: a letter is not in this class either.
+  // A quote CLOSES THE SIDE IT IS TIGHT AGAINST. The test needs both
+  // neighbours, and one round proved that empirically: these two have the
+  // same following character and opposite roles -
+  //   "preserve 'a, b'-style"   next '-'  -> CLOSER, content on the left
+  //   "then run '--force,"      next '-'  -> OPENER, content on the right
+  // so no forward-only rule can separate them. An earlier revision tried
+  // exactly that and broke in both directions at once (codex P1+P2, r10):
+  // it missed closers before token-joining punctuation and accepted
+  // "'.env" as a closer because a dot happened to be in its class.
+  //
+  //   never a closer   next is a letter/digit      "user's", "keep 'em"
+  //   closer           prev is non-whitespace      "'a, b' to", "'a, b'-style"
+  //   closer           next is whitespace or end   "preserve 'a, b ' exactly"
+  //   closer           next is clause punctuation  "preserve 'a, b ', then"
+  //                    that itself ends the token
+  //
+  // The last clause is what separates ", " from ".env": a dot followed by a
+  // letter joins a filename, a dot followed by space ends a sentence.
   for (let j = full.length - 1; j >= 0; j--) {
     if (full[j] !== "'") continue;
+    const prev = full[j - 1];
     const next = full[j + 1];
-    if (next === undefined || /[\s,;:.!?)\]}]/.test(next)) return j;
+    if (next !== undefined && /[\p{L}\p{N}]/u.test(next)) continue;
+    const tightBefore = prev !== undefined && !/\s/.test(prev);
+    const endsAfter = next === undefined || /\s/.test(next);
+    const afterNext = full[j + 2];
+    const clauseAfter =
+      next !== undefined && /[,;:.!?)\]}]/.test(next) &&
+      (afterNext === undefined || /\s/.test(afterNext));
+    if (tightBefore || endsAfter || clauseAfter) return j;
   }
   return -1;
 }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -144,25 +144,24 @@ function lastCloserIndex(full: string): number {
   // elisions ("keep 'em", "wait 'til", ...) made extraction quadratic and
   // could stall a moderately sized capture. Codex P2, r7.
   //
-  // Three shapes have to be separated, and no single test does it:
-  //   "user's"                  -> next is a LETTER, never a closer
-  //   "preserve 'a, b ' exactly" -> prev is SPACE, still a real closer
-  //   "run '--force, after"      -> next is punctuation, but this is an
-  //                                 OPENER of an unmatched token; treating
-  //                                 it as a closer let the elision earlier in
-  //                                 the sentence pair with it and swallowed
-  //                                 the clause boundary (codex P2, r8)
-  // So: never followed by a letter or digit, AND either tight against the
-  // text it closes (non-whitespace before) or trailed by whitespace/end.
-  // "'--force" fails both halves - space before, punctuation after.
+  // Decided by what FOLLOWS the quote, and nothing else. Three revisions of
+  // this predicate each added a clause about the preceding character, and
+  // each one broke a shape the last had fixed:
+  //   r7  next is not a letter          -> accepted "'--force" as a closer
+  //   r8  ...and tight-before OR loose-after -> rejected "'a, b ',"
+  // Looking only forward separates all four shapes with one positive class,
+  // because the distinction is really opener-versus-closer, not spacing:
+  //   "user's"            next 's'  - a letter continues a word
+  //   "run '--force,"     next '-'  - punctuation that STARTS a token
+  //   "pass 'a, b' to"    next ' '  - whitespace ENDS the literal
+  //   "preserve 'a, b '," next ','  - clause punctuation ENDS it too
+  // A closer is followed by end-of-string, whitespace, or clause/closing
+  // punctuation. Anything that begins a token is an opener. The earlier
+  // letter-exclusion is subsumed: a letter is not in this class either.
   for (let j = full.length - 1; j >= 0; j--) {
     if (full[j] !== "'") continue;
-    const prev = full[j - 1];
     const next = full[j + 1];
-    if (next !== undefined && /[\p{L}\p{N}]/u.test(next)) continue;
-    const tightBefore = prev !== undefined && !/\s/.test(prev);
-    const looseAfter = next === undefined || /\s/.test(next);
-    if (tightBefore || looseAfter) return j;
+    if (next === undefined || /[\s,;:.!?)\]}]/.test(next)) return j;
   }
   return -1;
 }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -144,16 +144,25 @@ function lastCloserIndex(full: string): number {
   // elisions ("keep 'em", "wait 'til", ...) made extraction quadratic and
   // could stall a moderately sized capture. Codex P2, r7.
   //
-  // A closer is an apostrophe NOT followed by a letter or digit. The earlier
-  // rule also demanded non-whitespace BEFORE it, which rejected the genuine
-  // closer in "Always preserve 'a, b ' exactly" and re-cut inside the
-  // literal (codex P2, r7). What actually distinguishes a closer from an
-  // in-word apostrophe is only what FOLLOWS it: "user's" has a letter, a
-  // closer has space, punctuation, or end-of-string.
+  // Three shapes have to be separated, and no single test does it:
+  //   "user's"                  -> next is a LETTER, never a closer
+  //   "preserve 'a, b ' exactly" -> prev is SPACE, still a real closer
+  //   "run '--force, after"      -> next is punctuation, but this is an
+  //                                 OPENER of an unmatched token; treating
+  //                                 it as a closer let the elision earlier in
+  //                                 the sentence pair with it and swallowed
+  //                                 the clause boundary (codex P2, r8)
+  // So: never followed by a letter or digit, AND either tight against the
+  // text it closes (non-whitespace before) or trailed by whitespace/end.
+  // "'--force" fails both halves - space before, punctuation after.
   for (let j = full.length - 1; j >= 0; j--) {
     if (full[j] !== "'") continue;
+    const prev = full[j - 1];
     const next = full[j + 1];
-    if (next === undefined || !/[\p{L}\p{N}]/u.test(next)) return j;
+    if (next !== undefined && /[\p{L}\p{N}]/u.test(next)) continue;
+    const tightBefore = prev !== undefined && !/\s/.test(prev);
+    const looseAfter = next === undefined || /\s/.test(next);
+    if (tightBefore || looseAfter) return j;
   }
   return -1;
 }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -167,13 +167,25 @@ function lastCloserIndex(full: string): number {
     const prev = full[j - 1];
     const next = full[j + 1];
     if (next !== undefined && /[\p{L}\p{N}]/u.test(next)) continue;
-    const tightBefore = prev !== undefined && !/\s/.test(prev);
+    // "tight against content" excludes an OPENING delimiter: in
+    // "call parse('--force" the paren is non-whitespace but the quote after
+    // it is an opener, and treating it as a closer let an earlier elision
+    // pair across the clause boundary. Codex P2, r11.
+    const tightBefore = prev !== undefined && !/[\s([{]/.test(prev);
     const endsAfter = next === undefined || /\s/.test(next);
+    // Punctuation splits in two, and this is the fact the last three
+    // revisions kept rediscovering piecemeal:
+    //   , ; : ! ? ) ] }  never join tokens - they end the literal whatever
+    //                    follows, so "'echo a, b ';then" closes at the ;
+    //   . - _ / @ #      DO join tokens - "'.env" and "'--force" continue a
+    //                    filename or flag, so these only close when trailed
+    //                    by whitespace
     const afterNext = full[j + 2];
-    const clauseAfter =
-      next !== undefined && /[,;:.!?)\]}]/.test(next) &&
+    const closesRegardless = next !== undefined && /[,;:!?)\]}]/.test(next);
+    const joinerThenSpace =
+      next !== undefined && /[.\-_/@#]/.test(next) &&
       (afterNext === undefined || /\s/.test(afterNext));
-    if (tightBefore || endsAfter || clauseAfter) return j;
+    if (tightBefore || endsAfter || closesRegardless || joinerThenSpace) return j;
   }
   return -1;
 }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -178,7 +178,13 @@ function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
       const atBoundary =
         (prev === undefined || /[\s([{]/.test(prev)) &&
         next !== undefined && !/\s/.test(next);
-      if (atBoundary) { quote = ch; }
+      // Pairing is VERIFIED, not assumed. A word-boundary test alone still
+      // opens quote mode on elided forms ("keep 'em", "wait 'til"), which
+      // have no closer, so the scanner never leaves quote mode and bounding
+      // is disabled for the rest of the capture. Requiring an actual closing
+      // quote later in the string replaces a guess with a checkable fact -
+      // an elided form simply has no partner. Codex P2, this round.
+      if (atBoundary && full.indexOf("'", i + 1) !== -1) { quote = ch; }
       continue;
     }
     if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -266,7 +266,16 @@ function extractFromPatterns(
         const rawPrefix = match[1] ?? '';
         const isLabelPrefix = /:\s*$/.test(rawPrefix) || /^\s*the\s+\w+\s+(?:is|was)\s*$/i.test(rawPrefix);
         const keywordPrefix = isLabelPrefix ? '' : rawPrefix;
-        const afterKeyword = match[2] ?? match[0];
+        // Scan the UNTRUNCATED remainder, not match[2]. The patterns cap
+        // their content group at 500 chars, so a quoted literal whose closer
+        // sits past that point had no visible partner and the pairing check
+        // read the opener as prose - cutting inside the literal. That was a
+        // blindness built into the scanner's INPUT, not a bad predicate, so
+        // no further predicate could have fixed it. boundToClause already
+        // caps its OUTPUT at maxLen, so widening the input costs nothing and
+        // makes pairing decidable on the whole sentence. Codex P2, round 5.
+        const contentStart = match.index !== undefined ? match.index + rawPrefix.length : -1;
+        const afterKeyword = contentStart >= 0 ? sentence.slice(contentStart) : (match[2] ?? match[0]);
         bounded = boundToClause(keywordPrefix + afterKeyword, keywordPrefix.length);
       }
       const content = cleanExtract(bounded);

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -132,19 +132,48 @@ function splitSentences(text: string): string[] {
  * it is truncated and stored.
  */
 function boundToClause(full: string, searchFrom: number, maxLen = 200): string {
+  // Scan for the first PROSE clause boundary after `searchFrom`.
+  //
+  // Depth-awareness is not a nicety here: hippo memories are full of code, and
+  // a naive scan reintroduces the exact fragment defect this whole change
+  // exists to remove. Measured before this guard existed:
+  //   "Always call build(x, y) before deploy."  ->  "Always call build(x"
+  //   "Never pass {a: 1, b: 2} to the writer."  ->  "Never pass {a"
+  // Both then PASS the write gate, because they contain code punctuation and
+  // so read as "specific" — a malformed fragment stored with high confidence.
+  // Codex review finding (P1) on this branch.
+  //
+  // So: a separator only ends the clause at bracket depth zero and outside
+  // quotes. Unbalanced closers are tolerated (depth floors at 0) because
+  // captured text often starts mid-expression.
+  let depth = 0;
+  let quote: string | null = null;
   let cutEnd = full.length;
-  const tail = full.slice(searchFrom);
 
-  const clause = tail.match(/[,;:]\s/);
-  if (clause && clause.index !== undefined) {
-    const idx = searchFrom + clause.index;
-    if (idx < cutEnd) cutEnd = idx;
-  }
+  for (let i = searchFrom; i < full.length; i++) {
+    const ch = full[i];
 
-  const terminator = tail.match(/[.!?](?=\s|$)/);
-  if (terminator && terminator.index !== undefined) {
-    const idx = searchFrom + terminator.index + 1;
-    if (idx < cutEnd) cutEnd = idx;
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
+    if (ch === ')' || ch === ']' || ch === '}') { if (depth > 0) depth--; continue; }
+    if (depth > 0) continue;
+
+    const next = full[i + 1];
+    // Prose clause separator: , ; : followed by whitespace.
+    if ((ch === ',' || ch === ';' || ch === ':') && next !== undefined && /\s/.test(next)) {
+      cutEnd = i;
+      break;
+    }
+    // Sentence terminator, but only when followed by whitespace or end — a
+    // bare [.!?] splits inside .env, capture.ts, v1.35.0.
+    if ((ch === '.' || ch === '!' || ch === '?') && (next === undefined || /\s/.test(next))) {
+      cutEnd = i + 1;
+      break;
+    }
   }
 
   let bounded = full.slice(0, cutEnd);
@@ -206,7 +235,7 @@ function extractFromPatterns(
         // Discriminator: a label ends in its own colon, or is a "the X is"
         // phrase.
         const rawPrefix = match[1] ?? '';
-        const isLabelPrefix = /:\s*$/.test(rawPrefix) || /^\s*the\s+\w+\s+is\s*$/i.test(rawPrefix);
+        const isLabelPrefix = /:\s*$/.test(rawPrefix) || /^\s*the\s+\w+\s+(?:is|was)\s*$/i.test(rawPrefix);
         const keywordPrefix = isLabelPrefix ? '' : rawPrefix;
         const afterKeyword = match[2] ?? match[0];
         bounded = boundToClause(keywordPrefix + afterKeyword, keywordPrefix.length);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.35.0';
+export const PACKAGE_VERSION = '1.36.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -143,6 +143,45 @@ describe('DF2 capture coherence', () => {
     expect(true).toBe(true);
   });
 
+  /**
+   * DOCUMENTED BOUNDARY: locally undecidable quote roles.
+   *
+   * These assert what the scanner CURRENTLY does on inputs where no local
+   * rule can be correct, so a future change to the predicate shows up as a
+   * failure here instead of passing silently.
+   *
+   * The proof is a measured pair. These two quotes have byte-identical
+   * neighbours and opposite correct answers:
+   *
+   *   "run 'echo a, b ';then"   prev=" " next=";" after="t"  -> must CLOSE
+   *   "set ';foo, after"        prev=" " next=";" after="f"  -> must NOT
+   *
+   * Same for prev="(" next="." after=letter, which is a closer in
+   * "'a, ('.trim()" and an opener in "parse('.env". Deciding these needs to
+   * know whether an earlier quote was an elision or a real opener - global
+   * pairing, not neighbour inspection - and pairing itself needs a notion of
+   * what a literal "looks like". Twelve review rounds converged here.
+   *
+   * The scanner favours the shapes that occur in real memory text (quoted
+   * shell commands, flags, filenames) and accepts the mirrored ones as a
+   * bounded cost: a slightly overlong or slightly short capture, never a
+   * semantic inversion, which is the defect this branch exists to fix.
+   */
+  it('16. known boundary: locally undecidable quote roles are pinned, not fixed', () => {
+    // favoured: a quoted shell command closes at the semicolon
+    expect(extractFromText("Always run 'echo a, b ';then verify.")[0]?.content)
+      .toContain("'echo a, b '");
+    // mirrored shape, accepted cost: the clause boundary is swallowed
+    expect(extractFromText("Always keep 'em enabled, then set ';foo, after restart.")[0]?.content)
+      .toContain("';foo");
+    // mirrored shape, accepted cost: a literal ending in an open delimiter
+    expect(extractFromText("Always pass 'a, ('.trim() to the parser, then verify.")[0]?.content)
+      .toBe("Always pass 'a");
+    // and the thing that must NEVER regress, whatever the quote rules do
+    expect(extractFromText('Never use --no-verify on git commits in this project.')[0]?.content)
+      .toContain('Never');
+  });
+
   // Codex P1 on this branch: the clause scanner cut inside code delimiters,
   // reintroducing the exact fragment defect this change exists to remove -
   // and the fragments PASSED the write gate because code punctuation reads as

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -235,6 +235,15 @@ describe('DF2 capture coherence', () => {
       // on the elision; a closer-SHAPED partner does not exist here.
       { text: "Always keep 'em enabled, then " + 'y'.repeat(520) + " check user's config.",
         mustContain: "'em enabled", mustNotContain: 'yyyy' },
+      // an elision plus an unmatched quoted token starting with punctuation.
+      // "not followed by a letter" alone accepts the quote before --force as
+      // a closer, pairing it with 'em and swallowing the clause boundary.
+      { text: "Always keep 'em enabled, then run '--force, after restart.",
+        mustContain: "'em enabled", mustNotContain: '--force' },
+      // a literal whose closer trails whitespace - prev is a SPACE, yet it is
+      // a genuine closer, so a tight-before-only rule rejects it.
+      { text: "Always preserve 'a, b ' exactly, then verify.",
+        mustContain: "'a, b '", mustNotContain: 'then verify' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -55,16 +55,23 @@ describe('DF2 capture coherence', () => {
     expect(shouldAlways[0].content.toLowerCase()).toContain('always run the suite twice');
   });
 
-  it('6. DECISION and ERROR sets keep their keyword too, not just RULE', () => {
+  it('6. DECISION and ERROR sets follow the same semantic-vs-label split as RULE', () => {
+    // SEMANTIC keyword ("decided to") carries the meaning -> preserved.
     const decision = extractFromText('We decided to pin the version to avoid a repeat of the outage.');
     expect(decision).toHaveLength(1);
     expect(decision[0].category).toBe('decision');
     expect(decision[0].content.toLowerCase()).toContain('decided');
 
+    // LABEL keyword ("the issue was") only names the category, which is
+    // already on the item -> dropped. An earlier revision of this test
+    // asserted the opposite, because the discriminator recognised "the X is"
+    // but not "the X was" and the label leaked through. Two reviewers found
+    // that gap independently; this now pins the corrected behaviour.
     const error = extractFromText('The issue was that the reserve loop did not dedupe entries.');
     expect(error).toHaveLength(1);
     expect(error[0].category).toBe('error');
-    expect(error[0].content.toLowerCase()).toContain('issue was');
+    expect(error[0].content.toLowerCase()).not.toContain('the issue was');
+    expect(error[0].content.toLowerCase()).toContain('reserve loop');
   });
 
   it('7. documented behaviour change: a short imperative is now captured', () => {
@@ -134,5 +141,34 @@ describe('DF2 capture coherence', () => {
     // This suite deliberately does not duplicate capture-last-session.test.ts;
     // the verification step runs that suite alongside this one instead.
     expect(true).toBe(true);
+  });
+
+  // Codex P1 on this branch: the clause scanner cut inside code delimiters,
+  // reintroducing the exact fragment defect this change exists to remove -
+  // and the fragments PASSED the write gate because code punctuation reads as
+  // "specific". Depth-aware scanning is the fix; these pin it.
+  it('11. clause scan ignores separators inside code delimiters', () => {
+    const cases: Array<[string, string]> = [
+      ['Always call build(x, y) before deploy.', 'build(x, y)'],
+      ['Never pass {a: 1, b: 2} directly to the writer.', '{a: 1, b: 2}'],
+      ['Never use arr[0, 1] indexing here.', 'arr[0, 1]'],
+    ];
+    for (const [text, mustContain] of cases) {
+      const items = extractFromText(text);
+      expect(items, `expected a capture from "${text}"`).toHaveLength(1);
+      expect(items[0].content, `code span must survive clause scanning`).toContain(mustContain);
+    }
+  });
+
+  it('12. label discriminator treats "the X was" like "the X is"', () => {
+    // ERROR_PATTERNS matches (?:the (?:issue|problem|fix) (?:is|was)); the
+    // discriminator originally only knew the "is" form, so the "was" branch
+    // kept its label prefix. Found independently by two reviewers.
+    const wasItems = extractFromText('The issue was the config file was missing from the deploy bundle.');
+    const isItems = extractFromText('The issue is the config file goes missing from the deploy bundle.');
+    expect(wasItems).toHaveLength(1);
+    expect(isItems).toHaveLength(1);
+    expect(wasItems[0].content.toLowerCase()).not.toContain('the issue was');
+    expect(isItems[0].content.toLowerCase()).not.toContain('the issue is');
   });
 });

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -171,4 +171,41 @@ describe('DF2 capture coherence', () => {
     expect(wasItems[0].content.toLowerCase()).not.toContain('the issue was');
     expect(isItems[0].content.toLowerCase()).not.toContain('the issue is');
   });
+
+  // STRUCTURAL GUARD — three rounds of defects in this scanner earned it.
+  // Each round, adversarial review supplied a prose shape I had not imagined
+  // (code delimiters, then apostrophes). Pinning individual cases as they are
+  // found is a losing game; this sweep exercises the scanner against the
+  // messy realities of English-plus-code in one place, so the NEXT unimagined
+  // shape fails here rather than in review.
+  it('13. adversarial prose corpus: clause bounding holds across real-world text shapes', () => {
+    const corpus: Array<{ text: string; mustContain: string; mustNotContain: string }> = [
+      // contractions and possessives (codex P1, round 2)
+      { text: "Always ensure it's enabled, then restart the service.",
+        mustContain: "it's enabled", mustNotContain: 'restart the service' },
+      { text: "Never touch the user's config, it is generated.",
+        mustContain: "user's config", mustNotContain: 'it is generated' },
+      // code delimiters (codex P1, round 1)
+      { text: 'Always call build(x, y) before deploy, then tag it.',
+        mustContain: 'build(x, y)', mustNotContain: 'then tag it' },
+      { text: 'Never pass {a: 1, b: 2} to the writer, it corrupts rows.',
+        mustContain: '{a: 1, b: 2}', mustNotContain: 'it corrupts rows' },
+      // periods inside tokens
+      { text: 'Never edit capture.ts in the same commit as audit.ts, it confuses review.',
+        mustContain: 'capture.ts', mustNotContain: 'confuses review' },
+      // double-quoted string containing a separator
+      { text: 'Always set the flag to "a, b" before running, then verify.',
+        mustContain: '"a, b"', mustNotContain: 'then verify' },
+      // plain prose, no traps
+      { text: 'Always run the suite twice, then deploy.',
+        mustContain: 'run the suite twice', mustNotContain: 'then deploy' },
+    ];
+    for (const c of corpus) {
+      const items = extractFromText(c.text);
+      expect(items, `expected a capture from "${c.text}"`).toHaveLength(1);
+      const content = items[0].content;
+      expect(content, `must keep: ${c.mustContain}`).toContain(c.mustContain);
+      expect(content, `must bound before: ${c.mustNotContain}`).not.toContain(c.mustNotContain);
+    }
+  });
 });

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -249,6 +249,13 @@ describe('DF2 capture coherence', () => {
       // phrased around the preceding character rejects a genuine closer.
       { text: "Always preserve 'a, b ', then verify.",
         mustContain: "'a, b '", mustNotContain: 'then verify' },
+      // THE PAIR THAT PROVES THE RULE NEEDS BOTH NEIGHBOURS. Identical
+      // following character, opposite roles - only the preceding side
+      // differs, so no forward-only test can separate them.
+      { text: "Always preserve 'a, b'-style text, then verify.",
+        mustContain: "'a, b'-style", mustNotContain: 'then verify' },
+      { text: "Always keep 'em enabled, then edit '.env, after restart.",
+        mustContain: "'em enabled", mustNotContain: '.env' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -179,7 +179,11 @@ describe('DF2 capture coherence', () => {
   // messy realities of English-plus-code in one place, so the NEXT unimagined
   // shape fails here rather than in review.
   it('13. adversarial prose corpus: clause bounding holds across real-world text shapes', () => {
-    const corpus: Array<{ text: string; mustContain: string; mustNotContain: string }> = [
+    // `mustNotContain` is optional: a few shapes are purely positive, where
+    // the whole literal must survive and no substring of the CORRECT output
+    // is a valid negative. Inventing one there would assert nothing, which
+    // is the vacuity trap this file already carries a guard against.
+    const corpus: Array<{ text: string; mustContain: string; mustNotContain?: string }> = [
       // contractions and possessives (codex P1, round 2)
       { text: "Always ensure it's enabled, then restart the service.",
         mustContain: "it's enabled", mustNotContain: 'restart the service' },
@@ -256,6 +260,14 @@ describe('DF2 capture coherence', () => {
         mustContain: "'a, b'-style", mustNotContain: 'then verify' },
       { text: "Always keep 'em enabled, then edit '.env, after restart.",
         mustContain: "'em enabled", mustNotContain: '.env' },
+      // an opener sitting tight against an OPENING delimiter. Non-whitespace
+      // before it, but "parse('" is an opener position, not a closer.
+      { text: "Always keep 'em enabled, then call parse('--force, after restart.",
+        mustContain: "'em enabled", mustNotContain: 'parse' },
+      // a closer before punctuation that does NOT join tokens. A semicolon
+      // ends the literal whatever follows it, unlike the dot in '.env.
+      { text: "Always run 'echo a, b ';then verify.",
+        mustContain: "'echo a, b '" },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },
@@ -265,7 +277,9 @@ describe('DF2 capture coherence', () => {
       expect(items, `expected a capture from "${c.text}"`).toHaveLength(1);
       const content = items[0].content;
       expect(content, `must keep: ${c.mustContain}`).toContain(c.mustContain);
-      expect(content, `must bound before: ${c.mustNotContain}`).not.toContain(c.mustNotContain);
+      if (c.mustNotContain !== undefined) {
+        expect(content, `must bound before: ${c.mustNotContain}`).not.toContain(c.mustNotContain);
+      }
     }
   });
 });

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -208,6 +208,14 @@ describe('DF2 capture coherence', () => {
       // vacuous on the first attempt.
       { text: "Never run 'rm -rf, x' in the deploy script, check first.",
         mustContain: "'rm -rf, x'", mustNotContain: 'check first' },
+      // elided forms - a leading apostrophe with NO closer. A word-boundary
+      // heuristic alone opened quote mode here and never left it, disabling
+      // bounding for the rest of the capture. Fixed by verifying the pairing
+      // (a closer must exist) rather than guessing from position.
+      { text: "Always keep 'em enabled, then restart the service.",
+        mustContain: "'em enabled", mustNotContain: 'restart the service' },
+      { text: "Never wait 'til the deploy finishes, check the logs first.",
+        mustContain: "'til the deploy finishes", mustNotContain: 'check the logs' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -244,6 +244,11 @@ describe('DF2 capture coherence', () => {
       // a genuine closer, so a tight-before-only rule rejects it.
       { text: "Always preserve 'a, b ' exactly, then verify.",
         mustContain: "'a, b '", mustNotContain: 'then verify' },
+      // a literal ending in whitespace and followed by CLAUSE punctuation -
+      // whitespace before the closer and a comma after it, so any rule
+      // phrased around the preceding character rejects a genuine closer.
+      { text: "Always preserve 'a, b ', then verify.",
+        mustContain: "'a, b '", mustNotContain: 'then verify' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -62,16 +62,27 @@ describe('DF2 capture coherence', () => {
     expect(decision[0].category).toBe('decision');
     expect(decision[0].content.toLowerCase()).toContain('decided');
 
-    // LABEL keyword ("the issue was") only names the category, which is
-    // already on the item -> dropped. An earlier revision of this test
-    // asserted the opposite, because the discriminator recognised "the X is"
-    // but not "the X was" and the label leaked through. Two reviewers found
-    // that gap independently; this now pins the corrected behaviour.
+    // COLON labels ("decision:", "error:") are dropped - they name the
+    // category, which is already on the item. "the X is/was" is KEPT.
+    //
+    // This reverses an earlier revision of this test, and the reversal is the
+    // point: dropping "the X is/was" too left the residue starting with
+    // "to ", which isFragment rejects outright, so "The plan is to ship on
+    // Friday" and "The fix was to bump the pool timeout" stored NOTHING where
+    // every prior version stored them. Silent loss on two high-traffic
+    // patterns, found only at the ship gate. The AT1 rejected-value evidence
+    // that motivated label-dropping involved colon labels exclusively
+    // (tests/rejection-acceptance.test.ts still passes), so the narrow rule
+    // keeps that guarantee without the collateral loss.
     const error = extractFromText('The issue was that the reserve loop did not dedupe entries.');
     expect(error).toHaveLength(1);
     expect(error[0].category).toBe('error');
-    expect(error[0].content.toLowerCase()).not.toContain('the issue was');
     expect(error[0].content.toLowerCase()).toContain('reserve loop');
+
+    // the regression this narrowing exists to prevent
+    const plan = extractFromText('The plan is to ship the DF2 branch on Friday afternoon, pending QA signoff.');
+    expect(plan, 'a "the plan is to ..." memory must not vanish').toHaveLength(1);
+    expect(plan[0].content.toLowerCase()).toContain('ship the df2 branch');
   });
 
   it('7. documented behaviour change: a short imperative is now captured', () => {
@@ -144,6 +155,38 @@ describe('DF2 capture coherence', () => {
   });
 
   /**
+   * Ship-gate findings. Every case here is a regression this branch
+   * introduced against master, each verified by running BOTH versions - not
+   * inferred. All three survived twelve codex rounds and five reviewers,
+   * because they live at the interaction between the new scanner and gates
+   * nobody re-swept.
+   */
+  it('17. ship gate: shorter-but-correct content must not fall under a downstream gate', () => {
+    // isFragment rejects content starting with "to " under 50 chars. Dropping
+    // the "the X is/was" label left exactly that residue, so these stored
+    // NOTHING while master stored them. Absence of a memory is invisible -
+    // no error, no log, nothing to notice in the field.
+    const plan = extractFromText('The plan is to ship the DF2 branch on Friday afternoon, pending QA signoff.');
+    expect(plan, 'a "the plan is to ..." memory must not vanish').toHaveLength(1);
+
+    const fix = extractFromText('The fix was to bump the pool timeout to 30s, because the recycler defaults were too aggressive.');
+    expect(fix, 'a "the fix was to ..." memory must not vanish').toHaveLength(1);
+    expect(fix[0].content).toContain('pool timeout');
+  });
+
+  it('18. ship gate: closing a literal uses the same shape test as opening', () => {
+    // The open decision took twelve rounds of care; the close accepted any
+    // bare quote. So a possessive INSIDE a literal closed it early and the
+    // comma after read as a clause boundary - a mid-literal fragment that
+    // then passes the write gate, the exact defect this branch removes, on
+    // ordinary prose master handles correctly.
+    const items = extractFromText("Always pass 'user's a, b list' to the parser.");
+    expect(items).toHaveLength(1);
+    expect(items[0].content, 'possessive inside a literal must not close it')
+      .toContain("'user's a, b list'");
+  });
+
+  /**
    * DOCUMENTED BOUNDARY: locally undecidable quote roles.
    *
    * These assert what the scanner CURRENTLY does on inputs where no local
@@ -158,9 +201,19 @@ describe('DF2 capture coherence', () => {
    *
    * Same for prev="(" next="." after=letter, which is a closer in
    * "'a, ('.trim()" and an opener in "parse('.env". Deciding these needs to
-   * know whether an earlier quote was an elision or a real opener - global
-   * pairing, not neighbour inspection - and pairing itself needs a notion of
-   * what a literal "looks like". Twelve review rounds converged here.
+   * know whether an earlier quote was an elision or a real opener.
+   *
+   * CORRECTION, from the ship-gate review: "undecidable" overstates it. These
+   * particular pairs ARE separable by a small elision lexicon ('em, 'til,
+   * 'tis, 'cause, 'n) - treat a known elision as never-an-opener and the
+   * mirrored quote stops pairing with it. What is genuinely undecidable is
+   * narrower: an UNKNOWN elision ahead of a quote-shaped token. That is rarer
+   * than the earlier wording implied, and the honest statement is that these
+   * shapes are UNRESOLVED rather than unresolvable.
+   *
+   * They stay pinned rather than fixed because a lexicon is a different kind
+   * of change - data, not logic - and belongs with the tokenizer question,
+   * not appended to a twelve-round predicate. Backlogged.
    *
    * The scanner favours the shapes that occur in real memory text (quoted
    * shell commands, flags, filenames) and accepts the mirrored ones as a
@@ -199,16 +252,26 @@ describe('DF2 capture coherence', () => {
     }
   });
 
-  it('12. label discriminator treats "the X was" like "the X is"', () => {
-    // ERROR_PATTERNS matches (?:the (?:issue|problem|fix) (?:is|was)); the
-    // discriminator originally only knew the "is" form, so the "was" branch
-    // kept its label prefix. Found independently by two reviewers.
+  it('12. "the X is" and "the X was" behave identically', () => {
+    // The original defect two reviewers found was an INCONSISTENCY: the
+    // discriminator knew "the X is" but not "the X was", so one kept its
+    // label and the other dropped it. Consistency was the requirement; which
+    // way to resolve it was the open choice.
+    //
+    // It was first resolved by dropping BOTH, which turned out to cause
+    // silent data loss (see test 6) because the residue starts with "to ".
+    // It is now resolved by KEEPING both. The invariant the reviewers
+    // actually asked for - identical handling - still holds, and is what
+    // this test pins.
     const wasItems = extractFromText('The issue was the config file was missing from the deploy bundle.');
     const isItems = extractFromText('The issue is the config file goes missing from the deploy bundle.');
     expect(wasItems).toHaveLength(1);
     expect(isItems).toHaveLength(1);
-    expect(wasItems[0].content.toLowerCase()).not.toContain('the issue was');
-    expect(isItems[0].content.toLowerCase()).not.toContain('the issue is');
+    expect(wasItems[0].content.toLowerCase()).toContain('the issue was');
+    expect(isItems[0].content.toLowerCase()).toContain('the issue is');
+    // both keep their content, neither is truncated to the label
+    expect(wasItems[0].content.toLowerCase()).toContain('config file');
+    expect(isItems[0].content.toLowerCase()).toContain('config file');
   });
 
   // STRUCTURAL GUARD — three rounds of defects in this scanner earned it.

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractFromText } from '../src/capture.js';
+
+/**
+ * DF2 — capture extractor: keyword-preserving, clause-bounded capture.
+ * Plan: docs/plans/2026-08-23-df2-capture-anchoring.md
+ *
+ * `extractFromText` is a pure function (no store, no I/O) — the exported
+ * seam the plan names. These are direct unit tests against it; no store or
+ * mocks are needed because nothing here touches persistence.
+ */
+describe('DF2 capture coherence', () => {
+  it('1. inversion pin: a prohibition keeps its keyword, not just the object', () => {
+    const items = extractFromText('Never use --no-verify on git commits in this project.');
+    expect(items).toHaveLength(1);
+    expect(items[0].content.toLowerCase()).toContain('never');
+    expect(items[0].content.toLowerCase()).not.toBe('use --no-verify on git commits in this project');
+  });
+
+  it('2. fragment self-rejects: clause-bounding shortens it, the write gate then drops it', () => {
+    const items = extractFromText(
+      'The captures had a few problems (two had never got entries), plus one documented exception.'
+    );
+    expect(items).toHaveLength(0);
+  });
+
+  it('3. overrun stops at the clause: content excludes the trailing "so it is" tail', () => {
+    const items = extractFromText(
+      'I have never seen this test fail on master before, so it is probably a flake.'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].content.toLowerCase()).toContain('never seen this test fail on master before');
+    expect(items[0].content.toLowerCase()).not.toContain('so it is');
+  });
+
+  it('4. periods inside tokens survive clause-bounding', () => {
+    const items = extractFromText(
+      'Never edit capture.ts and audit.ts in the same commit without running npm test.'
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].content).toContain('capture.ts');
+  });
+
+  it('5. genuine rules keep their keyword — must-never and should-always corpus', () => {
+    const mustNever = extractFromText('You must never commit the .env file to the repository.');
+    expect(mustNever).toHaveLength(1);
+    expect(mustNever[0].content.toLowerCase()).toContain('must never');
+    expect(mustNever[0].content).toContain('.env');
+
+    const shouldAlways = extractFromText(
+      'We should always run the suite twice locally before merging any change.'
+    );
+    expect(shouldAlways).toHaveLength(1);
+    expect(shouldAlways[0].content.toLowerCase()).toContain('always run the suite twice');
+  });
+
+  it('6. DECISION and ERROR sets keep their keyword too, not just RULE', () => {
+    const decision = extractFromText('We decided to pin the version to avoid a repeat of the outage.');
+    expect(decision).toHaveLength(1);
+    expect(decision[0].category).toBe('decision');
+    expect(decision[0].content.toLowerCase()).toContain('decided');
+
+    const error = extractFromText('The issue was that the reserve loop did not dedupe entries.');
+    expect(error).toHaveLength(1);
+    expect(error[0].category).toBe('error');
+    expect(error[0].content.toLowerCase()).toContain('issue was');
+  });
+
+  it('7. documented behaviour change: a short imperative is now captured', () => {
+    const items = extractFromText('Never force push to main.');
+    expect(items).toHaveLength(1);
+    expect(items[0].content.toLowerCase()).toContain('never force push to main');
+  });
+
+  it('8. pattern-set coverage sweep: one post-fix case per pattern array', () => {
+    const cases: Array<{ array: string; text: string; category: string; mustContain: string; mustNotContain?: string }> = [
+      {
+        array: 'DECISION',
+        text: "Let's go with the SQLite-backed store for the local cache.",
+        category: 'decision',
+        mustContain: 'go with',
+      },
+      {
+        array: 'RULE',
+        text: 'Always run lint before pushing any change.',
+        category: 'rule',
+        mustContain: 'always run lint',
+      },
+      {
+        array: 'ERROR',
+        // LABEL keyword: 'Error:' names the category (already recorded in
+        // `category`) and carries no semantic sign, so T1 drops it rather
+        // than prefixing it onto the content. Contrast the RULE case above,
+        // where 'always' IS the meaning and must survive. Preserving label
+        // prefixes also broke AT1's rejected-value digest, which hashes the
+        // bare content — see tests/rejection-acceptance.test.ts.
+        text: 'Error: the migration silently dropped the last batch of rows.',
+        category: 'error',
+        mustContain: 'migration silently dropped',
+        mustNotContain: 'error:',
+      },
+      {
+        array: 'PREFERENCE',
+        text: 'Avoid using synchronous fs calls in the hot path.',
+        category: 'preference',
+        mustContain: 'avoid using synchronous fs calls',
+      },
+    ];
+
+    for (const c of cases) {
+      const items = extractFromText(c.text);
+      expect(items, `${c.array} array: expected exactly one item from "${c.text}"`).toHaveLength(1);
+      expect(items[0].category).toBe(c.category);
+      expect(items[0].content.toLowerCase()).toContain(c.mustContain);
+      if (c.mustNotContain) {
+        expect(
+          items[0].content.toLowerCase(),
+          `${c.array} array: label prefix must be dropped, not stored`,
+        ).not.toContain(c.mustNotContain);
+      }
+    }
+  });
+
+  it('9. upper bound retained: a long clause-free span is stored truncated, not dropped', () => {
+    const longTail = 'x'.repeat(400); // no comma/semicolon/colon/terminator anywhere
+    const items = extractFromText(`Always keep going ${longTail} no matter what happens here today`);
+    expect(items).toHaveLength(1);
+    expect(items[0].content.length).toBeLessThanOrEqual(200);
+    expect(items[0].content.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('10. no-regression placeholder: covered by the pre-existing tests/capture*.test.ts suite', () => {
+    // This suite deliberately does not duplicate capture-last-session.test.ts;
+    // the verification step runs that suite alongside this one instead.
+    expect(true).toBe(true);
+  });
+});

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -216,6 +216,13 @@ describe('DF2 capture coherence', () => {
         mustContain: "'em enabled", mustNotContain: 'restart the service' },
       { text: "Never wait 'til the deploy finishes, check the logs first.",
         mustContain: "'til the deploy finishes", mustNotContain: 'check the logs' },
+      // a quoted literal whose closer sits past the patterns' 500-char
+      // content cap. The scanner used to see only the truncated match, so the
+      // closer was invisible and the opener read as prose - it cut inside the
+      // literal at the first comma. Fixed by widening the scanner's INPUT to
+      // the untruncated sentence; no predicate could have seen this.
+      { text: "Always pass '" + 'a, ' + 'x'.repeat(600) + "' to the parser.",
+        mustContain: "Always pass 'a, xxx", mustNotContain: "pass 'a'" },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -196,6 +196,18 @@ describe('DF2 capture coherence', () => {
       // double-quoted string containing a separator
       { text: 'Always set the flag to "a, b" before running, then verify.',
         mustContain: '"a, b"', mustNotContain: 'then verify' },
+      // single-quoted literals containing a separator. An earlier revision
+      // ignored the apostrophe entirely and CUT here, storing "Always pass
+      // 'a" - which passes the write gate because code punctuation reads as
+      // "specific". I had asserted in a code comment that cutting early was
+      // "the safe direction" without testing it; codex proved otherwise.
+      { text: "Always pass 'a, b' to the parser, then validate.",
+        mustContain: "'a, b'", mustNotContain: 'then validate' },
+      // NB: the trailing clause must be a token that is not a substring of
+      // the kept text - "ever" is inside "Never" and made this assertion
+      // vacuous on the first attempt.
+      { text: "Never run 'rm -rf, x' in the deploy script, check first.",
+        mustContain: "'rm -rf, x'", mustNotContain: 'check first' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-capture-coherence.test.ts
+++ b/tests/df2-capture-coherence.test.ts
@@ -223,6 +223,18 @@ describe('DF2 capture coherence', () => {
       // the untruncated sentence; no predicate could have seen this.
       { text: "Always pass '" + 'a, ' + 'x'.repeat(600) + "' to the parser.",
         mustContain: "Always pass 'a, xxx", mustNotContain: "pass 'a'" },
+      // DECISION_PATTERNS carry an UNCAPTURED subject before group 1, so an
+      // offset derived as match.index + prefix.length lands inside the
+      // keyword and duplicates text. Read group 2's real offset instead.
+      { text: 'We decided to pin the version to 1.35.0.',
+        mustContain: 'decided to pin the version', mustNotContain: 'to to' },
+      { text: "Let's go with SQLite for the store.",
+        mustContain: 'go with SQLite', mustNotContain: 'with  with' },
+      // an elision plus an unrelated IN-WORD apostrophe far downstream. Any
+      // apostrophe would satisfy a bare pairing check, re-opening quote mode
+      // on the elision; a closer-SHAPED partner does not exist here.
+      { text: "Always keep 'em enabled, then " + 'y'.repeat(520) + " check user's config.",
+        mustContain: "'em enabled", mustNotContain: 'yyyy' },
       // plain prose, no traps
       { text: 'Always run the suite twice, then deploy.',
         mustContain: 'run the suite twice', mustNotContain: 'then deploy' },

--- a/tests/df2-family-coverage.test.ts
+++ b/tests/df2-family-coverage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { extractFromText } from '../src/capture.js';
+import { isContentWorthStoring } from '../src/audit.js';
 
 /**
  * Family coverage sweep (DF2).
@@ -34,6 +35,12 @@ describe('DF2: every pattern family still extracts', () => {
     ['decision/lets', "Let's go with SQLite for the store."],
     ['decision/decided', 'We decided to use Postgres for the primary store.'],
     ['pref/prefer', 'Prefer using SQLite instead of Postgres for local runs.'],
+    // moved out of EXPECT_NULL when label-dropping was narrowed to colon
+    // labels: keeping "the issue was" makes the content long enough to clear
+    // the write gate, so this shape now stores where it previously vanished.
+    // The EXPECT_NULL guard is what surfaced the change - it failed loudly
+    // rather than letting a behaviour shift pass unnoticed.
+    ['error/issuewas', 'The issue was the reserve loop did not dedupe entries.'],
   ];
 
   // Shapes that extract NOTHING on this branch and extracted nothing on
@@ -45,7 +52,6 @@ describe('DF2: every pattern family still extracts', () => {
     ['decision/goingwith', "We're going with the batched writer approach."],
     ['pref/rather', 'I would rather batch the writes than lock the table.'],
     ['error/failed', 'The build failed because the token had expired.'],
-    ['error/issuewas', 'The issue was the reserve loop did not dedupe entries.'],
     ['error/bugwas', 'The bug was the offset assumed group one started the match.'],
     ['error/causewas', 'The cause was a stale base branch in the worktree.'],
     ['rule/importantshort', 'Important: rotate the token first.'],
@@ -72,6 +78,21 @@ describe('DF2: every pattern family still extracts', () => {
       expect(got!, `${name} duplicated a word`).not.toMatch(DUPLICATED_WORD);
     });
   }
+
+  it('ship gate: chat acronyms do not buy a specificity bypass', () => {
+    // The acronym signal exists so "every PR needs two approvals" survives
+    // clause-bounding. It must not also admit chat noise: this gate is shared
+    // with the recent-context floor and `hippo audit`, so widening it acts
+    // RETROACTIVELY over rows a user already holds.
+    for (const junk of ['TODO fix this thing', 'LGTM ship it', 'FYI all done here', 'IIRC that was fine']) {
+      expect(isContentWorthStoring(junk), `${junk} must stay rejected`).toBe(false);
+    }
+    for (const real of ['every PR needs two approvals', 'the CI runs on every push here', 'restart the DB pool after deploy']) {
+      expect(isContentWorthStoring(real), `${real} must be stored`).toBe(true);
+    }
+    // capitalisation alone still buys nothing
+    expect(isContentWorthStoring('FIXED SIGNALS')).toBe(false);
+  });
 
   it('the duplication assertion is not vacuous', () => {
     // Guards the guard. A regex mangled into control bytes still "passes"

--- a/tests/df2-family-coverage.test.ts
+++ b/tests/df2-family-coverage.test.ts
@@ -36,18 +36,27 @@ describe('DF2: every pattern family still extracts', () => {
     ['pref/prefer', 'Prefer using SQLite instead of Postgres for local runs.'],
   ];
 
-  // Shapes that do not match on this branch AND did not match on master.
-  // Recorded rather than omitted so a future change that starts or stops
-  // matching them shows up as a diff instead of passing silently.
-  const KNOWN_NULL = new Set([
-    'decision/goingwith',
-    'pref/rather',
-    'error/failed',
-    'error/issuewas',
-    'error/bugwas',
-    'error/causewas',
-    'rule/importantshort',
-  ]);
+  // Shapes that extract NOTHING on this branch and extracted nothing on
+  // master either. They are asserted, not skipped: an early `return` would
+  // make them pass without checking anything, so a known-null shape quietly
+  // starting to match - or a live one going dark - would be invisible. That
+  // is the same vacuity trap as the mangled regex below. Codex P2, r8.
+  const EXPECT_NULL: Array<[string, string]> = [
+    ['decision/goingwith', "We're going with the batched writer approach."],
+    ['pref/rather', 'I would rather batch the writes than lock the table.'],
+    ['error/failed', 'The build failed because the token had expired.'],
+    ['error/issuewas', 'The issue was the reserve loop did not dedupe entries.'],
+    ['error/bugwas', 'The bug was the offset assumed group one started the match.'],
+    ['error/causewas', 'The cause was a stale base branch in the worktree.'],
+    ['rule/importantshort', 'Important: rotate the token first.'],
+  ];
+
+  for (const [name, text] of EXPECT_NULL) {
+    it(`${name} is still a known non-match`, () => {
+      const got = extractFromText(text)[0]?.content ?? null;
+      expect(got, `${name} started matching - intended, or a silent change?`).toBeNull();
+    });
+  }
 
   // A word repeated back-to-back, e.g. "decided to to pin" - the signature of
   // the group-offset defect. Written as a literal so no escaping layer can
@@ -59,7 +68,6 @@ describe('DF2: every pattern family still extracts', () => {
   for (const [name, text] of cases) {
     it(`${name} extracts without duplication`, () => {
       const got = extractFromText(text)[0]?.content ?? null;
-      if (KNOWN_NULL.has(name)) return;
       expect(got, `${name} stopped extracting`).toBeTruthy();
       expect(got!, `${name} duplicated a word`).not.toMatch(DUPLICATED_WORD);
     });

--- a/tests/df2-family-coverage.test.ts
+++ b/tests/df2-family-coverage.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { extractFromText } from '../src/capture.js';
+
+/**
+ * Family coverage sweep (DF2).
+ *
+ * The adversarial corpus in df2-capture-coherence.test.ts proves the clause
+ * scanner handles hard TEXT SHAPES. It could not catch a whole pattern family
+ * silently ceasing to match - and one did: clause-bounding shortened
+ * "The rule is every PR needs two approvals, no exceptions." to "every PR
+ * needs two approvals", which then fell under the audit layer's 40-char
+ * vagueness gate and was DROPPED. A rule that stored before this branch
+ * stopped storing, and every shape-focused test stayed green.
+ *
+ * So this file asserts the complementary property: every pattern family still
+ * EXTRACTS, and none of them duplicates text (the DECISION_PATTERNS offset
+ * defect). Shape correctness and family coverage are different failures, and
+ * only one of them was being tested.
+ */
+describe('DF2: every pattern family still extracts', () => {
+  const cases: Array<[string, string]> = [
+    ['rule/never', 'Never use --no-verify on git commits in this project.'],
+    ['rule/always', 'Always run the migration before deploying, then verify.'],
+    ['rule/must', 'You must not commit the .env file to this repository.'],
+    ['rule/dont', "Don't ever force-push to master, it rewrites history."],
+    ['rule/theruleis', 'The rule is every PR needs two approvals, no exceptions.'],
+    ['rule/important', 'Important: rotate the token before the release ships.'],
+    ['rule/makesure', 'Make sure to run the linter, then push the branch.'],
+    ['rule/ensure', 'Ensure the cache is warm before benchmarking, then record.'],
+    ['rule/rulecolon', 'Rule: every PR needs two approvals.'],
+    ['rule/short', 'Always rotate the token before release.'],
+    ['rule/decisioncolon', 'Decision: we use DuckDB for all analytics.'],
+    ['decision/wedecided', 'We decided to pin the version to 1.35.0.'],
+    ['decision/lets', "Let's go with SQLite for the store."],
+    ['decision/decided', 'We decided to use Postgres for the primary store.'],
+    ['pref/prefer', 'Prefer using SQLite instead of Postgres for local runs.'],
+  ];
+
+  // Shapes that do not match on this branch AND did not match on master.
+  // Recorded rather than omitted so a future change that starts or stops
+  // matching them shows up as a diff instead of passing silently.
+  const KNOWN_NULL = new Set([
+    'decision/goingwith',
+    'pref/rather',
+    'error/failed',
+    'error/issuewas',
+    'error/bugwas',
+    'error/causewas',
+    'rule/importantshort',
+  ]);
+
+  // A word repeated back-to-back, e.g. "decided to to pin" - the signature of
+  // the group-offset defect. Written as a literal so no escaping layer can
+  // turn the backreference into control BYTES, which is exactly what happened
+  // when this file was first generated: the assertion compiled to a pattern
+  // over 0x08/0x01 that could never match, and the check passed vacuously.
+  const DUPLICATED_WORD = /\b(\w+)\s+\1\b/;
+
+  for (const [name, text] of cases) {
+    it(`${name} extracts without duplication`, () => {
+      const got = extractFromText(text)[0]?.content ?? null;
+      if (KNOWN_NULL.has(name)) return;
+      expect(got, `${name} stopped extracting`).toBeTruthy();
+      expect(got!, `${name} duplicated a word`).not.toMatch(DUPLICATED_WORD);
+    });
+  }
+
+  it('the duplication assertion is not vacuous', () => {
+    // Guards the guard. A regex mangled into control bytes still "passes"
+    // every negative assertion above; only a positive case proves it works.
+    expect('decided to to pin the version').toMatch(DUPLICATED_WORD);
+    expect('go with  with SQLite').toMatch(DUPLICATED_WORD);
+    expect('decided to pin the version').not.toMatch(DUPLICATED_WORD);
+  });
+});


### PR DESCRIPTION
## The severe part first

The session-capture distiller stored a **prohibition as an instruction**. Measured:

```
source: "Never use --no-verify on git commits in this project."
stored: "use --no-verify on git commits in this project"
```

That is a real pinned rule in a live store, and hippo injects stored rules into later prompts. Every pattern captured from *after* the keyword, so the word carrying the negation was discarded.

## One mechanism, two symptoms

Patterns were an unanchored keyword alternation plus a fixed-width capture beginning after the keyword — `/(?:never|always|must not|…)\s+(.{5,200})/i`. So (1) the sign-carrying keyword was dropped, and (2) the capture counted characters instead of respecting clause boundaries, running past commas into unrelated text and producing the mid-sentence shrapnel the roadmap reported.

**The roadmap's stated cause was wrong.** It blamed hard-slicing transcript text before extraction; the live fragment reproduces byte-identically from untruncated source. Corrected in this branch.

## Changes

- Two capture groups per pattern (keyword+separator, content); content bounded to its clause. The terminator must be followed by whitespace — a bare `[.!?]` splits inside `.env`, `capture.ts`, `v1.35.0`, and without the guard `"You must never commit the .env file"` captures `"must never commit the"`, fails the write gate and is silently dropped.
- 200-char ceiling retained, so a clause-free span is truncated-and-stored rather than exceeding the 500 gate and being dropped.
- Keyword preserved only when it carries **semantic sign**. Label keywords (`decision:`, `rule:`, `error:`, `important:`) name a category already recorded in `item.category`; prefixing them is duplication and it broke AT1's rejected-value guard, which digests the bare content.
- `cleanExtract` strips a trailing `)` only while closes exceed opens.

## Stated limits

This does **not** teach the extractor to tell a rule from narrative. `"I have never seen this test fail"` still captures — now as `"never seen this test fail on master before"`, a complete correctly-signed clause instead of shrapnel with the negation stripped. Backlogged, along with `PREFERENCE_PATTERNS[0]` reading only `match[1]` (`"Prefer using SQLite instead of Postgres"` stores `"using SQLite"`).

## Test plan
- [x] 10 tests, each red-under-old verified by reverting the fix rather than assumed
- [x] `tests/rejection-acceptance.test.ts` 14/14, `tests/capture*.test.ts` green
- [x] End-to-end: inversion fixed, fragment no longer stored, periods preserved, label prefixes dropped

Note: repo CI is currently failing for a GitHub Actions billing block affecting all runs on master, not this branch — verified locally instead.

Roadmap: Part VI DF2. Plan: `docs/plans/2026-08-23-df2-capture-anchoring.md` (gated over 3 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FW2AC8E9w6ZoEf9KK75n6