### PR TITLE
feat: auth-gated non-loopback serve + AML evaluation deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the image build context free of local state and secrets. The build
+# stage compiles from source (npm run build:all), so host artifacts are
+# never needed.
+.git
+node_modules
+dist
+coverage
+.hippo
+.env
+.env.*
+*.log
+.devrl-backlog.md

--- a/deploy/aml/Dockerfile
+++ b/deploy/aml/Dockerfile
@@ -1,0 +1,37 @@
+# AML (agentmemoryleaderboard.ai) evaluation deployment for hippo-memory.
+#
+# Runs hippo's own HTTP server with bearer auth required. The store lives on a
+# persistent volume at /data (the store ROOT is /data/.hippo - the .hippo
+# directory IS the root; see deploy/aml/README.md for the layout gotchas).
+#
+# Embeddings run on the LOCAL provider (@huggingface/transformers) - the
+# zero-dependency default hippo ships to every user. This is deliberate for
+# the open-source leaderboard category: the deployment benchmarks the system
+# as installed, with no external embedding API, and is reproducible by anyone
+# from this Dockerfile alone.
+
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+# --ignore-scripts: the postinstall hook is a dist/ trampoline whose script
+# file is not in this layer yet; it no-ops on fresh builds regardless.
+RUN npm ci --ignore-scripts
+COPY . .
+RUN npm run build:all
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/package.json /app/package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/bin ./bin
+COPY deploy/aml/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# /data is the Fly volume mount; the hippo store root is /data/.hippo.
+WORKDIR /data
+ENV HIPPO_REQUIRE_AUTH=1
+ENV HIPPO_PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/aml/README.md
+++ b/deploy/aml/README.md
@@ -1,0 +1,57 @@
+# AML evaluation deployment
+
+Public Add/Search endpoint for the [Agent Memory Leaderboard](https://agentmemories.ai)
+(open-source methods category). This directory is the complete, reproducible
+deployment: anyone can stand up the same endpoint from these three files.
+
+## What AML calls
+
+AML's protocol requires exactly two operations. hippo serves them natively:
+
+| AML operation | hippo route |
+|---|---|
+| Add | `POST /v1/memories` |
+| Search | `GET /v1/memories?q=<query>&limit=<n>` |
+
+Auth is a bearer token validated against a store-resident API key
+(scrypt-hashed at rest, tenant-scoped). Health: `GET /health`.
+
+An adapter translating AML's exact request/response schema onto these routes
+lands in this directory once written against the published API guide
+(https://agentmemories.ai/api-guide). If the schemas already align, no adapter
+is needed and this note gets replaced by that finding.
+
+## Configuration facts that matter for reproduction
+
+- **Embeddings: the local default** (`@huggingface/transformers`), no API key.
+  The deployment benchmarks hippo as installed, not a hosted-embedder variant.
+  A frontier-embedder configuration would be a separate, separately-labeled
+  leaderboard entry per AML's versioned-contract rules.
+- **Store root layout**: the root IS the `.hippo` directory (`/data/.hippo` on
+  the volume). `hippo init` run from `/data` creates it; `serve` resolves it
+  from the working directory.
+- **Single always-on machine, 1GB**: the local embedding model needs the
+  memory, and the ~5,000-question evaluation must not hit a cold start.
+
+## Operating it
+
+```sh
+# deploy (from the repo root)
+flyctl deploy --config deploy/aml/fly.toml --dockerfile deploy/aml/Dockerfile
+
+# mint the evaluation key (shown ONCE; hippo stores only a hash)
+fly ssh console -a hippo-aml -C "node /app/dist/src/cli.js auth create --label aml-eval --role member --json"
+
+# smoke-check from outside
+curl https://hippo-aml.fly.dev/health
+curl -H "Authorization: Bearer <key>" "https://hippo-aml.fly.dev/v1/memories?q=test"
+```
+
+## Submission state
+
+- [x] Endpoint scaffold (this directory)
+- [ ] Deploy + external smoke check
+- [ ] AML evaluation access request (https://agentmemories.ai/evaluation)
+- [ ] Compatibility smoke test with the issued AML Key
+- [ ] Full evaluation run
+- [ ] Publication review

--- a/deploy/aml/entrypoint.sh
+++ b/deploy/aml/entrypoint.sh
@@ -5,10 +5,24 @@
 # fresh volume, initialize it; on restarts the existing store persists.
 #
 # API keys are minted OUT OF BAND by the operator:
-#   fly ssh console -a hippo-aml -C "node /app/dist/src/cli.js auth create --label aml-eval --role writer --json"
+#   fly ssh console -a hippo-aml -C "node /app/dist/src/cli.js auth create --label aml-eval --role member --json"
 # The plaintext is shown exactly once; hippo stores only a scrypt hash.
 # Nothing here prints or stores a key.
 set -eu
+
+# Privilege drop: the Fly volume mounts root-owned, so first boot must chown
+# it. Do that as root, then re-exec this script as the unprivileged node user
+# via setpriv (execs in place, keeping PID 1 signal handling). Everything the
+# server creates under /data is node-owned from then on, so the non-recursive
+# chown of the mount point is sufficient.
+if [ "$(id -u)" = "0" ]; then
+  chown node:node /data
+  exec setpriv --reuid node --regid node --init-groups "$0" "$@"
+fi
+
+# setpriv changes uid but not the environment: HOME still says /root, and
+# hippo resolves its global store from $HOME. Point it at node's real home.
+export HOME=/home/node
 
 cd /data
 

--- a/deploy/aml/entrypoint.sh
+++ b/deploy/aml/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# First-boot init for the AML evaluation deployment.
+#
+# The store root is /data/.hippo (the .hippo directory IS the root). On a
+# fresh volume, initialize it; on restarts the existing store persists.
+#
+# API keys are minted OUT OF BAND by the operator:
+#   fly ssh console -a hippo-aml -C "node /app/dist/src/cli.js auth create --label aml-eval --role writer --json"
+# The plaintext is shown exactly once; hippo stores only a scrypt hash.
+# Nothing here prints or stores a key.
+set -eu
+
+cd /data
+
+if [ ! -f /data/.hippo/index.json ] && [ ! -f /data/.hippo/hippo.db ]; then
+  echo "[aml] fresh volume - initializing store at /data/.hippo"
+  node /app/dist/src/cli.js init --no-hooks --no-schedule --no-learn
+fi
+
+echo "[aml] starting hippo serve (auth required, port ${HIPPO_PORT:-8080})"
+exec node /app/dist/src/cli.js serve --host 0.0.0.0 --port "${HIPPO_PORT:-8080}"

--- a/deploy/aml/fly.toml
+++ b/deploy/aml/fly.toml
@@ -1,0 +1,40 @@
+# Fly.io app for the AML (agentmemoryleaderboard.ai) evaluation endpoint.
+#
+# Deploy from the REPO ROOT (the Dockerfile copies the whole build context):
+#   flyctl deploy --config deploy/aml/fly.toml --dockerfile deploy/aml/Dockerfile
+#
+# One always-on machine, no auto-stop: the AML evaluation drives ~5,000
+# questions against Add/Search and a cold-start mid-run would show up as
+# availability failure, not savings.
+
+app = "hippo-aml"
+primary_region = "lhr"
+
+[build]
+  dockerfile = "deploy/aml/Dockerfile"
+
+[env]
+  HIPPO_REQUIRE_AUTH = "1"
+  HIPPO_PORT = "8080"
+
+[[mounts]]
+  source = "hippo_aml_data"
+  destination = "/data"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/health"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/deploy/aml/fly.toml
+++ b/deploy/aml/fly.toml
@@ -16,6 +16,10 @@ primary_region = "lhr"
 [env]
   HIPPO_REQUIRE_AUTH = "1"
   HIPPO_PORT = "8080"
+  # Fly's edge always overwrites this header with the real client address,
+  # so the /v1 rate limiter keys per client instead of collapsing every
+  # request into the proxy's single source-IP bucket.
+  HIPPO_CLIENT_IP_HEADER = "fly-client-ip"
 
 [[mounts]]
   source = "hippo_aml_data"

--- a/src/server.ts
+++ b/src/server.ts
@@ -551,6 +551,32 @@ function buildMcpClientKey(req: IncomingMessage): string {
 }
 
 /**
+ * Rate-limit key for a request. Defaults to the socket's remote address.
+ *
+ * Behind a TLS-terminating proxy (Fly, most PaaS ingress) every socket
+ * carries the proxy's address, so per-IP buckets collapse into one global
+ * bucket that unauthenticated traffic can drain before auth runs. Set
+ * HIPPO_CLIENT_IP_HEADER to the header the proxy stamps with the real
+ * client address (fly-client-ip on Fly, which the edge always overwrites)
+ * to key buckets per client instead.
+ *
+ * Only set this when a trusted proxy fronts EVERY request: a directly
+ * reachable server honoring the header would let clients mint a fresh
+ * bucket per request and bypass the limiter entirely.
+ */
+export function clientIpForRateLimit(req: IncomingMessage): string {
+  const header = process.env.HIPPO_CLIENT_IP_HEADER?.toLowerCase();
+  if (header) {
+    const raw = req.headers[header];
+    const first = Array.isArray(raw) ? raw[0] : raw;
+    // Take the first entry of a comma-joined list (proxy chains append).
+    const ip = first?.split(',')[0]?.trim();
+    if (ip) return ip;
+  }
+  return req.socket.remoteAddress ?? 'unknown';
+}
+
+/**
  * Build a per-request Context from the Authorization header and remote
  * address. Throws HttpError(401) for invalid / missing credentials. Opens
  * the DB only when a Bearer token is present so loopback no-auth requests
@@ -697,12 +723,20 @@ async function handleRequest(
   const { method, path, query } = parseRequest(req);
 
   if (method === 'GET' && path === '/health') {
-    sendJson(res, 200, {
-      ok: true,
-      version: VERSION,
-      started_at: startedAt,
-      pid: process.pid,
-    });
+    // Loopback callers (detectServer's stale-pidfile probe reads version and
+    // pid) get the full body. Non-loopback callers get liveness only: the
+    // version string would fingerprint the build for the public internet and
+    // the pid is noise. Platform health checks only need the 200.
+    if (isLoopback(req.socket.remoteAddress)) {
+      sendJson(res, 200, {
+        ok: true,
+        version: VERSION,
+        started_at: startedAt,
+        pid: process.pid,
+      });
+    } else {
+      sendJson(res, 200, { ok: true });
+    }
     return;
   }
 
@@ -710,13 +744,13 @@ async function handleRequest(
   // (a liveness probe) and non-/v1 paths are never throttled. A 429 thrown
   // here lands in the createServer catch like any other HttpError.
   //
-  // Keyed on the socket's remote address. serve() binds loopback-only today,
-  // so in the default deployment this is effectively one global /v1 bucket,
-  // which still bounds enumeration. True per-client keying (and trusting an
-  // X-Forwarded-For only from a known proxy) belongs with the non-loopback
-  // serving that A5 v2 unlocks.
+  // Keyed on the socket's remote address by default. Behind a TLS-terminating
+  // proxy every socket carries the proxy's address, collapsing the per-IP
+  // buckets into one global bucket that pre-auth traffic can drain; set
+  // HIPPO_CLIENT_IP_HEADER there so each real client gets its own bucket
+  // (see clientIpForRateLimit).
   if (limiter && path.startsWith('/v1/')) {
-    const ip = req.socket.remoteAddress ?? 'unknown';
+    const ip = clientIpForRateLimit(req);
     if (!limiter.check(ip)) {
       throw new HttpError(429, 'rate limit exceeded');
     }
@@ -3267,8 +3301,10 @@ async function handleRequest(
  *
  * Refuses non-loopback hosts at boot (Footgun #3 from the A1 plan) unless
  * HIPPO_REQUIRE_AUTH=1 is set. The A5 v2 auth middleware (buildContextWithAuth /
- * requireAuth) has shipped and every route checks it except GET /health,
- * which is public by design for platform health checks. But the loopback
+ * requireAuth) has shipped and every route checks it except GET /health
+ * (public by design for platform health checks) and the two connector
+ * webhooks in PUBLIC_ROUTES, which are HMAC-gated by their own signing
+ * secrets and 404 when those secrets are unset. But the loopback
  * no-auth fallback inside buildContextWithAuth still admits unauthenticated
  * requests from a loopback remote address, so binding to a non-loopback host
  * is only safe once that fallback is disabled with HIPPO_REQUIRE_AUTH=1,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3265,10 +3265,16 @@ async function handleRequest(
 /**
  * Boot the HTTP daemon on host:port and write the pidfile under hippoRoot.
  *
- * Refuses non-loopback hosts at boot (Footgun #3 from the A1 plan): without
- * the A5 v2 auth middleware we have no way to gate remote requests, so we
- * fail fast rather than expose the DB to the network. Task 9 will lift this
- * restriction once Bearer-token validation lands.
+ * Refuses non-loopback hosts at boot (Footgun #3 from the A1 plan) unless
+ * HIPPO_REQUIRE_AUTH=1 is set. The A5 v2 auth middleware (buildContextWithAuth /
+ * requireAuth) has shipped and every route checks it except GET /health,
+ * which is public by design for platform health checks. But the loopback
+ * no-auth fallback inside buildContextWithAuth still admits unauthenticated
+ * requests from a loopback remote address, so binding to a non-loopback host
+ * is only safe once that fallback is disabled with HIPPO_REQUIRE_AUTH=1,
+ * which forces every request (loopback or not) through Bearer-token
+ * validation. Without that env var set, a non-loopback bind would expose the
+ * DB to the network with no auth, so we fail fast instead.
  *
  * Use port: 0 in tests to bind to an ephemeral port and read the actual
  * port back via server.address() after listen.
@@ -3277,11 +3283,11 @@ export async function serve(opts: ServeOpts): Promise<ServerHandle> {
   const host = opts.host ?? '127.0.0.1';
   const requestedPort = opts.port ?? Number(process.env.HIPPO_PORT ?? 6789);
 
-  if (!LOOPBACK_HOSTS.has(host)) {
+  if (!LOOPBACK_HOSTS.has(host) && process.env.HIPPO_REQUIRE_AUTH !== '1') {
     throw new Error(
       `Refusing to bind hippo serve to non-loopback host '${host}' without auth. ` +
-      `Remote-host serving requires the A5 v2 auth middleware (Task 9 of the A1 plan). ` +
-      `Bind to 127.0.0.1 / ::1 / localhost, or wait for auth support.`,
+      `Set HIPPO_REQUIRE_AUTH=1 to bind non-loopback; every request then requires ` +
+      `a valid API key. Bind to 127.0.0.1 / ::1 / localhost otherwise.`,
     );
   }
 

--- a/tests/serve-nonloopback-auth.test.ts
+++ b/tests/serve-nonloopback-auth.test.ts
@@ -123,3 +123,54 @@ describe('serve() non-loopback host guard', () => {
     });
   });
 });
+
+// clientIpForRateLimit: proxy-aware rate-limit keying. Behind a
+// TLS-terminating proxy every socket carries the proxy's address, so
+// HIPPO_CLIENT_IP_HEADER names the header the proxy stamps with the real
+// client address. Unset (the default), the socket address keys the bucket.
+import { clientIpForRateLimit } from '../src/server.js';
+import type { IncomingMessage } from 'node:http';
+
+function fakeReq(headers: Record<string, string | string[]>, remoteAddress = '10.0.0.9'): IncomingMessage {
+  return { headers, socket: { remoteAddress } } as unknown as IncomingMessage;
+}
+
+describe('clientIpForRateLimit', () => {
+  const saved = process.env.HIPPO_CLIENT_IP_HEADER;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.HIPPO_CLIENT_IP_HEADER;
+    else process.env.HIPPO_CLIENT_IP_HEADER = saved;
+  });
+
+  it('defaults to the socket remote address when the env var is unset', () => {
+    delete process.env.HIPPO_CLIENT_IP_HEADER;
+    expect(clientIpForRateLimit(fakeReq({ 'fly-client-ip': '203.0.113.7' }))).toBe('10.0.0.9');
+  });
+
+  it('uses the configured header when present', () => {
+    process.env.HIPPO_CLIENT_IP_HEADER = 'fly-client-ip';
+    expect(clientIpForRateLimit(fakeReq({ 'fly-client-ip': '203.0.113.7' }))).toBe('203.0.113.7');
+  });
+
+  it('matches the header case-insensitively (env var may be given uppercased)', () => {
+    process.env.HIPPO_CLIENT_IP_HEADER = 'Fly-Client-IP';
+    expect(clientIpForRateLimit(fakeReq({ 'fly-client-ip': '203.0.113.7' }))).toBe('203.0.113.7');
+  });
+
+  it('takes the first entry of a comma-joined proxy chain', () => {
+    process.env.HIPPO_CLIENT_IP_HEADER = 'x-forwarded-for';
+    expect(clientIpForRateLimit(fakeReq({ 'x-forwarded-for': '203.0.113.7, 198.51.100.2' }))).toBe('203.0.113.7');
+  });
+
+  it('takes the first value of a repeated header', () => {
+    process.env.HIPPO_CLIENT_IP_HEADER = 'x-forwarded-for';
+    expect(clientIpForRateLimit(fakeReq({ 'x-forwarded-for': ['203.0.113.7', '198.51.100.2'] }))).toBe('203.0.113.7');
+  });
+
+  it('falls back to the socket address when the header is absent or empty', () => {
+    process.env.HIPPO_CLIENT_IP_HEADER = 'fly-client-ip';
+    expect(clientIpForRateLimit(fakeReq({}))).toBe('10.0.0.9');
+    expect(clientIpForRateLimit(fakeReq({ 'fly-client-ip': '  ' }))).toBe('10.0.0.9');
+  });
+});

--- a/tests/serve-nonloopback-auth.test.ts
+++ b/tests/serve-nonloopback-auth.test.ts
@@ -1,0 +1,125 @@
+// tests/serve-nonloopback-auth.test.ts
+//
+// serve()'s non-loopback guard used to refuse EVERY non-loopback host
+// unconditionally, citing the A5 v2 auth middleware as "not yet built".
+// That middleware (buildContextWithAuth / requireAuth in src/server.ts) has
+// since shipped: every route except GET /health goes through it. This suite
+// asserts the updated guard:
+//   1. still refuses a non-loopback bind by default (no auth = no bind),
+//   2. allows a non-loopback bind when HIPPO_REQUIRE_AUTH=1, and once bound,
+//      every route behaves exactly as the Bearer-lockdown regime promises
+//      (public /health, 401 without a token, 200 with a valid one, and the
+//      created row is actually retrievable through the authed path),
+//   3. the loopback default path is unaffected (no regression).
+//
+// Store-root convention follows tests/c5-cli-cutoff-counters.test.ts's
+// makeEnv: the store root passed to initStore/serve IS the .hippo directory
+// itself, not its parent.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey } from '../src/auth.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+describe('serve() non-loopback host guard', () => {
+  let hippoRoot: string;
+  let handle: ServerHandle | undefined;
+  const savedRequireAuth = process.env.HIPPO_REQUIRE_AUTH;
+
+  beforeEach(() => {
+    hippoRoot = join(mkdtempSync(join(tmpdir(), 'hippo-nla-')), '.hippo');
+    initStore(hippoRoot);
+    delete process.env.HIPPO_REQUIRE_AUTH;
+  });
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.stop();
+      handle = undefined;
+    }
+    if (savedRequireAuth === undefined) {
+      delete process.env.HIPPO_REQUIRE_AUTH;
+    } else {
+      process.env.HIPPO_REQUIRE_AUTH = savedRequireAuth;
+    }
+    rmSync(hippoRoot, { recursive: true, force: true });
+  });
+
+  it('rejects a non-loopback bind without HIPPO_REQUIRE_AUTH', async () => {
+    await expect(serve({ hippoRoot, host: '0.0.0.0', port: 0 })).rejects.toThrow(
+      /Set HIPPO_REQUIRE_AUTH=1 to bind non-loopback/,
+    );
+  });
+
+  it('loopback bind still works without HIPPO_REQUIRE_AUTH (no regression)', async () => {
+    handle = await serve({ hippoRoot, host: '127.0.0.1', port: 0 });
+    const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+    expect(res.status).toBe(200);
+  });
+
+  describe('with HIPPO_REQUIRE_AUTH=1', () => {
+    beforeEach(async () => {
+      process.env.HIPPO_REQUIRE_AUTH = '1';
+      handle = await serve({ hippoRoot, host: '0.0.0.0', port: 0 });
+    });
+
+    it('starts and binds the requested non-loopback host', () => {
+      expect(handle!.port).toBeGreaterThan(0);
+    });
+
+    it('GET /health is public: 200 with no auth', async () => {
+      const res = await fetch(`http://127.0.0.1:${handle!.port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+
+    it('GET /v1/memories with no Authorization: 401', async () => {
+      const res = await fetch(`http://127.0.0.1:${handle!.port}/v1/memories?q=x`);
+      expect(res.status).toBe(401);
+    });
+
+    it('mints a key, authorized GET /v1/memories: 200, and a POST + follow-up search finds the row', async () => {
+      const db = openHippoDb(hippoRoot);
+      let plaintext: string;
+      try {
+        ({ plaintext } = createApiKey(db, { tenantId: 'default', label: 'nla-test' }));
+      } finally {
+        closeHippoDb(db);
+      }
+
+      const authHeaders = { authorization: `Bearer ${plaintext}` };
+
+      // 401 -> 200 with a valid bearer token on the read route.
+      const searchRes = await fetch(`http://127.0.0.1:${handle!.port}/v1/memories?q=x`, {
+        headers: authHeaders,
+      });
+      expect(searchRes.status).toBe(200);
+
+      // POST /v1/memories with the bearer succeeds.
+      const postRes = await fetch(`http://127.0.0.1:${handle!.port}/v1/memories`, {
+        method: 'POST',
+        headers: { ...authHeaders, 'content-type': 'application/json' },
+        body: JSON.stringify({ content: 'nonloopback-auth-marker unique content for search' }),
+      });
+      expect(postRes.status).toBeGreaterThanOrEqual(200);
+      expect(postRes.status).toBeLessThan(300);
+
+      // A follow-up authorized search finds the newly created row.
+      const followUpRes = await fetch(
+        `http://127.0.0.1:${handle!.port}/v1/memories?q=nonloopback-auth-marker`,
+        { headers: authHeaders },
+      );
+      expect(followUpRes.status).toBe(200);
+      const followUpBody = await followUpRes.json();
+      const found = (followUpBody.results as Array<{ content: string }>).some((r) =>
+        r.content.includes('nonloopback-auth-marker'),
+      );
+      expect(found).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What

Two things that together make hippo publicly servable for the [Agent Memory Leaderboard](https://agentmemoryleaderboard.ai) evaluation (open-source category):

1. **Lift the stale non-loopback bind guard.** `serve()` refused every non-loopback host, citing auth middleware "not yet built". That middleware shipped (`buildContextWithAuth` validates scrypt-hashed Bearer keys; every route checks it except `GET /health` and the HMAC-gated connector webhooks). The bind is now allowed only when `HIPPO_REQUIRE_AUTH=1`, which disables the loopback no-auth fallback so every request needs a key. Without the env var the refusal stands.
2. **`deploy/aml/`** - reproducible Fly.io deployment: two-stage Dockerfile (local embeddings, the zero-dependency default), init-once entrypoint with a root-to-node privilege drop, fly.toml (one always-on 1GB machine, lhr), README runbook.

## Security review

Fable adversarial review: **PASS** with advisories, all applied in the hardening commit:
- `HIPPO_CLIENT_IP_HEADER` keys the /v1 rate limiter on the proxy-stamped client address (single-bucket collapse behind Fly's proxy was pre-auth drainable)
- `/health` returns liveness only to non-loopback callers (version fingerprinting); loopback keeps the full body `detectServer` reads
- container runs as `node`, not root; `.dockerignore` added
- remaining advisory (parameterize the bearer-lockdown test over the full route table) backlogged

## Verification

- New test file: 12 tests. Red under the old guard (5/6 fail citing the stale message), green with the fix. Covers refusal without the env var, loopback regression, 0.0.0.0 boot, public /health, 401 unauthenticated, authorized add+search over real HTTP, and the rate-limit key helper.
- Container drive, outside-in: boot on 0.0.0.0, /health 200 (redacted body), search 401 without a key, member key minted in-container, authorized add+search round trip, store + key survive a restart with no re-init, pid 1 runs as node, /data node-owned.
- `tests/serve-nonloopback-auth.test.ts` + `tests/server-bearer-lockdown.test.ts` + `tests/auth.test.ts`: 41/41 green.

Note: repo CI will not report on this PR (org Actions billing block, since Aug-23). Full local suite run attached in the merge decision.

## Test plan

- [x] Red-under-old on the guard tests
- [x] 41-test server auth battery green
- [x] Container drive green end to end (including restart persistence and privilege drop)
- [ ] Full local suite green (running; gate for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FW2AC8E9w6ZoEf9KK75n6
