### PR TITLE
test: AML adapter pins 429 pass-through and cf-connecting-ip forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Tests
 - `tests/server-bearer-lockdown.test.ts` now derives its route table from `src/server.ts` source instead of a hand-copied list, so a new `/v1/*` route missing `buildContextWithAuth`/`requireAuth` fails CI instead of shipping unauthed.
+- **Pinned two release-safety behaviours of the AML adapter (`deploy/aml/adapter/adapter.mjs`) the existing suite could not catch.** A hippo non-200 (exercised with a real 429) now passes through with hippo's status and error body unchanged, and only the `cf-connecting-ip` header reaches hippo's per-client rate-limit key (`x-forwarded-for` and `x-real-ip` do not). `tests/aml-adapter.test.ts` gained a second real hippo plus adapter pair (`HIPPO_REQUIRE_AUTH=1`, `HIPPO_CLIENT_IP_HEADER=cf-connecting-ip`, `HIPPO_V1_RPS=0.5`) and two concurrency-based tests; the adapter spawn is now a shared `spawnAdapter` helper used by both describe blocks. No adapter behaviour change.
 
 ## 1.38.1 - 2026-09-05
 

--- a/docs/plans/2026-09-05-aml-adapter-status-and-ip-header.md
+++ b/docs/plans/2026-09-05-aml-adapter-status-and-ip-header.md
@@ -1,0 +1,120 @@
+# AML adapter: pin status pass-through and the forwarded client-IP header
+
+Episode 01M1S688Z5SHGAR9GNA7FEXJPQ. Backlog A3 item 8 (Fable advisory 2026-08-25).
+
+## Problem
+
+`tests/aml-adapter.test.ts` boots a real hippo server plus the real adapter
+process and covers happy paths, isolation, auth and validation. It never pins
+two release-safety behaviours of `deploy/aml/adapter/adapter.mjs`:
+
+1. A hippo non-200 that is not a 401 surfaces through the adapter with the
+   same status and hippo's error body. Today `handleAdd` / `handleSearch` do
+   `sendJson(res, status, hippoErrorBody(hippoBody))`; a regression that
+   mapped every upstream outcome to 200 would pass the suite.
+2. The adapter forwards the inbound `cf-connecting-ip` header to hippo as
+   `cf-connecting-ip`, and forwards no other client-address header. Production
+   (`deploy/aml/docker-compose.yml`) sets `HIPPO_CLIENT_IP_HEADER=cf-connecting-ip`,
+   so hippo's `/v1` rate limiter keys per real client only if this holds. A
+   regression that dropped the header, or read `x-forwarded-for` instead,
+   would pass the suite.
+
+## Facts read from source
+
+- `adapter.mjs` `clientIpOf` reads only `cf-connecting-ip`; `callHippo` sets
+  `cf-connecting-ip` on the upstream request only when that value is a
+  non-empty string. Non-200 upstream statuses are returned verbatim with
+  `hippoErrorBody` (`{error}` from hippo when present).
+- `src/server.ts:567` `clientIpForRateLimit` reads `process.env.HIPPO_CLIENT_IP_HEADER`
+  **per request** (not at boot) and falls back to `req.socket.remoteAddress`.
+- `src/server.ts:751-756`: the limiter runs on every `/v1/*` path before auth
+  and throws `HttpError(429, 'rate limit exceeded')`.
+- `src/server.ts:3351-3355`: `HIPPO_V1_RPS` is read at `serve()` boot; burst is
+  `rps * 2`. `HIPPO_V1_RPS=0.5` gives burst 1: a fresh key admits exactly one
+  request, then refills at 0.5 tokens/s (2 s per token).
+- `createRateLimiter` (`src/rate-limit.ts`) seeds an unseen key with a full
+  bucket, so the first request on any new key always passes.
+
+## Design: a second real server pair, no mocks
+
+Add a second `describe` block to `tests/aml-adapter.test.ts` that boots its
+own hippo (`serve` in-process, `HIPPO_REQUIRE_AUTH=1`) and its own adapter
+child process, with the production limiter env:
+
+```
+HIPPO_CLIENT_IP_HEADER=cf-connecting-ip   (production compose value)
+HIPPO_V1_RPS=0.5                          (burst 1: one request per fresh key)
+```
+
+The existing `beforeAll` spawn block becomes a top-level `spawnAdapter(hippoPort)`
+helper returning `{ process, baseUrl }` plus a `stopAdapter`, used by both
+describes (rule 8: hoist, do not clone). Store root and api-key creation follow
+the existing block exactly.
+
+Both env vars are set in the second describe's `beforeAll` and restored in its
+`afterAll`. `HIPPO_CLIENT_IP_HEADER` is read per request, so it must not be
+set while the first describe's tests run; vitest runs describe blocks in file
+order and hooks run with their own describe, so the first block is finished
+before the second `beforeAll` executes. The plan states this so a future
+reorder does not silently change the first block's limiter key.
+
+### Test 1: hippo non-200 passes through with its status and body
+
+Two `POST /search` requests fired concurrently (`Promise.all`) with the same
+`cf-connecting-ip: 203.0.113.10` and a valid Bearer. Exactly one lands in a
+full bucket, the other in an empty one. Assert the sorted status list is
+`[200, 429]` and the 429 body is `{ error: 'rate limit exceeded' }` (hippo's
+message, proving `hippoErrorBody` forwards the upstream text). Concurrency
+removes the timing dependence: the outcome is the same whether the two
+requests are 1 ms or 1.9 s apart, and a 2 s gap between two `Promise.all`
+requests would itself be a test-host failure worth seeing.
+
+Mutation this must catch: `sendJson(res, 200, ...)` on the non-200 branch, or
+`if (status !== 200 && status !== 429)`.
+
+### Test 2: only cf-connecting-ip reaches hippo's limiter key
+
+Part (i), forwarded: three concurrent `POST /search` with distinct
+`cf-connecting-ip` values `198.51.100.1/2/3`. Each is a fresh key, so all three
+are 200. A dropped header would collapse them into the adapter's socket bucket
+and yield `[200, 429, 429]`.
+
+Part (ii), not forwarded: two concurrent `POST /search` with distinct
+`x-forwarded-for` and distinct `x-real-ip` values and **no** `cf-connecting-ip`.
+Both land in the socket-address bucket (`127.0.0.1`), so the sorted statuses
+are `[200, 429]`. An adapter that read either header as the client IP (or
+that forwarded them and hippo were misconfigured to read them) would yield
+`[200, 200]`.
+
+Ordering constraint inside the describe: part (ii) is the only place a
+`/v1` request reaches this hippo without `cf-connecting-ip`, and it runs after
+part (i), so the socket bucket is still full when it starts. `/health` probes
+are not rate limited and do not consume it.
+
+Mutations this must catch: `clientIpOf` returning `undefined` always; `clientIpOf`
+reading `x-forwarded-for`; `callHippo` not setting the header.
+
+## Changes
+
+1. `tests/aml-adapter.test.ts`: hoist `spawnAdapter` / `stopAdapter`; add
+   `describe('rate-limit key forwarding and status pass-through')` with its own
+   `beforeAll` / `afterAll` and the two tests above. Env save/restore for both
+   variables. No change to the 13 existing tests' assertions.
+2. `CHANGELOG.md`: one bullet under `## 1.38.2 - unreleased` / `### Tests`.
+3. No change to `adapter.mjs`, `src/`, version, or deploy files.
+
+## Verification
+
+- `node ./node_modules/vitest/vitest.mjs run tests/aml-adapter.test.ts`: 15 pass.
+- Mutation runs (each reverted after): (a) adapter non-200 branch forced to 200,
+  (b) `clientIpOf` returns `undefined`, (c) `clientIpOf` reads `x-forwarded-for`.
+  Each must fail at least one new test and none of the existing 13.
+- `tsc --noEmit` and oxlint clean on the test file.
+
+## Out of scope
+
+- Simulating a hippo 5xx. Reaching a real 5xx from a healthy hippo needs a
+  fault injector; the 429 is a real non-200 from the real server and exercises
+  the same adapter branch. Noted for the follow-up if a stub upstream is ever
+  accepted in this file.
+- Any adapter behaviour change.

--- a/tests/aml-adapter.test.ts
+++ b/tests/aml-adapter.test.ts
@@ -434,8 +434,8 @@ describe('rate-limit key forwarding and status pass-through', () => {
     rlHippoRoot = join(mkdtempSync(join(tmpdir(), 'hippo-aml-adapter-ratelimit-')), '.hippo');
     initStore(rlHippoRoot);
 
-    // HIPPO_V1_RPS is read at serve() boot, so all three must be set before
-    // this call; clientIpForRateLimit reads its header per request either way.
+    // Only HIPPO_V1_RPS is read at serve() boot; the other two are read per
+    // request, so they are set here for one place to save and restore them.
     process.env.HIPPO_REQUIRE_AUTH = '1';
     process.env.HIPPO_CLIENT_IP_HEADER = 'cf-connecting-ip';
     process.env.HIPPO_V1_RPS = '0.5';

--- a/tests/aml-adapter.test.ts
+++ b/tests/aml-adapter.test.ts
@@ -50,13 +50,59 @@ async function waitForAdapterReady(baseUrl: string, timeoutMs = 10_000): Promise
   throw new Error(`adapter never became reachable at ${baseUrl}: ${String(lastErr)}`);
 }
 
+interface AdapterHandle {
+  child: ChildProcess;
+  baseUrl: string;
+  stderrChunks: Buffer[];
+}
+
+// Shared by both describe blocks below so a second real server pair costs
+// one call, not a second copy of the spawn wiring.
+function spawnAdapter(hippoPort: number): Promise<AdapterHandle> {
+  const stderrChunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    let stdoutBuf = '';
+    // stdout keeps growing with access-log lines, so the regex matches again on every chunk.
+    let readyStarted = false;
+    const child = spawn(process.execPath, [ADAPTER_PATH], {
+      env: {
+        ...process.env,
+        ADAPTER_PORT: '0',
+        HIPPO_URL: `http://127.0.0.1:${hippoPort}`,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString('utf8');
+      const match = /listening on :(\d+)/.exec(stdoutBuf);
+      if (match && !readyStarted) {
+        readyStarted = true;
+        const baseUrl = `http://127.0.0.1:${Number(match[1])}`;
+        waitForAdapterReady(baseUrl)
+          .then(() => resolve({ child, baseUrl, stderrChunks }))
+          .catch(reject);
+      }
+    });
+    child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code !== null && code !== 0) {
+        reject(new Error(`adapter process exited with code ${code}: ${Buffer.concat(stderrChunks).toString('utf8')}`));
+      }
+    });
+  });
+}
+
+function stopAdapter(handle: AdapterHandle | undefined): void {
+  handle?.child.kill();
+}
+
 describe('AML protocol adapter (deploy/aml/adapter/adapter.mjs)', () => {
   let hippoRoot: string;
   let hippoHandle: ServerHandle;
-  let adapterProcess: ChildProcess;
+  let adapterHandle: AdapterHandle;
   let baseUrl: string;
   let validKey: string;
-  const stderrChunks: Buffer[] = [];
   const savedRequireAuth = process.env.HIPPO_REQUIRE_AUTH;
 
   beforeAll(async () => {
@@ -76,37 +122,12 @@ describe('AML protocol adapter (deploy/aml/adapter/adapter.mjs)', () => {
       closeHippoDb(db);
     }
 
-    const adapterReady = new Promise<number>((resolve, reject) => {
-      let stdoutBuf = '';
-      adapterProcess = spawn(process.execPath, [ADAPTER_PATH], {
-        env: {
-          ...process.env,
-          ADAPTER_PORT: '0',
-          HIPPO_URL: `http://127.0.0.1:${hippoHandle.port}`,
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      adapterProcess.stdout?.on('data', (chunk: Buffer) => {
-        stdoutBuf += chunk.toString('utf8');
-        const match = /listening on :(\d+)/.exec(stdoutBuf);
-        if (match) resolve(Number(match[1]));
-      });
-      adapterProcess.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
-      adapterProcess.once('error', reject);
-      adapterProcess.once('exit', (code) => {
-        if (code !== null && code !== 0) {
-          reject(new Error(`adapter process exited with code ${code}: ${Buffer.concat(stderrChunks).toString('utf8')}`));
-        }
-      });
-    });
-
-    const adapterPort = await adapterReady;
-    baseUrl = `http://127.0.0.1:${adapterPort}`;
-    await waitForAdapterReady(baseUrl);
+    adapterHandle = await spawnAdapter(hippoHandle.port);
+    baseUrl = adapterHandle.baseUrl;
   }, 30_000);
 
   afterAll(async () => {
-    adapterProcess?.kill();
+    stopAdapter(adapterHandle);
     await hippoHandle?.stop();
     if (savedRequireAuth === undefined) {
       delete process.env.HIPPO_REQUIRE_AUTH;
@@ -383,5 +404,106 @@ describe('AML protocol adapter (deploy/aml/adapter/adapter.mjs)', () => {
     expect(row).toBeDefined();
     expect(row!.content).toContain('user: zqx7');
     expect(row!.content).toContain('assistant: wvk3');
+  });
+});
+
+// Second real server pair with the production limiter env, pinning the two
+// release-safety behaviours the first describe never exercises (see
+// docs/plans/2026-09-05-aml-adapter-status-and-ip-header.md).
+describe('rate-limit key forwarding and status pass-through', () => {
+  let rlHippoRoot: string;
+  let rlHippoHandle: ServerHandle;
+  let rlAdapterHandle: AdapterHandle;
+  let rlBaseUrl: string;
+  let rlValidKey: string;
+  const savedRequireAuth = process.env.HIPPO_REQUIRE_AUTH;
+  const savedClientIpHeader = process.env.HIPPO_CLIENT_IP_HEADER;
+  const savedV1Rps = process.env.HIPPO_V1_RPS;
+
+  beforeAll(async () => {
+    rlHippoRoot = join(mkdtempSync(join(tmpdir(), 'hippo-aml-adapter-ratelimit-')), '.hippo');
+    initStore(rlHippoRoot);
+
+    // HIPPO_V1_RPS is read at serve() boot, so all three must be set before
+    // this call; clientIpForRateLimit reads its header per request either way.
+    process.env.HIPPO_REQUIRE_AUTH = '1';
+    process.env.HIPPO_CLIENT_IP_HEADER = 'cf-connecting-ip';
+    process.env.HIPPO_V1_RPS = '0.5';
+    rlHippoHandle = await serve({ hippoRoot: rlHippoRoot, host: '127.0.0.1', port: 0 });
+
+    const db = openHippoDb(rlHippoRoot);
+    try {
+      ({ plaintext: rlValidKey } = createApiKey(db, { tenantId: 'default', label: 'aml-adapter-ratelimit-test' }));
+    } finally {
+      closeHippoDb(db);
+    }
+
+    rlAdapterHandle = await spawnAdapter(rlHippoHandle.port);
+    rlBaseUrl = rlAdapterHandle.baseUrl;
+  }, 30_000);
+
+  afterAll(async () => {
+    stopAdapter(rlAdapterHandle);
+    await rlHippoHandle?.stop();
+    if (savedRequireAuth === undefined) {
+      delete process.env.HIPPO_REQUIRE_AUTH;
+    } else {
+      process.env.HIPPO_REQUIRE_AUTH = savedRequireAuth;
+    }
+    if (savedClientIpHeader === undefined) {
+      delete process.env.HIPPO_CLIENT_IP_HEADER;
+    } else {
+      process.env.HIPPO_CLIENT_IP_HEADER = savedClientIpHeader;
+    }
+    if (savedV1Rps === undefined) {
+      delete process.env.HIPPO_V1_RPS;
+    } else {
+      process.env.HIPPO_V1_RPS = savedV1Rps;
+    }
+    rmSync(rlHippoRoot, { recursive: true, force: true });
+  });
+
+  // Clears adapter validation on every call so the request always reaches
+  // hippo; only the extra headers vary between calls.
+  function rlSearch(extraHeaders: Record<string, string>) {
+    return fetch(`${rlBaseUrl}/search`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${rlValidKey}`,
+        ...extraHeaders,
+      },
+      body: JSON.stringify({ query: 'x', user_id: 'user-ratelimit', top_k: 1 }),
+    });
+  }
+
+  it("a hippo non-200 (exercised with a real 429) passes through with hippo's status and body", async () => {
+    const [first, second] = await Promise.all([
+      rlSearch({ 'cf-connecting-ip': '203.0.113.10' }),
+      rlSearch({ 'cf-connecting-ip': '203.0.113.10' }),
+    ]);
+    const statuses = [first.status, second.status].sort((a, b) => a - b);
+    expect(statuses).toEqual([200, 429]);
+
+    const limited = first.status === 429 ? first : second;
+    const limitedBody = await limited.json();
+    expect(limitedBody).toEqual({ error: 'rate limit exceeded' });
+  });
+
+  it("only cf-connecting-ip reaches hippo's rate-limit key; x-forwarded-for and x-real-ip do not", async () => {
+    const forwarded = await Promise.all([
+      rlSearch({ 'cf-connecting-ip': '198.51.100.1' }),
+      rlSearch({ 'cf-connecting-ip': '198.51.100.2' }),
+      rlSearch({ 'cf-connecting-ip': '198.51.100.3' }),
+    ]);
+    expect(forwarded.map((r) => r.status).sort((a, b) => a - b)).toEqual([200, 200, 200]);
+
+    // No cf-connecting-ip: both fall back to the socket-address bucket, which
+    // no earlier request in this describe has touched.
+    const notForwarded = await Promise.all([
+      rlSearch({ 'x-forwarded-for': '198.51.100.4', 'x-real-ip': '198.51.100.5' }),
+      rlSearch({ 'x-forwarded-for': '198.51.100.6', 'x-real-ip': '198.51.100.7' }),
+    ]);
+    expect(notForwarded.map((r) => r.status).sort((a, b) => a - b)).toEqual([200, 429]);
   });
 });

--- a/tests/aml-adapter.test.ts
+++ b/tests/aml-adapter.test.ts
@@ -72,6 +72,13 @@ function spawnAdapter(hippoPort: number): Promise<AdapterHandle> {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    // No handle reaches the caller on a failed start, so the helper must reap its own child.
+    const fail = (err: unknown): void => {
+      clearTimeout(startupTimer);
+      child.kill();
+      reject(err);
+    };
+    const startupTimer = setTimeout(() => fail(new Error('adapter never printed its listening line')), 20_000);
     child.stdout?.on('data', (chunk: Buffer) => {
       stdoutBuf += chunk.toString('utf8');
       const match = /listening on :(\d+)/.exec(stdoutBuf);
@@ -79,15 +86,18 @@ function spawnAdapter(hippoPort: number): Promise<AdapterHandle> {
         readyStarted = true;
         const baseUrl = `http://127.0.0.1:${Number(match[1])}`;
         waitForAdapterReady(baseUrl)
-          .then(() => resolve({ child, baseUrl, stderrChunks }))
-          .catch(reject);
+          .then(() => {
+            clearTimeout(startupTimer);
+            resolve({ child, baseUrl, stderrChunks });
+          })
+          .catch(fail);
       }
     });
     child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
-    child.once('error', reject);
+    child.once('error', fail);
     child.once('exit', (code) => {
       if (code !== null && code !== 0) {
-        reject(new Error(`adapter process exited with code ${code}: ${Buffer.concat(stderrChunks).toString('utf8')}`));
+        fail(new Error(`adapter process exited with code ${code}: ${Buffer.concat(stderrChunks).toString('utf8')}`));
       }
     });
   });


### PR DESCRIPTION
## Summary
- `tests/aml-adapter.test.ts` gains a second real hippo + adapter pair booted with the production limiter env (`HIPPO_CLIENT_IP_HEADER=cf-connecting-ip`, `HIPPO_V1_RPS=0.5`, so a fresh key admits exactly one request).
- Test 1: two concurrent `/search` calls on one `cf-connecting-ip` return `[200, 429]` and the 429 body is hippo's `{ error: 'rate limit exceeded' }`. Pins that a hippo non-200 passes through the adapter with its status and body.
- Test 2: three concurrent calls on distinct `cf-connecting-ip` values all return 200, while two on distinct `x-forwarded-for` / `x-real-ip` values with no `cf-connecting-ip` return `[200, 429]`. Pins that only `cf-connecting-ip` reaches hippo's limiter key.
- Adapter spawn hoisted into one helper shared by both describe blocks. No change to `adapter.mjs`, `src/`, deploy files or version.

Backlog A3 item 8 (Fable advisory 2026-08-25). Plan: `docs/plans/2026-09-05-aml-adapter-status-and-ip-header.md`. Version stays 1.38.1; the batch gate bumps to 1.38.2.

## Test plan
- [ ] `node ./node_modules/vitest/vitest.mjs run tests/aml-adapter.test.ts` 15 pass
- [ ] Mutation (a) adapter non-200 branch forced to 200 fails test 1
- [ ] Mutation (b) `clientIpOf` returns undefined fails test 2
- [ ] Mutation (c) `clientIpOf` reads `x-forwarded-for` fails test 2
- [ ] tsc and oxlint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dkoAWom9UM8VMxVUwFdRj
