### PR TITLE
feat: AML protocol adapter in front of hippo

### DIFF
--- a/deploy/aml/README.md
+++ b/deploy/aml/README.md
@@ -10,21 +10,23 @@ container's port is bound to 127.0.0.1 only.
 
 ## What AML calls
 
-AML's protocol requires exactly two operations. hippo serves them natively:
+The public endpoints are served by `adapter/adapter.mjs`, a zero-dependency
+Node proxy that translates AML's contract (agentmemories.ai/api-guide, read
+2026-08-25) onto hippo's native API:
 
-| AML operation | hippo route |
-|---|---|
-| Add | `POST /v1/memories` |
-| Search | `GET /v1/memories?q=<query>&limit=<n>` |
+| AML operation | public route | behind it |
+|---|---|---|
+| Add | `POST /add` | one hippo memory per chunk: messages joined as a role-prefixed transcript, `scope: aml/<user_id>`, tagged `aml-session:<session_id>` |
+| Search | `POST /search` | `GET /v1/memories?q&limit=top_k&scope=aml/<user_id>`, results mapped to `{data:[{id, content, score}]}` |
+| Health | `GET /health` | mirrors hippo's health, unauthenticated |
 
-Auth is a bearer token validated against a store-resident API key
-(scrypt-hashed at rest, tenant-scoped). Health: `GET /health` (public,
-liveness-only body for non-loopback callers).
-
-An adapter translating AML's exact request/response schema onto these routes
-lands in this directory once written against the published API guide
-(https://agentmemories.ai/api-guide). If the schemas already align, no adapter
-is needed and this note gets replaced by that finding.
+Per-user isolation rides on hippo's shipped scope machinery: scoped recall is
+an exact-match filter, so no user's rows (and no unscoped row) can appear in
+another user's results. The adapter accepts `Bearer`, `Token`, or `X-Api-Key`
+credentials and forwards them verbatim to hippo, which validates against a
+store-resident API key (scrypt-hashed at rest). The adapter holds no secrets.
+It also forwards Cloudflare's `cf-connecting-ip` so hippo's rate limiter keys
+per real client.
 
 ## Configuration facts that matter for reproduction
 
@@ -44,31 +46,24 @@ is needed and this note gets replaced by that finding.
 ## Standing it up
 
 ```sh
-# 1. Build the image (from the repo root)
-docker build -f deploy/aml/Dockerfile -t hippo-aml:prod .
+# 1. Build and start both containers (from the repo root). Only the adapter
+#    is published, loopback-only, on 127.0.0.1:18081.
+docker compose -f deploy/aml/docker-compose.yml up -d --build
 
-# 2. Run the container: loopback-only publish, survives restarts
-docker volume create hippo-aml-data
-docker run -d --name hippo-aml --restart unless-stopped \
-  -v hippo-aml-data:/data \
-  -p 127.0.0.1:18080:8080 \
-  -e HIPPO_CLIENT_IP_HEADER=cf-connecting-ip \
-  hippo-aml:prod
-
-# 3. Cloudflare Tunnel (one-time): authorize the zone, create, route
+# 2. Cloudflare Tunnel (one-time): authorize the zone, create, route
 cloudflared tunnel login
 cloudflared tunnel create hippo-aml
 cloudflared tunnel route dns hippo-aml aml.hippo-memory.com
 
-# 4. ~/.cloudflared/config.yml
+# 3. ~/.cloudflared/config.yml
 #    tunnel: <tunnel id>
 #    credentials-file: <path printed by tunnel create>
 #    ingress:
 #      - hostname: aml.hippo-memory.com
-#        service: http://localhost:18080
+#        service: http://localhost:18081
 #      - service: http_status:404
 
-# 5. Run it (or install persistence: `cloudflared service install` from an
+# 4. Run it (or install persistence: `cloudflared service install` from an
 #    admin shell, or a user Startup entry running `cloudflared tunnel run hippo-aml`)
 cloudflared tunnel run hippo-aml
 ```
@@ -82,9 +77,10 @@ docker exec -w /data hippo-aml node /app/dist/src/cli.js auth create --label aml
 # revoke a key
 docker exec -w /data hippo-aml node /app/dist/src/cli.js auth revoke <keyId>
 
-# smoke-check from outside
+# smoke-check from outside (AML contract)
 curl https://aml.hippo-memory.com/health
-curl -H "Authorization: Bearer <key>" "https://aml.hippo-memory.com/v1/memories?q=test"
+curl -X POST https://aml.hippo-memory.com/add -H "Authorization: Bearer <key>"   -H "Content-Type: application/json"   -d '{"request_id":"r1","messages":[{"role":"user","content":"hi"}],"user_id":"u1","session_id":"s1"}'
+curl -X POST https://aml.hippo-memory.com/search -H "Authorization: Bearer <key>"   -H "Content-Type: application/json"   -d '{"query":"hi","user_id":"u1","top_k":5}'
 ```
 
 Operational notes:

--- a/deploy/aml/README.md
+++ b/deploy/aml/README.md
@@ -84,6 +84,10 @@ curl -X POST https://aml.hippo-memory.com/search -H "Authorization: Bearer <key>
 ```
 
 Operational notes:
+- **The API key is the only secret.** `user_id` is client-asserted; scope
+  partitioning isolates users inside one trusted tenant, it is not an auth
+  boundary. A leaked key reads any user's rows. Mint per evaluation, revoke
+  after.
 - The host must stay awake for the evaluation window (disable sleep during it).
 - The container auto-starts with Docker; the tunnel auto-starts at user logon
   (Startup entry) or as a Windows service if installed elevated.

--- a/deploy/aml/adapter/adapter.mjs
+++ b/deploy/aml/adapter/adapter.mjs
@@ -1,0 +1,332 @@
+// deploy/aml/adapter/adapter.mjs
+//
+// Translating proxy in front of hippo's HTTP API. hippo speaks its own
+// /v1/memories contract; the Agent Memory Leaderboard (AML) speaks a
+// different one (agentmemories.ai/api-guide, read 2026-08-25). This adapter
+// sits between them and does nothing else.
+//
+// Plain Node 22, zero npm dependencies, single file, no build step.
+//
+// Config (env):
+//   ADAPTER_PORT  port this adapter listens on. Default 8090.
+//   HIPPO_URL     base URL of the hippo HTTP server. Default http://127.0.0.1:18080.
+//
+// Routes:
+//   GET  /health   unauthenticated. Mirrors hippo's health as {ok: boolean}.
+//   POST /add      AML Add. Joins messages into one transcript, writes it as
+//                  one hippo memory scoped to the caller's user_id.
+//   POST /search   AML Search. Reads hippo's recall results back into AML's
+//                  {data: [...]} shape, scoped to the caller's user_id.
+//   anything else  404 {error}.
+
+import { createServer } from 'node:http';
+
+const ADAPTER_PORT = Number(process.env.ADAPTER_PORT || 8090);
+const HIPPO_URL = (process.env.HIPPO_URL || 'http://127.0.0.1:18080').replace(/\/+$/, '');
+const HIPPO_TIMEOUT_MS = 120_000;
+const MAX_BODY_BYTES = 1024 * 1024;
+
+// ---- small helpers ---------------------------------------------------
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+// Reads the request body up to maxBytes. Throws an error carrying
+// statusCode 413 once the cap is crossed, and destroys the socket so the
+// client is not kept waiting on a request we have already rejected.
+function readBody(req, maxBytes) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+    let settled = false;
+    const settle = (fn, arg) => {
+      if (settled) return;
+      settled = true;
+      fn(arg);
+    };
+    req.on('data', (chunk) => {
+      if (settled) return;
+      size += chunk.length;
+      if (size > maxBytes) {
+        const err = new Error('payload too large');
+        err.statusCode = 413;
+        req.destroy();
+        settle(reject, err);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => settle(resolve, Buffer.concat(chunks)));
+    req.on('error', (err) => settle(reject, err));
+  });
+}
+
+async function parseJsonBody(req) {
+  const buf = await readBody(req, MAX_BODY_BYTES);
+  if (buf.length === 0) return {};
+  try {
+    return JSON.parse(buf.toString('utf8'));
+  } catch {
+    const err = new Error('invalid JSON body');
+    err.statusCode = 400;
+    throw err;
+  }
+}
+
+// Client may send Authorization: Bearer <key>, Authorization: Token <key>,
+// or X-Api-Key: <key>. Normalize whichever arrives into one opaque
+// credential string, or undefined when none is present. Never logged.
+function extractCredential(req) {
+  const rawAuth = req.headers['authorization'];
+  const auth = Array.isArray(rawAuth) ? rawAuth[0] : rawAuth;
+  if (isNonEmptyString(auth)) {
+    const bearerMatch = /^Bearer\s+(.+)$/i.exec(auth);
+    if (bearerMatch) return bearerMatch[1].trim();
+    const tokenMatch = /^Token\s+(.+)$/i.exec(auth);
+    if (tokenMatch) return tokenMatch[1].trim();
+  }
+  const rawKey = req.headers['x-api-key'];
+  const apiKey = Array.isArray(rawKey) ? rawKey[0] : rawKey;
+  if (isNonEmptyString(apiKey)) return apiKey.trim();
+  return undefined;
+}
+
+// Cloudflare stamps the real client address here at the edge; nothing else
+// can reach the adapter, so the value is authoritative when present.
+function clientIpOf(req) {
+  const raw = req.headers['cf-connecting-ip'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return isNonEmptyString(value) ? value : undefined;
+}
+
+// Calls hippo. When credential is undefined, no Authorization header is
+// sent at all, so hippo's own auth gate decides the outcome (401 when
+// hippo requires auth, as the production deployment always does).
+// clientIp, when present, is forwarded as cf-connecting-ip so hippo's
+// per-client rate limiter keys on the real caller instead of collapsing
+// every adapter-relayed request into the adapter's own address. Only the
+// Cloudflare-stamped inbound value is ever forwarded; the adapter is not
+// reachable except through the tunnel, so the header is trustworthy.
+async function callHippo(method, path, { credential, jsonBody, clientIp } = {}) {
+  const headers = { Accept: 'application/json' };
+  if (jsonBody !== undefined) headers['Content-Type'] = 'application/json';
+  if (credential) headers['Authorization'] = `Bearer ${credential}`;
+  if (isNonEmptyString(clientIp)) headers['cf-connecting-ip'] = clientIp;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HIPPO_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(`${HIPPO_URL}${path}`, {
+      method,
+      headers,
+      body: jsonBody === undefined ? undefined : JSON.stringify(jsonBody),
+      signal: controller.signal,
+    });
+    const text = await upstream.text();
+    let body = {};
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = { error: text };
+      }
+    }
+    return { status: upstream.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function hippoErrorBody(hippoBody) {
+  if (hippoBody && typeof hippoBody === 'object' && isNonEmptyString(hippoBody.error)) {
+    return { error: hippoBody.error };
+  }
+  return { error: 'hippo request failed' };
+}
+
+// ---- /health -----------------------------------------------------------
+
+const HEALTH_TIMEOUT_MS = 5_000;
+
+async function handleHealth(_req, res) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
+  try {
+    const upstream = await fetch(`${HIPPO_URL}/health`, { signal: controller.signal });
+    const ok = upstream.status >= 200 && upstream.status < 300;
+    sendJson(res, ok ? 200 : 503, { ok });
+  } catch {
+    sendJson(res, 503, { ok: false });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---- /add ----------------------------------------------------------------
+
+function validateAddBody(body) {
+  if (!body || typeof body !== 'object') return 'request body must be a JSON object';
+  if (!isNonEmptyString(body.request_id)) return 'request_id is required';
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    return 'messages must be a non-empty array';
+  }
+  for (const message of body.messages) {
+    if (
+      !message ||
+      typeof message !== 'object' ||
+      !isNonEmptyString(message.role) ||
+      !isNonEmptyString(message.content)
+    ) {
+      return 'each message requires a role and content';
+    }
+  }
+  if (!isNonEmptyString(body.user_id)) return 'user_id is required';
+  if (!isNonEmptyString(body.session_id)) return 'session_id is required';
+  return undefined;
+}
+
+function joinTranscript(messages) {
+  return messages.map((message) => `${message.role}: ${message.content}`).join('\n');
+}
+
+async function handleAdd(req, res) {
+  const body = await parseJsonBody(req);
+  const validationError = validateAddBody(body);
+  if (validationError) {
+    sendJson(res, 400, { error: validationError });
+    return;
+  }
+
+  const credential = extractCredential(req);
+  const clientIp = clientIpOf(req);
+  const transcript = joinTranscript(body.messages);
+  const { status, body: hippoBody } = await callHippo('POST', '/v1/memories', {
+    credential,
+    clientIp,
+    jsonBody: {
+      content: transcript,
+      scope: `aml/${body.user_id}`,
+      tags: [`aml-session:${body.session_id}`],
+    },
+  });
+
+  if (status !== 200) {
+    sendJson(res, status, hippoErrorBody(hippoBody));
+    return;
+  }
+
+  // hippo's remember() writes synchronously before returning 200, so a 200
+  // here means the memory is already persisted. Echo the three ids exactly
+  // as received, no re-derivation.
+  sendJson(res, 200, {
+    success: true,
+    request_id: body.request_id,
+    user_id: body.user_id,
+    session_id: body.session_id,
+  });
+}
+
+// ---- /search ---------------------------------------------------------
+
+function validateSearchBody(body) {
+  if (!body || typeof body !== 'object') return 'request body must be a JSON object';
+  if (!isNonEmptyString(body.query)) return 'query is required';
+  if (!isNonEmptyString(body.user_id)) return 'user_id is required';
+  if (typeof body.top_k !== 'number' || !Number.isFinite(body.top_k) || body.top_k <= 0) {
+    return 'top_k must be a positive number';
+  }
+  return undefined;
+}
+
+async function handleSearch(req, res) {
+  const body = await parseJsonBody(req);
+  const validationError = validateSearchBody(body);
+  if (validationError) {
+    sendJson(res, 400, { error: validationError });
+    return;
+  }
+
+  const credential = extractCredential(req);
+  const clientIp = clientIpOf(req);
+  const topK = Math.floor(body.top_k);
+  // options is accepted and ignored: hippo takes the query only.
+  const params = new URLSearchParams({
+    q: body.query,
+    limit: String(topK),
+    scope: `aml/${body.user_id}`,
+  });
+  const { status, body: hippoBody } = await callHippo('GET', `/v1/memories?${params.toString()}`, {
+    credential,
+    clientIp,
+  });
+
+  if (status !== 200) {
+    sendJson(res, status, hippoErrorBody(hippoBody));
+    return;
+  }
+
+  const results = Array.isArray(hippoBody.results) ? hippoBody.results : [];
+  const data = results.slice(0, topK).map((row) => {
+    const item = { id: row.id, content: row.content };
+    if (typeof row.score === 'number') item.score = row.score;
+    if (isNonEmptyString(row.created_at)) item.created_at = row.created_at;
+    return item;
+  });
+
+  sendJson(res, 200, { data });
+}
+
+// ---- server ------------------------------------------------------------
+
+const server = createServer((req, res) => {
+  const start = Date.now();
+  const method = req.method || 'GET';
+  const path = (req.url || '/').split('?')[0];
+
+  // One line per request, method + path + status + duration only. Never
+  // credentials, never memory content.
+  res.on('finish', () => {
+    console.log(`${method} ${path} ${res.statusCode} ${Date.now() - start}ms`);
+  });
+
+  Promise.resolve()
+    .then(async () => {
+      if (method === 'GET' && path === '/health') {
+        await handleHealth(req, res);
+        return;
+      }
+      if (method === 'POST' && path === '/add') {
+        await handleAdd(req, res);
+        return;
+      }
+      if (method === 'POST' && path === '/search') {
+        await handleSearch(req, res);
+        return;
+      }
+      sendJson(res, 404, { error: 'not found' });
+    })
+    .catch((err) => {
+      if (res.headersSent) return;
+      const status = typeof err.statusCode === 'number' ? err.statusCode : 502;
+      const message = typeof err.statusCode === 'number' ? err.message : 'adapter error';
+      sendJson(res, status, { error: message });
+    });
+});
+
+server.listen(ADAPTER_PORT, () => {
+  // server.address().port is the actual bound port. Matters when
+  // ADAPTER_PORT=0 asks the OS for an ephemeral port (tests do this).
+  const address = server.address();
+  const boundPort = address && typeof address === 'object' ? address.port : ADAPTER_PORT;
+  console.log(`aml adapter listening on :${boundPort}, upstream hippo ${HIPPO_URL}`);
+});

--- a/deploy/aml/adapter/adapter.mjs
+++ b/deploy/aml/adapter/adapter.mjs
@@ -323,6 +323,11 @@ const server = createServer((req, res) => {
     });
 });
 
+// Bound the slow-client window: Cloudflare fronts this, but a stalled body
+// should not hold a connection for Node's default 300s.
+server.headersTimeout = 15_000;
+server.requestTimeout = 30_000;
+
 server.listen(ADAPTER_PORT, () => {
   // server.address().port is the actual bound port. Matters when
   // ADAPTER_PORT=0 asks the OS for an ephemeral port (tests do this).

--- a/deploy/aml/docker-compose.yml
+++ b/deploy/aml/docker-compose.yml
@@ -1,0 +1,44 @@
+# AML evaluation stack: hippo + the protocol adapter in front of it.
+#
+#   docker compose -f deploy/aml/docker-compose.yml up -d --build   (from repo root)
+#
+# Only the adapter is reachable from the host, and only on loopback; the
+# Cloudflare Tunnel points at it. hippo itself has no published ports - the
+# adapter reaches it over the compose network, and operators use docker exec.
+
+services:
+  hippo:
+    build:
+      context: ../..
+      dockerfile: deploy/aml/Dockerfile
+    container_name: hippo-aml
+    restart: unless-stopped
+    volumes:
+      - hippo-aml-data:/data
+    environment:
+      # The adapter forwards Cloudflare's cf-connecting-ip on every call, so
+      # the /v1 rate limiter keys per real client.
+      HIPPO_CLIENT_IP_HEADER: cf-connecting-ip
+      # AML drives up to 256 concurrent searches; the default 20 rps bucket
+      # would 429 the evaluation. hippo is only reachable through the
+      # adapter, so a generous ceiling is safe.
+      HIPPO_V1_RPS: "500"
+
+  adapter:
+    image: node:22-slim
+    container_name: hippo-aml-adapter
+    restart: unless-stopped
+    user: node
+    command: ["node", "/adapter/adapter.mjs"]
+    volumes:
+      - ./adapter:/adapter:ro
+    environment:
+      ADAPTER_PORT: "8090"
+      HIPPO_URL: http://hippo:8080
+    ports:
+      - "127.0.0.1:18081:8090"
+    depends_on:
+      - hippo
+
+volumes:
+  hippo-aml-data:

--- a/tests/aml-adapter.test.ts
+++ b/tests/aml-adapter.test.ts
@@ -1,0 +1,387 @@
+// tests/aml-adapter.test.ts
+//
+// Exercises deploy/aml/adapter/adapter.mjs against a real hippo store and a
+// real hippo HTTP server, spawned in a child process exactly the way it runs
+// in production (deploy/aml/entrypoint.sh starts hippo, the adapter runs as
+// its own process in front of it). Every request in this suite goes over
+// real HTTP, no mocks.
+//
+// Store-root convention follows tests/serve-nonloopback-auth.test.ts's
+// makeEnv: the store root passed to initStore/serve IS the .hippo directory
+// itself, not its parent. HIPPO_REQUIRE_AUTH=1 is set the same way that test
+// sets it, so the throwaway hippo server in this suite enforces Bearer auth
+// exactly like the production deployment (deploy/aml/Dockerfile bakes in the
+// same env var) -- without it, hippo's loopback no-auth fallback would admit
+// unauthenticated local requests and the "no credential -> 401" case below
+// would never actually exercise auth.
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { initStore } from '../src/store.js';
+import { openHippoDb, closeHippoDb } from '../src/db.js';
+import { createApiKey } from '../src/auth.js';
+import { serve, type ServerHandle } from '../src/server.js';
+
+const ADAPTER_PATH = fileURLToPath(new URL('../deploy/aml/adapter/adapter.mjs', import.meta.url));
+
+interface SearchRow {
+  id: string;
+  content: string;
+  score?: number;
+  created_at?: string;
+}
+
+async function waitForAdapterReady(baseUrl: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/health`);
+      if (res.status === 200 || res.status === 503) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`adapter never became reachable at ${baseUrl}: ${String(lastErr)}`);
+}
+
+describe('AML protocol adapter (deploy/aml/adapter/adapter.mjs)', () => {
+  let hippoRoot: string;
+  let hippoHandle: ServerHandle;
+  let adapterProcess: ChildProcess;
+  let baseUrl: string;
+  let validKey: string;
+  const stderrChunks: Buffer[] = [];
+  const savedRequireAuth = process.env.HIPPO_REQUIRE_AUTH;
+
+  beforeAll(async () => {
+    hippoRoot = join(mkdtempSync(join(tmpdir(), 'hippo-aml-adapter-')), '.hippo');
+    initStore(hippoRoot);
+
+    // Match the production deployment: hippo requires auth on every route
+    // except GET /health. Without this, hippo's loopback no-auth fallback
+    // would silently admit the adapter's unauthenticated forwards.
+    process.env.HIPPO_REQUIRE_AUTH = '1';
+    hippoHandle = await serve({ hippoRoot, host: '127.0.0.1', port: 0 });
+
+    const db = openHippoDb(hippoRoot);
+    try {
+      ({ plaintext: validKey } = createApiKey(db, { tenantId: 'default', label: 'aml-adapter-test' }));
+    } finally {
+      closeHippoDb(db);
+    }
+
+    const adapterReady = new Promise<number>((resolve, reject) => {
+      let stdoutBuf = '';
+      adapterProcess = spawn(process.execPath, [ADAPTER_PATH], {
+        env: {
+          ...process.env,
+          ADAPTER_PORT: '0',
+          HIPPO_URL: `http://127.0.0.1:${hippoHandle.port}`,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      adapterProcess.stdout?.on('data', (chunk: Buffer) => {
+        stdoutBuf += chunk.toString('utf8');
+        const match = /listening on :(\d+)/.exec(stdoutBuf);
+        if (match) resolve(Number(match[1]));
+      });
+      adapterProcess.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+      adapterProcess.once('error', reject);
+      adapterProcess.once('exit', (code) => {
+        if (code !== null && code !== 0) {
+          reject(new Error(`adapter process exited with code ${code}: ${Buffer.concat(stderrChunks).toString('utf8')}`));
+        }
+      });
+    });
+
+    const adapterPort = await adapterReady;
+    baseUrl = `http://127.0.0.1:${adapterPort}`;
+    await waitForAdapterReady(baseUrl);
+  }, 30_000);
+
+  afterAll(async () => {
+    adapterProcess?.kill();
+    await hippoHandle?.stop();
+    if (savedRequireAuth === undefined) {
+      delete process.env.HIPPO_REQUIRE_AUTH;
+    } else {
+      process.env.HIPPO_REQUIRE_AUTH = savedRequireAuth;
+    }
+    rmSync(hippoRoot, { recursive: true, force: true });
+  });
+
+  function authHeader(key: string): Record<string, string> {
+    return { Authorization: `Bearer ${key}` };
+  }
+
+  async function postAdd(body: unknown, headers: Record<string, string> = {}) {
+    return fetch(`${baseUrl}/add`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function postSearch(body: unknown, headers: Record<string, string> = {}) {
+    return fetch(`${baseUrl}/search`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  // 1. Health -----------------------------------------------------------
+
+  it('GET /health: 200 with no auth', async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  // 2. Add happy path + persistence --------------------------------------
+
+  it('POST /add happy path: 200, ids echoed byte-exactly, row is findable via /search', async () => {
+    const request_id = 'req-happy-0001';
+    const user_id = 'user-happy';
+    const session_id = 'sess-happy';
+
+    const addRes = await postAdd(
+      {
+        request_id,
+        user_id,
+        session_id,
+        messages: [{ role: 'user', content: 'aml-happy-path-marker distinctive text' }],
+      },
+      authHeader(validKey),
+    );
+    expect(addRes.status).toBe(200);
+    const addBody = await addRes.json();
+    expect(addBody).toEqual({ success: true, request_id, user_id, session_id });
+
+    const searchRes = await postSearch(
+      { query: 'aml-happy-path-marker', user_id, top_k: 5 },
+      authHeader(validKey),
+    );
+    expect(searchRes.status).toBe(200);
+    const searchBody = await searchRes.json();
+    expect(Array.isArray(searchBody.data)).toBe(true);
+    const found = (searchBody.data as SearchRow[]).some((row) =>
+      row.content.includes('aml-happy-path-marker'),
+    );
+    expect(found).toBe(true);
+  });
+
+  // 3. Isolation (load-bearing) -------------------------------------------
+
+  it('isolates by user_id: user_a search excludes user_b rows and an unscoped row written directly to hippo', async () => {
+    const marker = 'aml-isolation-marker-77';
+
+    const addA = await postAdd(
+      {
+        request_id: 'iso-a-1',
+        user_id: 'user-a-iso',
+        session_id: 'sess-a-iso',
+        messages: [{ role: 'user', content: `${marker} row-a content` }],
+      },
+      authHeader(validKey),
+    );
+    expect(addA.status).toBe(200);
+
+    const addB = await postAdd(
+      {
+        request_id: 'iso-b-1',
+        user_id: 'user-b-iso',
+        session_id: 'sess-b-iso',
+        messages: [{ role: 'user', content: `${marker} row-b content` }],
+      },
+      authHeader(validKey),
+    );
+    expect(addB.status).toBe(200);
+
+    // Bypasses the adapter entirely: talks straight to hippo with no scope.
+    const directRes = await fetch(`http://127.0.0.1:${hippoHandle.port}/v1/memories`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...authHeader(validKey) },
+      body: JSON.stringify({ content: `${marker} row-unscoped content, written direct to hippo` }),
+    });
+    expect(directRes.status).toBe(200);
+
+    const searchRes = await postSearch(
+      { query: marker, user_id: 'user-a-iso', top_k: 10 },
+      authHeader(validKey),
+    );
+    expect(searchRes.status).toBe(200);
+    const searchBody = await searchRes.json();
+    const contents = (searchBody.data as SearchRow[]).map((row) => row.content);
+
+    const hasA = contents.some((c) => c.includes('row-a content'));
+    const hasB = contents.some((c) => c.includes('row-b content'));
+    const hasUnscoped = contents.some((c) => c.includes('row-unscoped content'));
+
+    expect(hasA).toBe(true);
+    expect(hasB).toBe(false);
+
+    // OBSERVED (verified by running this suite, not inferred): hippo's
+    // GET /v1/memories?scope=X applies an EXACT-match filter once a
+    // non-empty scope is passed (src/api.ts recall(), line ~758:
+    // `entries = all.filter((e) => e.scope === opts.scope)`), and a
+    // directly-written row with no `scope` field has scope=null, which
+    // fails that exact match against 'aml/user-a-iso'. So the unscoped row
+    // does NOT leak into a scoped search. Operational consequence: an
+    // eval store that already has legacy unscoped rows in it does NOT need
+    // to start fresh for THIS adapter's isolation to hold, because the
+    // adapter always sends an explicit non-empty scope on both routes.
+    expect(hasUnscoped).toBe(false);
+  });
+
+  // 4. Search shape ---------------------------------------------------
+
+  it('POST /search: data array, items carry id + content, capped at top_k', async () => {
+    const user_id = 'user-shape';
+    const marker = 'aml-shape-marker-42';
+
+    await postAdd(
+      {
+        request_id: 'shape-1',
+        user_id,
+        session_id: 'sess-shape-1',
+        messages: [{ role: 'user', content: `${marker} first row` }],
+      },
+      authHeader(validKey),
+    );
+    await postAdd(
+      {
+        request_id: 'shape-2',
+        user_id,
+        session_id: 'sess-shape-2',
+        messages: [{ role: 'user', content: `${marker} second row` }],
+      },
+      authHeader(validKey),
+    );
+
+    const res = await postSearch({ query: marker, user_id, top_k: 1 }, authHeader(validKey));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeLessThanOrEqual(1);
+    for (const row of body.data as SearchRow[]) {
+      expect(typeof row.id).toBe('string');
+      expect(typeof row.content).toBe('string');
+    }
+  });
+
+  it('POST /search: an empty result set is a valid 200 with data: []', async () => {
+    const res = await postSearch(
+      { query: 'no-such-content-anywhere-zzz-999', user_id: 'user-empty-search', top_k: 5 },
+      authHeader(validKey),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ data: [] });
+  });
+
+  // 5. Auth ------------------------------------------------------------
+
+  describe('auth', () => {
+    it('no credential -> 401', async () => {
+      const res = await postSearch({ query: 'x', user_id: 'user-auth', top_k: 1 });
+      expect(res.status).toBe(401);
+    });
+
+    it('X-Api-Key header works', async () => {
+      const res = await postSearch(
+        { query: 'x', user_id: 'user-auth', top_k: 1 },
+        { 'X-Api-Key': validKey },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('Authorization: Token <key> works', async () => {
+      const res = await postSearch(
+        { query: 'x', user_id: 'user-auth', top_k: 1 },
+        { Authorization: `Token ${validKey}` },
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('garbage key -> 401', async () => {
+      const res = await postSearch(
+        { query: 'x', user_id: 'user-auth', top_k: 1 },
+        { Authorization: 'Bearer not-a-real-key' },
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // 6. Validation --------------------------------------------------------
+
+  describe('validation', () => {
+    it('POST /add missing request_id -> 400', async () => {
+      const res = await postAdd(
+        {
+          user_id: 'user-val',
+          session_id: 'sess-val',
+          messages: [{ role: 'user', content: 'hi' }],
+        },
+        authHeader(validKey),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(typeof body.error).toBe('string');
+    });
+
+    it('POST /add empty messages -> 400', async () => {
+      const res = await postAdd(
+        {
+          request_id: 'req-val-2',
+          user_id: 'user-val',
+          session_id: 'sess-val',
+          messages: [],
+        },
+        authHeader(validKey),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /search missing user_id -> 400', async () => {
+      const res = await postSearch({ query: 'x', top_k: 1 }, authHeader(validKey));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // 7. Transcript joining --------------------------------------------------
+
+  it('joins messages into "<role>: <content>" lines before writing to hippo', async () => {
+    const user_id = 'user-transcript';
+    const addRes = await postAdd(
+      {
+        request_id: 'req-transcript-1',
+        user_id,
+        session_id: 'sess-transcript',
+        messages: [
+          { role: 'user', content: 'zqx7' },
+          { role: 'assistant', content: 'wvk3' },
+        ],
+      },
+      authHeader(validKey),
+    );
+    expect(addRes.status).toBe(200);
+
+    const searchRes = await postSearch({ query: 'zqx7 wvk3', user_id, top_k: 5 }, authHeader(validKey));
+    expect(searchRes.status).toBe(200);
+    const searchBody = await searchRes.json();
+    const row = (searchBody.data as SearchRow[]).find(
+      (r) => r.content.includes('zqx7') && r.content.includes('wvk3'),
+    );
+    expect(row).toBeDefined();
+    expect(row!.content).toContain('user: zqx7');
+    expect(row!.content).toContain('assistant: wvk3');
+  });
+});


### PR DESCRIPTION
## What

The AML protocol adapter: `deploy/aml/adapter/adapter.mjs`, a zero-dependency Node proxy that becomes the public face of `aml.hippo-memory.com`. Translates the leaderboard's contract (POST /add with request_id echo + messages[], POST /search returning `{data:[...]}`) onto hippo's authenticated API. Per-user isolation maps `user_id` to hippo scope `aml/<user_id>`; scoped recall is an exact-match filter (api.ts), verified by test, so cross-user and unscoped rows cannot leak. Credentials forward verbatim (Bearer/Token/X-Api-Key); the adapter holds no secrets. Compose file runs hippo unpublished + adapter loopback-only, raises HIPPO_V1_RPS so the eval's concurrency cannot 429.

## Review

Fable adversarial security review: **PASS**. Verified against source: isolation unbypassable, no param/header injection (URLSearchParams + undici CRLF rejection), no credential/content in logs, no false-200 path (hippo remember is synchronous before its 200). Advisories applied: slow-client timeouts (headers 15s / request 30s), key-posture note in README. Remaining test-gap advisories backlogged.

## Tests

13 tests, real store + real `serve()` + adapter as a real child process: echo fidelity, the isolation matrix (user A / user B / unscoped row), top_k cap, all three credential forms, validation, transcript joining. CI absent (org billing block); suite run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FW2AC8E9w6ZoEf9KK75n6
