### PR TITLE
test: bearer lockdown covers the full route table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - **Consolidating 3+ related memories produced a different merged row for each ingest order.** `mergeContents` picked the merge base from a sorted view (content length desc, then the shared tie order) but listed the bullets from the raw cluster, which follows `created ASC, id ASC` in that store. The same three memories ingested in a different order gave a different `[Consolidated pattern from N related memories]` row and a different rejection digest, so a rollup a human had rejected could come back under a new digest. Bullets now follow the base order and the merged row's tags are sorted, so the row is byte-identical in any ingest order. One-time effect: a 3+ rollup rejected before this release regenerates once on the next `sleep` and can be rejected again.
 
+### Tests
+- `tests/server-bearer-lockdown.test.ts` now derives its route table from `src/server.ts` source instead of a hand-copied list, so a new `/v1/*` route missing `buildContextWithAuth`/`requireAuth` fails CI instead of shipping unauthed.
+
 ## 1.38.1 - 2026-09-05
 
 ### Fixed

--- a/docs/plans/2026-09-05-bearer-lockdown-route-table.md
+++ b/docs/plans/2026-09-05-bearer-lockdown-route-table.md
@@ -1,0 +1,65 @@
+# Plan: bearer-lockdown test covers the full route table
+
+Episode 01M1S3GMRFSR1BG8E4TTCC28QZ (A3 item 7, batch 01M1S1M74R8RW419AK3W17FB7X). Source: feat/aml-deploy security review, advisory #6.
+
+## Problem
+
+`tests/server-bearer-lockdown.test.ts` pins a 401 on 12 hand-picked routes. `src/server.ts` `handleRequest` has 64 route sites: `GET /health` (public), two `PUBLIC_ROUTES` entries (Slack and GitHub webhooks, HMAC-authed), and 61 routes that must carry `buildContextWithAuth` or `requireAuth`. A new `/v1` route added without the auth call passes CI today.
+
+## Root cause
+
+The route table is an ordered if-chain in three shapes, so nothing in the code enumerates routes and the test's list is a hand copy that drifted as entity routes (predictions, decisions, incidents, processes, policies, skills, project briefs, customer notes, graph, context, outcome, sleep, sessions assemble, recall drill) were added.
+
+| Shape | Count | Example |
+|---|---|---|
+| literal | 34 (incl. `GET /health`) | `if (method === 'GET' && path === '/v1/graph')` |
+| matchPath | 7 | `const idMatch = matchPath('/v1/memories/:id', path);` then `if (method === 'DELETE' && idMatch)` |
+| regex | 23 | `const decisionByIdMatch = path.match(/^\/v1\/decisions\/(\d+)$/);` then `if (method === 'GET' && decisionByIdMatch)` |
+
+Counts measured at c130d7a with `grep -c "path === '/"`, `grep -c "= matchPath('"` and `grep -c 'path\.match(/\^'` on `src/server.ts` (34 + 7 + 23 = 64). The test re-derives them at runtime; nothing hard-codes these numbers.
+
+## Options
+
+- **A. Refactor `server.ts` into a route table array.** Rejected: 3,400-line ordered chain (`/v1/predictions/stats` must match before `/v1/predictions/:id`), high blast radius for a coverage item.
+- **B. Test derives the route set from the `server.ts` source and asserts its own request table covers it exactly.** Chosen. `tests/audit-ops-*-lockstep.test.ts` already read `src/server.ts` source the same way.
+- **C. Hit every derived route with an empty body, no table.** Rejected: most handlers (30 of the 44 sampled by an auth-order pass; the remaining regex-shape handlers follow the same pattern) validate the body or query before `buildContextWithAuth` (cheap-reject by design, see the cap comment near `POST /v1/outcome`), so an invalid request returns 400, never reaching the 401.
+
+## Changes
+
+### 1. `tests/server-bearer-lockdown.test.ts` (rewrite in place, same file name)
+
+- `routesFromServerSource(text: string): Set<string>` returns `'METHOD /pattern'` keys from the three shapes. Regex routes: unescape `\/` and replace `(\d+)` with `:id`. matchPath and regex shapes take the method from the `if (method === 'X' && <name>Match)` line that follows the match assignment.
+- Raw-shape guard: count the occurrences of `path === '/`, `matchPath('`, and `path.match(/^\/` inside `handleRequest` and assert the count equals the number of parsed keys. A fourth route shape then fails loudly instead of vanishing from the derived set.
+- `publicRoutesFromServerSource(text)` parses the `PUBLIC_ROUTES` `Set([...])` literal; the test asserts it equals exactly `POST /v1/connectors/slack/events` and `POST /v1/connectors/github/events`, so a new public route is a deliberate test edit.
+- `AUTHED_ROUTES: ReadonlyArray<{ method; pattern; query?; body? }>` lists every non-public route with a request shape that passes pre-auth validation. Request path is `pattern` with each `:param` replaced by `1` (regex routes need digits; `ID_SEGMENT_RE` accepts `1`) plus `query`.
+- Completeness test: the set of `AUTHED_ROUTES` keys equals `derived - public - 'GET /health'`. On failure the message lists missing and extra keys.
+- The two existing `it.each` blocks (missing header, bad token) stay and run over `AUTHED_ROUTES`. Failure message includes the response body so a 400 (wrong request shape) is diagnosable from CI output.
+- `process.env.HIPPO_V1_RPS = '0'` is set before `serve()` and deleted in `afterEach`. `serve()` only builds a limiter when the value is finite and greater than zero, so `'0'` disables limiting entirely. Without it the default limiter (20 rps, burst 40) would 429 the roughly 122 `/v1` requests the expanded file sends. Vitest runs each file in its own fork, so the env edit does not leak to other files.
+- `HIPPO_REQUIRE_AUTH=1` stays.
+
+### 2. `src/server.ts`
+
+No code change. The comment above `PUBLIC_ROUTES` already says new unauth routes need a test entry; it stays.
+
+### 3. `CHANGELOG.md`
+
+New `## 1.38.2 - unreleased` heading above 1.38.1 with a `### Tests` bullet describing the source-derived completeness check. The heading form has no precedent inside CHANGELOG.md; it is this batch's convention (PR #164 adds the identical heading) and the batch deploy gate replaces `unreleased` with the date when the version is bumped. The rebase script `resolve-changelog.py` merges the two sections.
+
+### 4. `TODOS.md`
+
+No entry exists for this item. Nothing to update.
+
+## Verification
+
+1. Red first: run the new completeness test against the old 12-entry list. It must fail and name the missing routes.
+2. Green: `node ./node_modules/vitest/vitest.mjs run tests/server-bearer-lockdown.test.ts` passes (61 routes x 2 + completeness + public-set + shape-guard tests). `npm run build`, `npx tsc --noEmit`, `npx oxlint` clean.
+3. Mutation A (scratch, reverted): add `if (method === 'GET' && path === '/v1/zzz') { sendJson(res, 200, {}); return; }` to `handleRequest`. The completeness test must fail naming `GET /v1/zzz`.
+4. Mutation B (scratch, reverted): delete the `buildContextWithAuth` call from one handler, for example `GET /v1/decisions`. Both 401 tests for that route must fail.
+5. Full suite once before the PR (known flakes: `tests/session-end-snapshot-close.test.ts`, vitest worker IPC exit 1 with 0 failures).
+
+## Risks
+
+- Source parsing is coupled to the three shapes. The raw-shape guard turns a new shape into a red test with a clear message.
+- A handler that tightens validation later breaks its lockdown row with a 400. The failure message carries the body, and the fix is a one-line table edit.
+- `POST /v1/sleep` checks `isLoopback` before `buildContextWithAuth`, so a non-loopback caller sees 403 first. The test binds 127.0.0.1, so the loopback check passes and the 401 is reached. If the server ever moves that check after auth, the row still passes.
+- No behavior change in the server, so no runtime risk.

--- a/docs/plans/2026-09-05-bearer-lockdown-route-table.md
+++ b/docs/plans/2026-09-05-bearer-lockdown-route-table.md
@@ -63,3 +63,7 @@ No entry exists for this item. Nothing to update.
 - A handler that tightens validation later breaks its lockdown row with a 400. The failure message carries the body, and the fix is a one-line table edit.
 - `POST /v1/sleep` checks `isLoopback` before `buildContextWithAuth`, so a non-loopback caller sees 403 first. The test binds 127.0.0.1, so the loopback check passes and the 401 is reached. If the server ever moves that check after auth, the row still passes.
 - No behavior change in the server, so no runtime risk.
+
+## Review follow-up
+
+Codex (round 1) showed the three-shape raw count shared the parser's blind spots: a double-quoted path literal or a `.test(path)` regex route left both at 64. The guard now counts `if (method === '` dispatch lines in `handleRequest`, an axis independent of the path shape, and both parsers read the same `handleRequest` slice.

--- a/tests/server-bearer-lockdown.test.ts
+++ b/tests/server-bearer-lockdown.test.ts
@@ -70,9 +70,8 @@ function publicRoutesFromServerSource(text: string): Set<string> {
 const serverSource = readFileSync(join(repoRoot, 'src/server.ts'), 'utf8');
 const handleRequestSource = serverSource.slice(serverSource.indexOf('async function handleRequest'));
 
-// Every authed (non-public, non-health) route with a request shape that
-// clears pre-auth validation, so a 401 (not 400) proves the Bearer check ran.
-// :param segments become '1' (ID_SEGMENT_RE and \d+ regex routes both accept it).
+// Every authed route with a request shape that clears pre-auth validation, so a
+// 401 (not 400) proves the Bearer check ran. :param segments become '1'.
 const AUTHED_ROUTES: ReadonlyArray<{
   method: string;
   pattern: string;
@@ -168,14 +167,14 @@ describe('server Bearer lockdown', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('the three raw route shapes account for every parsed entry (guards a 4th shape)', () => {
-    const literalCount = (handleRequestSource.match(/path === '\//g) ?? []).length;
-    const matchPathCount = (handleRequestSource.match(/= matchPath\(/g) ?? []).length;
-    const regexCount = (handleRequestSource.match(/path\.match\(\/\^/g) ?? []).length;
-    const derived = routesFromServerSource(serverSource);
+  it('every method-check dispatch line parses into a route (guards an unknown path shape)', () => {
+    // Counts the method axis, not the path axis, so a path shape the parser
+    // does not know still shows up here and the two counts disagree loudly.
+    const dispatchCount = (handleRequestSource.match(/^\s*if \(method === '/gm) ?? []).length;
+    const derived = routesFromServerSource(handleRequestSource);
     expect(
-      literalCount + matchPathCount + regexCount,
-      `raw shape count (${literalCount} + ${matchPathCount} + ${regexCount}) must equal parsed routes (${derived.size})`,
+      dispatchCount,
+      `${dispatchCount} method-check dispatch lines must equal parsed routes (${derived.size})`,
     ).toBe(derived.size);
   });
 
@@ -188,7 +187,7 @@ describe('server Bearer lockdown', () => {
   });
 
   it('AUTHED_ROUTES covers exactly the derived routes minus public routes minus GET /health', () => {
-    const derived = routesFromServerSource(serverSource);
+    const derived = routesFromServerSource(handleRequestSource);
     const publicRoutes = publicRoutesFromServerSource(serverSource);
     const expected = new Set(derived);
     expected.delete('GET /health');

--- a/tests/server-bearer-lockdown.test.ts
+++ b/tests/server-bearer-lockdown.test.ts
@@ -1,18 +1,152 @@
+// Regression bar: with the loopback no-auth fallback off (HIPPO_REQUIRE_AUTH=1) every
+// /v1 and /mcp route must 401 without a valid Bearer. The route list is derived from
+// src/server.ts so a new route missing buildContextWithAuth/requireAuth fails here.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { initStore } from '../src/store.js';
 import { serve, type ServerHandle } from '../src/server.js';
 
-/**
- * Review patch #2 regression bar: when the loopback no-auth fallback is
- * disabled (HIPPO_REQUIRE_AUTH=1), every /v1/* route MUST return 401 without
- * a Bearer token. The Slack webhook route is the only documented exception
- * (covered by tests/slack-webhook-route.test.ts). A future change that drops
- * the Bearer gate by accident — e.g. by reordering middleware or by adding
- * a second public route — should fail this test.
- */
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// Parses the three route shapes handleRequest uses into 'METHOD /pattern'
+// keys, so completeness below catches a route missing its auth call.
+function routesFromServerSource(text: string): Set<string> {
+  const lines = text.split('\n');
+  const routes = new Set<string>();
+  const literalRe = /method === '([A-Z]+)' && path === '([^']+)'/;
+  const matchAssignRe = /const (\w+) = matchPath\('([^']+)', path\);/;
+  const regexAssignRe = /const (\w+) = path\.match\(\/\^(.+?)\$\/\);/;
+
+  const methodForVar = (startLine: number, varName: string): string | undefined => {
+    for (let j = startLine + 1; j < Math.min(startLine + 6, lines.length); j++) {
+      const m = lines[j].match(new RegExp(`method === '([A-Z]+)' && [^\\n]*\\b${varName}\\b`));
+      if (m) return m[1];
+    }
+    return undefined;
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lit = line.match(literalRe);
+    if (lit) {
+      routes.add(`${lit[1]} ${lit[2]}`);
+      continue;
+    }
+    const ma = line.match(matchAssignRe);
+    if (ma) {
+      const [, varName, pattern] = ma;
+      const method = methodForVar(i, varName);
+      if (method) routes.add(`${method} ${pattern}`);
+      continue;
+    }
+    const ra = line.match(regexAssignRe);
+    if (ra) {
+      const [, varName, rawPattern] = ra;
+      const pattern = rawPattern.replace(/\\\//g, '/').replace(/\(\\d\+\)/g, ':id');
+      const method = methodForVar(i, varName);
+      if (method) routes.add(`${method} ${pattern}`);
+      continue;
+    }
+  }
+  return routes;
+}
+
+// Parses the PUBLIC_ROUTES Set literal in server.ts source.
+function publicRoutesFromServerSource(text: string): Set<string> {
+  const m = text.match(/const PUBLIC_ROUTES: ReadonlySet<string> = new Set\(\[([\s\S]*?)\]\);/);
+  if (!m) throw new Error('PUBLIC_ROUTES literal not found in server.ts');
+  const routes = new Set<string>();
+  const entryRe = /'([^']+)'/g;
+  let entry: RegExpExecArray | null;
+  while ((entry = entryRe.exec(m[1])) !== null) {
+    routes.add(entry[1]);
+  }
+  return routes;
+}
+
+const serverSource = readFileSync(join(repoRoot, 'src/server.ts'), 'utf8');
+const handleRequestSource = serverSource.slice(serverSource.indexOf('async function handleRequest'));
+
+// Every authed (non-public, non-health) route with a request shape that
+// clears pre-auth validation, so a 401 (not 400) proves the Bearer check ran.
+// :param segments become '1' (ID_SEGMENT_RE and \d+ regex routes both accept it).
+const AUTHED_ROUTES: ReadonlyArray<{
+  method: string;
+  pattern: string;
+  query?: string;
+  body?: string;
+}> = [
+  { method: 'POST', pattern: '/v1/memories', body: '{"content":"x"}' },
+  { method: 'GET', pattern: '/v1/graph' },
+  { method: 'GET', pattern: '/v1/memories', query: '?q=test' },
+  { method: 'GET', pattern: '/v1/sessions/:id/assemble' },
+  { method: 'GET', pattern: '/v1/recall/drill/:id' },
+  { method: 'POST', pattern: '/v1/memories/:id/archive', body: '{"reason":"x"}' },
+  { method: 'POST', pattern: '/v1/memories/:id/supersede', body: '{"content":"y"}' },
+  { method: 'POST', pattern: '/v1/memories/:id/promote' },
+  { method: 'DELETE', pattern: '/v1/memories/:id' },
+  { method: 'POST', pattern: '/v1/outcome', body: '{"good":true}' },
+  { method: 'GET', pattern: '/v1/context' },
+  { method: 'POST', pattern: '/v1/sleep' },
+  { method: 'POST', pattern: '/v1/auth/keys', body: '{"label":"x"}' },
+  { method: 'GET', pattern: '/v1/auth/keys' },
+  { method: 'DELETE', pattern: '/v1/auth/keys/:keyId' },
+  { method: 'GET', pattern: '/v1/audit' },
+  { method: 'POST', pattern: '/v1/predictions', body: '{"claim":"x","classTag":"y"}' },
+  { method: 'GET', pattern: '/v1/predictions' },
+  { method: 'GET', pattern: '/v1/predictions/stats', query: '?class=x' },
+  { method: 'GET', pattern: '/v1/predictions/:id' },
+  { method: 'POST', pattern: '/v1/predictions/:id/close', body: '{"state":"closed"}' },
+  { method: 'POST', pattern: '/v1/decisions', body: '{"text":"x"}' },
+  { method: 'GET', pattern: '/v1/decisions' },
+  { method: 'POST', pattern: '/v1/decisions/:id/supersede', body: '{"text":"x"}' },
+  { method: 'POST', pattern: '/v1/decisions/:id/close' },
+  { method: 'GET', pattern: '/v1/decisions/:id' },
+  { method: 'POST', pattern: '/v1/incidents', body: '{"text":"x"}' },
+  { method: 'GET', pattern: '/v1/incidents' },
+  { method: 'POST', pattern: '/v1/incidents/:id/resolve', body: '{"resolutionText":"x"}' },
+  { method: 'POST', pattern: '/v1/incidents/:id/close' },
+  { method: 'GET', pattern: '/v1/incidents/:id' },
+  { method: 'POST', pattern: '/v1/processes', body: '{"processName":"x"}' },
+  { method: 'GET', pattern: '/v1/processes' },
+  { method: 'POST', pattern: '/v1/processes/:id/supersede', body: '{"steps":["x"]}' },
+  { method: 'POST', pattern: '/v1/processes/:id/close' },
+  { method: 'GET', pattern: '/v1/processes/:id' },
+  { method: 'POST', pattern: '/v1/policies', body: '{"policyName":"x","policyText":"y"}' },
+  { method: 'GET', pattern: '/v1/policies' },
+  { method: 'GET', pattern: '/v1/policies/asof', query: '?date=2026-01-01' },
+  { method: 'POST', pattern: '/v1/policies/:id/supersede', body: '{"policyText":"x"}' },
+  { method: 'POST', pattern: '/v1/policies/:id/close' },
+  { method: 'GET', pattern: '/v1/policies/:id' },
+  { method: 'POST', pattern: '/v1/skills', body: '{"skillName":"x","instructions":"y"}' },
+  { method: 'GET', pattern: '/v1/skills' },
+  { method: 'GET', pattern: '/v1/skills/export' },
+  { method: 'POST', pattern: '/v1/skills/:id/supersede', body: '{"instructions":"x"}' },
+  { method: 'POST', pattern: '/v1/skills/:id/close' },
+  { method: 'GET', pattern: '/v1/skills/:id' },
+  { method: 'POST', pattern: '/v1/project-briefs', body: '{"repo":"x","summary":"y"}' },
+  { method: 'GET', pattern: '/v1/project-briefs' },
+  { method: 'POST', pattern: '/v1/project-briefs/refresh', body: '{"repo":"x"}' },
+  { method: 'POST', pattern: '/v1/project-briefs/:id/supersede', body: '{"summary":"x"}' },
+  { method: 'POST', pattern: '/v1/project-briefs/:id/close' },
+  { method: 'GET', pattern: '/v1/project-briefs/:id' },
+  { method: 'POST', pattern: '/v1/customer-notes', body: '{"customer":"x","note":"y"}' },
+  { method: 'GET', pattern: '/v1/customer-notes' },
+  { method: 'POST', pattern: '/v1/customer-notes/:id/supersede', body: '{"note":"x"}' },
+  { method: 'POST', pattern: '/v1/customer-notes/:id/close' },
+  { method: 'GET', pattern: '/v1/customer-notes/:id' },
+  { method: 'POST', pattern: '/mcp', body: '{"jsonrpc":"2.0","method":"tools/list","id":1}' },
+  { method: 'GET', pattern: '/mcp/stream' },
+];
+
+function requestPath(pattern: string, query?: string): string {
+  const path = pattern.replace(/:\w+/g, '1');
+  return query ? `${path}${query}` : path;
+}
+
 describe('server Bearer lockdown', () => {
   let root: string;
   let handle: ServerHandle;
@@ -21,49 +155,69 @@ describe('server Bearer lockdown', () => {
     root = mkdtempSync(join(tmpdir(), 'hippo-lockdown-'));
     initStore(root);
     process.env.HIPPO_REQUIRE_AUTH = '1';
+    // '0' disables the default limiter (20 rps/burst 40), which would
+    // 429 the ~120 /v1 requests this file sends.
+    process.env.HIPPO_V1_RPS = '0';
     handle = await serve({ hippoRoot: root, host: '127.0.0.1', port: 0 });
   });
 
   afterEach(async () => {
     delete process.env.HIPPO_REQUIRE_AUTH;
+    delete process.env.HIPPO_V1_RPS;
     await handle.stop();
     rmSync(root, { recursive: true, force: true });
   });
 
-  // v0.39 commit 5: route-parity expansion — every authed route in
-  // src/server.ts is parameterized here. /v1/connectors/slack/events is
-  // public-by-design (HMAC-verified) and covered by Slack tests; /health
-  // is public and needs no test. 12 authed routes total.
-  const authedRoutes: ReadonlyArray<{ method: string; path: string; body?: string }> = [
-    { method: 'POST', path: '/v1/memories', body: '{"content":"x"}' },
-    { method: 'GET', path: '/v1/memories?q=test' },
-    { method: 'POST', path: '/v1/memories/abc/archive', body: '{"reason":"x"}' },
-    { method: 'POST', path: '/v1/memories/abc/supersede', body: '{"content":"y"}' },
-    { method: 'POST', path: '/v1/memories/abc/promote' },
-    { method: 'DELETE', path: '/v1/memories/abc' },
-    { method: 'POST', path: '/v1/auth/keys', body: '{"label":"x"}' },
-    { method: 'GET', path: '/v1/auth/keys' },
-    { method: 'DELETE', path: '/v1/auth/keys/hk_xyz' },
-    { method: 'GET', path: '/v1/audit' },
-    { method: 'POST', path: '/mcp', body: '{"jsonrpc":"2.0","method":"tools/list","id":1}' },
-    { method: 'GET', path: '/mcp/stream' },
-  ];
+  it('the three raw route shapes account for every parsed entry (guards a 4th shape)', () => {
+    const literalCount = (handleRequestSource.match(/path === '\//g) ?? []).length;
+    const matchPathCount = (handleRequestSource.match(/= matchPath\(/g) ?? []).length;
+    const regexCount = (handleRequestSource.match(/path\.match\(\/\^/g) ?? []).length;
+    const derived = routesFromServerSource(serverSource);
+    expect(
+      literalCount + matchPathCount + regexCount,
+      `raw shape count (${literalCount} + ${matchPathCount} + ${regexCount}) must equal parsed routes (${derived.size})`,
+    ).toBe(derived.size);
+  });
 
-  it.each(authedRoutes)(
-    'requires Bearer: $method $path (missing header)',
+  it('PUBLIC_ROUTES contains exactly the two documented unauth routes', () => {
+    const publicRoutes = publicRoutesFromServerSource(serverSource);
+    expect([...publicRoutes].sort()).toEqual([
+      'POST /v1/connectors/github/events',
+      'POST /v1/connectors/slack/events',
+    ]);
+  });
+
+  it('AUTHED_ROUTES covers exactly the derived routes minus public routes minus GET /health', () => {
+    const derived = routesFromServerSource(serverSource);
+    const publicRoutes = publicRoutesFromServerSource(serverSource);
+    const expected = new Set(derived);
+    expected.delete('GET /health');
+    for (const r of publicRoutes) expected.delete(r);
+
+    const actual = new Set(AUTHED_ROUTES.map((r) => `${r.method} ${r.pattern}`));
+    const missing = [...expected].filter((r) => !actual.has(r));
+    const extra = [...actual].filter((r) => !expected.has(r));
+    expect(missing, `AUTHED_ROUTES is missing: ${missing.join(', ')}`).toEqual([]);
+    expect(extra, `AUTHED_ROUTES has extra rows not in server.ts: ${extra.join(', ')}`).toEqual([]);
+  });
+
+  it.each(AUTHED_ROUTES)(
+    'requires Bearer: $method $pattern (missing header)',
     async (r) => {
       const init: RequestInit = {
         method: r.method,
         headers: { 'content-type': 'application/json' },
       };
       if (r.body !== undefined) init.body = r.body;
-      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, init);
-      expect(res.status, `${r.method} ${r.path}`).toBe(401);
+      const path = requestPath(r.pattern, r.query);
+      const res = await fetch(`http://127.0.0.1:${handle.port}${path}`, init);
+      const text = await res.text();
+      expect(res.status, `${r.method} ${path} -> ${res.status}: ${text}`).toBe(401);
     },
   );
 
-  it.each(authedRoutes)(
-    'requires Bearer: $method $path (bad token)',
+  it.each(AUTHED_ROUTES)(
+    'requires Bearer: $method $pattern (bad token)',
     async (r) => {
       const init: RequestInit = {
         method: r.method,
@@ -73,8 +227,10 @@ describe('server Bearer lockdown', () => {
         },
       };
       if (r.body !== undefined) init.body = r.body;
-      const res = await fetch(`http://127.0.0.1:${handle.port}${r.path}`, init);
-      expect(res.status, `${r.method} ${r.path}`).toBe(401);
+      const path = requestPath(r.pattern, r.query);
+      const res = await fetch(`http://127.0.0.1:${handle.port}${path}`, init);
+      const text = await res.text();
+      expect(res.status, `${r.method} ${path} -> ${res.status}: ${text}`).toBe(401);
     },
   );
 });


### PR DESCRIPTION
## Summary

`tests/server-bearer-lockdown.test.ts` derives its route table from `src/server.ts` source instead of a hand-copied list, so a new `/v1/*` or `/mcp` route that skips `buildContextWithAuth`/`requireAuth` fails CI.

- Three parsers cover the dispatch shapes in `handleRequest`: literal `path === '...'`, `matchPath(...)` assignments, and `path.match(/^...$/)` assignments. A raw-shape-count guard (64 sites) fails loudly if a fourth shape appears.
- The 61-row `AUTHED_ROUTES` request table is asserted equal to the derived set minus `PUBLIC_ROUTES` minus `GET /health`. Missing and extra rows are listed in the failure message.
- Every row is probed twice under `HIPPO_REQUIRE_AUTH=1`: no header and a bad `hk_` token, both expecting 401. `HIPPO_V1_RPS=0` disables the limiter so 122 probes do not trip it.
- CHANGELOG `1.38.2 - unreleased` Tests bullet. Plan doc at `docs/plans/2026-09-05-bearer-lockdown-route-table.md`. No server code change.

Backlog item: A3 item 7 (`.devrl-backlog.md`).

## Test plan

- [x] Red-first: the old 12-row list fails the completeness assertion with 49 missing routes
- [x] Mutation A: a fake `GET /v1/zzz` dispatch site fails the completeness test
- [x] Mutation B: removing `buildContextWithAuth` from `GET /v1/decisions` fails exactly that route's two 401 tests
- [x] `tests/server-bearer-lockdown.test.ts` green (125 tests)
- [x] `npm run build`, `tsc --noEmit`, oxlint clean
- [ ] Full vitest suite in the worktree
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dkoAWom9UM8VMxVUwFdRj
