### PR TITLE
fix: run the test suite in prepublishOnly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
         run: npm run audit:security
       - run: npm run build
       - run: node scripts/check-openclaw-dist.mjs
-      # Some CLI-driven tests (cli-multihop, cli-dag, etc.) shell out to
-      # `hippo` and expect it on PATH. Local devs have it via global install;
-      # CI gets it via npm link.
-      - run: npm link
       - name: Vitest
         run: npx vitest run
       - name: Provenance gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.38.1 - 2026-09-04
+## 1.38.1 - 2026-09-05
 
 ### Fixed
 - **`openclaw plugins install hippo-memory` failed on every published release since the plugin shipped.** Reproduced on the 1.38.0 tarball with `npm run smoke:openclaw-install`: `package install requires compiled runtime output for TypeScript entry ./extensions/openclaw-plugin/index.ts: expected ./dist/extensions/openclaw-plugin/index.js, ...`. OpenClaw resolves a `.ts` extension entry to its compiled twin under `dist/`, but the `build` script only compiled `src/` and `benchmarks/`, so no published release ever shipped that file (the plugin dates from 0.4.0; the failure was confirmed on 1.38.0 and had been filed unmerged since 2026-07-30). `build` now also runs a new `tsconfig.extensions.json` pass that compiles `extensions/openclaw-plugin/index.ts` to `dist/extensions/openclaw-plugin/index.js`.
@@ -9,6 +9,11 @@
 - **Fixed a strict-mode type error surfaced by first-time type-checking the extension.** `HippoPluginDeps` hand narrowed Node's overloaded `execFileSync`/`spawn` option types, so no overload matched and `tsc --noEmit` failed with TS2322 at `index.ts:56`. The interface now uses Node's own `ExecFileSyncOptionsWithStringEncoding` and `SpawnOptions` types, and the spawn return is typed `Pick<ChildProcess, 'unref'>`. No behavior change; call sites and test fakes are unchanged.
 - **`hippo context` no longer crashes on a store missing a continuity table.** A store stamped at schema version 41 but missing `session_handoffs`, `session_events` or `task_snapshots` threw "no such table" on every read (2026-08-15 home-store incident). The hook runs `hippo context` on every prompt, so the whole session lost memory injection, and a migration never reruns below its own version. Every open of an existing store now re-asserts the three tables before the migration loop (so a store below v22 that lost `task_snapshots` no longer dies inside the v4, v16 or v22 migrations either) and their indexes after it. Healthy stores are untouched.
 - **Dedupe survivor metadata was insertion-order random.** `compareEntryIdentity` compared content and then the random UUID, so two byte-identical memories that differed only in tags or source kept whichever copy happened to sort first, and a semantic/episodic pair always kept the episodic copy because `mem_` ids sort before `sem_` ids. The shared tie key now orders content, then layer (semantic, episodic, trace, buffer), then distinct tag count, sorted tags, source, and id last. Every sort site that routes through it (dedupe, consolidate merge base, search and recall ties) inherits the same order. Dedupe now only considers current distilled rows: raw (append-only) rows used to abort `sleep` mid-loop when they lost a tie, and superseded rows could delete the current copy. Cross-layer twins now keep the higher-ranked layer's copy, so a semantic/episodic pair keeps the semantic one, since that is the consolidated copy. `sleep-redact.ts` comments no longer call `crossDups` a cross-tenant counter; it counts cross-layer pairs.
+
+### Changed
+- `prepublishOnly` now runs the test suite last (`scripts/check-tests-pass.mjs`) and refuses to
+  publish on a red run. `HIPPO_PUBLISH_SKIP_TESTS="<reason>"` is the documented escape hatch for
+  the vitest worker-IPC exit-1 artifact; `--ignore-scripts` is not.
 
 ## 1.38.0 - 2026-08-24
 

--- a/benchmarks/sequential-learning/README.md
+++ b/benchmarks/sequential-learning/README.md
@@ -52,7 +52,7 @@ node benchmarks/sequential-learning/run.mjs --output my-results/
 
 Requirements:
 - Node.js 22.5+
-- For the hippo adapter: `hippo` CLI on PATH
+- For the hippo adapter: a built checkout (`npm run build`), so `bin/hippo.js` can load `dist/cli.js`; set `HIPPO_BENCH_CLI=<path>` to benchmark another CLI file
 
 No npm dependencies. Uses only Node.js built-in modules.
 

--- a/benchmarks/sequential-learning/adapters/hippo.mjs
+++ b/benchmarks/sequential-learning/adapters/hippo.mjs
@@ -19,9 +19,13 @@
 
 import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { createAdapter } from './interface.mjs';
+
+// This repo's CLI, not a PATH-resolved global install (which may be an older release).
+const HIPPO_BIN = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'bin', 'hippo.js');
 
 // POST-AUDIT P1-4 (v1.7.8): session id and counters were module-level `let`
 // in v1.7.5..v1.7.7 — two parallel adapter consumers (e.g. future --workers N)
@@ -57,7 +61,7 @@ function hippoExec(storeDir, args, sessionId = null) {
       XDG_DATA_HOME: '',
     };
     if (sessionId) env.HIPPO_SESSION_ID = sessionId;
-    const result = execSync(`hippo ${args}`, {
+    const result = execSync(`node ${JSON.stringify(HIPPO_BIN)} ${args}`, {
       cwd: storeDir,
       env,
       encoding: 'utf-8',

--- a/benchmarks/sequential-learning/adapters/hippo.mjs
+++ b/benchmarks/sequential-learning/adapters/hippo.mjs
@@ -19,14 +19,16 @@
 
 import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { createAdapter } from './interface.mjs';
 
 // This repo's CLI, not a PATH-resolved global install (which may be an older release).
-const HIPPO_BIN =
-  process.env.HIPPO_BENCH_CLI || join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'bin', 'hippo.js');
+// resolve() pins a relative override to the startup cwd; hippoExec later runs with the temp store as cwd.
+const HIPPO_BIN = resolve(
+  process.env.HIPPO_BENCH_CLI || join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'bin', 'hippo.js'),
+);
 
 // POST-AUDIT P1-4 (v1.7.8): session id and counters were module-level `let`
 // in v1.7.5..v1.7.7 — two parallel adapter consumers (e.g. future --workers N)
@@ -47,9 +49,10 @@ const HIPPO_BIN =
  * @param {string} storeDir
  * @param {string} args
  * @param {string|null} [sessionId=null] - Optional HIPPO_SESSION_ID for this exec.
+ * @param {boolean} [strict=false] - Rethrow on any failure instead of returning partial stdout or null.
  * @returns {string|null} stdout, or null on failure.
  */
-function hippoExec(storeDir, args, sessionId = null) {
+function hippoExec(storeDir, args, sessionId = null, strict = false) {
   try {
     const env = {
       ...process.env,
@@ -71,6 +74,7 @@ function hippoExec(storeDir, args, sessionId = null) {
     });
     return result.trim();
   } catch (err) {
+    if (strict) throw err;
     // Some commands (recall with no results) exit non-zero
     if (err.stdout) return err.stdout.trim();
     return null;
@@ -96,10 +100,15 @@ export default createAdapter({
     this._sessionId = null;
     this._pushedCount = 0;
     this._completedCount = 0;
-    // hippoExec swallows failures on purpose (recall with no results exits non-zero); this first
-    // call is the one place a missing CLI can be told apart from a quiet success (codex round 3).
-    if (hippoExec(this._storeDir, 'init --no-schedule') === null) {
-      throw new Error(`hippo CLI failed to start at ${HIPPO_BIN}; run \`npm run build\` first or set HIPPO_BENCH_CLI`);
+    // Strict: a missing or half-failing CLI must abort the run, not report a fake trap-hit rate (codex rounds 3-4).
+    try {
+      hippoExec(this._storeDir, 'init --no-schedule', null, true);
+    } catch (err) {
+      rmSync(this._storeDir, { recursive: true, force: true });
+      this._storeDir = null;
+      throw new Error(
+        `hippo CLI failed to start at ${HIPPO_BIN} (run \`npm run build\` first or set HIPPO_BENCH_CLI): ${err.message}`,
+      );
     }
   },
 

--- a/benchmarks/sequential-learning/adapters/hippo.mjs
+++ b/benchmarks/sequential-learning/adapters/hippo.mjs
@@ -14,7 +14,7 @@
  * the session so cross-task state cannot leak. Both methods hard-fail (no swallow)
  * so the simulator's eval-strict mode can detect a broken mechanism.
  *
- * Requires: hippo CLI on PATH (npm link or global install).
+ * Requires: a built checkout (`npm run build`), or HIPPO_BENCH_CLI pointing at another CLI file.
  */
 
 import { execSync } from 'node:child_process';
@@ -25,7 +25,8 @@ import { tmpdir } from 'node:os';
 import { createAdapter } from './interface.mjs';
 
 // This repo's CLI, not a PATH-resolved global install (which may be an older release).
-const HIPPO_BIN = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'bin', 'hippo.js');
+const HIPPO_BIN =
+  process.env.HIPPO_BENCH_CLI || join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'bin', 'hippo.js');
 
 // POST-AUDIT P1-4 (v1.7.8): session id and counters were module-level `let`
 // in v1.7.5..v1.7.7 — two parallel adapter consumers (e.g. future --workers N)
@@ -95,7 +96,11 @@ export default createAdapter({
     this._sessionId = null;
     this._pushedCount = 0;
     this._completedCount = 0;
-    hippoExec(this._storeDir, 'init --no-schedule');
+    // hippoExec swallows failures on purpose (recall with no results exits non-zero); this first
+    // call is the one place a missing CLI can be told apart from a quiet success (codex round 3).
+    if (hippoExec(this._storeDir, 'init --no-schedule') === null) {
+      throw new Error(`hippo CLI failed to start at ${HIPPO_BIN}; run \`npm run build\` first or set HIPPO_BENCH_CLI`);
+    }
   },
 
   async store(content, tags) {

--- a/docs/plans/2026-09-05-prepublish-runs-tests.md
+++ b/docs/plans/2026-09-05-prepublish-runs-tests.md
@@ -131,3 +131,15 @@ recursively for any `.ts/.mjs/.js`. Red first: the contract test failed with the
 stripped from PATH; the adapter, budget, gate and cli-dag files pass (17 tests) after the change.
 `extensions/*` spawn `hippo` by name on purpose (they call the user's installed CLI) and are out
 of scope.
+
+## Review round 4 (codex P1 on the ba35764 delta)
+
+Codex: in a fresh checkout `dist/` is gitignored, so `bin/hippo.js` cannot load; `hippoExec` swallows
+that (by design, recall with no results exits non-zero) and `init` ignored the null, so
+`run.mjs --adapter hippo` exited 0 with a 100% trap-hit rate. Pre-existing swallow, but the change
+moved the trigger from "hippo not on PATH" to "repo not built" and left the README stale. Fix at the
+one place a missing CLI is distinguishable from a quiet success: `init()` throws when the first exec
+returns null, naming `npm run build`. `HIPPO_BENCH_CLI` overrides the CLI file (benchmark another
+build; also how the test points at a missing file). README requirement line updated. Red first:
+`tests/sl-adapter-cli-missing.test.ts` resolved instead of rejecting before the fix; 17 tests across
+the adapter, budget, gate and new file pass after it with the global npm dir stripped from PATH.

--- a/docs/plans/2026-09-05-prepublish-runs-tests.md
+++ b/docs/plans/2026-09-05-prepublish-runs-tests.md
@@ -143,3 +143,16 @@ returns null, naming `npm run build`. `HIPPO_BENCH_CLI` overrides the CLI file (
 build; also how the test points at a missing file). README requirement line updated. Red first:
 `tests/sl-adapter-cli-missing.test.ts` resolved instead of rejecting before the fix; 17 tests across
 the adapter, budget, gate and new file pass after it with the global npm dir stripped from PATH.
+
+## Review round 5 (codex on the 47a27f6 delta: one P1, two P2)
+
+P1: `hippoExec` returns partial stdout from its catch block, so a CLI that prints during `init` and then
+exits non-zero passed the null check. P2: a relative `HIPPO_BENCH_CLI` was kept verbatim while
+`hippoExec` runs with the temp store as cwd, so Node looked for it in the wrong place. P2: `init`
+threw after creating `_storeDir`, and the runner only reaches `cleanup()` after a successful init, so
+every failed run left a `hippo-bench-*` directory behind. Fix: `hippoExec` gains a `strict` flag that
+rethrows (init is the only strict caller; recall keeps the partial-stdout path on purpose);
+`HIPPO_BIN` is `resolve()`d at load; init removes the temp store and nulls `_storeDir` before
+rethrowing with the child's message. Red first: three cases in `tests/sl-adapter-cli-missing.test.ts`
+(missing file, fixture that prints then exits 1, relative override) failed for exactly the three
+reasons above; 20 tests across five files pass after the fix with the global npm dir stripped from PATH.

--- a/docs/plans/2026-09-05-prepublish-runs-tests.md
+++ b/docs/plans/2026-09-05-prepublish-runs-tests.md
@@ -1,0 +1,110 @@
+# prepublishOnly runs the test suite
+
+Episode 01M1RCX0X21M3MT5J6FQTY4GFW, devrl loop hippoloop-20260904T205515Z, backlog A3 item 4.
+
+## Problem (reproduced)
+
+`package.json:40` on origin/master `90e4344`:
+
+```
+"prepublishOnly": "node scripts/check-manifest-versions.mjs && node scripts/check-em-dashes-in-release-notes.mjs && node scripts/check-graph-writes.mjs && npm run build:all"
+```
+
+No `vitest run` anywhere in the chain. CI (`.github/workflows/ci.yml:46`) runs `npx vitest run` on
+pull requests, but `npm publish` runs from a local checkout that can differ from the merged head,
+so a red suite can publish. `gh pr list --search prepublish` shows only the v1.15.0 release PR;
+nothing shipped a test gate.
+
+## Root cause
+
+The release gate is `prepublishOnly` itself. Every other release invariant (manifest lockstep,
+em dashes, graph writes) lives there; the test suite was never added. Fix at that seam.
+
+## Fix (at root)
+
+### scripts/check-tests-pass.mjs (new, sibling of the three check-* scripts)
+
+- Spawns vitest directly: `spawnSync(process.execPath, [<vitest bin>, 'run', ...extraArgv],
+  { stdio: 'inherit' })`, where the bin is resolved from `vitest/package.json` (`bin.vitest`,
+  `./vitest.mjs` in 3.2.6) through `createRequire(import.meta.url)`. No `npm` shim, so no
+  `shell: true` and no ENOENT on Windows (plan-eng round 1), and no `pretest` rebuild
+  (`package.json:30` runs `npm run build` before every `npm test`, redundant right after
+  `build:all`). This is the same command CI runs (`.github/workflows/ci.yml:46`).
+- Extra argv is appended to the vitest args, so `node scripts/check-tests-pass.mjs
+  tests/foo.test.ts` gates on one file. The tests use the same seam with `--root` (below); it
+  is a vitest passthrough, not a fake-command hook.
+- Exits with the child's exit code (1 when the child died on a signal or failed to spawn).
+- On a non-zero exit, prints to stderr: the exit code, a note that a run with zero failed tests
+  and exit 1 is the known vitest worker-IPC artifact (`[vitest-worker]: Timeout calling
+  "onTaskUpdate"`), the instruction to rerun the failed files alone first, and the escape hatch.
+- Escape hatch: `HIPPO_PUBLISH_SKIP_TESTS="<reason>"`. When set to a non-empty string and the
+  suite fails, the script prints `WARNING: publishing with a failed test run. Reason: <reason>`
+  and exits 0. It never auto-passes on its own reading of the output: the human states the
+  reason every time. `npm publish --ignore-scripts` is NOT the hatch because it skips the three
+  other guards too.
+
+### package.json
+
+`prepublishOnly` gains `&& node scripts/check-tests-pass.mjs` after `npm run build:all`, so the
+CLI-spawning tests see the fresh `dist/`.
+
+### docs/release-policy.md
+
+New section "Test suite (pre-publish guard)" after the em-dash section: what runs, the artifact,
+the hatch, and why `--ignore-scripts` is not it.
+
+### CHANGELOG.md
+
+Bullet under a new `## 1.38.1 - 2026-09-05` heading. The heading does not exist in this
+worktree; #158, #160 and #161 each add the same heading, so the rebase at the batch gate merges
+the bullets under one heading (the known, expected conflict, same as #160 and #161).
+
+## Tests
+
+### Fixtures: tests/fixtures/prepublish-gate/{passing,failing}/*.spec.mjs
+
+Two one-test files plus a shared `tests/fixtures/prepublish-gate/vitest.config.mjs`
+(`include: ['**/*.spec.mjs']`). The `.spec.mjs` suffix keeps them out of the main suite, whose
+include is `tests/**/*.test.{ts,mjs}` (`vitest.config.ts:21`). Vitest resolves its config by
+walking UP from `--root` (`findUp(configFiles, { cwd: root })`, vitest 3.2.6
+`dist/chunks/cli-api.*.js:10203`), so without the shared config a fixture run picked up the repo
+config and found no files (probed: exit 1 for both dirs). With it, probed in this worktree:
+`--root .../passing` exits 0 (1 passed), `--root .../failing` exits 1 (1 failed). Every test
+below therefore drives the real spawn path (process.execPath + vitest bin) end to end.
+
+### tests/prepublish-test-gate.test.ts (new; spawns the real script with spawnSync)
+
+1. `node scripts/check-tests-pass.mjs --root <passing>` exits 0.
+2. `... --root <failing>` exits 1 and stderr names `HIPPO_PUBLISH_SKIP_TESTS` and the
+   worker-IPC artifact.
+3. same with `HIPPO_PUBLISH_SKIP_TESTS=reason` exits 0 and stderr contains `WARNING` and the
+   reason.
+4. `HIPPO_PUBLISH_SKIP_TESTS=""` (empty) does not skip: exits 1.
+5. package.json contract: `scripts.prepublishOnly` ends with `node scripts/check-tests-pass.mjs`
+   and still contains the three existing checks and `build:all` (red today).
+
+Red-before: cases 1-4 fail today because the script does not exist; case 5 fails on the
+package.json string. The nested vitest inherits `HIPPO_HOME` from the outer run's environment,
+and the fixtures never touch a store, so the real-store guard is not at risk.
+
+### Blast radius
+
+`tests/cli-version.test.ts`, `tests/openclaw-package.test.ts` (package.json readers), build,
+oxlint. One quiet full `npx vitest run` in the worktree to record this box's exit code for the
+worker-IPC question (result goes in the verify manifest, not in code).
+
+## Acceptance
+
+- A failing test makes `npm run prepublishOnly` exit non-zero (case 2 proves the script; the
+  package.json contract test proves it is wired last in the chain).
+- The escape hatch is documented and requires a stated reason; it never masks the failure
+  silently.
+
+## Non-goals
+
+- Fixing the vitest worker-IPC artifact (backlog below-bar item; not reproduced at triage).
+- Persisting the escape-hatch use anywhere beyond stderr (plan-eng round 1, low): npm's own
+  publish log and the human's stated reason are the trail; a file write inside prepublishOnly
+  would itself need a home in the tarball or the repo.
+- Version bump (rides 1.38.1).
+- Changing CI.

--- a/docs/plans/2026-09-05-prepublish-runs-tests.md
+++ b/docs/plans/2026-09-05-prepublish-runs-tests.md
@@ -107,4 +107,27 @@ worker-IPC question (result goes in the verify manifest, not in code).
   publish log and the human's stated reason are the trail; a file write inside prepublishOnly
   would itself need a home in the tarball or the repo.
 - Version bump (rides 1.38.1).
-- Changing CI.
+
+## Review round 2 (codex P1, fe3398a)
+
+Codex (wrapper and GitHub bot) found that `tests/cli-dag.test.ts` and `tests/cli-multihop.test.ts`
+execSync a bare `hippo`, which only CI's `npm link` put on PATH; in a clean checkout the gate
+fails with command-not-found, and on a dev box it tests the global install (1.38.0 here), not the
+checkout. Root fix: both files run `node bin/hippo.js` like `tests/cli-version.test.ts`; a guard
+case in `tests/prepublish-test-gate.test.ts` fails on any future bare `hippo` spawn (it matched
+7 sites in the old files); the CI `npm link` step is removed as dead. Red first: cli-dag failed
+with the global npm dir stripped from PATH; the four CLI and gate files pass with the same PATH
+after the change.
+
+## Review round 3 (codex P1 on the delta, plus CI red on fe3398a)
+
+Codex's delta review and CI (2 failed files) found a third bare `hippo` spawn: the benchmark
+adapter `benchmarks/sequential-learning/adapters/hippo.mjs` (`hippoExec`), which
+`tests/sequential-learning-adapter-contract.test.ts` and `tests/sl-adapter-budget.test.ts` drive
+end to end. The round-2 guard scanned only `tests/*.test.*`, so it missed a helper. Fix: the
+adapter resolves `bin/hippo.js` from its own `import.meta.url` (the .mjs is not compiled or
+copied, per `tsconfig.benchmarks.json`), and the guard now scans `tests/` and `benchmarks/`
+recursively for any `.ts/.mjs/.js`. Red first: the contract test failed with the global npm dir
+stripped from PATH; the adapter, budget, gate and cli-dag files pass (17 tests) after the change.
+`extensions/*` spawn `hippo` by name on purpose (they call the user's installed CLI) and are out
+of scope.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -77,6 +77,20 @@ gets scanned.
 Why scoped: backporting em-dash purity to v0.x-v1.13.x CHANGELOG
 entries is a separate doc-clean-up task, not a release blocker.
 
+## Test suite (pre-publish guard)
+
+`prepublishOnly` ends with `node scripts/check-tests-pass.mjs`, which runs `vitest run` through
+node and vitest's own bin (no npm shim, no `pretest` rebuild) and exits with the suite's status.
+It runs after `build:all` so the CLI-spawning tests see the fresh `dist/`. Extra arguments pass
+through to vitest, so `node scripts/check-tests-pass.mjs tests/foo.test.ts` gates on one file.
+
+Known artifact: under load vitest can exit 1 with zero failed tests and
+`[vitest-worker]: Timeout calling "onTaskUpdate"`. Rerun the failed files alone first. If the
+suite is green that way and you still need to publish, set
+`HIPPO_PUBLISH_SKIP_TESTS="<reason>"`; the gate prints a WARNING with the reason and exits 0. An
+empty value does not skip. `npm publish --ignore-scripts` is not the escape hatch: it skips the
+manifest, em-dash and graph-write guards too.
+
 ## Test isolation patterns
 
 Tests that mutate `process.env.HIPPO_LOSS_AVERSION_RATIO` (or any other

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "smoke:openclaw-install": "node scripts/smoke-openclaw-install.mjs",
     "build:ui": "cd ui && npm install && npm run build",
     "build:all": "npm run build && npm run build:ui",
-    "prepublishOnly": "node scripts/check-manifest-versions.mjs && node scripts/check-em-dashes-in-release-notes.mjs && node scripts/check-graph-writes.mjs && npm run build:all && node scripts/check-openclaw-dist.mjs && npm run smoke:openclaw-install"
+    "prepublishOnly": "node scripts/check-manifest-versions.mjs && node scripts/check-em-dashes-in-release-notes.mjs && node scripts/check-graph-writes.mjs && npm run build:all && node scripts/check-openclaw-dist.mjs && npm run smoke:openclaw-install && node scripts/check-tests-pass.mjs"
   },
   "keywords": [
     "memory",

--- a/scripts/check-tests-pass.mjs
+++ b/scripts/check-tests-pass.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Pre-publish guard: the test suite must pass before `npm publish` (docs/release-policy.md).
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const vitestPkgPath = require.resolve('vitest/package.json');
+const vitestBin = path.join(path.dirname(vitestPkgPath), require(vitestPkgPath).bin.vitest);
+
+// process.execPath + the bin file: no npm shim (ENOENT on Windows) and no pretest rebuild.
+const run = spawnSync(process.execPath, [vitestBin, 'run', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+});
+
+const code = run.status ?? 1;
+if (code === 0) process.exit(0);
+
+const reason = process.env.HIPPO_PUBLISH_SKIP_TESTS;
+if (reason) {
+  console.error(`WARNING: publishing with a failed test run. Reason: ${reason}`);
+  process.exit(0);
+}
+
+console.error(
+  [
+    `check-tests-pass: vitest exited with ${run.signal ?? code}; refusing to publish.`,
+    'If the run above shows zero failed tests, that is the vitest worker IPC artifact',
+    '([vitest-worker]: Timeout calling "onTaskUpdate"): rerun the failed files alone first.',
+    'Fix: make the suite green, or set HIPPO_PUBLISH_SKIP_TESTS="<reason>" to publish anyway.',
+    'npm publish --ignore-scripts is NOT the escape hatch: it skips the other guards too.',
+  ].join('\n'),
+);
+process.exit(code);

--- a/scripts/check-tests-pass.mjs
+++ b/scripts/check-tests-pass.mjs
@@ -13,10 +13,15 @@ const run = spawnSync(process.execPath, [vitestBin, 'run', ...process.argv.slice
   stdio: 'inherit',
 });
 
+if (run.error) {
+  console.error(`check-tests-pass: could not start vitest (${run.error.message}); refusing to publish.`);
+  process.exit(1);
+}
+
 const code = run.status ?? 1;
 if (code === 0) process.exit(0);
 
-const reason = process.env.HIPPO_PUBLISH_SKIP_TESTS;
+const reason = (process.env.HIPPO_PUBLISH_SKIP_TESTS ?? '').trim();
 if (reason) {
   console.error(`WARNING: publishing with a failed test run. Reason: ${reason}`);
   process.exit(0);

--- a/tests/cli-dag.test.ts
+++ b/tests/cli-dag.test.ts
@@ -4,12 +4,15 @@ import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 
+// The worktree's own CLI, not a PATH-resolved global install (which may be an older release).
+const HIPPO = `node ${JSON.stringify(path.join(process.cwd(), 'bin', 'hippo.js'))}`;
+
 describe('hippo dag', () => {
   let hippoRoot: string;
 
   beforeEach(() => {
     hippoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-cli-dag-'));
-    execSync(`hippo init --no-hooks --no-schedule --no-learn`, {
+    execSync(`${HIPPO} init --no-hooks --no-schedule --no-learn`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
     });
@@ -20,7 +23,7 @@ describe('hippo dag', () => {
   });
 
   it('runs without error and shows dag stats', () => {
-    const result = execSync(`hippo dag --stats`, {
+    const result = execSync(`${HIPPO} dag --stats`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
       encoding: 'utf-8',

--- a/tests/cli-multihop.test.ts
+++ b/tests/cli-multihop.test.ts
@@ -4,12 +4,15 @@ import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 
+// The worktree's own CLI, not a PATH-resolved global install (which may be an older release).
+const HIPPO = `node ${JSON.stringify(path.join(process.cwd(), 'bin', 'hippo.js'))}`;
+
 describe('hippo recall --multihop', () => {
   let hippoRoot: string;
 
   beforeEach(() => {
     hippoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-cli-multihop-'));
-    execSync(`hippo init --no-hooks --no-schedule --no-learn`, {
+    execSync(`${HIPPO} init --no-hooks --no-schedule --no-learn`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
     });
@@ -20,12 +23,12 @@ describe('hippo recall --multihop', () => {
   });
 
   it('accepts --multihop flag without error', () => {
-    execSync(`hippo remember "John loves basketball"`, {
+    execSync(`${HIPPO} remember "John loves basketball"`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
     });
 
-    const result = execSync(`hippo recall "basketball" --multihop`, {
+    const result = execSync(`${HIPPO} recall "basketball" --multihop`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
       encoding: 'utf-8',
@@ -34,12 +37,12 @@ describe('hippo recall --multihop', () => {
   });
 
   it('works without --multihop (normal recall)', () => {
-    execSync(`hippo remember "Tim reads books"`, {
+    execSync(`${HIPPO} remember "Tim reads books"`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
     });
 
-    const result = execSync(`hippo recall "reading"`, {
+    const result = execSync(`${HIPPO} recall "reading"`, {
       cwd: hippoRoot,
       env: { ...process.env, HIPPO_HOME: hippoRoot },
       encoding: 'utf-8',

--- a/tests/fixtures/prepublish-gate/failing/fail.spec.mjs
+++ b/tests/fixtures/prepublish-gate/failing/fail.spec.mjs
@@ -1,0 +1,5 @@
+import { test } from 'vitest';
+
+test('prepublish gate fixture: fails on purpose', () => {
+  throw new Error('red on purpose');
+});

--- a/tests/fixtures/prepublish-gate/passing/pass.spec.mjs
+++ b/tests/fixtures/prepublish-gate/passing/pass.spec.mjs
@@ -1,0 +1,3 @@
+import { test } from 'vitest';
+
+test('prepublish gate fixture: passes', () => {});

--- a/tests/fixtures/prepublish-gate/vitest.config.mjs
+++ b/tests/fixtures/prepublish-gate/vitest.config.mjs
@@ -1,0 +1,2 @@
+// Vitest finds the repo config by walking up from --root, so the fixture runs pin their own.
+export default { test: { include: ['**/*.spec.mjs'] } };

--- a/tests/fixtures/sl-adapter/fake-cli-fails-late.mjs
+++ b/tests/fixtures/sl-adapter/fake-cli-fails-late.mjs
@@ -1,0 +1,2 @@
+console.log('init started');
+process.exit(1);

--- a/tests/fixtures/sl-adapter/fake-cli-ok.mjs
+++ b/tests/fixtures/sl-adapter/fake-cli-ok.mjs
@@ -1,0 +1,1 @@
+console.log('ok');

--- a/tests/prepublish-test-gate.test.ts
+++ b/tests/prepublish-test-gate.test.ts
@@ -36,8 +36,8 @@ describe('prepublish test gate (scripts/check-tests-pass.mjs)', () => {
     expect(r.stderr).toContain('flaky worker IPC, reran files alone');
   });
 
-  test('an empty HIPPO_PUBLISH_SKIP_TESTS does not skip', () => {
-    const r = runGate('failing', { HIPPO_PUBLISH_SKIP_TESTS: '' });
+  test.each(['', '   '])('HIPPO_PUBLISH_SKIP_TESTS=%j is not a reason and does not skip', (value) => {
+    const r = runGate('failing', { HIPPO_PUBLISH_SKIP_TESTS: value });
     expect(r.status).toBe(1);
     expect(r.stderr).toContain('refusing to publish');
   });

--- a/tests/prepublish-test-gate.test.ts
+++ b/tests/prepublish-test-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const REPO = process.cwd();
@@ -54,5 +54,14 @@ describe('prepublish test gate (scripts/check-tests-pass.mjs)', () => {
       expect(chain).toContain(step);
     }
     expect(chain.endsWith('&& node scripts/check-tests-pass.mjs')).toBe(true);
+  });
+});
+
+describe('tests run the worktree CLI, never a PATH-resolved hippo', () => {
+  test('no test spawns a bare `hippo` command', () => {
+    const offenders = readdirSync(path.join(REPO, 'tests'))
+      .filter((f) => /\.test\.(ts|mjs)$/.test(f))
+      .filter((f) => /(exec|spawn)\w*\(\s*[`'"]hippo\b/.test(readFileSync(path.join(REPO, 'tests', f), 'utf-8')));
+    expect(offenders).toEqual([]);
   });
 });

--- a/tests/prepublish-test-gate.test.ts
+++ b/tests/prepublish-test-gate.test.ts
@@ -58,10 +58,12 @@ describe('prepublish test gate (scripts/check-tests-pass.mjs)', () => {
 });
 
 describe('tests run the worktree CLI, never a PATH-resolved hippo', () => {
-  test('no test spawns a bare `hippo` command', () => {
-    const offenders = readdirSync(path.join(REPO, 'tests'))
-      .filter((f) => /\.test\.(ts|mjs)$/.test(f))
-      .filter((f) => /(exec|spawn)\w*\(\s*[`'"]hippo\b/.test(readFileSync(path.join(REPO, 'tests', f), 'utf-8')));
+  test('no test or benchmark helper spawns a bare `hippo` command', () => {
+    // benchmarks/ holds adapters the tests import, so it is scanned too (codex round 2).
+    const offenders = ['tests', 'benchmarks']
+      .flatMap((dir) => readdirSync(path.join(REPO, dir), { recursive: true, encoding: 'utf-8' }).map((f) => path.join(dir, f)))
+      .filter((f) => /\.(ts|mjs|js)$/.test(f))
+      .filter((f) => /(exec|spawn)\w*\(\s*[`'"]hippo\b/.test(readFileSync(path.join(REPO, f), 'utf-8')));
     expect(offenders).toEqual([]);
   });
 });

--- a/tests/prepublish-test-gate.test.ts
+++ b/tests/prepublish-test-gate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const REPO = process.cwd();
+const SCRIPT = path.join(REPO, 'scripts', 'check-tests-pass.mjs');
+const FIXTURES = path.join(REPO, 'tests', 'fixtures', 'prepublish-gate');
+
+function runGate(fixture: string, env: Record<string, string | undefined> = {}) {
+  const r = spawnSync(process.execPath, [SCRIPT, '--root', path.join(FIXTURES, fixture)], {
+    cwd: REPO,
+    encoding: 'utf-8',
+    env: { ...process.env, HIPPO_PUBLISH_SKIP_TESTS: undefined, ...env },
+  });
+  return { status: r.status, stderr: r.stderr, stdout: r.stdout };
+}
+
+describe('prepublish test gate (scripts/check-tests-pass.mjs)', () => {
+  test('exits 0 when the suite passes', () => {
+    const r = runGate('passing');
+    expect(r.status, r.stderr).toBe(0);
+  });
+
+  test('exits 1 when the suite fails and names the escape hatch', () => {
+    const r = runGate('failing');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('HIPPO_PUBLISH_SKIP_TESTS');
+    expect(r.stderr).toContain('onTaskUpdate');
+  });
+
+  test('a non-empty HIPPO_PUBLISH_SKIP_TESTS reason turns a failure into a warning', () => {
+    const r = runGate('failing', { HIPPO_PUBLISH_SKIP_TESTS: 'flaky worker IPC, reran files alone' });
+    expect(r.status, r.stderr).toBe(0);
+    expect(r.stderr).toContain('WARNING');
+    expect(r.stderr).toContain('flaky worker IPC, reran files alone');
+  });
+
+  test('an empty HIPPO_PUBLISH_SKIP_TESTS does not skip', () => {
+    const r = runGate('failing', { HIPPO_PUBLISH_SKIP_TESTS: '' });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('refusing to publish');
+  });
+
+  test('prepublishOnly keeps the three checks and build:all, then runs the gate last', () => {
+    const pkg = JSON.parse(readFileSync(path.join(REPO, 'package.json'), 'utf-8'));
+    const chain: string = pkg.scripts.prepublishOnly;
+    for (const step of [
+      'node scripts/check-manifest-versions.mjs',
+      'node scripts/check-em-dashes-in-release-notes.mjs',
+      'node scripts/check-graph-writes.mjs',
+      'npm run build:all',
+    ]) {
+      expect(chain).toContain(step);
+    }
+    expect(chain.endsWith('&& node scripts/check-tests-pass.mjs')).toBe(true);
+  });
+});

--- a/tests/sl-adapter-cli-missing.test.ts
+++ b/tests/sl-adapter-cli-missing.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+// Own file: HIPPO_BENCH_CLI is read at module load, so the override must be set before the import.
+describe('sequential-learning hippo adapter refuses to run without a working CLI', () => {
+  it('init() throws and names the build step when the CLI file cannot start', async () => {
+    process.env.HIPPO_BENCH_CLI = join(process.cwd(), 'does-not-exist', 'hippo.js');
+    // @ts-expect-error - .mjs adapter module without .d.ts
+    const { default: adapter } = await import('../benchmarks/sequential-learning/adapters/hippo.mjs');
+    await expect(adapter.init()).rejects.toThrow(/npm run build/);
+    await adapter.cleanup();
+  });
+});

--- a/tests/sl-adapter-cli-missing.test.ts
+++ b/tests/sl-adapter-cli-missing.test.ts
@@ -1,13 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-// Own file: HIPPO_BENCH_CLI is read at module load, so the override must be set before the import.
+// HIPPO_BENCH_CLI is read at module load, so each case resets modules and re-imports the adapter.
+async function loadAdapter(cli: string) {
+  process.env.HIPPO_BENCH_CLI = cli;
+  vi.resetModules();
+  // @ts-expect-error - .mjs adapter module without .d.ts
+  const { default: adapter } = await import('../benchmarks/sequential-learning/adapters/hippo.mjs');
+  return adapter;
+}
+
 describe('sequential-learning hippo adapter refuses to run without a working CLI', () => {
-  it('init() throws and names the build step when the CLI file cannot start', async () => {
-    process.env.HIPPO_BENCH_CLI = join(process.cwd(), 'does-not-exist', 'hippo.js');
-    // @ts-expect-error - .mjs adapter module without .d.ts
-    const { default: adapter } = await import('../benchmarks/sequential-learning/adapters/hippo.mjs');
+  afterEach(() => {
+    delete process.env.HIPPO_BENCH_CLI;
+  });
+
+  it('init() rejects, names the build step and leaves no temp store when the CLI file is missing', async () => {
+    const adapter = await loadAdapter(join(process.cwd(), 'does-not-exist', 'hippo.js'));
     await expect(adapter.init()).rejects.toThrow(/npm run build/);
+    expect(adapter._storeDir).toBeNull();
+  });
+
+  it('init() rejects when the CLI prints to stdout and then exits non-zero (codex round 4 P1)', async () => {
+    const adapter = await loadAdapter(join(process.cwd(), 'tests', 'fixtures', 'sl-adapter', 'fake-cli-fails-late.mjs'));
+    await expect(adapter.init()).rejects.toThrow(/failed to start/);
+    expect(adapter._storeDir).toBeNull();
+  });
+
+  it('a relative HIPPO_BENCH_CLI resolves against the startup cwd, not the temp store', async () => {
+    const adapter = await loadAdapter('tests/fixtures/sl-adapter/fake-cli-ok.mjs');
+    await adapter.init();
+    const dir = adapter._storeDir;
+    expect(dir && existsSync(dir)).toBe(true);
     await adapter.cleanup();
+    expect(existsSync(dir)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`npm publish` never ran the test suite. Every other release invariant lives in `prepublishOnly` (manifest lockstep, em dashes, graph writes); the tests were missing from the chain, so a red suite could publish from a local checkout that differs from the merged head.

- `scripts/check-tests-pass.mjs` is now the last step of `prepublishOnly`, after `build:all` so the CLI-spawning tests see the fresh `dist/`.
- It spawns node with vitest's own bin (no npm shim, so no ENOENT on Windows and no `pretest` rebuild) and exits with the child's status. Extra args pass through to vitest.
- On failure it names the known worker-IPC artifact (exit 1 with zero failed tests, `[vitest-worker]: Timeout calling "onTaskUpdate"`) and the escape hatch `HIPPO_PUBLISH_SKIP_TESTS="<reason>"`. An empty value does not skip. `npm publish --ignore-scripts` is documented as not the hatch because it drops the other three guards too.
- `docs/release-policy.md` gains a "Test suite (pre-publish guard)" section; CHANGELOG gets the bullet under a new `## 1.38.1 - 2026-09-05` heading.

No version bump. Rides 1.38.1 with #158, #160 and #161. Merge order at the batch gate: #159, #158, #160, #161, then this one; the CHANGELOG heading conflict is expected and resolves by merging the bullets under one heading.

## Test plan

- [x] `tests/prepublish-test-gate.test.ts` was red before the script existed (4 of 5 cases; the fifth gained a stderr assertion so it is red too) and is green after.
- [x] Fixtures under `tests/fixtures/prepublish-gate/{passing,failing}` drive the real spawn path: `--root passing` exits 0, `--root failing` exits 1. The shared fixture `vitest.config.mjs` exists because vitest walks up from `--root` to find a config and would otherwise pick up the repo one.
- [x] `tests/cli-version.test.ts` and `tests/openclaw-package.test.ts` green (package.json readers).
- [x] `npm run build`, oxlint, `node scripts/check-em-dashes-in-release-notes.mjs` clean.
- [ ] CI green on this branch.

## Review round 2 (Codex P1)

Codex flagged that `tests/cli-dag.test.ts` and `tests/cli-multihop.test.ts` execSync a bare `hippo`, which only CI's `npm link` put on PATH. In a clean checkout the new gate failed with command-not-found; on a dev box it tested the global install (1.38.0 here), not this checkout.

Fixed at root in fe3398a: both files run `node bin/hippo.js` like `tests/cli-version.test.ts`; a guard case in `tests/prepublish-test-gate.test.ts` fails on any future bare `hippo` spawn (it matched 7 sites in the old files); the CI `npm link` step and its comment are removed as dead.

- [x] Red first: with the global npm dir stripped from PATH, cli-dag failed with `'hippo' is not recognized`
- [x] After the change, cli-dag, cli-multihop, cli-version and the gate test pass (12 tests) with the same stripped PATH

## Review round 3 (Codex delta P1, CI red on fe3398a)

CI on fe3398a failed 2 files and Codex's delta review named the cause: `benchmarks/sequential-learning/adapters/hippo.mjs` also execSyncs a bare `hippo`, and `tests/sequential-learning-adapter-contract.test.ts` plus `tests/sl-adapter-budget.test.ts` drive it end to end. The round-2 guard scanned only `tests/*.test.*`, so an imported helper slipped past.

Fixed in ba35764: the adapter resolves `bin/hippo.js` from its own `import.meta.url`; the guard scans `tests/` and `benchmarks/` recursively (it matched the old adapter). `extensions/*` call `hippo` by name on purpose (the user's installed CLI) and are out of scope.

- [x] Red first: the contract test failed with the global npm dir stripped from PATH
- [x] Adapter, budget, gate and cli-dag files pass (17 tests) with the same stripped PATH after the change
- [x] CI green on ba35764 (run 33959300016)

## Review round 4 (Codex delta P1 on ba35764)

In a fresh checkout `dist/` is gitignored, so `bin/hippo.js` cannot load. The adapter's `hippoExec` swallows that on purpose (recall with no results exits non-zero) and `init` ignored the null, so `run.mjs --adapter hippo` exited 0 with a 100% trap-hit rate. Same swallow as before this PR, but the trigger moved from "hippo not on PATH" to "repo not built".

Fixed in 47a27f6: `init()` throws when the first exec returns null and names `npm run build`. `HIPPO_BENCH_CLI=<path>` overrides the CLI file. The benchmark README requirement line now says so.

- [x] Red first: `tests/sl-adapter-cli-missing.test.ts` resolved instead of rejecting before the fix
- [x] Adapter, budget, gate and new file pass (17 tests) with the global npm dir stripped from PATH
- [x] CI green on 47a27f6 (run 33959912337)

## Review round 5 (Codex on the 47a27f6 delta: one P1, two P2)

`hippoExec` returned partial stdout from its catch block, so a CLI that printed during `init` and then exited non-zero passed the null check. A relative `HIPPO_BENCH_CLI` was kept verbatim while `hippoExec` runs with the temp store as cwd. `init` threw after creating the temp store and the runner never reached `cleanup()`, leaking a `hippo-bench-*` directory per failed run.

Fixed in 27bb83d: `hippoExec` gains a `strict` flag that rethrows (init is its only caller; recall keeps the partial-stdout path on purpose), `HIPPO_BIN` is resolved at load, and init removes the temp store before rethrowing with the child's message.

- [x] Red first: three cases (missing file, fixture that prints then exits 1, relative override) failed for exactly the three reasons above
- [x] 20 tests across five files pass with the global npm dir stripped from PATH
- [x] CI green on 27bb83d (run 33960395809)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dkoAWom9UM8VMxVUwFdRj

