### PR TITLE
test: pin slack backfill cursor resume, close two false-open TODOS

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -452,7 +452,7 @@ From the B3 dlPFC ship (v0.38.0). 3 of 5 items closed in v1.7.4 (2026-05-07); co
 From the E1.3 Slack ingestion ship (v0.37.0). Operator UX, eval polish, and
 ranking improvements; none are correctness blockers.
 
-- [ ] **DLQ replay command.** `hippo slack dlq retry <id>` to re-run a parked event after fixing the underlying parser. Today the DLQ is read-only via `hippo slack dlq list`.
+- [x] **DLQ replay command.** ALREADY SHIPPED, found 2026-09-07. The verb is `replay`, not `retry`: `hippo slack dlq replay <id> [--force]` dispatches at `src/cli.ts:8245`, `replayDlqEntry` imported at `src/cli.ts:239`, usage string at `src/cli.ts:8267`. This item stayed open because every grep searched for the name in the TODO rather than the capability.
 
 - [x] **Workspace registration CLI.** SHIPPED 2026-05-24 — `hippo slack workspaces <add|list|remove>`. `add --team <T> --tenant <t>` upserts on team_id conflict (operators move workspaces between tenants). `list` returns tab-separated rows sorted by team_id. `remove --team <T>` reports not-found on miss. Helper module at `src/connectors/slack/workspaces.ts`; 7 unit + 10 CLI tests at `tests/slack-workspaces.test.ts` + `tests/slack-workspaces-cli.test.ts`.
 
@@ -460,7 +460,7 @@ ranking improvements; none are correctness blockers.
 
 - [ ] **Thread-aware ranking.** Treat `thread_ts` as a parent boost so replies surface their thread root in recall. V1 ranks each message independently.
 
-- [ ] **Incremental real-time backfill.** Today `backfillChannel` drains the channel until exhaustion. For live workspaces add a "stop at cursor" mode so the loop terminates when it catches up to the live cursor instead of paginating to history start.
+- [x] **Incremental real-time backfill.** ALREADY SHIPPED, premise was false, checked 2026-09-07. `backfillChannel` does NOT drain on rerun: the persisted cursor is replayed as `oldest` on page 0 (`src/connectors/slack/backfill.ts:92`) and `web-client.ts:31` sets it as a query param, so Slack bounds the range server-side. Only a FIRST run on a fresh channel drains, which is what backfill means. Verified by probe, then pinned: `tests/slack-backfill-cursor.test.ts` case 3 asserts a rerun makes one call with `oldest=<stored cursor>`. Mutation-tested (forcing `oldest: undefined` fails it).
 
 - [x] **BM25 sentinel-token leakage in evals.** SHIPPED v1.12.6 — `docs/evals/AUTHORING.md` documents the lesson (descriptive scenario IDs leak into ambient noise via shared tokens, inflating BM25 recall scores) + pre-commit checklist (list every shared string between signal/noise fixtures, confirm it's intentional signal or opaque enough not to bias scoring, run noise-only baseline). Also documents 3 other eval-authoring lessons: pre-registration discipline (v1.8.1 rule), multi-seed harnesses + paired-comparison statistics, workload-validity gate before mechanism gate. Template at end of doc.
 

--- a/tests/slack-backfill-cursor.test.ts
+++ b/tests/slack-backfill-cursor.test.ts
@@ -88,4 +88,40 @@ describe('backfillChannel cursor / oldest semantics', () => {
     expect(calls[1].cursor).toBe('OPAQUE_PAGE2_TOKEN');
     expect(calls[1].oldest).toBeUndefined(); // Page 2+ never sets oldest.
   });
+  it('a rerun resumes at the stored cursor instead of re-paging history', async () => {
+    // TODOS v0.38.0 asked for a "stop at cursor" mode on the claim that backfill
+    // drains a channel every run. It does not: the persisted cursor is replayed as
+    // `oldest`, so Slack bounds the range server-side. This pins that.
+    const mkPage = (tss: string[], next: string | null) => ({
+      messages: tss.map((ts) => ({ ts, text: `m${ts}`, user: 'U1', type: 'message' })),
+      next_cursor: next,
+    });
+
+    let firstRun = 0;
+    const seed: SlackHistoryFetcher = async () => {
+      firstRun++;
+      return firstRun === 1 ? mkPage(['300.0', '200.0'], 'PAGE2') : mkPage(['100.0'], null);
+    };
+    const r1 = await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher: seed,
+    });
+    expect(r1.pages).toBe(2); // Fresh channel: drains, which is what backfill means.
+
+    const calls: Array<{ cursor: string | null; oldest?: string }> = [];
+    const rerun: SlackHistoryFetcher = async ({ cursor, oldest }) => {
+      calls.push({ cursor, oldest });
+      return mkPage([], null);
+    };
+    await backfillChannel(ctx(root), {
+      teamId: 'T1',
+      channel: { id: 'C1', is_private: false },
+      fetcher: rerun,
+    });
+
+    expect(calls).toHaveLength(1); // Caught up: one page, no walk back through history.
+    expect(calls[0].oldest).toBe('300.0'); // Newest ts from run 1, replayed as the bound.
+    expect(calls[0].cursor).toBeNull();
+  });
 });


### PR DESCRIPTION
Two backlog items kept surviving triage because nothing in the test suite pinned the behaviour they asked for. Both already ship. This closes them with evidence and adds the missing regression test.

## DLQ replay: already shipped under a different verb

`TODOS.md` asked for `hippo slack dlq retry <id>`. The code shipped `replay`:

- dispatch: `src/cli.ts:8245`
- `replayDlqEntry` import: `src/cli.ts:239`
- usage string: `src/cli.ts:8267`

Every grep for the TODO's own wording came back empty, so the item read as open on each pass.

## Incremental backfill stop-at-cursor: the premise was false

The item claimed `backfillChannel` "drains the channel until exhaustion" on every run. It does not. The persisted cursor is replayed as `oldest` on page 0 (`src/connectors/slack/backfill.ts:92`), and `web-client.ts:31` sends it as a query param, so Slack bounds the range server-side. A rerun makes exactly one call and returns nothing new. Only a first run on a fresh channel drains, which is what backfill means.

Probed before believing it. A second `backfillChannel` call against a caught-up channel produced:

```
RERUN CALLS: [{"oldest":"300.0","cursor":null}]
```

`tests/slack-backfill-cursor.test.ts` had two cases, and neither covered a rerun. That hole is why the false premise survived two triage passes.

## What changed

- `tests/slack-backfill-cursor.test.ts`: new case asserting a rerun makes one call with `oldest=<stored cursor>` and a null pagination cursor.
- `TODOS.md`: both items marked done with the file and line evidence above.

No source change, no version bump, no CHANGELOG entry.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run`: 3266 passed, 4 skipped, 0 failed
- [x] `tests/slack-backfill-cursor.test.ts`: 3 passed
- [x] Mutation test: forcing `oldest: undefined` in `backfill.ts:92` fails the new case (`expected undefined to be '300.0'`) and one sibling; restoring it returns 3 passed
- [x] codex review against `origin/master`: no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf7WiWEEpbHXbBtQJ5tKoH
