### PR TITLE
docs: LoCoMo per-category disclosure table on README and website (F19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.38.3 - unreleased
+
+### Added
+- **LoCoMo per-category disclosure table.** The v1.25.0 evidence recall@5 numbers per question category (single-hop 0.239, multi-hop 0.491, temporal-reasoning 0.169, open-domain 0.450, adversarial 0.226, overall 0.363) used to live only in `benchmarks/LOCOMO_INVESTIGATION.md`. README's Benchmarks section and the website benchmarks page now carry the table with the conditions that must travel with it: MiniLM-L6 default embedder, single run, v1.25.0 build, pre-#126 harness, no LLM judge. `website/scripts/check-readme-sync.mjs` fails the site build if the page's LoCoMo rows drift from the README (F19).
+
 ## 1.38.2 - 2026-09-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ Different tools answer different questions. Mem0 and Basic Memory implement "sav
 
 ## Benchmarks
 
-Two benchmarks testing two different things. Full details in [`benchmarks/`](benchmarks/).
+Three benchmarks testing three different things. Full details in [`benchmarks/`](benchmarks/).
 
 ### LongMemEval (retrieval accuracy)
 
@@ -846,6 +846,23 @@ python ingest_direct.py --data data/longmemeval_oracle.json --store-dir ./store
 python retrieve_fast.py --data data/longmemeval_oracle.json --store-dir ./store --output results/retrieval.jsonl
 python evaluate_retrieval.py --retrieval results/retrieval.jsonl --data data/longmemeval_oracle.json
 ```
+
+### LoCoMo (conversational evidence recall)
+
+[LoCoMo](https://arxiv.org/abs/2402.17753) is 10 long multi-session conversations (5,882 turns, 1,986 questions). Hippo scores it with a deterministic metric: did the gold evidence turn land in the top 5 recalled memories? No LLM judge is in the scoring path, so the numbers are not comparable to the LLM-as-judge accuracy Mem0 and Letta publish for LoCoMo.
+
+**v1.25.0 baseline (measured 2026-07-05, single run).** Zero-dependency default embedder (`Xenova/all-MiniLM-L6-v2`), fresh store per conversation, `hippo recall --budget 4000`, top-k 5, 1,982 scored questions:
+
+| Category | n | Evidence recall@5 |
+|----------|--:|------------------:|
+| single-hop | 282 | 0.239 |
+| multi-hop | 321 | 0.491 |
+| temporal-reasoning | 92 | 0.169 |
+| open-domain | 841 | 0.450 |
+| adversarial | 446 | 0.226 |
+| **overall** | 1,982 | **0.363** |
+
+Read these as a point estimate, not an exact value: n=1, and the run predates the v1.26.0 determinism fix and the harness fix in [#126](https://github.com/kitfunso/hippo-memory/pull/126) (0.9% of stored rows lost their tags at run time). The table has not been re-run on a newer build. Overall recall is 2.10x the April v0.32.0 baseline under the identical protocol. Informational only, gates no feature. Full protocol, caveats and regeneration commands: [`benchmarks/LOCOMO_INVESTIGATION.md`](benchmarks/LOCOMO_INVESTIGATION.md); harness in [`benchmarks/locomo/`](benchmarks/locomo/).
 
 ### Sequential Learning Benchmark (agent improvement over time)
 

--- a/docs/plans/2026-09-05-f19-locomo-per-category-disclosure.md
+++ b/docs/plans/2026-09-05-f19-locomo-per-category-disclosure.md
@@ -1,0 +1,95 @@
+# F19: LoCoMo per-category disclosure table (README + website)
+
+Episode `01M1SNEVHH9PV1BWJXFQG6WG33` (loop `hippoloop-20260904T205515Z`, A3 item 11). Docs only.
+
+## Problem
+
+Hippo's own LoCoMo result exists in two places only: the full per-category table in
+`benchmarks/LOCOMO_INVESTIGATION.md` (lines 147-156) and the overall number in
+`benchmarks/README.md` (line 102). `README.md` mentions LoCoMo only in competitor cells of the
+Comparison row (line 786) and its Benchmarks section (heading line 799, sentence line 801) says "Two benchmarks", covering
+LongMemEval and Sequential Learning. `website/src/pages/benchmarks.astro` is LongMemEval-only.
+A reader of the README or the site cannot see how hippo does on LoCoMo, per category, or under
+what conditions the number was measured.
+
+## Source facts (read 2026-09-05 from origin/master d3c77ba)
+
+| Category | n | v1.25.0 evidence recall@5 | 3 dp |
+|---|---:|---:|---:|
+| single-hop | 282 | 0.238882 | 0.239 |
+| multi-hop | 321 | 0.490914 | 0.491 |
+| temporal-reasoning | 92 | 0.169384 | 0.169 |
+| open-domain | 841 | 0.450258 | 0.450 |
+| adversarial | 446 | 0.226457 | 0.226 |
+| overall | 1982 | 0.363369 | 0.363 |
+
+Source: `benchmarks/LOCOMO_INVESTIGATION.md:147-156` ("Per-category (same rescore, canonical
+numbers)"), rescored by `score_evidence.py`. 3 dp matches the precision `benchmarks/README.md:102`
+already uses for the overall number.
+
+Conditions that must travel with the table:
+
+- **Build and date:** hippo v1.25.0 (`f20d9e9`), run 2026-07-05 (`LOCOMO_INVESTIGATION.md:5, 92`),
+  93.6 min, 1,982 scored QAs of 1,986 (`:102-118`).
+- **Embedder:** the zero-dependency default. `benchmarks/locomo/run.py` `hippo_init` runs
+  `hippo init --no-hooks --no-schedule --no-learn` and writes a config only for `--salience`
+  (run.py:186-204), so `config.embeddings.provider` stays `local` (CHANGELOG 1.23.0) and the model
+  is `src/embeddings.ts:27` `DEFAULT_EMBEDDING_MODEL = 'Xenova/all-MiniLM-L6-v2'`.
+- **n = 1:** a single run, a point estimate. Pre-1.26.0 builds showed run-to-run spread
+  (conversation 1 repeated 4 times: mean 0.3630, range 0.3401-0.3820, stdev 0.0175;
+  `LOCOMO_INVESTIGATION.md:181-193`). v1.26.0 removed the dominant variance source; the table has
+  not been re-run on a post-1.26.0 build.
+- **Harness bug present at run time:** `run.py` used `shell=True` on Windows and cmd.exe truncated
+  turns at embedded newlines, so 0.9% of stored rows lost their tags (`LOCOMO_INVESTIGATION.md:20-30, 215-244`; fixed in PR #126, commit `9da6d3f`
+  "fix: locomo harness newline truncation").
+- **Metric:** deterministic gold-`dia_id` evidence recall@5, no LLM judge. Not comparable to the
+  LLM-as-judge numbers Mem0 and Letta publish (`LOCOMO_INVESTIGATION.md:166-170`). Informational
+  only, gates no feature (`:11-12`).
+
+## Changes
+
+1. `README.md`, Benchmarks section (line 799 onward):
+   - "Two benchmarks testing two different things" -> "Three benchmarks testing three different
+     things".
+   - New `### LoCoMo (conversational evidence recall)` subsection between the LongMemEval and
+     Sequential Learning subsections: one paragraph naming the dataset, the metric and the
+     conditions above; the 6-row table (Category, n, evidence recall@5); a closing line linking
+     `benchmarks/LOCOMO_INVESTIGATION.md` and `benchmarks/locomo/`.
+2. `website/src/pages/benchmarks.astro`:
+   - Frontmatter: `const locomo = [...]` rows (category, n, r5) with a comment citing the doc,
+     mirroring the existing `perHaystack` / `globalPool` consts.
+   - New section at the end of the page, after "Reproduce it" (the LongMemEval sections and their
+     reproduce block stay contiguous; the LoCoMo section carries its own doc link): heading "LoCoMo: conversational evidence recall", the same table markup as the
+     per-haystack section, a caveat paragraph (v1.25.0, 2026-07-05, MiniLM default, single run,
+     no LLM judge), a link to `LOCOMO_INVESTIGATION.md` on GitHub.
+   - Hero paragraph (line 54) gains "and LoCoMo" so the page's own framing matches its content.
+     `title`, `description`, `heroChips` and `jsonLd` stay LongMemEval-led: the headline numbers
+     do not change.
+3. `website/scripts/check-readme-sync.mjs`: extend the drift guard so the `locomo` rows in
+   `benchmarks.astro` (category names and r5 strings) must appear in the README's `### LoCoMo`
+   subsection. A new parallel check block in the same best-effort text-extraction style as the
+   existing `cells:` check (second source file, second README section scope); fails the website
+   build on drift. This is the repo's established pattern for site-vs-README numbers.
+4. `CHANGELOG.md`: new `## 1.38.3 - unreleased` heading with an `### Added` bullet (version bump
+   happens at the batch deploy gate).
+
+No `src/` change. No version bump. No ROADMAP edit: F19 is tracked in the loop backlog, ROADMAP has
+no F-list entry for it.
+
+## Verification
+
+- `node website/scripts/check-readme-sync.mjs` passes in the worktree, and fails when one astro
+  r5 cell is deliberately changed (mutation), then passes again after revert.
+- `npm --prefix website run build` (runs the sync check, then `astro build`) succeeds; the built
+  `dist/benchmarks/index.html` contains the six category rows.
+- A scratch python check reads the README table and `LOCOMO_INVESTIGATION.md:149-156` and
+  asserts each README cell equals the doc value rounded to 3 dp.
+- Grep the diff for em dashes (none allowed in the site copy or CHANGELOG) and for
+  `sk-|api_key=|password=`.
+
+## Risks
+
+- Publishing a v1.25.0 number on a v1.38.x README could read as current. Mitigation: the build,
+  date and "not re-run since" line sit in the same paragraph as the table, on both surfaces.
+- The website `astro build` needs `npm ci` in `website/` inside the worktree (no build cache).
+  Cost: one install, a few minutes.

--- a/docs/plans/2026-09-05-f19-locomo-per-category-disclosure.md
+++ b/docs/plans/2026-09-05-f19-locomo-per-category-disclosure.md
@@ -66,8 +66,9 @@ Conditions that must travel with the table:
      `title`, `description`, `heroChips` and `jsonLd` stay LongMemEval-led: the headline numbers
      do not change.
 3. `website/scripts/check-readme-sync.mjs`: extend the drift guard so the `locomo` rows in
-   `benchmarks.astro` (category names and r5 strings) must appear in the README's `### LoCoMo`
-   subsection. A new parallel check block in the same best-effort text-extraction style as the
+   `benchmarks.astro` must each match one README `### LoCoMo` table line as a whole
+   (`| category | n | r5 |`), so a swapped or copied score fails, not only a missing one (codex
+   review round 1 P2). A new parallel check block in the same best-effort text-extraction style as the
    existing `cells:` check (second source file, second README section scope); fails the website
    build on drift. This is the repo's established pattern for site-vs-README numbers.
 4. `CHANGELOG.md`: new `## 1.38.3 - unreleased` heading with an `### Added` bullet (version bump

--- a/website/scripts/check-readme-sync.mjs
+++ b/website/scripts/check-readme-sync.mjs
@@ -54,18 +54,17 @@ if (warns.length) {
   console.warn('[readme-sync] WARN: receipt claim(s) not found verbatim in README (verify wording):', warns.join(' | '));
 }
 
-// LoCoMo rows on the benchmarks page must match the README's "### LoCoMo" subsection (same
-// best-effort extraction: category + r5 literals from `const locomo = [...]` in benchmarks.astro).
+// LoCoMo rows on the benchmarks page must match the README's "### LoCoMo" subsection row for
+// row (category, n and r5 on one table line), so a swapped or copied score cannot pass.
 const bench = await readFile(join(root, 'src', 'pages', 'benchmarks.astro'), 'utf8');
 const locoStart = readme.indexOf('### LoCoMo');
 const locoEnd = locoStart >= 0 ? readme.indexOf('\n### ', locoStart + 3) : -1;
-const locoNorm = normalize(locoStart >= 0 ? readme.slice(locoStart, locoEnd > 0 ? locoEnd : undefined) : '');
+const locoNorm = normalize(locoStart >= 0 ? readme.slice(locoStart, locoEnd > 0 ? locoEnd : undefined) : '').replace(/\*/g, '');
 const locoBlock = (bench.match(/const locomo = \[([\s\S]*?)\];/) || [])[1] || '';
-const locoRows = [...locoBlock.matchAll(/category:\s*'([^']*)'.*?r5:\s*'([^']*)'/g)];
+const locoRows = [...locoBlock.matchAll(/\{\s*category:\s*'([^']*)',\s*n:\s*'([^']*)',\s*r5:\s*'([^']*)'\s*\}/g)];
 if (!locoRows.length) missing.push('locomo: no rows found in benchmarks.astro');
-for (const [, category, r5] of locoRows) {
-  if (!locoNorm.includes(`| ${category} |`) && !locoNorm.includes(`| **${category}** |`)) missing.push(`locomo category: "${category}"`);
-  if (!locoNorm.includes(r5)) missing.push(`locomo r5: "${category}" ${r5}`);
+for (const [, category, n, r5] of locoRows) {
+  if (!locoNorm.includes(`| ${category} | ${n} | ${r5} |`)) missing.push(`locomo row: | ${category} | ${n} | ${r5} |`);
 }
 
 if (missing.length) {

--- a/website/scripts/check-readme-sync.mjs
+++ b/website/scripts/check-readme-sync.mjs
@@ -54,11 +54,25 @@ if (warns.length) {
   console.warn('[readme-sync] WARN: receipt claim(s) not found verbatim in README (verify wording):', warns.join(' | '));
 }
 
+// LoCoMo rows on the benchmarks page must match the README's "### LoCoMo" subsection (same
+// best-effort extraction: category + r5 literals from `const locomo = [...]` in benchmarks.astro).
+const bench = await readFile(join(root, 'src', 'pages', 'benchmarks.astro'), 'utf8');
+const locoStart = readme.indexOf('### LoCoMo');
+const locoEnd = locoStart >= 0 ? readme.indexOf('\n### ', locoStart + 3) : -1;
+const locoNorm = normalize(locoStart >= 0 ? readme.slice(locoStart, locoEnd > 0 ? locoEnd : undefined) : '');
+const locoBlock = (bench.match(/const locomo = \[([\s\S]*?)\];/) || [])[1] || '';
+const locoRows = [...locoBlock.matchAll(/category:\s*'([^']*)'.*?r5:\s*'([^']*)'/g)];
+if (!locoRows.length) missing.push('locomo: no rows found in benchmarks.astro');
+for (const [, category, r5] of locoRows) {
+  if (!locoNorm.includes(`| ${category} |`) && !locoNorm.includes(`| **${category}** |`)) missing.push(`locomo category: "${category}"`);
+  if (!locoNorm.includes(r5)) missing.push(`locomo r5: "${category}" ${r5}`);
+}
+
 if (missing.length) {
-  console.error('[readme-sync] DRIFT: site.ts comparison entries missing from README.md #comparison:');
+  console.error('[readme-sync] DRIFT: website entries missing from README.md (comparison cells vs #comparison, locomo rows vs ### LoCoMo):');
   for (const m of missing) console.error('  - ' + m);
   console.error('Fix: the README is the source of truth - update README.md and site.ts together.');
   process.exit(1);
 }
 
-console.log(`[readme-sync] OK: ${distinctive.length} distinctive cells + ${systems.length} systems match README #comparison.`);
+console.log(`[readme-sync] OK: ${distinctive.length} distinctive cells + ${systems.length} systems match README #comparison; ${locoRows.length} LoCoMo rows match README ### LoCoMo.`);

--- a/website/src/pages/benchmarks.astro
+++ b/website/src/pages/benchmarks.astro
@@ -18,6 +18,17 @@ const globalPool = [
   { embedder: 'voyage-3-large (opt-in)', r5: '56.4' },
 ];
 
+// Verified against benchmarks/LOCOMO_INVESTIGATION.md "Per-category" table (v1.25.0 run, 2026-07-05, 3 dp).
+const locomo = [
+  { category: 'single-hop', n: '282', r5: '0.239' },
+  { category: 'multi-hop', n: '321', r5: '0.491' },
+  { category: 'temporal-reasoning', n: '92', r5: '0.169' },
+  { category: 'open-domain', n: '841', r5: '0.450' },
+  { category: 'adversarial', n: '446', r5: '0.226' },
+  { category: 'overall', n: '1,982', r5: '0.363' },
+];
+const locomoDocUrl = `${site.links.repo}/blob/master/benchmarks/LOCOMO_INVESTIGATION.md`;
+
 const benchUrl = `${site.links.longmemeval}`;
 
 // Hero chip group: reuses the page's own receipts (no new claims).
@@ -51,7 +62,7 @@ const jsonLd = {
             Numbers, with the <span class="text-gradient">methodology</span>.
           </h1>
           <p class="mt-5 max-w-2xl leading-relaxed text-zinc-400">
-            hippo's retrieval, measured on <a class="link" href="https://arxiv.org/abs/2410.10813" target="_blank" rel="noopener noreferrer">LongMemEval<span class="sr-only"> (opens in new tab)</span></a> (ICLR 2025), the public 500-question memory benchmark. The harness, the data hash, and the per-question results are in the repo so you can rerun them.
+            hippo's retrieval, measured on <a class="link" href="https://arxiv.org/abs/2410.10813" target="_blank" rel="noopener noreferrer">LongMemEval<span class="sr-only"> (opens in new tab)</span></a> (ICLR 2025), the public 500-question memory benchmark, and on <a class="link" href="https://arxiv.org/abs/2402.17753" target="_blank" rel="noopener noreferrer">LoCoMo<span class="sr-only"> (opens in new tab)</span></a>, 10 long multi-session conversations. The harness, the data hash, and the per-question results are in the repo so you can rerun them.
           </p>
         </div>
         <!-- Metric chips fill the hero's right side on wide viewports; duplicates on-page data. -->
@@ -157,6 +168,38 @@ const jsonLd = {
           <a href={benchUrl} target="_blank" rel="noopener noreferrer" class="rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-900 transition hover:bg-white">Benchmark harness &amp; data<span class="sr-only"> (opens in new tab)</span></a>
           <a href={site.links.repo} target="_blank" rel="noopener noreferrer" class="rounded-lg border border-white/12 px-5 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/25">Repository<span class="sr-only"> (opens in new tab)</span></a>
         </div>
+      </div>
+    </section>
+    <!-- LoCoMo per-category disclosure -->
+    <section class="relative scroll-mt-20 border-t border-white/5 bg-white/[0.02]">
+      <div class="mx-auto max-w-6xl px-5 py-24">
+        <h2 class="text-balance text-3xl leading-tight sm:text-4xl">LoCoMo: conversational evidence&nbsp;recall</h2>
+        <p class="mt-4 max-w-2xl leading-relaxed text-zinc-400">
+          <a class="link" href="https://arxiv.org/abs/2402.17753" target="_blank" rel="noopener noreferrer">LoCoMo<span class="sr-only"> (opens in new tab)</span></a> is 10 long multi-session conversations, 5,882 turns and 1,986 questions. hippo scores it deterministically: did the gold evidence turn land in the top 5 recalled memories? No LLM judge. Measured once on v1.25.0 (2026-07-05) with the zero-dependency default embedder, MiniLM-L6:
+        </p>
+        <div class="mt-8 overflow-hidden rounded-2xl border border-white/8">
+          <table class="w-full text-left text-sm">
+            <thead class="bg-white/[0.03] font-mono text-xs uppercase tracking-wider text-zinc-400">
+              <tr>
+                <th scope="col" class="px-5 py-3 font-medium">Category</th>
+                <th scope="col" class="px-5 py-3 font-medium">n</th>
+                <th scope="col" class="px-5 py-3 font-medium">Evidence R@5</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/5">
+              {locomo.map((row) => (
+                <tr class="text-zinc-300">
+                  <th scope="row" class="px-5 py-3.5 text-left font-normal">{row.category}</th>
+                  <td class="px-5 py-3.5 font-mono">{row.n}</td>
+                  <td class="px-5 py-3.5 font-mono font-semibold text-gradient">{row.r5}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-5 max-w-2xl text-sm leading-relaxed text-zinc-400">
+          A point estimate, not an exact value: n=1, and the run predates the v1.26.0 determinism fix and a harness fix that lost tags on 0.9% of stored rows. Not comparable to the LLM-as-judge numbers Mem0 and Letta publish. Informational only, gates no feature. Protocol, caveats and regeneration commands: <a class="link" href={locomoDocUrl} target="_blank" rel="noopener noreferrer">LOCOMO_INVESTIGATION.md<span class="sr-only"> (opens in new tab)</span></a>.
+        </p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary

- F19 (loop backlog A3 item 11). Hippo's own LoCoMo result lived only in `benchmarks/LOCOMO_INVESTIGATION.md` (per-category table) and `benchmarks/README.md` (overall number). `README.md` mentioned LoCoMo only in competitor cells of the Comparison row, and the website benchmarks page was LongMemEval-only.
- README Benchmarks gains a `### LoCoMo (conversational evidence recall)` subsection: the v1.25.0 evidence recall@5 per category (single-hop 0.239, multi-hop 0.491, temporal-reasoning 0.169, open-domain 0.450, adversarial 0.226, overall 0.363; 3 dp like `benchmarks/README.md`) plus the conditions that travel with it: zero-dependency default embedder (`Xenova/all-MiniLM-L6-v2`; the harness writes no embeddings config), single run on 2026-07-05, pre-1.26.0 determinism fix, pre-#126 harness fix (0.9% of stored rows lost tags), deterministic gold-evidence metric with no LLM judge, informational only, not re-run on a newer build.
- `website/src/pages/benchmarks.astro` carries the same table and caveats in a new closing section; the hero sentence names LoCoMo. Headline numbers, title and JSON-LD stay LongMemEval-led.
- `website/scripts/check-readme-sync.mjs` now also fails the site build if a LoCoMo row on the page drifts from the README subsection. Each site row must match one README table line as a whole (category, n, r5), so a swapped or copied score fails too (codex review round 1 found the first version was swap-blind).
- CHANGELOG under `1.38.3 - unreleased` (bump at the batch gate). No `src/` change.

Plan: `docs/plans/2026-09-05-f19-locomo-per-category-disclosure.md`. Episode `01M1SNEVHH9PV1BWJXFQG6WG33`.

## Test plan

- [x] Every README cell equals `LOCOMO_INVESTIGATION.md:150-156` rounded to 3 dp (scratch cross-check, 6 rows)
- [x] `npm --prefix website run build` rc=0; `dist/benchmarks/index.html` contains all six categories, six scores and the doc link
- [x] `check-readme-sync.mjs` clean: 6 LoCoMo rows; mutations (swapped score, changed n, changed category, bold overall row, README-side edit) each fail naming the row
- [x] 0 em dashes and 0 secret patterns in the diff
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dkoAWom9UM8VMxVUwFdRj
