### PR TITLE
v1.38.2 fix: consolidate 3+ bullets follow the merge-base order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.38.2 - unreleased
+
+### Fixed
+- **Consolidating 3+ related memories produced a different merged row for each ingest order.** `mergeContents` picked the merge base from a sorted view (content length desc, then the shared tie order) but listed the bullets from the raw cluster, which follows `created ASC, id ASC` in that store. The same three memories ingested in a different order gave a different `[Consolidated pattern from N related memories]` row and a different rejection digest, so a rollup a human had rejected could come back under a new digest. Bullets now follow the base order and the merged row's tags are sorted, so the row is byte-identical in any ingest order. One-time effect: a 3+ rollup rejected before this release regenerates once on the next `sleep` and can be rejected again.
+
 ## 1.38.1 - 2026-09-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.38.2 - unreleased
+## 1.38.2 - 2026-09-05
 
 ### Fixed
 - **Consolidating 3+ related memories produced a different merged row for each ingest order.** `mergeContents` picked the merge base from a sorted view (content length desc, then the shared tie order) but listed the bullets from the raw cluster, which follows `created ASC, id ASC` in that store. The same three memories ingested in a different order gave a different `[Consolidated pattern from N related memories]` row and a different rejection digest, so a rollup a human had rejected could come back under a new digest. Bullets now follow the base order and the merged row's tags are sorted, so the row is byte-identical in any ingest order. One-time effect: a 3+ rollup rejected before this release regenerates once on the next `sleep` and can be rejected again.

--- a/TODOS.md
+++ b/TODOS.md
@@ -63,16 +63,13 @@ reattributed and resolved the same day (harness bug, not hippo).
   + an empirically verified quantization mutant-kill; pre-fix red runs
   captured. See CHANGELOG 1.26.3 +
   docs/plans/2026-07-16-dedupe-survivor-determinism.md.
-- **Follow-up (from the dedupe-determinism episode): consolidate 3+ merge
-  bullet ORDER inherits cluster-assembly order.** `mergeContents`
-  (src/consolidate.ts) now breaks equal-LENGTH base ties deterministically,
-  but for 3+ entry clusters the bulleted summary lists members in cluster
-  order, which derives from upstream consolidation assembly (per-instance
-  stable via `created ASC, id ASC`, NOT cross-ingest stable). Content-noise
-  only (no survivor choice); land only with a deliberate cluster-ordering
-  decision in the consolidation pass, not as a drive-by
-  (docs/plans/2026-07-16-dedupe-survivor-determinism.md T2 out-of-scope
-  note).
+- **RESOLVED 2026-09-05 (episode 01M1S1MH5XZ4STGM08PBD5X3ZP): consolidate 3+
+  merge bullet order now follows the merge-base order.** Decision: render
+  order = base order (`sorted.map` in `mergeContents`), merged tags sorted;
+  upstream cluster assembly deliberately untouched because sorting candidates
+  there can change cluster membership. Permutation test 14 in
+  tests/dedupe-survivor-determinism.test.ts. See CHANGELOG 1.38.2 +
+  docs/plans/2026-09-05-consolidate-bullet-order.md.
 - **RESOLVED 2026-07-05 (same day) — silent loss of user-supplied `--tag`
   values was a harness bug, not a hippo write-path bug.** The rows this
   bullet originally described (13 tagless rows in the LoCoMo v1.25.0 run)

--- a/docs/plans/2026-09-05-consolidate-bullet-order.md
+++ b/docs/plans/2026-09-05-consolidate-bullet-order.md
@@ -1,0 +1,105 @@
+# Consolidation 3+ bullet order follows the merge order, not ingest order
+
+Episode 01M1S1MH5XZ4STGM08PBD5X3ZP (devrl loop hippoloop-20260904T205515Z, batch 01M1S1M7). Backlog A3 item 6.
+
+## Problem
+
+`mergeContents` (`src/consolidate.ts:933-948`) sorts the cluster once to pick the merge base
+(`content.length` desc, then `compareEntryIdentity`, line 938) but renders the 3+ entry bullet
+list from the RAW cluster (`entries.map`, line 946). The cluster is assembled in
+`mergeCandidates` order, which is `loadAllEntries` order (`created ASC, id ASC`): stable within
+one store, not stable across ingest orders. Two stores holding the same three memories ingested
+in different orders produce two different semantic rows for the same rollup.
+
+Filed as the T2 out-of-scope follow-up of `docs/plans/2026-07-16-dedupe-survivor-determinism.md`
+(TODOS.md:66-75), with the condition "land only with a deliberate cluster-ordering decision".
+
+## Root cause
+
+One function holds two orders: the sorted view decides the base, the raw view renders the members.
+The deliberate decision is that the merged row renders its members in the SAME order that chose
+its base. Bullet 1 is the base; the rest follow the same total order. No upstream change: the
+greedy pivot clustering in the merge pass (lines 731-745) is left alone, because sorting the
+candidates there can change cluster MEMBERSHIP when overlap is non-transitive, and that pass was
+stabilised recently (#111, T1 tenant partition). The filed defect is rendering noise, not
+membership.
+
+Same class, one block up at the call site (line 748): `allTags = Array.from(new Set(cluster.flatMap(...)))`
+also inherits cluster order into the merged row's `tags`. Fixed in the same PR by sorting.
+
+## Consequence the plan owns: rejection tombstones
+
+The merged content is digested (`rejectionDigest(semantic.content)`, line 773) and looked up
+against human-rejected rollups. Today that digest for a 3+ cluster depends on ingest order, so a
+tombstone only matches while the store keeps the order it had when the human rejected it. After
+this change the digest is order-independent, so tombstones become MORE stable. One-time effect:
+a 3+ rollup rejected before this release whose stored digest was computed from a non-sorted order
+regenerates once on the next sleep and can be rejected again. No migration (the old digests are
+not recomputable without the original order, and the class was already unstable). Called out in
+CHANGELOG.
+
+## Changes (all in the worktree branch `fix/consolidate-bullet-order`, base c130d7a)
+
+### 1. `src/consolidate.ts`
+
+- line 946: `entries.map(...)` -> `sorted.map(...)`. One identifier. Comment (one line, WHY):
+  bullets follow the base order so the merged row is byte-identical across ingest orders and the
+  rejection digest is stable.
+- line 748: `const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));` ->
+  `... .sort()` (default UTF-16 code-unit order, matching `compareStrings` in `compare.ts`; no
+  `localeCompare`, per the compare.ts rationale).
+
+Nothing else. `mergeContents` stays module-private; its single caller (line 747) is unchanged.
+`refine-llm.ts` matches only the `[Consolidated pattern from` prefix, so the bullet body is free to
+reorder.
+
+### 2. `tests/dedupe-survivor-determinism.test.ts` (existing real-DB file, next to test 7)
+
+New test 14, `mergeContents 3+ bullets: bullet order and merged tags identical across all 6 ingest
+orders (base order: length desc -> content asc)`. Reuses the file's `VARIANT_A/B/C` (each pair
+Jaccard 18/22 = 0.82 > `MERGE_OVERLAP_THRESHOLD` 0.35, so any pivot clusters all three and
+membership is order-independent), `permutationsOf3`, `tmpHome`, and a fixed `now`. Each variant
+carries one distinct tag (`['t-a']`, `['t-b']`, `['t-c']`) so the tags assertion has something to
+reorder. Per permutation: write the three, `consolidate(home, { now })`, expect `merged > 0`, load
+the one semantic row starting with `[Consolidated pattern from 3 related memories]`, collect the
+bullet block (`content.split('\n\n')[1]`) and `tags`. Assert all six bullet blocks are identical
+and equal the expected order computed in the test from the same rule (A and C are equal length
+and longer than B; `A < C` by content, so `A, C, B`), and all six tag arrays equal
+`['t-a','t-b','t-c']`.
+
+Red-first: on unchanged `master` the bullet block follows ingest order, so at least the
+`[A,B,C]` and `[C,B,A]` permutations differ and the test fails at the first `toBe`. Captured
+before the fix commit.
+
+Sad paths, enumerated up front: decay between permutations is neutralised by the shared `now`;
+`VARIANT_*` lengths are asserted in the test (`A.length === C.length`, `B.length < A.length`) so a
+later constant edit cannot silently turn the length tie into a non-tie; the semantic-row filter
+requires exactly one match so a partial cluster (2+1) fails loudly instead of passing on the
+wrong row.
+
+### 3. `CHANGELOG.md`
+
+New heading `## 1.38.2 - unreleased` above 1.38.1 (the batch's shared heading; the deploy gate
+bumps the version and dates it). One `### Fixed` bullet: bullets in a 3+ consolidation now follow
+the merge order (base first, then the shared tie order) and merged tags are sorted, so the same
+memories produce the same semantic row in any ingest order; note the one-time tombstone
+regeneration.
+
+### 4. `TODOS.md:66-75`
+
+Replace the follow-up with a RESOLVED line naming this episode and the decision (render order =
+base order; upstream cluster assembly deliberately untouched).
+
+## Out of scope
+
+- Sorting `mergeCandidates` upstream (membership change, see Root cause).
+- The 2-entry branch (line 941-943): it renders only the base, already deterministic since 1.26.3.
+- Audit `sourceIds: cluster.map(e => e.id)` (line 794): an audit payload, not a stored memory
+  row; ids are per-instance random anyway so no order of them is cross-ingest stable.
+
+## Verification
+
+- Targeted: `node ./node_modules/vitest/vitest.mjs run tests/dedupe-survivor-determinism.test.ts tests/consolidate.test.ts tests/consolidate-tenant-landing.test.ts tests/rejection-acceptance.test.ts`.
+- `npx tsc --noEmit`, `npx oxlint` on the touched files.
+- Drive the affected flow: a scratch `HIPPO_HOME` store, three near-duplicate `hippo remember` calls in two orders, `hippo sleep`, compare the semantic row text with `hippo recall`.
+- CI green on the PR head.

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.38.1",
+  "version": "1.38.2",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "type": "module",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.38.1",
+      "version": "1.38.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -745,7 +745,7 @@ export async function consolidate(
 
       // Create a semantic summary
       const mergedContent = mergeContents(cluster);
-      const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags)));
+      const allTags = Array.from(new Set(cluster.flatMap((e) => e.tags))).sort();
       const maxValence = pickStrongestValence(cluster);
 
       // AT1 P2 fix: build the semantic entry FIRST — createMemory is cheap
@@ -942,8 +942,9 @@ function mergeContents(entries: MemoryEntry[]): string {
     return `[Consolidated from ${entries.length} related memories]\n\n${base}`;
   }
 
-  // For 3+ entries, create a bulleted summary
-  const bullets = entries.map((e) => `- ${e.content.split('\n')[0].slice(0, 120)}`).join('\n');
+  // Bullets follow the base order (not raw cluster order) so the merged row
+  // and its rejection digest are byte-identical across ingest orders.
+  const bullets = sorted.map((e) => `- ${e.content.split('\n')[0].slice(0, 120)}`).join('\n');
   return `[Consolidated pattern from ${entries.length} related memories]\n\n${bullets}`;
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.38.1';
+export const PACKAGE_VERSION = '1.38.2';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/dedupe-survivor-determinism.test.ts
+++ b/tests/dedupe-survivor-determinism.test.ts
@@ -422,4 +422,42 @@ describe('dedupe survivor determinism', () => {
       restore();
     }
   });
+
+  it('14. mergeContents 3+ bullets: bullet order and merged tags identical across all 6 ingest orders (base order: length desc -> content asc)', async () => {
+    // Guards: a future VARIANT_* edit that breaks the length tie/non-tie shape fails here loudly.
+    expect(VARIANT_A.length).toBe(VARIANT_C.length);
+    expect(VARIANT_B.length).toBeLessThan(VARIANT_A.length);
+
+    const now = new Date();
+    const variants = [
+      { content: VARIANT_A, tags: ['t-a'] },
+      { content: VARIANT_B, tags: ['t-b'] },
+      { content: VARIANT_C, tags: ['t-c'] },
+    ];
+    const expectedOrder = [...variants].sort(
+      (a, b) => b.content.length - a.content.length || (a.content < b.content ? -1 : a.content > b.content ? 1 : 0),
+    );
+    const expectedBlock = expectedOrder.map((v) => `- ${v.content.slice(0, 120)}`).join('\n');
+
+    for (const perm of permutationsOf3()) {
+      const { home, restore } = tmpHome('hippo-dedupe-det-14-');
+      try {
+        for (const idx of perm) {
+          writeEntry(home, createMemory(variants[idx].content, { layer: Layer.Episodic, tags: variants[idx].tags }));
+        }
+
+        const result = await consolidate(home, { now });
+        expect(result.merged).toBeGreaterThan(0);
+
+        const semantics = loadAllEntries(home).filter(
+          (e) => e.layer === Layer.Semantic && e.content.startsWith('[Consolidated pattern from 3 related memories]'),
+        );
+        expect(semantics.length).toBe(1);
+        expect(semantics[0].content.split('\n\n')[1]).toBe(expectedBlock);
+        expect([...semantics[0].tags]).toEqual(['t-a', 't-b', 't-c']);
+      } finally {
+        restore();
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`mergeContents` in `src/consolidate.ts` picked the merge base from a sorted view (content length desc, then the shared tie order) but rendered the 3+ entry bullet list from the raw cluster, which follows the store's `created ASC, id ASC` walk. The same three memories ingested in a different order produced a different `[Consolidated pattern from N related memories]` row and a different rejection digest, so a rollup a human had rejected could come back under a new digest.

- Bullets now render from the sorted view (`sorted.map`), so bullet 1 is the base and the rest follow the same total order.
- The merged row's tags are sorted (default UTF-16 order, same as `compareStrings`).
- Upstream cluster assembly is deliberately untouched: sorting candidates there can change cluster membership when overlap is non-transitive.
- Resolves the TODOS.md follow-up filed by the 2026-07-16 dedupe-determinism plan. Plan: `docs/plans/2026-09-05-consolidate-bullet-order.md`.

One-time effect: a 3+ rollup rejected before this release regenerates once on the next `sleep` and can be rejected again. No migration.

## Test plan

- [x] New test 14 in `tests/dedupe-survivor-determinism.test.ts`: all 6 ingest orders against real stores, one identical bullet block and tag list. Failed on unchanged master (raw order rendered VARIANT_B before VARIANT_C).
- [x] Targeted vitest 49/49: dedupe-survivor-determinism, consolidate, consolidate-tenant-landing, rejection-acceptance.
- [x] `tsc --noEmit` clean, oxlint no new warnings, `npm run build` green.
- [x] Drove the flow with two scratch `HIPPO_HOME` stores (orders ABC and CBA): `hippo remember` x3, `hippo sleep`, `hippo recall` returned byte-identical merged rows.
- [ ] CI green.

Part of the 1.38.2 batch (version bump at the deploy gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dkoAWom9UM8VMxVUwFdRj
