### PR TITLE
fix: keep the stored confidence tier out of the staleness marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.38.6 - 2026-09-06
 
 ### Fixed
 - **Sleep was overwriting the stored confidence tier with a time-derived guess, silently upgrading `inferred` memories to `observed`.** Reproduced on a real store: an `inferred` entry 40 days stale went to `stale` on disk after one `consolidate` and then `observed` after one `markRetrieved`, with nothing left to say it had ever been `inferred`. Root cause was `src/replay.ts:104` reading eligibility off the stored `confidence` column instead of deriving it, which forced `src/consolidate.ts` to persist `resolveConfidence`'s time-derived value back to disk on every sleep at three sites, destroying the stored tier for any entry that aged past 30 days. Replay now calls `resolveConfidence` directly; consolidate persists only `strength` and leaves `confidence` as stored. This reverses the confidence half of review round P2-1 (the strength half, refreshing stored strength on every survivor, is untouched and still correct). `src/search.ts:1263`'s `stale` -> `observed` mapping on recall now only fires for rows deliberately marked `stale` by invalidation or already flattened by a pre-fix sleep; those rows cannot be recovered, because the tier is already gone from disk. No export or signature change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Sleep was overwriting the stored confidence tier with a time-derived guess, silently upgrading `inferred` memories to `observed`.** Reproduced on a real store: an `inferred` entry 40 days stale went to `stale` on disk after one `consolidate` and then `observed` after one `markRetrieved`, with nothing left to say it had ever been `inferred`. Root cause was `src/replay.ts:104` reading eligibility off the stored `confidence` column instead of deriving it, which forced `src/consolidate.ts` to persist `resolveConfidence`'s time-derived value back to disk on every sleep at three sites, destroying the stored tier for any entry that aged past 30 days. Replay now calls `resolveConfidence` directly; consolidate persists only `strength` and leaves `confidence` as stored. This reverses the confidence half of review round P2-1 (the strength half, refreshing stored strength on every survivor, is untouched and still correct). `src/search.ts:1263`'s `stale` -> `observed` mapping on recall now only fires for rows deliberately marked `stale` by invalidation or already flattened by a pre-fix sleep; those rows cannot be recovered, because the tier is already gone from disk. No export or signature change.
+
 ## 1.38.5 - 2026-09-06
 
 ### Fixed

--- a/extensions/openclaw-plugin/openclaw.plugin.json
+++ b/extensions/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.38.5",
+  "version": "1.38.6",
 
   "configSchema": {
     "type": "object",

--- a/extensions/openclaw-plugin/package.json
+++ b/extensions/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "type": "module",
   "description": "Hippo Memory plugin for OpenClaw - biologically-inspired agent memory",
   "main": "index.ts",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hippo-memory",
   "name": "Hippo Memory",
   "description": "Biologically-inspired memory for AI agents. Decay by default, retrieval strengthening, sleep consolidation.",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hippo-memory",
-      "version": "1.38.5",
+      "version": "1.38.6",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hippo-memory",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "description": "Biologically-inspired memory system for AI agents. Decay by default, strength through use.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -8,7 +8,7 @@
  */
 
 import { evalNow, isRecallBoostAblated } from './ablation.js';
-import { MemoryEntry, Layer, calculateStrength, createMemory, resolveConfidence, type DecayOptions } from './memory.js';
+import { MemoryEntry, Layer, calculateStrength, createMemory, type DecayOptions } from './memory.js';
 import {
   loadAllEntries,
   writeEntry,
@@ -240,17 +240,12 @@ export async function consolidate(
       const strength = strengthById.get(entry.id)!;
       if (!entry.pinned && strength < DECAY_THRESHOLD) {
         if (rescuedIds.has(entry.id)) {
-          // Rescued (D1): standard survivor bookkeeping refresh — same
-          // stored-strength + effective-confidence update every other
-          // survivor gets (round-2 code-review P2-1). D1's "kept as-is"
-          // protects against half-life edits and rank-derived writes, not
-          // against the ordinary decay-pass refresh every survivor
-          // receives; leaving a rescued entry's stale strength (e.g. 1.0)
-          // on disk would mislead downstream replay/admission reads.
-          const effectiveConfidence = resolveConfidence(entry, now);
-          const updated = { ...entry, strength, confidence: effectiveConfidence };
+          // Rescued (D1): standard survivor stored-strength refresh (P2-1).
+          // Confidence is left alone here: it is an epistemic tier, not a
+          // cached computation, so resolveConfidence derives it on read.
+          const updated = { ...entry, strength };
           survivors.push(updated);
-          if (!dryRun && (strength !== entry.strength || effectiveConfidence !== entry.confidence)) {
+          if (!dryRun && strength !== entry.strength) {
             pendingWrites.push(updated);
           }
           result.decayed++;
@@ -268,10 +263,9 @@ export async function consolidate(
           }
         }
       } else {
-        const effectiveConfidence = resolveConfidence(entry, now);
-        const updated = { ...entry, strength, confidence: effectiveConfidence };
+        const updated = { ...entry, strength };
         survivors.push(updated);
-        if (!dryRun && (strength !== entry.strength || effectiveConfidence !== entry.confidence)) {
+        if (!dryRun && strength !== entry.strength) {
           pendingWrites.push(updated);
         }
         result.decayed++;
@@ -288,15 +282,10 @@ export async function consolidate(
           pendingDeletes.push(entry.id);
         }
       } else {
-        // Update the stored strength value and persist stale confidence when applicable.
-        const effectiveConfidence = resolveConfidence(entry, now);
-        const updated = {
-          ...entry,
-          strength,
-          confidence: effectiveConfidence,
-        };
+        // Only strength is a cached computation; confidence stays as stored.
+        const updated = { ...entry, strength };
         survivors.push(updated);
-        if (!dryRun && (strength !== entry.strength || effectiveConfidence !== entry.confidence)) {
+        if (!dryRun && strength !== entry.strength) {
           pendingWrites.push(updated);
         }
         result.decayed++;

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -24,7 +24,7 @@
  */
 
 import { isOutcomeSlowAblated } from './ablation.js';
-import type { MemoryEntry, EmotionalValence } from './memory.js';
+import { resolveConfidence, type MemoryEntry, type EmotionalValence } from './memory.js';
 
 const VALENCE_WEIGHT = {
   neutral: 1.0,
@@ -99,9 +99,10 @@ export function sampleForReplay(
   if (count <= 0 || survivors.length === 0) return [];
   const rng = mulberry32(seed);
 
-  // Stale memories have been deliberately marked as untrusted; rehearsing
-  // them would defeat the purpose of staleness. Skip them entirely.
-  const eligible = survivors.filter((e) => e.confidence !== 'stale');
+  // Deliberately-marked and aged-out memories are both untrusted; rehearsing
+  // them would defeat the purpose of staleness, so derive rather than trust
+  // the stored value (it no longer carries the age-out case, see memory.ts).
+  const eligible = survivors.filter((e) => resolveConfidence(e, now) !== 'stale');
   if (eligible.length === 0) return [];
 
   const pool = eligible.map((entry, idx) => ({

--- a/src/search.ts
+++ b/src/search.ts
@@ -1259,7 +1259,9 @@ export function markRetrieved(entries: MemoryEntry[], now: Date = evalNow()): Me
       last_retrieved: now.toISOString(),
       // Extend half-life by +2 days per retrieval (PLAN.md)
       half_life_days: e.half_life_days + 2,
-      // A stale memory that gets used again becomes live context.
+      // Only fires for rows deliberately marked 'stale' (invalidation.ts,
+      // cli.ts) or already flattened by a pre-fix sleep; age-out staleness
+      // is derived by resolveConfidence and never stored, so it never reaches this branch.
       confidence: e.confidence === 'stale' ? 'observed' : e.confidence,
     };
     updated.strength = calculateStrength(updated, now);

--- a/src/version.ts
+++ b/src/version.ts
@@ -18,7 +18,7 @@
  * an ESM `import` can resolve cleanly, and a hardcoded constant survives
  * any packager that drops .json files.
  */
-export const PACKAGE_VERSION = '1.38.5';
+export const PACKAGE_VERSION = '1.38.6';
 // Bump on every release alongside the 4 other manifests + lockfile.
 
 /**

--- a/tests/confidence-tier-preserved.test.ts
+++ b/tests/confidence-tier-preserved.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { consolidate } from '../src/consolidate.js';
+import { initStore, writeEntry, readEntry } from '../src/store.js';
+import { createMemory, resolveConfidence, type MemoryEntry } from '../src/memory.js';
+import { markRetrieved } from '../src/search.js';
+import { sampleForReplay } from '../src/replay.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hippo-confidence-tier-'));
+  // replay picking this test's own fixtures would confound the assertions
+  // on stored confidence, so disable it via the store's own config file.
+  fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({ replay: { count: 0 } }), 'utf8');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function agedEntry(overrides: Partial<MemoryEntry> & { confidence: MemoryEntry['confidence'] }): MemoryEntry {
+  const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
+  return {
+    ...createMemory('an aged memory used to probe the confidence tier', { confidence: overrides.confidence }),
+    last_retrieved: old,
+    half_life_days: 3650, // survives DECAY_THRESHOLD so it stays a survivor
+    ...overrides,
+  };
+}
+
+describe('confidence tier survives sleep', () => {
+  it('an inferred memory stays inferred through sleep and markRetrieved, never silently upgraded', async () => {
+    initStore(tmpDir);
+    const entry = agedEntry({ confidence: 'inferred' });
+    writeEntry(tmpDir, entry);
+    expect(readEntry(tmpDir, entry.id)!.confidence).toBe('inferred');
+
+    await consolidate(tmpDir, { now: new Date() });
+    const afterSleep = readEntry(tmpDir, entry.id)!;
+    expect(afterSleep.confidence).toBe('inferred');
+    expect(resolveConfidence(afterSleep, new Date())).toBe('stale');
+
+    const [afterRecall] = markRetrieved([afterSleep]);
+    expect(afterRecall.confidence).toBe('inferred');
+  });
+
+  it('distinguishes an aged-out stored tier from a deliberately invalidated one', async () => {
+    initStore(tmpDir);
+    const now = new Date();
+    const aged = agedEntry({ confidence: 'observed' });
+    const invalidated = agedEntry({ confidence: 'stale', tags: ['invalidated'] });
+    writeEntry(tmpDir, aged);
+    writeEntry(tmpDir, invalidated);
+
+    await consolidate(tmpDir, { now });
+
+    const loadedAged = readEntry(tmpDir, aged.id)!;
+    expect(loadedAged.confidence).toBe('observed');
+    expect(resolveConfidence(loadedAged, now)).toBe('stale');
+
+    const loadedInvalidated = readEntry(tmpDir, invalidated.id)!;
+    expect(loadedInvalidated.confidence).toBe('stale');
+  });
+
+  it('replay skips both an aged-out survivor and a deliberately marked one', () => {
+    const now = new Date();
+    const aged = agedEntry({ confidence: 'observed' });
+    const marked = agedEntry({ confidence: 'stale' });
+    const fresh = { ...agedEntry({ confidence: 'observed' }), last_retrieved: now.toISOString() };
+
+    const picked = sampleForReplay([aged, marked, fresh], 3, now, 42);
+    expect(picked.map((e) => e.id)).toEqual([fresh.id]);
+  });
+
+  it('verified and pinned memories are exempt from staleness regardless of age', async () => {
+    initStore(tmpDir);
+    const now = new Date();
+    const verified = agedEntry({ confidence: 'verified' });
+    const pinned = { ...agedEntry({ confidence: 'observed' }), pinned: true };
+    writeEntry(tmpDir, verified);
+    writeEntry(tmpDir, pinned);
+
+    await consolidate(tmpDir, { now });
+
+    expect(resolveConfidence(readEntry(tmpDir, verified.id)!, now)).toBe('verified');
+    expect(resolveConfidence(readEntry(tmpDir, pinned.id)!, now)).toBe('observed');
+  });
+});

--- a/tests/consolidate.test.ts
+++ b/tests/consolidate.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { consolidate } from '../src/consolidate.js';
 import { initStore, writeEntry, loadAllEntries, readEntry, listMemoryConflicts } from '../src/store.js';
-import { createMemory, Layer, calculateStrength } from '../src/memory.js';
+import { createMemory, Layer, calculateStrength, resolveConfidence } from '../src/memory.js';
 
 let tmpDir: string;
 
@@ -65,19 +65,23 @@ describe('Decay pass', () => {
     expect(remaining.find((e) => e.id === ancient.id)).toBeDefined();
   });
 
-  it('persists stale confidence for old non-verified memories during sleep', async () => {
+  it('keeps the stored confidence tier for old non-verified memories through sleep, while resolveConfidence reports stale', async () => {
     initStore(tmpDir);
 
     const entry = createMemory('stale memory candidate', { confidence: 'observed', tags: ['error'] });
-    const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+    const now = new Date();
+    const oldDate = new Date(now.getTime() - 31 * 24 * 60 * 60 * 1000).toISOString();
     const staleCandidate = { ...entry, last_retrieved: oldDate, confidence: 'observed' as const };
     writeEntry(tmpDir, staleCandidate);
 
-    await consolidate(tmpDir, { now: new Date() });
+    await consolidate(tmpDir, { now });
 
     const loaded = readEntry(tmpDir, staleCandidate.id);
     expect(loaded).not.toBeNull();
-    expect(loaded!.confidence).toBe('stale');
+    // Confidence is an epistemic tier, not a cached computation (reverses
+    // the confidence half of P2-1; strength refresh is untouched).
+    expect(loaded!.confidence).toBe('observed');
+    expect(resolveConfidence(loaded!, now)).toBe('stale');
   });
 });
 

--- a/tests/memory-value-wiring.test.ts
+++ b/tests/memory-value-wiring.test.ts
@@ -23,7 +23,7 @@ import {
   loadSessionDecayContext,
   batchWriteAndDelete,
 } from '../src/store.js';
-import { createMemory, Layer, calculateStrength, type MemoryEntry, type DecayOptions } from '../src/memory.js';
+import { createMemory, Layer, calculateStrength, resolveConfidence, type MemoryEntry, type DecayOptions } from '../src/memory.js';
 import { loadConfig, type HippoConfig } from '../src/config.js';
 import { openHippoDb, closeHippoDb } from '../src/db.js';
 import { queryAuditEvents, type AuditEvent } from '../src/audit.js';
@@ -437,7 +437,7 @@ describe('(e) rescue semantics', () => {
     }
   });
 
-  it('rescued entries get the standard survivor bookkeeping refresh (stored strength + confidence), not left stale', async () => {
+  it('rescued entries get the standard survivor bookkeeping refresh (stored strength), confidence tier preserved', async () => {
     initStore(dir);
     enableMemoryValue(dir);
 
@@ -470,9 +470,10 @@ describe('(e) rescue semantics', () => {
       // from createMemory).
       expect(refreshed!.strength).toBeLessThan(0.05); // DECAY_THRESHOLD
       expect(refreshed!.strength).not.toBe(orig.strength);
-      // Effective confidence is refreshed too (observed -> stale after 3650
-      // ancient days via resolveConfidence), not left at the original value.
-      expect(refreshed!.confidence).toBe('stale');
+      // Confidence is an epistemic tier, not a cached computation: the store
+      // keeps 'observed', while resolveConfidence still reports 'stale'.
+      expect(refreshed!.confidence).toBe('observed');
+      expect(resolveConfidence(refreshed!, NOW)).toBe('stale');
       // D1 still holds: no half-life edits, no rank-derived writes.
       expect(refreshed!.half_life_days).toBe(orig.half_life_days);
     }


### PR DESCRIPTION
## What

`hippo sleep` was overwriting the stored confidence tier with a time-derived guess. An entry stored as `inferred` came back as `observed`.

Reproduced on a real store before the fix:

```
stored before sleep : inferred
stored after sleep  : stale
after markRetrieved : observed
```

The epistemic tier is destroyed on disk and then guessed wrong on the next recall. The guess is right for rows that were `observed` and wrong for every row that was `inferred`, and nothing records which it was.

## Why it happened

`ConfidenceLevel` holds four values. Three are epistemic tiers (`verified`, `observed`, `inferred`); `stale` is a time property. They share one slot, so a time fact can evict a tier fact.

The chain runs backwards from where the symptom shows:

1. `src/replay.ts:104` decided rehearsal eligibility from the **stored** confidence.
2. So `src/consolidate.ts` persisted the **derived** value back to disk on every sleep, at three sites, to keep replay correct.
3. So the stored tier was gone after the first sleep past the 30 day threshold.
4. So `src/search.ts:1263` guessed `observed` when it saw `stale`.

Step 1 is the root cause. Fix it and steps 2 and 3 stop being necessary.

## The change

Replay derives staleness with `resolveConfidence`. Consolidate persists only `strength`, which is a genuinely cached computation, and leaves `confidence` as stored.

This reverses the confidence half of review round P2-1. Its strength half is untouched and still correct: a rescued entry's stale strength on disk really would mislead downstream reads, which is what that round was about. The confidence half was bundled in by symmetry and is the half that destroys data.

`search.ts:1263` keeps its mapping. It still fires for rows deliberately marked `stale` by `invalidation.ts` or `cli.ts`, and for rows already flattened by a pre-fix sleep. Its comment now says so, so it is not read as general policy.

## Tests

New `tests/confidence-tier-preserved.test.ts`, real store, no mocks, four cases: the reproduction inverted, an aged-out tier distinguished from a deliberately invalidated one, replay skipping both stale classes, and `verified` / `pinned` still exempt.

Two existing tests pinned the removed behaviour and are inverted rather than deleted: `tests/memory-value-wiring.test.ts` (the P2-1 test) and `tests/consolidate.test.ts`. Both now assert the stored tier survives while `resolveConfidence` still reports `stale`.

## Not in scope

Rows already flattened by past sleeps cannot be recovered. The tier is gone from disk and no backfill can invent it.

A dedicated stored column for the untrust marker is the clean separation and needs a migration, so it is not attempted here.

`markRetrieved` restoring trust in a deliberately invalidated memory is a separate defect with the same smell, filed rather than fixed.

No export change, no signature change, no migration.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf7WiWEEpbHXbBtQJ5tKoH
