### PR TITLE
v1.38.0 fix: the recall cutoff line never fired on the CLI path (C5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 1.37.0 - 2026-08-23
+## 1.38.0 - 2026-08-24
+
+### Fixed
+- **`hippo recall` silently discarded most candidates (C5).** The transparency line that exists to stop an agent treating a truncated result set as the whole picture could not fire on the CLI path. Measured on 1.37.0: six recalls across three queries and two budgets, `totalCandidates` 192 to 400, 1 to 6 returned, and `droppedByBudget` 0 every time, so the `clauses.length > 0` guard suppressed the `Cutoff:` line entirely. The count was derived from the post-search `--limit` slice, but results arrive from the search already ranked and truncated, so the counter ran after the cut it was measuring. It is now derived as `totalCandidates + graphAdded - droppedPreRank - returned`, so the accounting closes by construction: `totalCandidates == droppedPreRank + droppedByBudget + returned`.
+- **Graph-expanded recalls (`--hops`) are counted correctly.** `graphExpandRecall` both surfaces neighbours and evicts weak base rows in one call, so a net-length comparison scored 3 added plus 3 evicted as no change. Counted by identity now, and the graph-surfaced rows are included in the reported `totalCandidates` so the published numbers satisfy the same invariant the internal arithmetic does.
+- **The cutoff message named a control the caller may not have used.** It read "N dropped to fit limit" even for a `--budget` recall with no `--limit` flag. It now reads "N not shown (rank, budget or limit)".
+
+### Notes
+- **Accounting convention change.** Search-engine rank-step drops were previously excluded from `droppedByBudget` by a documented v1 convention. That convention is why the line was unfireable in the common case, so it now counts them. `dropped_pre_rank` keeps its exact filters-not-ranking meaning. Counts remain per-path honest reports rather than normalised cross-surface numbers, so the CLI and `api.recall` figures answer the same question differently and should not be compared directly.
+- `hippo recall --why` will now print a `Cutoff:` line on most non-trivial stores. That is the intended behaviour: the line only appears when candidates were actually excluded, and `--why` is the flag that asks for it.
+
+## 1.37.0 - 2026-08-24
 
 ### Fixed
 - **Git auto-learn stored commit subjects that carry no information (DF4).** `hippo learn` parsed git subjects and stored every match with no quality predicate, so bare subjects landed in the store and `hippo audit` flagged them afterwards - measured on a live store, 36 of 37 issues were this class ("fixed signals", "mobile responsive polish", "corrected entry prices"). The quality check existed only downstream in audit. It now runs at the producer: a new `partitionLessons` applies `isContentWorthStoring` and BOTH write paths use it, the CLI `learn` command and the MCP `learn` tool. Measured against real data: of 413 rows written by auto-learn across four project stores, 24 (6%) would have been gated, and the gated set is exactly the junk class. The parser `extractLessons` is unchanged - it is a published export and stays a pure parser; admission is a separate step.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -371,8 +371,10 @@ Continuous background representation: physics-engine energy + velocity-distribut
 Sub-millisecond pre-LLM classifier. Cosine of query embedding against particle-cluster centroids. Predicts: relevant knowledge present? familiar vs novel? about to repeat known mistake?
 **Effort:** 8d. **Success:** ≥70% accuracy on labeled trace; <1ms p99 latency.
 
-### C5. WYSIATI cutoff transparency [next]
+### C5. WYSIATI cutoff transparency [SHIPPED 2026-08-24, PR #154, v1.38.0]
 When `hippo recall --budget N` truncates the candidate set, surface the suppressed-set summary in the response: "showing 5/47 by strength; 38 below decay threshold; 4 suppressed by interference filter." Today the cut is silent and the calling agent treats the cutoff as the full picture (Kahneman, "What You See Is All There Is", TFAS ch. 7). Hippo's lifecycle metadata is uniquely positioned to surface *what was excluded and why* -- a signal no static-store competitor has.
+**PREMISE CORRECTION (measured 2026-08-24).** This item was not unbuilt: it shipped in v1.12.13 and was refined in v1.13.3 with passing tests. Driving the live binary showed it could not FIRE on the CLI path - cmdRecall derived droppedByBudget from the post-search --limit slice, after the search had already truncated, so the counter read 0 while hundreds of candidates vanished and the guard suppressed the line. The tests passed because they exercise api.recall, the path that was already correct. v1.38.0 derives the count arithmetically so the published invariant (totalCandidates == droppedPreRank + droppedByBudget + returned) holds by construction, including on --hops recalls where graph expansion adds out-of-pool rows. **Success (met):** the Cutoff line prints on truncated --why recalls, pinned by tests verified red against the pre-fix code on the budget, limit and graph paths. **Not done, deliberate:** the paired tier-1 micro-eval (decision-quality non-regression) was not run this episode; the accounting-convention change is documented in the CHANGELOG including cross-surface non-comparability.
+
 **Effort:** 1-2d. **Success:** `recall --why` output includes a suppressed-tier breakdown on every truncated recall; integration test asserts the breakdown appears whenever total_candidates > budget; paired tier-1 micro-eval shows agent decision quality non-regression with the breakdown injected.
 
 ---

--- a/docs/plans/2026-08-24-c5-cli-cutoff-counters.md
+++ b/docs/plans/2026-08-24-c5-cli-cutoff-counters.md
@@ -1,0 +1,91 @@
+# C5: the CLI cutoff line never fires
+
+Episode `01M0SB83EW4JF1RCFC1GAWTAQN`. Roadmap Track C, C5.
+
+## Problem, measured on the live v1.37.0 binary
+
+`hippo recall` drops almost every candidate and tells the caller nothing. Six
+measurements, three queries, two budgets:
+
+| query | budget | returned | totalCandidates | droppedByBudget | droppedPreRank |
+|---|---|---|---|---|---|
+| test | 20 | 1 | 192 | 0 | 0 |
+| test | 100 | 6 | 192 | 0 | 0 |
+| memory | 20 | 1 | 400 | 0 | 0 |
+| memory | 100 | 3 | 400 | 0 | 0 |
+| the | 20 | 1 | 400 | 0 | 0 |
+| the | 100 | 1 | 400 | 0 | 0 |
+
+397 of 400 candidates vanish with every counter at zero. The print is guarded
+on `clauses.length > 0` (`cli.ts:1998`), so the `Cutoff:` line never appears.
+
+C5 exists to stop an agent treating a truncated set as the whole picture. On
+the CLI path - the one agents actually use - that failure is still shipping.
+
+## Why the counters are zero
+
+`cmdRecall` computes `droppedByBudget` from the post-search `--limit` slice
+(`cli.ts:1547`, `results.length - limit`). But `results` arrives from the
+search call ALREADY ranked and truncated to a handful, so `limit <
+results.length` is false and the counter stays 0. The counter runs after the
+cut it is meant to measure.
+
+`api.recall` measures the same concept correctly (`api.ts:783`,
+`entries.length - baseSlice.length`) because it slices the full candidate list
+itself. Two pipelines, one correct, and only the correct one has tests
+(`api-recall-suppression-summary`, `http-recall-suppression-summary`). Nothing
+tests the CLI path's summary - which is why this survived two refinement
+rounds of C5.
+
+## The accounting decision, stated explicitly
+
+`cli.ts:977-980` documents a v1 convention: *"Search-engine internal drops
+(scored-to-zero rows that hybridSearch/physicsSearch returns fewer of) are NOT
+counted in v1 - they are part of the rank step, not a filter."*
+
+That convention is why the gap is unreported. This plan CHANGES it for
+`droppedByBudget` only: rank-step drops are counted as budget drops.
+
+Rationale: `dropped_pre_rank` keeps its meaning exactly (filters, not ranking),
+so the documented distinction survives. What changes is that "loaded 400,
+showed 3" stops being invisible. The user-facing failure is real whichever
+bucket is philosophically correct - an agent seeing 3 of 400 with no signal is
+the exact WYSIATI harm C5 was built to prevent.
+
+## The invariant (this is the acceptance criterion)
+
+For every recall, the candidate accounting must close:
+
+    totalCandidates == droppedPreRank + droppedByBudget + returned
+
+Today it does not: 400 != 0 + 0 + 3. This is falsifiable, easy to assert, and
+catches arithmetic slips that prose review would not.
+
+Care needed: `droppedPreRankCountCmd` accumulates at BOTH pre-search sites
+(`cli.ts:998, 1021, 1026` on the entry lists) and post-search sites (`1270,
+1528, 1541` on `results`). The new budget count must not double-count those.
+
+## Tasks
+
+- **T1** Compute `droppedByBudgetCountCmd` so the invariant closes: everything
+  lost that was not attributed to a pre-rank filter. Keep the existing
+  `--limit` slice drop included.
+- **T2** Update the v1 convention comment to state the new accounting, and WHY
+  (the line never fired otherwise). A stale comment is how this stayed hidden.
+- **T3** Tests: the invariant asserted over several budgets against a real
+  store; a test that the `Cutoff:` line actually PRINTS on a truncated CLI
+  recall (the specific gap - no existing test drives the CLI summary).
+
+## Success criteria
+
+1. The invariant holds across at least three budget/query combinations.
+2. `hippo recall <q> --budget <small> --why` prints a `Cutoff:` line naming
+   the dropped count.
+3. `droppedPreRank` semantics unchanged; the api and http paths untouched and
+   their existing tests still pass.
+4. Full suite green.
+
+## Not in scope
+
+- Changing `api.recall` or the http path. They already report correctly.
+- Re-tuning what the search engine drops. This is about REPORTING the drop.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.37.0",
+  "version": "1.38.0",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",
   "openclaw": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -975,9 +975,21 @@ async function cmdRecall(
 
   // v1.12.13 / C5 — WYSIATI counters. Track filter activity per the plan v3
   // Task 3 mapping table. dropped_pre_rank is the SUM of all non-budget
-  // filter drops (pre-rank AND post-rank). Search-engine internal drops
-  // (scored-to-zero rows that hybridSearch/physicsSearch returns fewer of)
-  // are NOT counted in v1 — they are part of the rank step, not a filter.
+  // filter drops (pre-rank AND post-rank); its meaning is unchanged by C5.
+  //
+  // C5 (2026-08-24): search-engine internal drops (scored-to-zero rows that
+  // hybridSearch/physicsSearch returns fewer of than they were given) now
+  // count toward droppedByBudget, not "not counted at all" as the old v1
+  // convention had it. That old convention is exactly why the `Cutoff:` line
+  // never printed: cmdRecall measured droppedByBudget from `results.length -
+  // limit` (cli.ts ~1547) AFTER the search call, but `results` had already
+  // been ranked and truncated by the search engine to a handful of rows, so
+  // `limit < results.length` was almost always false and the counter stayed
+  // 0 while hundreds of candidates silently vanished (see the plan's measured
+  // table: 397 of 400 candidates gone, every counter reading 0). droppedByBudget
+  // is now derived as "everything not attributed to a named pre-rank filter",
+  // computed after the final `--limit` slice — see the definition near
+  // line ~1545 for the exact formula and the double-count argument.
   // totalCandidates = post-SQL-predicate count (api.recall parity: measured
   // after loadRecallSearchEntries, before the JS scope filter). NOTE the
   // v1.12.13 accounting convention: SQL-excluded rows (quarantine + the
@@ -1541,12 +1553,32 @@ async function cmdRecall(
     droppedPreRankCountCmd += beforeLayerFilter - results.length;
   }
 
-  // v1.12.13 / C5 — WYSIATI dropped_by_budget counter (final limit cut).
-  let droppedByBudgetCountCmd = 0;
+  // v1.12.13 / C5 — WYSIATI dropped_by_budget counter. Apply the final
+  // `--limit` slice first, then derive the count ARITHMETICALLY as
+  // "everything lost that droppedPreRank did not already claim":
+  //
+  //   droppedByBudget = totalCandidates - droppedPreRank - returned
+  //
+  // This is the invariant the plan requires (totalCandidates == droppedPreRank
+  // + droppedByBudget + returned) restated as an assignment, so it holds by
+  // construction rather than by two counters happening to agree. It also
+  // cannot double-count the post-search droppedPreRank sites (--filter-
+  // conflicts, --outcome, --layer, ~1270/1528/1541): those are subtracted
+  // once here, not re-counted, because this line does not re-walk any filter
+  // — it only compares the two totals already tracked above. Everything left
+  // over — search-engine internal rank-step drops AND the `--limit` slice
+  // itself — lands in droppedByBudget, per the C5 accounting change in the
+  // comment near line ~976. Clamped at 0 as a defensive floor: if a future
+  // pipeline change ever returns MORE rows than totalCandidates minus
+  // droppedPreRank (should not happen), report "nothing dropped" rather than
+  // a negative count.
   if (limit < results.length) {
-    droppedByBudgetCountCmd = results.length - limit;
     results = results.slice(0, limit);
   }
+  const droppedByBudgetCountCmd = Math.max(
+    0,
+    totalCandidatesCountCmd - droppedPreRankCountCmd - results.length,
+  );
 
   // v0.33 / J1 — CLI per-pipeline anchoring detector. Each pipeline (api.recall,
   // cmdRecall, MCP) computes its own AnchoringHint via the shared detectAnchoring

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -998,6 +998,9 @@ async function cmdRecall(
   // defense-in-depth (LIKE/regex divergence, exact-mode mismatch).
   const totalCandidatesCountCmd = localEntries.length + globalEntries.length;
   let droppedPreRankCountCmd = 0;
+  // Graph expansion adds candidates AFTER totalCandidatesCountCmd is taken,
+  // so they are folded back in before the budget residual is derived.
+  let graphAddedCountCmd = 0;
 
   // v1.25.0: JS half of the recall scope rule (private-scope regex deny with
   // explicit-request unlock), via the canonical helper — do not inline a
@@ -1187,6 +1190,14 @@ async function cmdRecall(
       }
     }
     if (hops > 0) {
+      // graphExpandRecall can SURFACE rows that were never in the lexical
+      // candidate pool (a graph neighbour reached by entity edge, not by
+      // query match), and totalCandidatesCountCmd was snapshotted before the
+      // search. Without this the derived budget count goes negative, clamps
+      // to 0, and the accounting silently breaks: 1 candidate, 2 returned,
+      // 0 drops. Found independently by two reviewers. Count the additions
+      // so the invariant holds on graph-expanded recalls too.
+      const beforeGraphExpand = results.length;
       results = graphExpandRecall(results, {
         hops,
         maxNeighbors,
@@ -1201,6 +1212,8 @@ async function cmdRecall(
           ? { requested: recallExplicitScope, additive: true }
           : {},
       });
+      // Rows the graph surfaced that the lexical pool never held.
+      graphAddedCountCmd += Math.max(0, results.length - beforeGraphExpand);
     }
   }
 
@@ -1577,7 +1590,7 @@ async function cmdRecall(
   }
   const droppedByBudgetCountCmd = Math.max(
     0,
-    totalCandidatesCountCmd - droppedPreRankCountCmd - results.length,
+    totalCandidatesCountCmd + graphAddedCountCmd - droppedPreRankCountCmd - results.length,
   );
 
   // v0.33 / J1 — CLI per-pipeline anchoring detector. Each pipeline (api.recall,
@@ -2022,7 +2035,11 @@ async function cmdRecall(
   if (showWhy) {
     const s = cmdSuppressionSummary;
     const clauses: string[] = [];
-    if (s.droppedByBudget > 0) clauses.push(`${s.droppedByBudget} dropped to fit limit`);
+    // "dropped to fit limit" pointed at the wrong control: the residual covers
+    // search-ranking and token-budget drops too, and fires even when --limit
+    // was never passed. Measured: `recall --budget 20 --why` printed "39
+    // dropped to fit limit" with no --limit flag in the command at all.
+    if (s.droppedByBudget > 0) clauses.push(`${s.droppedByBudget} not shown (rank, budget or limit)`);
     if (s.droppedPreRank > 0) clauses.push(`${s.droppedPreRank} filtered pre-rank`);
     if (s.summarySubstitutionsAdded > 0) clauses.push(`${s.summarySubstitutionsAdded} summary substitutions added`);
     if (s.freshTailAdded > 0) clauses.push(`${s.freshTailAdded} fresh-tail added`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1197,7 +1197,12 @@ async function cmdRecall(
       // to 0, and the accounting silently breaks: 1 candidate, 2 returned,
       // 0 drops. Found independently by two reviewers. Count the additions
       // so the invariant holds on graph-expanded recalls too.
-      const beforeGraphExpand = results.length;
+      // GROSS, not net. graphExpandRecall both adds neighbours AND evicts weak
+      // base rows in one call (graph-recall.ts:285), so a net delta of 0 hides
+      // 3 added + 3 evicted: the additions escape the candidate total and the
+      // evictions escape the drop count, and the Cutoff line goes silent again.
+      // Compare ID sets so both directions are counted.
+      const beforeGraphIds = new Set(results.map((r) => r.entry.id));
       results = graphExpandRecall(results, {
         hops,
         maxNeighbors,
@@ -1213,7 +1218,9 @@ async function cmdRecall(
           : {},
       });
       // Rows the graph surfaced that the lexical pool never held.
-      graphAddedCountCmd += Math.max(0, results.length - beforeGraphExpand);
+      for (const r of results) {
+        if (!beforeGraphIds.has(r.entry.id)) graphAddedCountCmd++;
+      }
     }
   }
 
@@ -1633,7 +1640,13 @@ async function cmdRecall(
   // interference; query_repeat is a re-ask, not memory competition).
   const cmdSuppressedByInterference = cmdAnchoringHint?.reason === 'memory_dominance' ? 1 : 0;
   const cmdSuppressionSummary = api.buildSuppressionSummary({
-    totalCandidates: totalCandidatesCountCmd,
+    // PUBLISHED total includes graph-surfaced rows. Folding graphAdded into
+    // the derivation but not into the reported total made the invariant hold
+    // internally and break externally by exactly that count: JSON consumers
+    // saw total != preRank + byBudget + returned, and the text line could
+    // read "showing 8 of 10" having actually considered 12. The number a
+    // caller sees must be the number the arithmetic used.
+    totalCandidates: totalCandidatesCountCmd + graphAddedCountCmd,
     droppedPreRank: droppedPreRankCountCmd,
     droppedByBudget: droppedByBudgetCountCmd,
     summarySubstitutionsAdded: 0,

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.37.0';
+export const PACKAGE_VERSION = '1.38.0';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/c5-cli-cutoff-counters.test.ts
+++ b/tests/c5-cli-cutoff-counters.test.ts
@@ -29,7 +29,9 @@ import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { initStore } from '../src/store.js';
+import { initStore, writeEntry } from '../src/store.js';
+import { createMemory, Layer } from '../src/memory.js';
+import { insertEntity, insertRelation } from '../src/graph.js';
 import { remember, type Context } from '../src/api.js';
 
 const CLI = join(process.cwd(), 'dist', 'src', 'cli.js');
@@ -172,6 +174,71 @@ describe('C5: cmdRecall candidate accounting closes (2026-08-24)', () => {
   });
 });
 
+
+
+describe('C5: graph-expanded recall keeps the published accounting honest', () => {
+  let home: string;
+  afterEach(() => {
+    if (home) rmSync(home, { recursive: true, force: true });
+  });
+
+  // The graph fix has to be proven by EXECUTION, with a real edge. Two
+  // earlier attempts to verify it used fixtures with no entity relations, so
+  // the hops path added nothing and the checks were vacuous. This seeds the
+  // same shape as tests/graph-recall.test.ts: B is lexically orthogonal to
+  // the query and reachable only through a supersedes edge.
+  it('a row surfaced by edge is included in the published total and the invariant closes', () => {
+    // Same root convention as makeEnv: the store ROOT is the .hippo directory
+    // itself. initStore(home) with a bare dir leaves cwd/.hippo uninitialized
+    // and the CLI exits "No .hippo directory found".
+    home = mkdtempSync(join(tmpdir(), 'c5-graph-'));
+    const root = join(home, '.hippo');
+    const globalRoot = join(home, 'global-hippo');
+    mkdirSync(globalRoot, { recursive: true });
+    initStore(root);
+    const T = 'default';
+    const mk = (text: string) => {
+      const m = createMemory(text, {
+        tags: [], layer: Layer.Semantic, confidence: 'verified', source: 'test', tenantId: T,
+      });
+      writeEntry(root, m, { actor: 'test' });
+      return m;
+    };
+    const a = mk('decision quokka about cache invalidation strategy');
+    const b = mk('wholly unrelated wording xyzzy plugh frobnicate');
+    const ea = insertEntity(root, T, { entityType: 'decision', name: 'A', memoryId: a.id }).id;
+    const eb = insertEntity(root, T, { entityType: 'decision', name: 'B', memoryId: b.id }).id;
+    insertRelation(root, T, { fromEntityId: eb, toEntityId: ea, relType: 'supersedes', memoryId: b.id });
+
+    // cwd is `home` so no stray local store joins the recall: this test pins
+    // the SINGLE-store graph case. (A worktree cwd would silently merge its
+    // local .hippo - remember() writes to cwd/.hippo, HIPPO_HOME only moves
+    // the global store. That exact confusion made two earlier probes invalid.)
+    const raw = execFileSync(
+      'node',
+      [CLI, 'recall', 'quokka', '--hops', '1', '--json'],
+      {
+        cwd: home,
+        env: { ...process.env, HIPPO_HOME: globalRoot, HIPPO_TENANT: T, HIPPO_SKIP_AUTO_INTEGRATIONS: '1' },
+        encoding: 'utf8',
+      },
+    );
+    const d = JSON.parse(raw.slice(raw.indexOf('{')));
+    const s = d.suppressionSummary as SuppressionSummary;
+    const rows = (d.memories ?? d.results ?? []) as Array<{ entry?: { id: string }; id?: string }>;
+    const ids = rows.map((r) => (r.entry ?? r).id);
+
+    // the edge must actually fire, or this test proves nothing
+    expect(ids, 'graph neighbour must be surfaced by edge').toContain(b.id);
+    // the graph-added row must be inside the PUBLISHED total, not only the
+    // internal arithmetic - this is what broke: total said 1, returned said 2
+    expect(
+      s.totalCandidates,
+      'published invariant must close when the graph adds an out-of-pool row',
+    ).toBe(s.droppedPreRank + s.droppedByBudget + rows.length);
+    expect(s.totalCandidates, 'total must count the edge-surfaced row').toBeGreaterThanOrEqual(rows.length);
+  });
+});
 
 describe('C5: BUDGET-driven truncation is counted (the measured failure)', () => {
   let env: TestEnv;

--- a/tests/c5-cli-cutoff-counters.test.ts
+++ b/tests/c5-cli-cutoff-counters.test.ts
@@ -1,0 +1,181 @@
+// tests/c5-cli-cutoff-counters.test.ts
+//
+// C5 (2026-08-24 follow-up, episode 01M0SB83EW4JF1RCFC1GAWTAQN): the CLI
+// `hippo recall` path dropped almost every candidate and reported it via
+// counters that never moved. `droppedByBudgetCountCmd` was computed from
+// `results.length - limit` (src/cli.ts) AFTER the search call, but `results`
+// had already been ranked and truncated by hybridSearch/physicsSearch, so
+// the counter read 0 while hundreds of candidates silently vanished. The
+// `Cutoff:` line (guarded on `clauses.length > 0`) never printed as a result.
+//
+// This suite asserts the fix at the level the plan's acceptance criteria
+// name:
+//   1. The invariant `totalCandidates == droppedPreRank + droppedByBudget +
+//      returned` holds across several --limit/query combinations, driven
+//      through the real CLI subprocess against a real seeded store.
+//   2. The `Cutoff:` line actually PRINTS in CLI text output when a recall
+//      is truncated (the specific gap: no prior test drove the CLI summary
+//      output at all).
+//   3. The line does NOT print when nothing was truncated (guard against
+//      always-on noise).
+//
+// Same isolation harness as tests/b3-retrieval-policy.test.ts: per-test cwd
+// tempdir, separate HIPPO_HOME global root, HIPPO_SKIP_AUTO_INTEGRATIONS=1,
+// initStore + api.remember for seeding, execFileSync against dist/src/cli.js
+// for the recall itself (real DB, real CLI, project convention).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { initStore } from '../src/store.js';
+import { remember, type Context } from '../src/api.js';
+
+const CLI = join(process.cwd(), 'dist', 'src', 'cli.js');
+
+interface TestEnv {
+  cwd: string;
+  hippoRoot: string;
+  globalRoot: string;
+}
+
+function makeEnv(prefix: string): TestEnv {
+  const cwd = mkdtempSync(join(tmpdir(), `hippo-c5-${prefix}-`));
+  const hippoRoot = join(cwd, '.hippo');
+  const globalRoot = join(cwd, 'global-hippo');
+  mkdirSync(globalRoot, { recursive: true });
+  initStore(hippoRoot);
+  return { cwd, hippoRoot, globalRoot };
+}
+
+function ctxFor(root: string): Context {
+  return { hippoRoot: root, tenantId: 'default', actor: { subject: 'c5-test', role: 'admin' } };
+}
+
+/** Seed `count` distinct memories that all match `keyword`. */
+function seedMatchingMemories(env: TestEnv, keyword: string, count: number): void {
+  const ctx = ctxFor(env.hippoRoot);
+  for (let i = 0; i < count; i++) {
+    remember(ctx, { content: `${keyword} candidate number ${i} carries unique detail ${i}` });
+  }
+}
+
+interface SuppressionSummary {
+  totalCandidates: number;
+  droppedPreRank: number;
+  droppedByBudget: number;
+}
+
+function recallJson(
+  env: TestEnv,
+  query: string,
+  limit: number,
+): { results: unknown[]; suppressionSummary: SuppressionSummary } {
+  const raw = execFileSync(
+    'node',
+    [CLI, 'recall', query, '--json', '--limit', String(limit)],
+    {
+      cwd: env.cwd,
+      env: {
+        ...process.env,
+        HIPPO_HOME: env.globalRoot,
+        HIPPO_TENANT: 'default',
+        HIPPO_SKIP_AUTO_INTEGRATIONS: '1',
+      },
+      encoding: 'utf8',
+    },
+  );
+  const start = raw.indexOf('{');
+  return JSON.parse(raw.slice(start));
+}
+
+function recallText(env: TestEnv, query: string, limit: number): string {
+  return execFileSync(
+    'node',
+    [CLI, 'recall', query, '--why', '--limit', String(limit)],
+    {
+      cwd: env.cwd,
+      env: {
+        ...process.env,
+        HIPPO_HOME: env.globalRoot,
+        HIPPO_TENANT: 'default',
+        HIPPO_SKIP_AUTO_INTEGRATIONS: '1',
+      },
+      encoding: 'utf8',
+    },
+  );
+}
+
+describe('C5: cmdRecall candidate accounting closes (2026-08-24)', () => {
+  let env: TestEnv;
+
+  afterEach(() => {
+    if (env?.cwd) rmSync(env.cwd, { recursive: true, force: true });
+  });
+
+  it.each([
+    { keyword: 'widgetalpha', seeded: 30, limit: 5 },
+    { keyword: 'widgetbeta', seeded: 30, limit: 15 },
+    { keyword: 'widgetgamma', seeded: 12, limit: 4 },
+  ])(
+    'totalCandidates == droppedPreRank + droppedByBudget + returned ($keyword, limit=$limit)',
+    ({ keyword, seeded, limit }) => {
+      env = makeEnv(keyword);
+      seedMatchingMemories(env, keyword, seeded);
+
+      const out = recallJson(env, keyword, limit);
+      const s = out.suppressionSummary;
+      const returned = out.results.length;
+
+      expect(s.totalCandidates).toBe(s.droppedPreRank + s.droppedByBudget + returned);
+      // Sanity: the invariant should not be trivially true by everything
+      // being zero — this recall must actually have candidates and a cut.
+      expect(s.totalCandidates).toBeGreaterThanOrEqual(seeded);
+      expect(returned).toBeLessThanOrEqual(limit);
+    },
+  );
+
+  it('invariant also holds when nothing is truncated (droppedByBudget == 0)', () => {
+    env = makeEnv('notrunc');
+    seedMatchingMemories(env, 'widgetdelta', 5);
+
+    const out = recallJson(env, 'widgetdelta', 100);
+    const s = out.suppressionSummary;
+    const returned = out.results.length;
+
+    expect(s.totalCandidates).toBe(s.droppedPreRank + s.droppedByBudget + returned);
+    expect(s.droppedByBudget).toBe(0);
+  });
+});
+
+describe('C5: the `Cutoff:` line prints on a truncated CLI recall (2026-08-24)', () => {
+  let env: TestEnv;
+
+  afterEach(() => {
+    if (env?.cwd) rmSync(env.cwd, { recursive: true, force: true });
+  });
+
+  it('prints "Cutoff:" naming the dropped count when --limit truncates the result set', () => {
+    env = makeEnv('print-gap');
+    seedMatchingMemories(env, 'widgetepsilon', 30);
+
+    const output = recallText(env, 'widgetepsilon', 5);
+
+    // This is the specific gap the plan names: no prior test drove the CLI
+    // summary output, so the line's guard (`clauses.length > 0`) being
+    // permanently false went uncaught. Assert the exact shape the line
+    // takes (cli.ts ~1998: "Cutoff: showing N of M candidates; ... dropped
+    // to fit limit ...").
+    expect(output).toMatch(/^Cutoff: showing \d+ of \d+ candidates;.*dropped to fit limit/m);
+  });
+
+  it('does NOT print "Cutoff:" when the recall is not truncated (no always-on noise)', () => {
+    env = makeEnv('no-print');
+    seedMatchingMemories(env, 'widgetzeta', 3);
+
+    const output = recallText(env, 'widgetzeta', 100);
+
+    expect(output).not.toMatch(/^Cutoff:/m);
+  });
+});

--- a/tests/c5-cli-cutoff-counters.test.ts
+++ b/tests/c5-cli-cutoff-counters.test.ts
@@ -67,6 +67,29 @@ interface SuppressionSummary {
   droppedByBudget: number;
 }
 
+function recallJsonBudget(
+  env: TestEnv,
+  query: string,
+  budget: number,
+): { results: unknown[]; suppressionSummary: SuppressionSummary } {
+  const raw = execFileSync(
+    'node',
+    [CLI, 'recall', query, '--json', '--budget', String(budget)],
+    {
+      cwd: env.cwd,
+      env: {
+        ...process.env,
+        HIPPO_HOME: env.globalRoot,
+        HIPPO_TENANT: 'default',
+        HIPPO_SKIP_AUTO_INTEGRATIONS: '1',
+      },
+      encoding: 'utf8',
+    },
+  );
+  const start = raw.indexOf('{');
+  return JSON.parse(raw.slice(start));
+}
+
 function recallJson(
   env: TestEnv,
   query: string,
@@ -146,6 +169,40 @@ describe('C5: cmdRecall candidate accounting closes (2026-08-24)', () => {
 
     expect(s.totalCandidates).toBe(s.droppedPreRank + s.droppedByBudget + returned);
     expect(s.droppedByBudget).toBe(0);
+  });
+});
+
+
+describe('C5: BUDGET-driven truncation is counted (the measured failure)', () => {
+  let env: TestEnv;
+  afterEach(() => {
+    if (env?.cwd) rmSync(env.cwd, { recursive: true, force: true });
+  });
+
+  // THE GAP THIS FILE ORIGINALLY MISSED. Every other test here passes
+  // --limit, and the OLD code counted the --limit slice correctly, so those
+  // tests pass on master and prove only that the wording changed.
+  //
+  // The measured production failure was budget/rank driven with NO --limit:
+  // totalCandidates 400, returned 3, droppedByBudget 0, Cutoff line silent.
+  // This is the case that must go red without the derivation fix.
+  it('reports drops when a small --budget truncates and --limit is never passed', () => {
+    env = makeEnv('budget-gap');
+    seedMatchingMemories(env, 'widgetbudget', 40);
+
+    const out = recallJsonBudget(env, 'widgetbudget', 40);
+    const s = out.suppressionSummary;
+    const returned = out.results.length;
+
+    expect(returned, 'a small budget must truncate').toBeLessThan(s.totalCandidates);
+    expect(
+      s.droppedByBudget,
+      'budget/rank drops must be counted - this read 0 in production',
+    ).toBeGreaterThan(0);
+    expect(
+      s.totalCandidates,
+      'published invariant must close on the budget path too',
+    ).toBe(s.droppedPreRank + s.droppedByBudget + returned);
   });
 });
 

--- a/tests/c5-cli-cutoff-counters.test.ts
+++ b/tests/c5-cli-cutoff-counters.test.ts
@@ -164,10 +164,17 @@ describe('C5: the `Cutoff:` line prints on a truncated CLI recall (2026-08-24)',
 
     // This is the specific gap the plan names: no prior test drove the CLI
     // summary output, so the line's guard (`clauses.length > 0`) being
-    // permanently false went uncaught. Assert the exact shape the line
-    // takes (cli.ts ~1998: "Cutoff: showing N of M candidates; ... dropped
-    // to fit limit ...").
-    expect(output).toMatch(/^Cutoff: showing \d+ of \d+ candidates;.*dropped to fit limit/m);
+    // permanently false went uncaught.
+    //
+    // The wording is asserted deliberately. It used to read "dropped to fit
+    // limit", which named a control the caller often never passed - review
+    // caught it printing that for a `--budget 20` command with no --limit
+    // flag at all. The residual covers rank, budget AND limit, so the text
+    // must not single one out.
+    expect(output).toMatch(/^Cutoff: showing \d+ of \d+ candidates;/m);
+    expect(output).toMatch(/not shown \(rank, budget or limit\)/);
+    expect(output, 'must not name a control the caller may never have passed')
+      .not.toMatch(/dropped to fit limit/);
   });
 
   it('does NOT print "Cutoff:" when the recall is not truncated (no always-on noise)', () => {


### PR DESCRIPTION
Roadmap Track C, C5. Episode `01M0SB83EW4JF1RCFC1GAWTAQN`. Six commits.

## The finding

C5 shipped in v1.12.13, was refined in v1.13.3, has passing tests. Reading the source says done. **Driving the shipped v1.37.0 binary says it never fires**: six measurements across three queries and two budgets, `totalCandidates` 192 to 400, 1 to 6 returned, `droppedByBudget` 0 every time. The `clauses.length > 0` guard then suppresses the `Cutoff:` line entirely - the exact WYSIATI failure C5 exists to prevent.

## Root cause

`cmdRecall` computed `droppedByBudget` from the post-search `--limit` slice, but `results` arrives already ranked and truncated. The counter ran **after** the cut it measured. `api.recall` slices the full list itself, and only that path had tests.

## Fix

Derived, not accumulated, computed after the final slice:

```
droppedByBudget = max(0, totalCandidates + graphAdded - droppedPreRank - returned)
```

so the published invariant holds by construction: `totalCandidates == droppedPreRank + droppedByBudget + returned`.

## Review findings folded in (2 codex rounds, Sonnet reviewer, Fable ship gate)

- `graphExpandRecall` both adds and evicts in one call - net-length counting hid 3-added-3-evicted as zero. Counted by ID set now, and the graph-surfaced rows are included in the **published** total, not only the internal arithmetic.
- The message read "N dropped to fit limit" even with no `--limit` flag passed. Now "N not shown (rank, budget or limit)".
- The original test suite exercised only `--limit` - which the old code counted correctly - so it **passed on master**. The budget-driven case (the measured failure) and a real-graph-edge hops case are now committed, each verified red against origin/master ("expected 0 to be greater than 0" / "expected 1 to be 2").

## Verified end to end, same store both ways

```
before   Found 1 memories (17 tokens) for: "alpha"
after    Cutoff: showing 1 of 40 candidates; 39 not shown (rank, budget or limit).
         Found 1 memories (17 tokens) for: "alpha"
```

Invariant closes on the budget path (20/60/200), the limit path, and the hops path with a genuine entity edge. `api.recall` and http untouched; their tests pass unchanged.

## Accounting change, stated deliberately

`cli.ts:977` documented that rank-step drops are not counted in v1. That convention is why the line was unfireable, so it changes for `droppedByBudget` only; `dropped_pre_rank` keeps its exact meaning. Counts stay per-path honest reports - CLI and `api.recall` figures are not comparable across surfaces, and the CHANGELOG says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)